### PR TITLE
[eda] add non-parametric interaction tests

### DIFF
--- a/eda/src/autogluon/eda/analysis/interaction.py
+++ b/eda/src/autogluon/eda/analysis/interaction.py
@@ -146,10 +146,14 @@ class NonparametricAssociation(AbstractAnalysis):
     """
 
     def __init__(self,
+                 data = None,
+                 association_cols: list = [],
                  parent: Union[None, AbstractAnalysis] = None,
                  children: List[AbstractAnalysis] = [],
                  **kwargs) -> None:
         super().__init__(parent, children, **kwargs)
+        self.association_cols = association_cols
+        self.data = data
 
     @staticmethod
     def custom_kruskal(df, obj_col_name, num_col_name):
@@ -195,17 +199,12 @@ class NonparametricAssociation(AbstractAnalysis):
             return NonparametricAssociation.custom_kruskal(df, object_col[0], numeric_col[0])
 
     def can_handle(self, state: AnalysisState, args: AnalysisState) -> bool:
-        print('hello')
-        print(args)
-        return ('association_cols' in args)
+        return True
 
     def _fit(self, state: AnalysisState, args: AnalysisState, **fit_kwargs) -> None:
-        print(args)
-        state.association_tests = {}
-        for (ds, df) in self.available_datasets(args):
-            tests = {}
-            for i, col1 in enumerate(args['association_cols'][:-1]):
-                for col2 in args['association_cols'][i+1:]:
-                    print(ds, col1, col2)
-                    tests[(col1, col2)] = NonparametricAssociation.nonparametric_test(df, col1, col2)
-            state.association_tests[ds] = tests
+        print(self.association_cols)
+        tests = {}
+        for i, col1 in enumerate(self.association_cols[:-1]):
+            for col2 in self.association_cols[i+1:]:
+                tests[(col1, col2)] = NonparametricAssociation.nonparametric_test(self.data, col1, col2)
+        state.association_tests = tests

--- a/eda/src/autogluon/eda/analysis/interaction.py
+++ b/eda/src/autogluon/eda/analysis/interaction.py
@@ -145,8 +145,11 @@ class NonparametricAssociation(AbstractAnalysis):
     """
     """
 
-    def __init__(self):
-        pass
+    def __init__(self,
+                 parent: Union[None, AbstractAnalysis] = None,
+                 children: List[AbstractAnalysis] = [],
+                 **kwargs) -> None:
+        super().__init__(parent, children, **kwargs)
 
     @staticmethod
     def custom_kruskal(df, obj_col_name, num_col_name):
@@ -192,8 +195,17 @@ class NonparametricAssociation(AbstractAnalysis):
             return NonparametricAssociation.custom_kruskal(df, object_col[0], numeric_col[0])
 
     def can_handle(self, state: AnalysisState, args: AnalysisState) -> bool:
-        pass
+        print('hello')
+        print(args)
+        return ('association_cols' in args)
 
     def _fit(self, state: AnalysisState, args: AnalysisState, **fit_kwargs) -> None:
-        pass
-
+        print(args)
+        state.association_tests = {}
+        for (ds, df) in self.available_datasets(args):
+            tests = {}
+            for i, col1 in enumerate(args['association_cols'][:-1]):
+                for col2 in args['association_cols'][i+1:]:
+                    print(ds, col1, col2)
+                    tests[(col1, col2)] = NonparametricAssociation.nonparametric_test(df, col1, col2)
+            state.association_tests[ds] = tests

--- a/eda/src/autogluon/eda/analysis/interaction.py
+++ b/eda/src/autogluon/eda/analysis/interaction.py
@@ -175,7 +175,7 @@ class NonparametricAssociation(AbstractAnalysis):
     """
 
     def __init__(self,
-                 data = None,
+                 data=None,
                  association_cols: list = [],
                  parent: Union[None, AbstractAnalysis] = None,
                  children: List[AbstractAnalysis] = [],
@@ -186,7 +186,7 @@ class NonparametricAssociation(AbstractAnalysis):
 
     @staticmethod
     def custom_kruskal(df, obj_col_name, num_col_name):
-        cat_groups = [v[num_col_name] for i,v in df[[obj_col_name, num_col_name]].groupby(obj_col_name)]
+        cat_groups = [v[num_col_name] for i, v in df[[obj_col_name, num_col_name]].groupby(obj_col_name)]
         test_res = kruskal(*cat_groups)
         return {'test_statistic': test_res.statistic,
                 'pvalue': test_res.pvalue,
@@ -240,7 +240,7 @@ class NonparametricAssociation(AbstractAnalysis):
         for i in range(n_cols):
             for j in range(n_cols):
                 if i == j:
-                    pval_matrix[i,j] = 1.0
+                    pval_matrix[i, j] = 1.0
                     continue
                 if i < j:
                     col1 = self.association_cols[i]
@@ -248,9 +248,9 @@ class NonparametricAssociation(AbstractAnalysis):
                 else:
                     col1 = self.association_cols[j]
                     col2 = self.association_cols[i]
-                pval_matrix[i,j] = tests[(col1, col2)]['pvalue']
+                pval_matrix[i, j] = tests[(col1, col2)]['pvalue']
         state.association_pvalue_matrix = pd.DataFrame(pval_matrix,
-                     columns = self.association_cols,
-                     index = self.association_cols)
+                                                       columns=self.association_cols,
+                                                       index=self.association_cols)
         state.association_cols = self.association_cols
         state.association_tests = sorted(tests.items(), key=lambda x: x[1]['pvalue'])

--- a/eda/src/autogluon/eda/visualization/__init__.py
+++ b/eda/src/autogluon/eda/visualization/__init__.py
@@ -4,3 +4,4 @@ from .layouts import *
 from .model import *
 from .shift import *
 from .missing import *
+from .interaction import NonparametricSignificanceVisualization

--- a/eda/src/autogluon/eda/visualization/interaction.py
+++ b/eda/src/autogluon/eda/visualization/interaction.py
@@ -297,4 +297,4 @@ class NonparametricSignificanceVisualization(AbstractVisualization, JupyterMixin
                     square=True,
                     # cbar_kws={"shrink": 0.5},
                     **args)
-        self.display_obj(fig)
+        # self.display_obj(fig)

--- a/eda/src/autogluon/eda/visualization/interaction.py
+++ b/eda/src/autogluon/eda/visualization/interaction.py
@@ -263,6 +263,7 @@ class FeatureDistanceAnalysisVisualization(AbstractVisualization, StateCheckMixi
                 message += f'\n - `{"`, `".join(sorted(group["nodes"]))}` - distance `{group["distance"]:.2f}`'
             self.render_markdown(message)
 
+
 class NonparametricSignificanceVisualization(AbstractVisualization, JupyterMixin):
 
     def __init__(self,

--- a/eda/src/autogluon/eda/visualization/interaction.py
+++ b/eda/src/autogluon/eda/visualization/interaction.py
@@ -255,3 +255,39 @@ class FeatureDistanceAnalysisVisualization(AbstractVisualization, StateCheckMixi
         ax.grid(False)
         hc.dendrogram(ax=ax, Z=state.feature_distance.linkage, labels=state.feature_distance.columns, **{**default_args, **self._kwargs})
         plt.show(fig)
+
+class NonparametricSignificanceVisualization(AbstractVisualization, JupyterMixin):
+
+    def __init__(self,
+                 headers: bool = False,
+                 namespace: str = None,
+                 fig_args: Union[None, Dict[str, Any]] = {},
+                 pvalue_cmap: str = 'rocket',
+                 **kwargs) -> None:
+        super().__init__(namespace, **kwargs)
+        self.headers = headers
+        self.fig_args = fig_args
+        self.cmap = pvalue_cmap
+
+    def can_handle(self, state: AnalysisState) -> bool:
+        return 'association_pvalue_matrix' in state
+
+    def _render(self, state: AnalysisState) -> None:
+        if self.headers:
+            self.render_header_if_needed(state, 'P-values for non-parametric association tests')
+
+        fig, ax = plt.subplots(**self.fig_args)
+        args = {'vmin': 0, 'vmax': 1, 'cmap': self.cmap}
+        corr = state.association_pvalue_matrix
+
+        sns.heatmap(corr,
+                    annot=True,
+                    ax=ax,
+                    linewidths=.9,
+                    linecolor='white',
+                    fmt='.2f',
+                    square=True,
+                    # cbar_kws={"shrink": 0.5},
+                    **args)
+        plt.yticks(rotation=0)
+        plt.show(fig)


### PR DESCRIPTION
*Description of changes:*
This PR introduces nonparametric independence tests to evaluate interactions between various tabular data types.  These tests are...
- Chi2 test: cat v cat
- Spearman R: numeric v numeric
- Kruskal-Wallace: numeric v cat

The adds the result of the test to the state (test statistic, p-value, test name).  The p-values can be compared between tests since they are pivotal statistics.  We can then produce a heatmap of these p-values as well, which is added to the visualization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
