### PR TITLE
[timeseries] Fix pandas groupby bug + GluonTS index bug

### DIFF
--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -109,7 +109,6 @@ class TimeSeriesDataFrame(pd.DataFrame):
         super().__init__(data=data, *args, **kwargs)
         self._static_features: Optional[pd.DataFrame] = None
         if static_features is not None:
-            # TODO: These two checks should go inside the setter
             if isinstance(static_features, pd.Series):
                 static_features = static_features.to_frame()
             if not isinstance(static_features, pd.DataFrame):
@@ -156,10 +155,6 @@ class TimeSeriesDataFrame(pd.DataFrame):
         # subset to ensure consistency
         if value is not None and len(set(value.index) - set(self.item_ids)) > 0:
             value = value.loc[self.item_ids].copy()
-
-        if value is not None and value.index.name != ITEMID:
-            value = value.copy()
-            value.index.rename(ITEMID, inplace=True)
 
         self._static_features = value
 

--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -324,9 +324,6 @@ class TimeSeriesDataFrame(pd.DataFrame):
             assert timestamp_column in df.columns, f"Column {timestamp_column} not found!"
             df.rename(columns={timestamp_column: TIMESTAMP}, inplace=True)
 
-        if not df[TIMESTAMP].dtype == "datetime64[ns]":
-            df[TIMESTAMP] = pd.to_datetime(df[TIMESTAMP])
-
         cls._validate_data_frame(df)
         return df.set_index([ITEMID, TIMESTAMP])
 

--- a/timeseries/src/autogluon/timeseries/evaluator.py
+++ b/timeseries/src/autogluon/timeseries/evaluator.py
@@ -19,30 +19,30 @@ def in_sample_naive_1_error(*, y_history: pd.Series) -> pd.Series:
     """Compute the error of naive forecast (predict previous value) for each time series."""
     diff = y_history.diff()
     # We ignore the differences between the last value of prev item and the first value of the next item
-    length_per_item = y_history.groupby(ITEMID, sort=False).size()
+    length_per_item = y_history.groupby(level=ITEMID, sort=False).size()
     first_index_for_each_item = length_per_item.cumsum().values[:-1]
     diff.iloc[first_index_for_each_item] = np.nan
-    return diff.abs().groupby(ITEMID, sort=False).mean()
+    return diff.abs().groupby(level=ITEMID, sort=False).mean()
 
 
 def mse_per_item(*, y_true: pd.Series, y_pred: pd.Series) -> pd.Series:
     """Compute Mean Squared Error for each item (time series)."""
-    return (y_true - y_pred).pow(2.0).groupby(ITEMID, sort=False).mean()
+    return (y_true - y_pred).pow(2.0).groupby(level=ITEMID, sort=False).mean()
 
 
 def mae_per_item(*, y_true: pd.Series, y_pred: pd.Series) -> pd.Series:
     """Compute Mean Absolute Error for each item (time series)."""
-    return (y_true - y_pred).abs().groupby(ITEMID, sort=False).mean()
+    return (y_true - y_pred).abs().groupby(level=ITEMID, sort=False).mean()
 
 
 def mape_per_item(*, y_true: pd.Series, y_pred: pd.Series) -> pd.Series:
     """Compute Mean Absolute Percentage Error for each item (time series)."""
-    return ((y_true - y_pred) / y_true).abs().groupby(ITEMID, sort=False).mean()
+    return ((y_true - y_pred) / y_true).abs().groupby(level=ITEMID, sort=False).mean()
 
 
 def symmetric_mape_per_item(*, y_true: pd.Series, y_pred: pd.Series) -> pd.Series:
     """Compute symmetric Mean Absolute Percentage Error for each item (time series)."""
-    return (2 * (y_true - y_pred).abs() / (y_true.abs() + y_pred.abs())).groupby(ITEMID, sort=False).mean()
+    return (2 * (y_true - y_pred).abs() / (y_true.abs() + y_pred.abs())).groupby(level=ITEMID, sort=False).mean()
 
 
 def quantile_loss(*, y_true: pd.Series, y_pred: pd.Series, q: float) -> float:

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
@@ -210,7 +210,7 @@ class AutoGluonTabularModel(AbstractTimeSeriesModel):
             new_df = pd.DataFrame(new_values, index=new_index, columns=[self.target])
             return pd.concat([group.droplevel(ITEMID), new_df])
 
