### PR TITLE
[Post 0.6][Tabular] Speed up feature transform in tabular NN model

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -31,7 +31,7 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
     """
 
     # Constants used throughout this class:
-    unique_category_str = '!missing!'  # string used to represent missing values and unknown categories for categorical features.
+    unique_category_str = np.nan  # string used to represent missing values and unknown categories for categorical features.
     params_file_name = 'net.params'  # Stores parameters of final network
     temp_file_name = 'temp_net.params'  # Stores temporary network parameters (eg. during the course of training)
 
@@ -488,7 +488,10 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
                 df = df.drop(columns=drop_cols)
 
         # self.feature_arraycol_map, self.feature_type_map have been previously set while processing training data.
+        import time
+        tic = time.time()
         df = self.processor.transform(df)
+        print(f"elapsed (transform): {(time.time()-tic)*1000:.0f} ms")
         return TabularTorchDataset(df, self.feature_arraycol_map, self.feature_type_map, self.problem_type, labels)
 
     def _process_train_data(self, df, impute_strategy, max_category_levels, skew_threshold,

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -488,10 +488,7 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
                 df = df.drop(columns=drop_cols)
 
         # self.feature_arraycol_map, self.feature_type_map have been previously set while processing training data.
-        import time
-        tic = time.time()
         df = self.processor.transform(df)
-        print(f"elapsed (transform): {(time.time()-tic)*1000:.0f} ms")
         return TabularTorchDataset(df, self.feature_arraycol_map, self.feature_type_map, self.problem_type, labels)
 
     def _process_train_data(self, df, impute_strategy, max_category_levels, skew_threshold,

--- a/tabular/src/autogluon/tabular/models/tabular_nn/utils/data_preprocessor.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/utils/data_preprocessor.py
@@ -30,7 +30,6 @@ def create_preprocessor(impute_strategy, max_category_levels, unique_category_st
         transformers.append( ('onehot', onehot_transformer, onehot_features) )
     if embed_features:  # Ordinal transformer applied to convert to-be-embedded categorical features to integer levels
         ordinal_transformer = Pipeline(steps=[
-            ('to_str', FunctionTransformer(convert_df_dtype_to_str)),
             ('imputer', SimpleImputer(strategy='constant', fill_value=unique_category_str)),
             ('ordinal', OrdinalMergeRaresHandleUnknownEncoder(max_levels=max_category_levels))])  # returns 0-n when max_category_levels = n-1. category n is reserved for unknown test-time categories.
         transformers.append( ('ordinal', ordinal_transformer, embed_features) )


### PR DESCRIPTION
*Description of changes:*

This PR simplifies the feature transform function in tabular NN model.
1. avoid using string-based processing
2. leverage `numpy.isin(b, a, invert=True)` function instead of running `np.array([item in b for item in a])`

Benchmark results are shown below
![image](https://user-images.githubusercontent.com/857821/202818078-d06e9f6e-4fe4-4430-9c79-054e8cf05d2d.png)

![image](https://user-images.githubusercontent.com/857821/202818634-a899b9d0-b9b1-4858-9ebd-9d3695aae038.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
