### PR TITLE
Use bytearray in cloud server

### DIFF
--- a/cloud/src/autogluon/cloud/scripts/multimodal_serve.py
+++ b/cloud/src/autogluon/cloud/scripts/multimodal_serve.py
@@ -14,18 +14,6 @@ from autogluon.core.utils import get_pred_from_proba_df
 from autogluon.multimodal import MultiModalPredictor
 
 
-def _save_image_and_update_dataframe_column(bytes):
-    im_bytes = base64.b85decode(bytes)
-    # nosec B303 - not a cryptographic use
-    im_hash = hashlib.sha1(im_bytes).hexdigest()
-    im = Image.open(BytesIO(im_bytes))
-    im_name = f"multimodal_image_{im_hash}.png"
-    im.save(im_name)
-    print(f"Image saved as {im_name}")
-
-    return im_name
-
-
 def _cleanup_images():
     files = os.listdir(".")
     for file in files:
@@ -45,7 +33,7 @@ def model_fn(model_dir):
 
 
 def transform_fn(model, request_body, input_content_type, output_content_type="application/json"):
-    image_paths = None
+    image_bytearrays = None
     if input_content_type == "application/x-parquet":
         buf = BytesIO(request_body)
         data = pd.read_parquet(buf)
@@ -65,29 +53,20 @@ def transform_fn(model, request_body, input_content_type, output_content_type="a
     elif input_content_type == "application/x-npy":
         buf = BytesIO(request_body)
         data = np.load(buf, allow_pickle=True)
-        image_paths = []
+        image_bytearrays = []
         for bytes in data:
             im_bytes = base64.b85decode(bytes)
-            # nosec B303 - not a cryptographic use
-            im_hash = hashlib.sha1(im_bytes).hexdigest()
-            im_name = f"multimodal_image_{im_hash}.png"
-            im = Image.open(BytesIO(im_bytes))
-            im.save(im_name)
-            image_paths.append(im_name)
+            image_bytearrays.append(im_bytes)
 
     elif input_content_type == "application/x-image":
-        buf = BytesIO(request_body)
-        im = Image.open(buf)
-        image_paths = []
-        im_name = "test.png"
-        im.save(im_name)
-        image_paths.append(im_name)
+        image_bytearrays = []
+        image_bytearrays.append(request_body)
 
     else:
         raise ValueError(f"{input_content_type} input content type not supported.")
 
-    if image_paths is not None:
-        data = dict(image=image_paths)  # multimodal image prediction takes in a dict containing image paths
+    if image_bytearrays is not None:
+        data = dict(image=image_bytearrays)  # multimodal image prediction takes in a dict containing image bytearrays
     else:
         # no header
         test_columns = sorted(list(data.columns))
@@ -108,13 +87,12 @@ def transform_fn(model, request_body, input_content_type, output_content_type="a
         # find image column
         image_column = None
         for column_name, column_type in model._column_types.items():
-            if column_type in ("image_path", "image"):
+            if column_type in ("image_path", "image", "image_bytearray"):
                 image_column = column_name
                 break
-        # save image column bytes to disk and update the column with saved path
         if image_column is not None:
             print(f"Detected image column {image_column}")
-            data[image_column] = [_save_image_and_update_dataframe_column(bytes) for bytes in data[image_column]]
+            data[image_column] = [base64.b85decode(bytes) for bytes in data[image_column]]
 
     if model.problem_type == BINARY or model.problem_type == MULTICLASS:
         pred_proba = model.predict_proba(data, as_pandas=True)

--- a/common/src/autogluon/common/features/types.py
+++ b/common/src/autogluon/common/features/types.py
@@ -42,6 +42,9 @@ S_TEXT_NGRAM = 'text_ngram'
 # feature is an object type that contains a string path to an image that can be utilized in computer vision
 S_IMAGE_PATH = 'image_path'
 
+# feature is an object type that contains bytearray of an image that can be utilized in computer vision
+S_IMAGE_BYTEARRAY = 'image_bytearray'
+
 # feature is a generated feature based off of a ML model's prediction probabilities of the label column for the row.
 # Any model which takes a stack feature as input is a stack ensemble.
 S_STACK = 'stack'

--- a/features/src/autogluon/features/generators/auto_ml_pipeline.py
+++ b/features/src/autogluon/features/generators/auto_ml_pipeline.py
@@ -1,6 +1,6 @@
 import logging
 
-from autogluon.common.features.types import R_INT, R_FLOAT, S_TEXT, R_OBJECT, S_IMAGE_PATH
+from autogluon.common.features.types import R_INT, R_FLOAT, S_TEXT, R_OBJECT, S_IMAGE_PATH, S_IMAGE_BYTEARRAY
 
 from .pipeline import PipelineFeatureGenerator
 from .category import CategoryFeatureGenerator
@@ -114,7 +114,7 @@ class AutoMLPipelineFeatureGenerator(PipelineFeatureGenerator):
                 valid_raw_types=[R_INT, R_FLOAT])))
         if self.enable_raw_text_features:
             generator_group.append(IdentityFeatureGenerator(infer_features_in_args=dict(
-                required_special_types=[S_TEXT], invalid_special_types=[S_IMAGE_PATH]), name_suffix='_raw_text'))
+                required_special_types=[S_TEXT], invalid_special_types=[S_IMAGE_PATH, S_IMAGE_BYTEARRAY]), name_suffix='_raw_text'))
         if self.enable_categorical_features:
             generator_group.append(CategoryFeatureGenerator())
         if self.enable_datetime_features:
