### PR TITLE
[timeseries] Silence GluonTS JSON warning

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/gluonts/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/__init__.py
@@ -1,3 +1,12 @@
+import warnings
+
+gluonts_json_warning = (
+    "Using `json`-module for json-handling. "
+    "Consider installing one of `orjson`, `ujson` "
+    "to speed up serialization and deserialization."
+)
+warnings.filterwarnings("ignore", message=gluonts_json_warning)
+
 from .torch import DeepARModel, SimpleFeedForwardModel
 
 __all__ = ["DeepARModel", "SimpleFeedForwardModel"]


### PR DESCRIPTION
*Description of changes:*
- Silences a warning produced by GluonTS if either `orjson` or `ujson` are not installed. JSON loading is not used by AutoGluon, so it doesn't apply to us.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
