### PR TITLE
[Post 0.6][Tabular] make tabular nn dataset iterable

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_torch_dataset.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_torch_dataset.py
@@ -9,7 +9,7 @@ from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION, SOFTCLASS, 
 logger = logging.getLogger(__name__)
 
 
-class TabularTorchDataset(torch.utils.data.Dataset):
+class TabularTorchDataset(torch.utils.data.IterableDataset):
     """
         This class follows the structure of TabularNNDataset in tabular_nn_dataset.py (using Pytorch DataLoader instead of MXNet DataLoader),
 
@@ -122,17 +122,31 @@ class TabularTorchDataset(torch.utils.data.Dataset):
         self.num_categories_per_embed_feature = None
         self.num_categories_per_embedfeature = self.getNumCategoriesEmbeddings()
 
-    def __getitem__(self, idx):
-        output_dict = {}
-        if self.has_vector_features():
-            output_dict['vector'] = self.data_list[self.vectordata_index][idx]
-        if self.num_embed_features() > 0:
-            output_dict['embed'] = []
-            for i in self.embed_indices:
-                output_dict['embed'].append(self.data_list[i][idx])
-        if self.label_index is not None:
-            output_dict['label'] = self.data_list[self.label_index][idx]
-        return output_dict
+        self.has_vector_features = self.vectordata_index is not None
+        self.has_embed_features = len(self.feature_groups['embed']) > 0
+
+    def __iter__(self):
+        idxarray = np.arange(self.num_examples)
+        if self.shuffle:
+            np.random.shuffle(idxarray)
+        indices = range(0, self.num_examples, self.batch_size)
+        for idx_start in indices:
+            if self.drop_last and (idx_start + self.batch_size) > self.num_examples:
+                break
+            idx = range(idx_start, min(self.num_examples, idx_start + self.batch_size))
+            if self.shuffle:
+                idx = idxarray[idx]
+            output_list = []
+            if self.has_vector_features:
+                output_list.append(self.data_list[self.vectordata_index][idx])
+            if self.has_embed_features:
+                output_embed = []
+                for i in self.embed_indices:
+                    output_embed.append(self.data_list[i][idx])
+                output_list.append(output_embed)
+            if self.label_index is not None:
+                output_list.append(self.data_list[self.label_index][idx])
+            yield tuple(output_list)
 
     def __len__(self):
         return self.num_examples
@@ -211,8 +225,10 @@ class TabularTorchDataset(torch.utils.data.Dataset):
     def build_loader(self, batch_size, num_workers, is_test=False):
         def worker_init_fn(worker_id):
             np.random.seed(np.random.get_state()[1][0] + worker_id)
-        loader = torch.utils.data.DataLoader(self, batch_size=batch_size, num_workers=num_workers,
-                                             shuffle=False if is_test else True,
-                                             drop_last=False if is_test else True,
+        self.batch_size = batch_size
+        self.shuffle = False if is_test else True
+        self.drop_last = False if is_test else True
+        loader = torch.utils.data.DataLoader(self, num_workers=num_workers,
+                                             batch_size=None, # no collation
                                              worker_init_fn=worker_init_fn)
         return loader

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/torch_network_modules.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/torch_network_modules.py
@@ -162,7 +162,6 @@ class EmbedNet(nn.Module):
             embed_data = data_batch[input_offset]
             for i in range(len(self.embed_blocks)):
                 input_data.append(self.embed_blocks[i](embed_data[i].to(self.device)))
-            input_offset += 1
 
         if len(input_data) > 1:
             input_data = torch.cat(input_data, dim=1)

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/torch_network_modules.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/torch_network_modules.py
@@ -33,8 +33,8 @@ class EmbedNet(nn.Module):
             params = self._set_params(**kwargs)
             # adpatively specify network architecture based on training dataset
             self.from_logits = False
-            self.has_vector_features = train_dataset.has_vector_features()
-            self.has_embed_features = train_dataset.num_embed_features() > 0
+            self.has_vector_features = train_dataset.has_vector_features
+            self.has_embed_features = train_dataset.has_embed_features
             if self.has_embed_features:
                 num_categs_per_feature = train_dataset.getNumCategoriesEmbeddings()
                 embed_dims = get_embed_sizes(train_dataset, params, num_categs_per_feature)
@@ -154,12 +154,15 @@ class EmbedNet(nn.Module):
 
     def forward(self, data_batch):
         input_data = []
+        input_offset = 0
         if self.has_vector_features:
-            input_data.append(data_batch['vector'].to(self.device))
+            input_data.append(data_batch[0].to(self.device))
+            input_offset += 1
         if self.has_embed_features:
-            embed_data = data_batch['embed']
+            embed_data = data_batch[input_offset]
             for i in range(len(self.embed_blocks)):
                 input_data.append(self.embed_blocks[i](embed_data[i].to(self.device)))
+            input_offset += 1
 
         if len(input_data) > 1:
             input_data = torch.cat(input_data, dim=1)
@@ -227,7 +230,7 @@ class EmbedNet(nn.Module):
         # train mode
         self.train()
         predict_data = self(data_batch)
-        target_data = data_batch['label'].to(self.device)
+        target_data = data_batch[-1].to(self.device)
         if self.problem_type in [BINARY, MULTICLASS]:
             target_data = target_data.type(torch.long)  # Windows default int type is int32. Need to explicit convert to Long.
         if self.problem_type == QUANTILE:


### PR DESCRIPTION
*Description of changes:*
This PR converts map-based tabular nn dataset class into an iterable dataset, which makes batch-based data loading significantly faster. 

For instance, loading 9769 rows in [test.csv](https://autogluon.s3.amazonaws.com/datasets/Inc/test.csv) has been reduced from 49 ms to 9 ms.

Data loading time has been measured with following code snippet.
```python
        tic = time.time()
        subtotal = 0
        for batch_idx, data_batch in enumerate(val_dataloader):
            tik = time.time()
            preds_batch = self.model.predict(data_batch)
            preds_dataset.append(preds_batch)
            subtotal += time.time() - tik
        total = time.time()-tic
        print(f"elapsed (dataloader): {(total-subtotal)*1000:.0f} ms")
        print(f"elapsed (predict): {subtotal*1000:.0f} ms")
```

Under Linux, we are able to achieve 40% overall time savings for batch_size>10000.

![image](https://user-images.githubusercontent.com/857821/202010639-1be02817-3362-47ab-b9e8-e8974997d07a.png)

See following chart for more benchmark results.

![image](https://user-images.githubusercontent.com/857821/202007648-c307453a-cd77-40b3-a69c-8141da8b0de8.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