-        extended_data = data.groupby(ITEMID, sort=False).apply(extend_single_time_series)
+        extended_data = data.groupby(level=ITEMID, sort=False).apply(extend_single_time_series)
         extended_data.static_features = data.static_features
         return extended_data
 
@@ -242,7 +242,7 @@ class AutoGluonTabularModel(AbstractTimeSeriesModel):
         """Normalize data such that each the average absolute value of each time series is equal to 1."""
         # TODO: Implement other scalers (min/max)?
         # TODO: Don't include validation data when computing the scale
-        scale_per_item = data.abs().groupby(ITEMID, sort=False)[self.target].mean().clip(lower=min_scale)
+        scale_per_item = data.abs().groupby(level=ITEMID, sort=False)[self.target].mean().clip(lower=min_scale)
         normalized_data = data.copy()
         for col in normalized_data.columns:
             normalized_data[col] = normalized_data[col] / scale_per_item

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -21,6 +21,7 @@ from autogluon.core.utils.savers import save_pkl
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP, TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 from autogluon.timeseries.utils.features import get_categorical_and_continuous_features
+from autogluon.timeseries.utils.forecast import get_forecast_horizon_index_ts_dataframe
 from autogluon.timeseries.utils.warning_filters import disable_root_logger
 
 logger = logging.getLogger(__name__)
@@ -361,7 +362,10 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
                     )
 
         # Make sure the item_ids are sorted in the same order as in data
-        return df.loc[data.item_ids]
+        df = df.loc[data.item_ids]
+        # Set correct timestamp index
+        df.index = get_forecast_horizon_index_ts_dataframe(data, self.prediction_length)
+        return df
 
     def _predict_gluonts_forecasts(
         self, data: TimeSeriesDataFrame, known_covariates: Optional[TimeSeriesDataFrame] = None, **kwargs

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -77,7 +77,7 @@ class SimpleGluonTSDataset(GluonTSDataset):
             df = self.target_df.loc[item_id]
             time_series = {
                 FieldName.ITEM_ID: item_id,
-                FieldName.TARGET: df.squeeze().to_numpy(dtype=self.float_dtype),
+                FieldName.TARGET: df.to_numpy(dtype=self.float_dtype).ravel(),
                 FieldName.START: pd.Period(df.index[0], freq=self.freq),
             }
             if self.feat_static_cat is not None:

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -363,7 +363,8 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
 
         # Make sure the item_ids are sorted in the same order as in data
         df = df.loc[data.item_ids]
-        # Set correct timestamp index
+        # GluonTS uses pd.Period internally, which may lead to loss of precision (e.g., "2020-01-01 12:00" becomes
+        # "2020-01-01 00:00"). We manually set the index to avoid such problems.
         df.index = get_forecast_horizon_index_ts_dataframe(data, self.prediction_length)
         return df
 

--- a/timeseries/src/autogluon/timeseries/models/sktime/abstract_sktime.py
+++ b/timeseries/src/autogluon/timeseries/models/sktime/abstract_sktime.py
@@ -12,6 +12,7 @@ from statsmodels.tools.sm_exceptions import ConvergenceWarning
 from autogluon.common.utils.log_utils import set_logger_verbosity
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP, TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
+from autogluon.timeseries.utils.forecast import get_forecast_horizon_index_ts_dataframe
 from autogluon.timeseries.utils.hashing import hash_ts_dataframe_items
 from autogluon.timeseries.utils.seasonality import get_seasonality
 
@@ -175,8 +176,5 @@ class AbstractSktimeModel(AbstractTimeSeriesModel):
         predictions = pd.concat([mean_predictions, quantile_predictions], axis=1)
         predictions_df = self._to_time_series_data_frame(predictions, freq=data.freq)
         # Make sure item_id matches `data` (in case trainining and prediction data use different `item_id`s)
-        fit_item_id_to_pred_item_id = dict(zip(self._fit_hash.index, data_hash.index))
-        pred_item_id = predictions_df.index.get_level_values(ITEMID).map(fit_item_id_to_pred_item_id.get)
-        pred_timestamp = predictions_df.index.get_level_values(TIMESTAMP)
-        predictions_df.index = pd.MultiIndex.from_arrays([pred_item_id, pred_timestamp], names=(ITEMID, TIMESTAMP))
+        predictions_df.index = get_forecast_horizon_index_ts_dataframe(data, self.prediction_length)
         return predictions_df

--- a/timeseries/src/autogluon/timeseries/utils/forecast.py
+++ b/timeseries/src/autogluon/timeseries/utils/forecast.py
@@ -27,4 +27,4 @@ def get_forecast_horizon_index_ts_dataframe(
             past_timestamps=timestamps, freq=ts_dataframe.freq, prediction_length=prediction_length
         ).to_frame()
 
-    return ts_dataframe.groupby(ITEMID, sort=False).apply(get_series_with_timestamps_per_item).index
+    return ts_dataframe.groupby(level=ITEMID, sort=False).apply(get_series_with_timestamps_per_item).index

--- a/timeseries/src/autogluon/timeseries/utils/hashing.py
+++ b/timeseries/src/autogluon/timeseries/utils/hashing.py
@@ -17,4 +17,4 @@ def hash_ts_dataframe_items(ts_dataframe: TimeSeriesDataFrame) -> pd.Series:
     df_with_timestamp = ts_dataframe.reset_index(level=TIMESTAMP)
     hash_per_timestep = pd.util.hash_pandas_object(df_with_timestamp, index=False)
     # groupby preserves the order of the timesteps
-    return hash_per_timestep.groupby(ITEMID, sort=False).apply(lambda x: hashlib.md5(x.values).hexdigest())
+    return hash_per_timestep.groupby(level=ITEMID, sort=False).apply(lambda x: hashlib.md5(x.values).hexdigest())

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -6,11 +6,13 @@ import tempfile
 from unittest import mock
 
 import numpy as np
+import pandas as pd
 import pytest
 from flaky import flaky
 
 import autogluon.core as ag
 from autogluon.timeseries import TimeSeriesDataFrame, TimeSeriesEvaluator
+from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP
 from autogluon.timeseries.models import DeepARModel, ETSModel
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 
@@ -22,6 +24,7 @@ from .test_sktime import TESTABLE_MODELS as SKTIME_TESTABLE_MODELS
 
 AVAILABLE_METRICS = TimeSeriesEvaluator.AVAILABLE_METRICS
 TESTABLE_MODELS = GLUONTS_TESTABLE_MODELS + SKTIME_TESTABLE_MODELS + TABULAR_TESTABLE_MODELS + LOCAL_TESTABLE_MODELS
+DUMMY_HYPERPARAMETERS = {"epochs": 1, "num_batches_per_epoch": 1, "maxiter": 1}
 TESTABLE_PREDICTION_LENGTHS = [1, 5]
 
 
@@ -35,7 +38,7 @@ def trained_models():
             path=temp_model_path + os.path.sep,
             freq="H",
             prediction_length=prediction_length,
-            hyperparameters={"epochs": 1, "maxiter": 1},
+            hyperparameters=DUMMY_HYPERPARAMETERS,
         )
 
         model.fit(train_data=DUMMY_TS_DATAFRAME)