@@ -125,10 +125,10 @@ class AutoMLPipelineFeatureGenerator(PipelineFeatureGenerator):
             generator_group.append(TextNgramFeatureGenerator(vectorizer=vectorizer, **self.text_ngram_params))
         if self.enable_vision_features:
             generator_group.append(IdentityFeatureGenerator(infer_features_in_args=dict(
-                valid_raw_types=[R_OBJECT], required_special_types=[S_IMAGE_PATH],
+                valid_raw_types=[R_OBJECT], valid_special_types=[S_IMAGE_PATH, S_IMAGE_BYTEARRAY], required_at_least_one_special=True,
             )))
             generator_group.append(IsNanFeatureGenerator(infer_features_in_args=dict(
-                valid_raw_types=[R_OBJECT], required_special_types=[S_IMAGE_PATH],
+                valid_raw_types=[R_OBJECT], valid_special_types=[S_IMAGE_PATH, S_IMAGE_BYTEARRAY], required_at_least_one_special=True,
             )))
         generators = [generator_group]
         return generators

--- a/features/src/autogluon/features/generators/category.py
+++ b/features/src/autogluon/features/generators/category.py
@@ -5,7 +5,7 @@ import pandas as pd
 from pandas import DataFrame
 from pandas.api.types import CategoricalDtype
 
-from autogluon.common.features.types import R_BOOL, R_CATEGORY, R_OBJECT, S_DATETIME_AS_OBJECT, S_IMAGE_PATH, S_TEXT, S_TEXT_AS_CATEGORY
+from autogluon.common.features.types import R_BOOL, R_CATEGORY, R_OBJECT, S_DATETIME_AS_OBJECT, S_IMAGE_PATH, S_IMAGE_BYTEARRAY, S_TEXT, S_TEXT_AS_CATEGORY
 
 from .abstract import AbstractFeatureGenerator
 from .memory_minimize import CategoryMemoryMinimizeFeatureGenerator
@@ -99,7 +99,7 @@ class CategoryFeatureGenerator(AbstractFeatureGenerator):
     def get_default_infer_features_in_args() -> dict:
         return dict(
             valid_raw_types=[R_OBJECT, R_CATEGORY, R_BOOL],
-            invalid_special_types=[S_DATETIME_AS_OBJECT, S_IMAGE_PATH]
+            invalid_special_types=[S_DATETIME_AS_OBJECT, S_IMAGE_PATH, S_IMAGE_BYTEARRAY]
         )
 
     def _generate_features_category(self, X: DataFrame) -> DataFrame:

