### PR TITLE
[CI] Moved short_sha from env variable to the running command

### DIFF
--- a/.github/actions/setup-env-vars/action.yml
+++ b/.github/actions/setup-env-vars/action.yml
@@ -10,9 +10,10 @@ runs:
         SHA: ${{ github.sha }}
         branch: ${{ github.ref }}
         git_repo: ${{ github.repository }}
-        short_sha: $(git rev-parse --short "${{ github.sha }}")
         pr_number: ""
       run: |
+        
+        short_sha=$(git rev-parse --short "$SHA")
         echo "BRANCH=$branch" >> $GITHUB_ENV
         echo "GIT_REPO=$git_repo" >> $GITHUB_ENV
         echo "SHORT_SHA=$short_sha" >> $GITHUB_ENV
@@ -24,10 +25,9 @@ runs:
         SHA: ${{ github.event.pull_request.head.sha }}
         branch: ${{ github.event.pull_request.head.ref }}
         git_repo: ${{ github.event.pull_request.head.repo.full_name }}
-        short_sha: $(git rev-parse --short "${{ github.event.pull_request.head.sha }}")
         pr_number: PR-${{ github.event.number }}
       run: |
-
+        short_sha=$(git rev-parse --short "$SHA")
         echo "BRANCH=$branch" >> $GITHUB_ENV
         echo "GIT_REPO=$git_repo" >> $GITHUB_ENV
         echo "SHORT_SHA=$short_sha" >> $GITHUB_ENV


### PR DESCRIPTION
*Issue #, if available:*
Fix the CI [failure](https://github.com/autogluon/autogluon/actions/runs/3562103876/jobs/5993588145) at copy_doc step

*Description of changes:*
Moved `short_sha` from env variable to the running command

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
