### PR TITLE
Support image bytearray in AutoMM

### DIFF
--- a/multimodal/src/autogluon/multimodal/constants.py
+++ b/multimodal/src/autogluon/multimodal/constants.py
@@ -4,6 +4,7 @@ CATEGORICAL = "categorical"
 TEXT = "text"
 NUMERICAL = "numerical"
 IMAGE_PATH = "image_path"
+IMAGE_BYTEARRAY = "image_bytearray"
 IDENTIFIER = "identifier"
 
 # Problem types

--- a/multimodal/src/autogluon/multimodal/data/infer_types.py
+++ b/multimodal/src/autogluon/multimodal/data/infer_types.py
@@ -229,6 +229,8 @@ def is_imagebytearray_column(
         One column of a multimodal pd.DataFrame for training.
     col_name
         Name of column.
+    sample_n
+        Number of sample images to open for sanity check.
 
     Returns
     -------
@@ -259,7 +261,7 @@ def is_imagebytearray_column(
         if failure_ratio > 0:
             warnings.warn(
                 f"Among {sample_num} sampled images in column '{col_name}', "
-                f"{failure_ratio:.0%} images can't be open. "
+                f"{failure_count} images can't be open. "
                 "You may need to thoroughly check your data to see the percentage of missing images, "
                 "and estimate the potential influence. By default, we skip the samples with missing images. "
                 "You can also set hyperparameter 'data.image.missing_value_strategy' to be 'zero', "

--- a/multimodal/src/autogluon/multimodal/data/infer_types.py
+++ b/multimodal/src/autogluon/multimodal/data/infer_types.py
@@ -162,6 +162,7 @@ def is_numerical_column(
 def is_imagepath_column(
     data: pd.Series,
     col_name: str,
+    sample_n: Optional[int] = 500,
 ) -> bool:
     """
     Identify if a column is one image-path column.
@@ -179,7 +180,7 @@ def is_imagepath_column(
     -------
     Whether the column is an image-path column.
     """
-    sample_num = min(len(data), 500)
+    sample_num = min(len(data), sample_n)
     data = data.sample(n=sample_num, random_state=0)
     data = data.apply(lambda ele: str(ele).split(";")).tolist()
     failure_count = 0
@@ -217,6 +218,7 @@ def is_imagepath_column(
 def is_imagebytearray_column(
     data: pd.Series,
     col_name: str,
+    sample_n: Optional[int] = 500,
 ) -> bool:
     """
     Identify if a column contains valid image bytearray.
@@ -232,7 +234,7 @@ def is_imagebytearray_column(
     -------
     Whether the column is an image-bytearray column.
     """
-    sample_num = min(len(data), 500)
+    sample_num = min(len(data), sample_n)
     data = data.sample(n=sample_num, random_state=0)
     data = data.tolist()
     failure_count = 0

--- a/multimodal/src/autogluon/multimodal/data/infer_types.py
+++ b/multimodal/src/autogluon/multimodal/data/infer_types.py
@@ -85,8 +85,8 @@ def is_categorical_column(
                 oov_ratio_threshold = 0
                 ratio = 0.1
         threshold = min(int(len(data) * ratio), threshold)
-        data_value_counts = data.value_counts(dropna=False)
         try:
+            data_value_counts = data.value_counts(dropna=False)
             key_set = set(data_value_counts.keys())
             if len(data_value_counts) < threshold:
                 valid_value_counts = valid_data.value_counts(dropna=False)
@@ -378,10 +378,10 @@ def infer_id_mappings_types(id_mappings: Union[Dict[str, Dict], Dict[str, pd.Ser
             )
         if is_imagepath_column(per_id_mappings, col_name=per_name):
             id_mappings_types[per_name] = IMAGE_PATH
-        if is_imagebytearray_column(per_id_mappings, col_name=per_name):
-            id_mappings_types[per_name] = IMAGE_BYTEARRAY
         elif is_text_column(per_id_mappings):
             id_mappings_types[per_name] = TEXT
+        elif is_imagebytearray_column(per_id_mappings, col_name=per_name):
+            id_mappings_types[per_name] = IMAGE_BYTEARRAY
         else:
             raise ValueError(
                 f"{per_name} in the id_mappings has an invalid type. Currently, we only support image and text types."
@@ -474,10 +474,10 @@ def infer_column_types(
             column_types[col_name] = NUMERICAL
         elif is_imagepath_column(data[col_name], col_name):  # Infer image-path column
             column_types[col_name] = IMAGE_PATH
-        elif is_imagebytearray_column(data[col_name], col_name):  # Infer image-bytearray column
-            column_types[col_name] = IMAGE_BYTEARRAY
         elif is_text_column(data[col_name]):  # Infer text column
             column_types[col_name] = TEXT
+        elif is_imagebytearray_column(data[col_name], col_name):  # Infer image-bytearray column
+            column_types[col_name] = IMAGE_BYTEARRAY
         else:  # All the other columns are treated as categorical
             column_types[col_name] = CATEGORICAL
 

--- a/multimodal/src/autogluon/multimodal/data/process_image.py
+++ b/multimodal/src/autogluon/multimodal/data/process_image.py
@@ -402,6 +402,7 @@ class ImageProcessor:
         image_features: Dict[str, Union[List[str], List[bytearray]]],
         feature_modalities: Dict[str, List[str]],
         is_training: bool,
+        image_mode: Optional[str] = "RGB",
     ) -> Dict:
         """
         Read images, process them, and stack them. One sample can have multiple images,
@@ -409,11 +410,16 @@ class ImageProcessor:
 
         Parameters
         ----------
-        image_paths
+        image_features
             One sample may have multiple image columns in a pd.DataFrame and multiple images
             inside each image column.
+        feature_modalities
+            What modality each column belongs to.
         is_training
             Whether to process images in the training mode.
+        image_mode
+            A string which defines the type and depth of a pixel in the image.
+            For example, RGB, RGBA, CMYK, and etc.
 
         Returns
         -------
@@ -453,11 +459,11 @@ class ImageProcessor:
                             else:
                                 image_feature = img_feature
                             with PIL.Image.open(image_feature) as img:
-                                img = img.convert("RGB")
+                                img = img.convert(image_mode)
                         except Exception as e:
                             if self.missing_value_strategy.lower() == "zero":
                                 logger.debug(f"Using a zero image due to '{e}'")
-                                img = PIL.Image.new("RGB", (self.size, self.size), color=0)
+                                img = PIL.Image.new(image_mode, (self.size, self.size), color=0)
                                 is_zero_img = True
                             else:
                                 raise e

--- a/multimodal/src/autogluon/multimodal/data/process_image.py
+++ b/multimodal/src/autogluon/multimodal/data/process_image.py
@@ -440,6 +440,9 @@ class ImageProcessor:
                     if feature_modalities.get(per_col_name) == IMAGE_PATH:
                         with PIL.Image.open(per_col_content[0]) as img:
                             mm_data["img_info"] = dict(filename=per_col_content[0], height=img.height, width=img.width)
+                    elif feature_modalities.get(per_col_name) == IMAGE_BYTEARRAY:
+                        # TODO: add bytearray support for detection
+                        raise NotImplementedError
             if self.requires_column_info:
                 pass  # TODO
         else:

--- a/multimodal/tests/unittests/others/unittest_datasets.py
+++ b/multimodal/tests/unittests/others/unittest_datasets.py
@@ -7,12 +7,13 @@ from sklearn.model_selection import train_test_split
 from autogluon.multimodal.constants import BINARY, MULTICLASS, REGRESSION
 from autogluon.multimodal.utils import download
 
-from .utils import get_data_home_dir, get_repo_url, path_expander, protected_zip_extraction
+from .utils import get_data_home_dir, get_repo_url, path_expander, path_to_bytearray_expander, protected_zip_extraction
 
 
 class PetFinderDataset:
     def __init__(
         self,
+        is_bytearray=False,
     ):
         sha1sum_id = "72cb19612318bb304d4a169804f525f88dc3f0d0"
         dataset = "petfinder"
@@ -32,12 +33,13 @@ class PetFinderDataset:
         )
         self._train_df = pd.read_csv(os.path.join(self._path, "train.csv"), index_col=0)
         self._test_df = pd.read_csv(os.path.join(self._path, "test.csv"), index_col=0)
+        expander = path_to_bytearray_expander if is_bytearray else path_expander
         for img_col in self.image_columns:
             self._train_df[img_col] = self._train_df[img_col].apply(
-                lambda ele: path_expander(ele, base_folder=os.path.join(self._path, "images"))
+                lambda ele: expander(ele, base_folder=os.path.join(self._path, "images"))
             )
             self._test_df[img_col] = self._test_df[img_col].apply(
-                lambda ele: path_expander(ele, base_folder=os.path.join(self._path, "images"))
+                lambda ele: expander(ele, base_folder=os.path.join(self._path, "images"))
             )
             print(self._train_df[img_col][0])
             print(self._test_df[img_col][0])
@@ -119,6 +121,7 @@ class PetFinderDataset:
 class HatefulMeMesDataset:
     def __init__(
         self,
+        is_bytearray=False,
     ):
         sha1sum_id = "2aae657b786f505004ac2922b66097d60a540a58"
         dataset = "hateful_memes"
@@ -138,12 +141,13 @@ class HatefulMeMesDataset:
         )
         self._train_df = pd.read_csv(os.path.join(self._path, "train.csv"), index_col=0)
         self._test_df = pd.read_csv(os.path.join(self._path, "test.csv"), index_col=0)
+        expander = path_to_bytearray_expander if is_bytearray else path_expander
         for img_col in self.image_columns:
             self._train_df[img_col] = self._train_df[img_col].apply(
-                lambda ele: path_expander(ele, base_folder=os.path.join(self._path, "images"))
+                lambda ele: expander(ele, base_folder=os.path.join(self._path, "images"))
             )
             self._test_df[img_col] = self._test_df[img_col].apply(
-                lambda ele: path_expander(ele, base_folder=os.path.join(self._path, "images"))
+                lambda ele: expander(ele, base_folder=os.path.join(self._path, "images"))
             )
             print(self._train_df[img_col][0])
             print(self._test_df[img_col][0])

--- a/multimodal/tests/unittests/others/utils.py
+++ b/multimodal/tests/unittests/others/utils.py
@@ -3,9 +3,21 @@ import os
 import zipfile
 
 
+def read_byte(file):
+    with open(file, "rb") as image:
+        f = image.read()
+        b = bytearray(f)
+    return b
+
+
 def path_expander(path, base_folder):
     path_l = path.split(";")
     return ";".join([os.path.join(base_folder, path) for path in path_l])
+
+
+def path_to_bytearray_expander(path, base_folder):
+    path_l = path.split(";")
+    return [read_byte(os.path.join(base_folder, path)) for path in path_l]
 
 
 def get_home_dir():

--- a/multimodal/tests/unittests/predictor/test_predictor.py
+++ b/multimodal/tests/unittests/predictor/test_predictor.py
@@ -30,14 +30,17 @@ from autogluon.multimodal.constants import (
     UNIFORM_SOUP,
 )
 from autogluon.multimodal.utils import modify_duplicate_model_names
+from autogluon.multimodal.utils.misc import shopee_dataset
 
 from ..others.unittest_datasets import AEDataset, HatefulMeMesDataset, PetFinderDataset
 from ..others.utils import get_home_dir
 
 ALL_DATASETS = {
-    "petfinder": PetFinderDataset,
-    "hateful_memes": HatefulMeMesDataset,
-    "ae": AEDataset,
+    "petfinder": PetFinderDataset(),
+    "petfinder_bytearray": PetFinderDataset(is_bytearray=True),
+    "hateful_memes": HatefulMeMesDataset(),
+    "hateful_memes_bytearray": HatefulMeMesDataset(is_bytearray=True),
+    "ae": AEDataset(),
 }
 
 
@@ -110,7 +113,7 @@ def verify_realtime_inference(predictor, df, verify_embedding=True):
             "auto",
         ),
         (
-            "hateful_memes",
+            "hateful_memes_bytearray",
             ["timm_image", "hf_text", "clip", "fusion_mlp"],
             "monsoon-nlp/hindi-bert",
             "mobilenetv3_small_100",
@@ -119,7 +122,7 @@ def verify_realtime_inference(predictor, df, verify_embedding=True):
             "auto",
         ),
         (
-            "petfinder",
+            "petfinder_bytearray",
             ["numerical_mlp", "categorical_mlp", "timm_image", "fusion_mlp"],
             None,
             "mobilenetv3_small_100",
@@ -183,7 +186,7 @@ def test_predictor(
     efficient_finetune,
     loss_function,
 ):
-    dataset = ALL_DATASETS[dataset_name]()
+    dataset = ALL_DATASETS[dataset_name]
     metric_name = dataset.metric
 
     predictor = MultiModalPredictor(
@@ -268,7 +271,7 @@ def test_standalone():  # test standalone feature in MultiModalPredictor.save()
         mock.Mock(side_effect=RuntimeError("Please use the `responses` library to mock HTTP in your tests.")),
     )
 
-    dataset = PetFinderDataset()
+    dataset = ALL_DATASETS["petfinder"]
 
     hyperparameters = {
         "optimization.max_epochs": 1,
@@ -350,7 +353,7 @@ def test_standalone():  # test standalone feature in MultiModalPredictor.save()
 def test_customizing_model_names(
     hyperparameters,
 ):
-    dataset = ALL_DATASETS["petfinder"]()
+    dataset = ALL_DATASETS["petfinder"]
     metric_name = dataset.metric
 
     predictor = MultiModalPredictor(
@@ -411,7 +414,7 @@ def test_customizing_model_names(
 
 
 def test_model_configs():
-    dataset = ALL_DATASETS["petfinder"]()
+    dataset = ALL_DATASETS["petfinder"]
     metric_name = dataset.metric
 
     predictor = MultiModalPredictor(
@@ -566,7 +569,7 @@ def test_model_configs():
 
 
 def test_modifying_duplicate_model_names():
-    dataset = ALL_DATASETS["petfinder"]()
+    dataset = ALL_DATASETS["petfinder"]
     metric_name = dataset.metric
 
     teacher_predictor = MultiModalPredictor(
@@ -621,3 +624,41 @@ def test_modifying_duplicate_model_names():
     for per_modality_processors in teacher_predictor._data_processors.values():
         for per_processor in per_modality_processors:
             assert per_processor.prefix in teacher_predictor._config.model.names
+
+
+def test_image_bytearray():
+    download_dir = "./"
+    train_data_1, test_data_1 = shopee_dataset(download_dir=download_dir)
+    train_data_2, test_data_2 = shopee_dataset(download_dir=download_dir, is_bytearray=True)
+    predictor_1 = MultiModalPredictor(
+        label="label",
+    )
+    predictor_2 = MultiModalPredictor(
+        label="label",
+    )
+    model_names = ["timm_image"]
+    hyperparameters = {
+        "optimization.max_epochs": 2,
+        "model.names": model_names,
+        "model.timm_image.checkpoint_name": "swin_tiny_patch4_window7_224",
+    }
+
+    predictor_1.fit(
+        train_data=train_data_1,
+        hyperparameters=hyperparameters,
+        seed=42,
+    )
+    predictor_2.fit(
+        train_data=train_data_2,
+        hyperparameters=hyperparameters,
+        seed=42,
+    )
+    score_1 = predictor_1.evaluate(test_data_1)
+    score_2 = predictor_2.evaluate(test_data_2)
+    prediction_1 = predictor_1.predict(test_data_1, as_pandas=False)
+    prediction_2 = predictor_2.predict(test_data_2, as_pandas=False)
+    prediction_prob_1 = predictor_1.predict_proba(test_data_1, as_pandas=False)
+    prediction_prob_2 = predictor_2.predict_proba(test_data_2, as_pandas=False)
+    npt.assert_equal(score_1, score_2)
+    npt.assert_equal(prediction_1, prediction_2)
+    npt.assert_equal(prediction_prob_1, prediction_prob_2)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds support for image bytearrays in AutoMM.
The DataFrame column can be either `bytearray` or `list[bytearray]`.

Benchmarking on the original `image_path` workflow with [dataset](https://automl-mm-bench.s3.amazonaws.com/petfinder_for_tutorial.zip) on SageMaker endpoint

test data:
100 x bytearray-encoded images 

data preprocess:
0.5s to decode and save to disk to generate `image_path` to pass in `MultiModalPredictor.fit()`

predict_proba:
0.1s

With the support of bytearray, we can save the time spent on data preprocessing, which majority of the time is on saving the image to disk.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
