### PR TITLE
[Bugfix] Fix matcher cpu inference bug

### DIFF
--- a/multimodal/src/autogluon/multimodal/matcher.py
+++ b/multimodal/src/autogluon/multimodal/matcher.py
@@ -1137,7 +1137,7 @@ class MultiModalMatcher:
         strategy = "dp"  # default used in inference.
 
         num_gpus = compute_num_gpus(config_num_gpus=self._config.env.num_gpus, strategy="dp")
-        if num_gpus == 1:
+        if num_gpus <= 1:
             strategy = None
 
         precision = infer_precision(num_gpus=num_gpus, precision=self._config.env.precision)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Previously I only fixed the cpu inference bug (cpu cannot use "dp") in `predictor.py`. However, I just noticed that we should also fix `matcher.py`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
