### PR TITLE
Simplified infer speed throughput calculation

### DIFF
--- a/core/src/autogluon/core/utils/infer_utils.py
+++ b/core/src/autogluon/core/utils/infer_utils.py
@@ -7,6 +7,7 @@ def get_model_true_infer_speed_per_row_batch(
         predictor,
         batch_size: int = 100000,
         repeats=1,
+        persist_models=True,
         silent=False):
     """
     Get per-model true inference speed per row for a given batch size of data.

--- a/core/src/autogluon/core/utils/infer_utils.py
+++ b/core/src/autogluon/core/utils/infer_utils.py
@@ -1,3 +1,4 @@
+import pandas as pd
 
 
 def get_model_true_infer_speed_per_row_batch(
@@ -22,6 +23,8 @@ def get_model_true_infer_speed_per_row_batch(
         If simulating large-scale batch inference, values of 100000+ are recommended to get genuine throughput estimates.
     repeats : int, default = 1
         Repeats of calling leaderboard. Repeat times are averaged to get more stable inference speed estimates.
+    persist_models : bool, default = True
+        If True, attempts to persist models into memory for more genuine throughput calculation.
     silent : False
         If False, logs information regarding the speed of each model + feature preprocessing.
 
@@ -55,7 +58,8 @@ def get_model_true_infer_speed_per_row_batch(
     if len_data != batch_size:
         raise AssertionError(f'len(data_batch) must equal batch_size! ({len_data} != {batch_size})')
 
-    predictor.persist_models(models='all')
+    if persist_models:
+        predictor.persist_models(models='all')
 
     ts = time.time()
     for i in range(repeats):
@@ -75,6 +79,7 @@ def get_model_true_infer_speed_per_row_batch(
     time_per_row_transform = time_transform / batch_size
 
     if not silent:
+        print(f'Throughput for batch_size={batch_size}:')
         for index, row in time_per_row_df.iterrows():
             time_per_row = row['pred_time_test_with_transform']
             time_per_row_print = time_per_row
@@ -85,7 +90,7 @@ def get_model_true_infer_speed_per_row_batch(
                 if time_per_row_print < 1e-2:
                     time_per_row_print *= 1000
                     unit = 'μs'
-            print(f"{round(time_per_row_print, 3)}{unit} per row | {index}")
+            print(f"\t{round(time_per_row_print, 3)}{unit} per row | {index}")
         time_per_row_transform_print = time_per_row_transform
         unit = 's'
         if time_per_row_transform_print < 1e-2:
@@ -94,6 +99,94 @@ def get_model_true_infer_speed_per_row_batch(
             if time_per_row_transform_print < 1e-2:
                 time_per_row_transform_print *= 1000
                 unit = 'μs'
-        print(f"{round(time_per_row_transform_print, 3)}{unit} per row | transform_features")
+        print(f"\t{round(time_per_row_transform_print, 3)}{unit} per row | transform_features")
 
     return time_per_row_df, time_per_row_transform
+
+
+def get_model_true_infer_speed_per_row_batch_bulk(data: pd.DataFrame,
+                                                  *,
+                                                  predictor,
+                                                  batch_sizes: list = None,
+                                                  repeats=1,
+                                                  persist_models=True,
+                                                  include_transform_features=False,
+                                                  silent=False) -> (pd.DataFrame, pd.DataFrame):
+    """
+    Get per-model true inference speed per row for a list of batch sizes of data.
+
+    Parameters
+    ----------
+    data : :class:`TabularDataset` or :class:`pd.DataFrame`
+        Table of the data, which is similar to a pandas DataFrame.
+        Must contain the label column to be compatible with leaderboard call.
+    predictor : TabularPredictor
+        Fitted predictor to get inference speeds for.
+    batch_sizes : List[int], default = [1, 10, 100, 1000, 10000]
+        Batch sizes to use when calculating speed. `data` will be modified to have this many rows.
+        If simulating large-scale batch inference, values of 100000+ are recommended to get genuine throughput estimates.
+    repeats : int, default = 1
+        Repeats of calling leaderboard. Repeat times are averaged to get more stable inference speed estimates.
+    persist_models : bool, default = True
+        If True, attempts to persist models into memory for more genuine throughput calculation.
+    include_transform_features : bool, default = False
+        If True, adds transform_features (data preprocessing) speeds into the first DataFrame output as if it was a model with the name "transform_features".
+        Useful when plotting model throughput to see if data preprocessing is a bottleneck.
+    silent : False
+        If False, logs information regarding the speed of each model + feature preprocessing.
+
+    Returns
+    -------
+    time_per_row_df : pd.DataFrame, time_per_row_df_transform : pd.DataFrame
+        time_per_row_df contains the following columns.
+            'model' is the model name.
+            'pred_time_test_with_transform' is the end-to-end prediction time per row in seconds if calling `predictor.predict(data, model=model)`
+            'pred_time_test' is the end-to-end prediction time per row in seconds minus the global feature preprocessing time.
+            'pred_time_test_marginal' is the prediction time needed to predict for this particular model minus dependent model inference times and global preprocessing time.
+            'batch_size' is the inference batch size used to calculate the pred_time columns.
+        time_per_row_df_transform is the time in seconds per row to do the feature preprocessing.
+            It contains the same columns as time_per_row_df but without the model column.
+    """
+    if batch_sizes is None:
+        batch_sizes = [
+            1,
+            10,
+            100,
+            1000,
+            10000,
+        ]
+    infer_dfs = dict()
+    infer_transform_dfs = dict()
+
+    if persist_models:
+        predictor.persist_models(models='all')
+
+    for batch_size in batch_sizes:
+        infer_df, time_per_row_transform = get_model_true_infer_speed_per_row_batch(data=data,
+                                                                                    predictor=predictor,
+                                                                                    batch_size=batch_size,
+                                                                                    repeats=repeats,
+                                                                                    persist_models=False,
+                                                                                    silent=silent)
+        infer_dfs[batch_size] = infer_df
+        infer_transform_dfs[batch_size] = time_per_row_transform
+    for key in infer_dfs.keys():
+        infer_dfs[key] = infer_dfs[key].reset_index()
+        infer_dfs[key]['batch_size'] = key
+
+    infer_df_full_transform = pd.Series(infer_transform_dfs, name='pred_time_test').to_frame().rename_axis('batch_size')
+    infer_df_full_transform['pred_time_test_marginal'] = infer_df_full_transform['pred_time_test']
+    infer_df_full_transform['pred_time_test_with_transform'] = infer_df_full_transform['pred_time_test']
+    infer_df_full_transform = infer_df_full_transform.reset_index()
+
+    infer_df_full = pd.concat([infer_dfs[key] for key in infer_dfs.keys()])
+
+    if include_transform_features:
+        infer_df_full_transform_include = infer_df_full_transform.copy()
+        infer_df_full_transform_include['model'] = 'transform_features'
+        infer_df_full = pd.concat([infer_df_full, infer_df_full_transform_include])
+
+    infer_df_full = infer_df_full.sort_values(by=['batch_size'])
+    infer_df_full = infer_df_full.reset_index(drop=True)
+
+    return infer_df_full, infer_df_full_transform


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Simplified infer speed throughput calculation when needing to compute multiple different batch size throughputs and plot them.

Example script:

```python3
import pandas as pd

from autogluon.tabular import TabularPredictor, TabularDataset
from autogluon.core.utils.infer_utils import get_model_true_infer_speed_per_row_batch_bulk


if __name__ == '__main__':
    train_path = 'https://autogluon.s3.amazonaws.com/datasets/CoverTypeMulticlassClassification/train_data.csv'
    test_path = 'https://autogluon.s3.amazonaws.com/datasets/CoverTypeMulticlassClassification/test_data.csv'
    label = 'Cover_Type'

    train_data = TabularDataset(train_path)
    subsample_size = 1000  # subsample subset of data for faster demo, try setting this to much larger values
    if subsample_size is not None and subsample_size < len(train_data):
        train_data = train_data.sample(n=subsample_size, random_state=0)


    hyperparameters = {
        'GBM': {},
        'NN_TORCH': {},
    }

    predictor = TabularPredictor(
        label=label,
    )

    predictor.fit(
        train_data,
        fit_weighted_ensemble=False,
        hyperparameters=hyperparameters,
    )

    test_data = TabularDataset(test_path)

    predictor.persist_models('all')
    leaderboard = predictor.leaderboard(test_data)

    repeats = 2
    batch_sizes = [
        1,
        10,
        100,
        1000,
        10000,
        100000,
    ]

    infer_df_full, infer_df_full_transform = get_model_true_infer_speed_per_row_batch_bulk(
        data=test_data,
        predictor=predictor,
        batch_sizes=batch_sizes,
        repeats=repeats,
        include_transform_features=True,
    )

    infer_df_full['rows_per_second'] = 1 / infer_df_full['pred_time_test']

    import matplotlib.pyplot as plt

    fig, ax = plt.subplots()
    fig.set_size_inches(12, 12)
    fig.set_dpi(300)

    plt.xscale('log')
    plt.yscale('log')

    models = list(infer_df_full['model'].unique())
    batch_sizes = list(infer_df_full['batch_size'].unique())
    for model in models:
        infer_df_model = infer_df_full[infer_df_full['model'] == model]
        ax.plot(infer_df_model['batch_size'].values, infer_df_model['rows_per_second'].values, label=model)

    ax.set(xlabel='batch_size', ylabel='rows_per_second',
           title='Rows per second inference throughput by data batch_size (AdultIncome)')
    ax.grid()
    ax.legend()
    fig.savefig('infer_speed.png', dpi=300)
    plt.show()

```

Example output:
```
Throughput for batch_size=1:
	0.021s per row | LightGBM
	0.029s per row | NeuralNetTorch
	0.019s per row | transform_features
Throughput for batch_size=10:
	2.076ms per row | LightGBM
	2.934ms per row | NeuralNetTorch
	1.872ms per row | transform_features
Throughput for batch_size=100:
	0.257ms per row | LightGBM
	0.318ms per row | NeuralNetTorch
	0.207ms per row | transform_features
Throughput for batch_size=1000:
	0.046ms per row | LightGBM
	0.035ms per row | NeuralNetTorch
	0.021ms per row | transform_features
Throughput for batch_size=10000:
	0.025ms per row | LightGBM
	8.97μs per row | NeuralNetTorch
	3.032μs per row | transform_features
Throughput for batch_size=100000:
	0.025ms per row | LightGBM
	8.815μs per row | NeuralNetTorch
	4.065μs per row | transform_features
```
![infer_speed_adult_rf_onnx](https://user-images.githubusercontent.com/16392542/203461105-9ce69dea-5f62-409b-96c6-bf5e32f6135e.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