@@ -166,10 +169,7 @@ def test_when_fit_called_then_models_train_and_returned_predictor_inference_has_
         freq="H",
         prediction_length=3,
         quantile_levels=quantile_levels,
-        hyperparameters={
-            "epochs": 1,
-            "maxiter": 1,
-        },
+        hyperparameters=DUMMY_HYPERPARAMETERS,
     )
     # TFT cannot handle arbitrary quantiles
     if "TemporalFusionTransformer" in model.name:
@@ -219,7 +219,7 @@ def test_when_fit_called_then_models_train_and_returned_predictor_inference_alig
         path=temp_model_path,
         freq="H",
         prediction_length=prediction_length,
-        hyperparameters={"epochs": 1},
+        hyperparameters=DUMMY_HYPERPARAMETERS,
     )
 
     model.fit(train_data=train_data)
@@ -229,6 +229,32 @@ def test_when_fit_called_then_models_train_and_returned_predictor_inference_alig
     min_hour_in_pred = predictions.index.levels[1].min().hour
 
     assert min_hour_in_pred == max_hour_in_test + 1
+
+
+@pytest.mark.parametrize("freq", ["D", "H", "S", "M"])
+@pytest.mark.parametrize("model_class", TESTABLE_MODELS)
+def test_when_predict_called_then_predicted_timestamps_align_with_time(model_class, freq, temp_model_path):
+    prediction_length = 4
+    train_length = 20
+    item_id = "A"
+    timestamps = pd.date_range(start=pd.Timestamp("2020-01-05 12:05:01"), freq=freq, periods=train_length)
+    index = pd.MultiIndex.from_product([(item_id,), timestamps], names=[ITEMID, TIMESTAMP])
+    train_data = TimeSeriesDataFrame(pd.DataFrame({"target": np.random.rand(train_length)}, index=index))
+
+    model = model_class(
+        path=temp_model_path,
+        freq=train_data.freq,
+        prediction_length=prediction_length,
+        hyperparameters=DUMMY_HYPERPARAMETERS,
+    )
+
+    model.fit(train_data=train_data)
+    predictions = model.predict(train_data)
+
+    offset = pd.tseries.frequencies.to_offset(freq)
+    preds_first_item = predictions.loc[item_id]
+    for i in range(prediction_length):
+        assert preds_first_item.index[i] == timestamps[-1] + offset * (i + 1)
 
 
 @pytest.mark.parametrize(
@@ -265,7 +291,7 @@ def test_when_predict_called_with_test_data_then_predictor_inference_correct(
         path=temp_model_path,
         freq="H",
         prediction_length=prediction_length,
-        hyperparameters={"epochs": 1},
+        hyperparameters=DUMMY_HYPERPARAMETERS,
     )
 
     model.fit(train_data=train_data)

--- a/timeseries/tests/unittests/models/test_sktime.py
+++ b/timeseries/tests/unittests/models/test_sktime.py
@@ -113,7 +113,11 @@ def test_when_predict_called_with_test_data_then_predictor_inference_correct(
     model.fit(train_data=train_data)
     with mock.patch.object(AbstractSktimeModel, "_fit") as mock_fit:
 
-        _ = model.predict(test_data)
+        # Mock breaks the internals of the `predict` method
+        try:
+            _ = model.predict(test_data)
+        except:
+            pass
         mock_fit.assert_called_with(test_data)
 
 

--- a/timeseries/tests/unittests/test_utils.py
+++ b/timeseries/tests/unittests/test_utils.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP, TimeSeriesDataFrame
+from autogluon.timeseries.utils.forecast import get_forecast_horizon_index_ts_dataframe
+
+
+@pytest.mark.parametrize("freq", ["H", "min", "S", "D", "W", "M", "Q", "Y", "3H", "17S"])
+@pytest.mark.parametrize("prediction_length", [1, 7])
+def test_when_start_times_dont_match_freq_then_forecast_timestamps_are_correct(freq, prediction_length):
+    item_ids_to_length = {"B": 14, "A": 12, "1": 7}
+    start_timestamps = {
+        "B": pd.Timestamp("2020-01-05 12:05:01"),
+        "A": pd.Timestamp("2017-04-20 07:14:55"),
+        "1": pd.Timestamp("1901-12-31 20:14:07"),
+    }
+    dfs = []
+    for item_id, length in item_ids_to_length.items():
+        timestamps = pd.date_range(start=start_timestamps[item_id], periods=length, freq=freq)
+        index = pd.MultiIndex.from_product([(item_id,), timestamps], names=[ITEMID, TIMESTAMP])
+        dfs.append(pd.DataFrame({"CustomTarget": np.random.rand(length)}, index=index))
+    ts_dataframe = TimeSeriesDataFrame(pd.concat(dfs))
+
+    prediction_index = get_forecast_horizon_index_ts_dataframe(ts_dataframe, prediction_length)
+    preds = TimeSeriesDataFrame(pd.DataFrame({"mean": np.random.rand(len(prediction_index))}, index=prediction_index))
+    offset = pd.tseries.frequencies.to_offset(freq)
+    for item_id in ts_dataframe.item_ids:
+        for i, timestamp in enumerate(preds.loc[item_id].index):
+            assert timestamp == ts_dataframe.loc[item_id].index[-1] + (i + 1) * offset


### PR DESCRIPTION
*Description of changes:*
- Fix where pandas groupby would sort item ids even when `sort=False`(related to https://github.com/pandas-dev/pandas/issues/17537)
- Fix incorrect forecast index generated by GluonTS and Sktime models in some cases.
  - For example, if data has timestamps `"2022-01-01 12:00"`, `"2022-01-02 12:00"` (frequency is daily), GluonTS will produce forecasts with timestamps `"2022-01-01 00:00"`, `"2022-01-02 00:00"`, which results in an AssertionError inside the `TimeSeriesEvaluator` [here](https://github.com/awslabs/autogluon/blob/master/timeseries/src/autogluon/timeseries/evaluator.py#L203)
- Add tests covering these cases

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
