### PR TITLE
Tabular: Switched KNN and RF to use refit_folds instead of use_child_oof

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -801,14 +801,27 @@ class AbstractModel:
 
         return template
 
-    def convert_to_refit_full_template(self):
-        """After calling this function, returned model should be able to be fit without X_val, y_val using the iterations trained by the original model."""
-        params = copy.deepcopy(self.get_params())
-        params['hyperparameters'].update(self.params_trained)
-        params['name'] = params['name'] + REFIT_FULL_SUFFIX
-        template = self.__class__(**params)
+    def convert_to_refit_full_template(self, name_suffix=REFIT_FULL_SUFFIX):
+        """
+        After calling this function, returned model should be able to be fit without X_val, y_val using the iterations trained by the original model.
 
-        return template
+        Parameters
+        ----------
+        name_suffix : str, default = '_FULL'
+            If name_suffix is not None, will append name_suffix to self.name when creating the template model's name.
+            Be careful of setting to None or empty string, as this will lead to the template overwriting self on disk when saved.
+
+        Returns
+        -------
+        model_full_template : AbstractModel
+            Unfit model capable of being fit without X_val, y_val. Hyperparameters are based on post-fit self hyperparameters.
+        """
+        init_args = self.get_params()
+        init_args['hyperparameters'].update(self.params_trained)
+        if name_suffix:
+            init_args['name'] = init_args['name'] + name_suffix
+        model_full_template = self.__class__(**init_args)
+        return model_full_template
 
     def hyperparameter_tune(self, scheduler_options, time_limit=None, **kwargs):
         scheduler_options = copy.deepcopy(scheduler_options)

--- a/tabular/src/autogluon/tabular/models/knn/knn_model.py
+++ b/tabular/src/autogluon/tabular/models/knn/knn_model.py
@@ -77,7 +77,7 @@ class KNNModel(AbstractModel):
     @classmethod
     def _get_default_ag_args_ensemble(cls, **kwargs) -> dict:
         default_ag_args_ensemble = super()._get_default_ag_args_ensemble(**kwargs)
-        extra_ag_args_ensemble = {'use_child_oof': True}
+        extra_ag_args_ensemble = {'refit_folds': True}
         default_ag_args_ensemble.update(extra_ag_args_ensemble)
         return default_ag_args_ensemble
 

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -309,9 +309,8 @@ class RFModel(AbstractModel):
     @classmethod
     def _get_default_ag_args_ensemble(cls, problem_type=None, **kwargs) -> dict:
         default_ag_args_ensemble = super()._get_default_ag_args_ensemble(problem_type=problem_type, **kwargs)
-        if problem_type != QUANTILE:  # use_child_oof not supported in quantile regression
-            extra_ag_args_ensemble = {'use_child_oof': True}
-            default_ag_args_ensemble.update(extra_ag_args_ensemble)
+        extra_ag_args_ensemble = {'refit_folds': True}
+        default_ag_args_ensemble.update(extra_ag_args_ensemble)
         return default_ag_args_ensemble
 
     def _more_tags(self):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Switched KNN and RF to use refit_folds instead of use_child_oof during bagging
- This results in the same model at test time for RF and KNN, but different out of fold predictions.
- While being 10x slower to train, this will reduce stack information leakage significantly while keeping inference speed identical. I would guess that assuming enough time is given, this will improve stack quality.

TODO:

- [ ] Benchmark


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
