### PR TITLE
[Tabular] Remove TorchThreadManager in TabularNN and hack in LightGBM

### DIFF
--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -382,16 +382,7 @@ class NNFastAiTabularModel(AbstractModel):
             objective_func_name_to_monitor = monitor_obj_func[objective_func_name]
         return objective_func_name_to_monitor
 
-    # FIXME: torch.set_num_threads(self._num_cpus_infer) is required because XGBoost<=1.5 mutates global OpenMP thread limit
-    #  If this isn't here, inference speed is slowed down massively.
-    #  Remove once upgraded to XGBoost>=1.6
     def _predict_proba(self, X, **kwargs):
-        from .._utils.torch_utils import TorchThreadManager
-        with TorchThreadManager(num_threads=self._num_cpus_infer):
-            pred_proba = self._predict_proba_internal(X=X, **kwargs)
-        return pred_proba
-
-    def _predict_proba_internal(self, X, **kwargs):
         X = self.preprocess(X, **kwargs)
 
         single_row = len(X) == 1

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -220,16 +220,11 @@ class LGBModel(AbstractModel):
 
     def _predict_proba(self, X, num_cpus=0, **kwargs):
         X = self.preprocess(X, **kwargs)
-        # FIXME This is a HACK. Passing in value -1, 0, or None will only use 1 cores. Need to pass in a large number instead
-        if num_cpus == 0:
-            # TODO Avoid using psutil when lgb fixed the mem leak.
-            # logical=True is faster in inference
-            num_cpus = ResourceManager.get_cpu_count_psutil(logical=True)
-        if self.problem_type == REGRESSION:
-            return self.model.predict(X, num_threads=num_cpus)
 
         y_pred_proba = self.model.predict(X, num_threads=num_cpus)
-        if self.problem_type == BINARY:
+        if self.problem_type == REGRESSION:
+            return y_pred_proba
+        elif self.problem_type == BINARY:
             if len(y_pred_proba.shape) == 1:
                 return y_pred_proba
             elif y_pred_proba.shape[1] > 1:

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -395,19 +395,7 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
         self.params_trained['batch_size'] = batch_size
         self.params_trained['num_epochs'] = best_epoch
 
-    # FIXME: torch.set_num_threads(self._num_cpus_infer) is required because XGBoost<=1.5 mutates global OpenMP thread limit
-    #  If this isn't here, inference speed is slowed down massively.
-    #  Remove once upgraded to XGBoost>=1.6
-    def _predict_proba(self, X, _reset_threads=True, **kwargs):
-        if _reset_threads:
-            from ..._utils.torch_utils import TorchThreadManager
-            with TorchThreadManager(num_threads=self._num_cpus_infer):
-                pred_proba = self._predict_proba_internal(X=X, **kwargs)
-        else:
-            pred_proba = self._predict_proba_internal(X=X, **kwargs)
-        return pred_proba
-
-    def _predict_proba_internal(self, X, **kwargs):
+    def _predict_proba(self, X, **kwargs):
         """ To align predict with abstract_model API.
             Preprocess here only refers to feature processing steps done by all AbstractModel objects,
             not tabularNN-specific preprocessing steps.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Predict tabular NN without modifying num_thread, since we are upgrade xgboost to >=1.6
2. removed the hack that changes num_thread in lightgbm, since the bug (https://github.com/microsoft/LightGBM/issues/4607) in lightgbm has been fixed
  a. See original topic: https://github.com/autogluon/autogluon/pull/1329#discussion_r730063716

For an ensemble model with both TabularFastAI model and XGBoost model, the overall inference speed is reduced from 49 ms to 33 ms (batch size=1). Because of the removal of TorchThreadManager, XGBoost prediction time reduced from 16 ms to 1.6 ms. (Tested on Linux with AdultIncomeBinaryClassification task trained with high_quality preset.)

Code snippet to reproduce the results:
```python
import time
from autogluon.tabular import TabularDataset, TabularPredictor

# Training time:
label = 'class'  # specifies which column do we want to predict
save_path_clone_opt = '~/Downloads/AdultIncomeBinaryClassificationModel_0_6_2'

predictor = TabularPredictor.load(save_path_clone_opt)

# Inference time:
test_data = TabularDataset('https://autogluon.s3.amazonaws.com/datasets/Inc/test.csv')  # another Pandas DataFrame
test_data = test_data.head(1)
test_data = test_data.drop(labels=[label], axis=1)  # delete labels from test data since we wouldn't have them in practice

predictor.persist_models()
for _ in range(10):
    tic = time.time()
    y_pred = predictor.predict(test_data)
    print(f"elapsed: {(time.time()-tic)*1000:.0f} ms")
````

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
