### PR TITLE
[timeseries] Gracefully handle inconsistencies in static_features provided by user

### DIFF
--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -154,9 +154,10 @@ class TimeSeriesDataFrame(pd.DataFrame):
                 )
             # if provided static features are a strict superset of the item index, we take a subset to ensure consistency
             if len(value.index.difference(self.item_ids)) > 0:
-                value = value.loc[self.item_ids].copy()
+                value = value.loc[self.item_ids]
+            # Avoid modifying static features inplace
+            value = value.copy()
             if value.index.name != ITEMID:
-                value = value.copy()
                 value.index.rename(ITEMID, inplace=True)
 
         self._static_features = value

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -602,7 +602,16 @@ def test_when_dataset_sliced_by_step_then_static_features_are_correct():
     assert dfv.static_features.equals(df.static_features)
 
 
-def test_when_dataset_subsequenced_then_static_features_are_correct():
+def test_when_static_features_index_has_wrong_name_then_its_renamed_to_item_id():
+    original_df = SAMPLE_TS_DATAFRAME.copy()
+    item_ids = original_df.item_ids
+    static_features = pd.DataFrame({"feat1": np.zeros_like(item_ids)}, index=item_ids.rename("wrong_index_name"))
+    original_df.static_features = static_features
+    assert static_features.index.name != ITEMID
+    assert original_df.static_features.index.name == ITEMID
+
+
+def test_when_dataset_sliced_by_time_then_static_features_are_correct():
     df = SAMPLE_TS_DATAFRAME_STATIC
     dfv = df.subsequence(START_TIMESTAMP, START_TIMESTAMP + datetime.timedelta(days=1))
 
@@ -659,7 +668,7 @@ def test_given_wrong_static_feature_index_when_constructing_data_frame_then_erro
         },
         index=static_feature_index,  # noqa
     )
-    with pytest.raises(ValueError, match="match item index"):
+    with pytest.raises(ValueError, match="are missing from the index of static_features"):
         TimeSeriesDataFrame(data=SAMPLE_DATAFRAME, static_features=static_features)
 
 

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -690,7 +690,7 @@ def test_when_dataframe_sliced_by_item_array_then_static_features_stay_consisten
 
 def test_when_dataframe_reindexed_view_called_then_static_features_stay_consistent():
     view = SAMPLE_TS_DATAFRAME_STATIC.get_reindexed_view()
-    assert view._static_features is SAMPLE_TS_DATAFRAME_STATIC._static_features
+    assert view._static_features.equals(SAMPLE_TS_DATAFRAME_STATIC._static_features)
 
 
 SAMPLE_DATAFRAME_WITH_MIXED_INDEX = pd.DataFrame(


### PR DESCRIPTION
*Description of changes:*
- Automatically convert the `static_features` to a `pd.DataFrame` if a `pd.Series` is provided
- Always rename the index of `static_features` to `"item_id"`. If we don't rename the index, we will run into an exception inside the splitter [here](https://github.com/awslabs/autogluon/blob/master/timeseries/src/autogluon/timeseries/splitter.py#L63).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