--- a/features/src/autogluon/features/generators/drop_unique.py
+++ b/features/src/autogluon/features/generators/drop_unique.py
@@ -2,7 +2,7 @@ import logging
 
 from pandas import DataFrame
 
-from autogluon.common.features.types import R_CATEGORY, R_OBJECT, S_TEXT, S_IMAGE_PATH
+from autogluon.common.features.types import R_CATEGORY, R_OBJECT, S_TEXT, S_IMAGE_PATH, S_IMAGE_BYTEARRAY
 from autogluon.common.features.feature_metadata import FeatureMetadata
 
 from .abstract import AbstractFeatureGenerator
@@ -49,6 +49,9 @@ class DropUniqueFeatureGenerator(AbstractFeatureGenerator):
                     continue
                 elif S_IMAGE_PATH in special_types:
                     # We should not drop an image path column
+                    continue
+                elif S_IMAGE_BYTEARRAY in special_types:
+                    # We should not drop an image bytearray column
                     continue
                 else:
                     features_to_drop.append(column)

--- a/features/src/autogluon/features/generators/text_ngram.py
+++ b/features/src/autogluon/features/generators/text_ngram.py
@@ -8,7 +8,7 @@ import psutil
 from pandas import DataFrame, Series
 from sklearn.feature_selection import SelectKBest, f_classif, f_regression
 
-from autogluon.common.features.types import S_IMAGE_PATH, S_TEXT, S_TEXT_NGRAM
+from autogluon.common.features.types import S_IMAGE_PATH, S_IMAGE_BYTEARRAY, S_TEXT, S_TEXT_NGRAM
 
 from .abstract import AbstractFeatureGenerator
 from ..vectorizers import get_ngram_freq, downscale_vectorizer, vectorizer_auto_ml_default
@@ -112,7 +112,7 @@ class TextNgramFeatureGenerator(AbstractFeatureGenerator):
 
     @staticmethod
     def get_default_infer_features_in_args() -> dict:
-        return dict(required_special_types=[S_TEXT], invalid_special_types=[S_IMAGE_PATH])
+        return dict(required_special_types=[S_TEXT], invalid_special_types=[S_IMAGE_PATH, S_IMAGE_BYTEARRAY])
 
     def _fit_transform_ngrams(self, X):
         if not self.features_in:

--- a/features/src/autogluon/features/generators/text_special.py
+++ b/features/src/autogluon/features/generators/text_special.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 from pandas import DataFrame, Series
 
-from autogluon.common.features.types import S_IMAGE_PATH, S_TEXT, S_TEXT_SPECIAL
+from autogluon.common.features.types import S_IMAGE_PATH, S_IMAGE_BYTEARRAY, S_TEXT, S_TEXT_SPECIAL
 
 from .abstract import AbstractFeatureGenerator
 from .binned import BinnedFeatureGenerator
@@ -80,7 +80,7 @@ class TextSpecialFeatureGenerator(AbstractFeatureGenerator):
 
     @staticmethod
     def get_default_infer_features_in_args() -> dict:
-        return dict(required_special_types=[S_TEXT], invalid_special_types=[S_IMAGE_PATH])
+        return dict(required_special_types=[S_TEXT], invalid_special_types=[S_IMAGE_PATH, S_IMAGE_BYTEARRAY])
 
     def _filter_symbols(self, X: DataFrame, symbols: list) -> dict:
         symbols_per_feature = {}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR adds bytearray support in cloud module multimodal inference script. 

Instead of saving encoded image bytearrays to disk and update the test data with `image_path`, we can now directly make calls to `MultiModalPredictor` with decoded bytearrays. 

We have also added `S_IMAGE_BYTEARRAY` to feature generator.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
