### PR TITLE
[Tabular] Convert ColumnTransformer in tabular NN from sklearn to onnx

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -1040,7 +1040,12 @@ class AbstractModel:
                                             compiler_fallback_to_native=compiler_fallback_to_native)
         if self._compiler is not None:
             input_types = self._get_input_types(batch_size=batch_size)
-            self.model = self._compiler.compile(model=self.model, path=self.path, input_types=input_types)
+            self._compile(input_types=input_types)
+
+    def _compile(self, **kwargs):
+        """Take the compiler to perform actual compilation."""
+        input_types = kwargs.get('input_types', self._get_input_types(batch_size=None))
+        self.model = self._compiler.compile(model=self.model, path=self.path, input_types=input_types)
 
     # FIXME: This won't work for all models, and self._features is not
     # a trustworthy variable for final input shape

--- a/tabular/src/autogluon/tabular/models/tabular_nn/compilers/native.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/compilers/native.py
@@ -1,0 +1,45 @@
+import os
+import pickle
+
+
+class AbstractNativeCompiler:
+    name = 'native'
+    save_in_pkl = True
+
+    @staticmethod
+    def can_compile():
+        return True
+
+    @staticmethod
+    def compile(model, path: str, input_types=None):
+        """
+        Compile the trained model for faster inference.
+
+        Parameters
+        ----------
+        model
+            The native model that is expected to be compiled.
+        path : str
+            The path for saving the compiled model.
+        input_types : list, default=None
+            A list of tuples containing shape and element type info, e.g. [((1, 14), np.float32),].
+            The list would be used as the input data for the model.
+            The compiler would optimize the model to perform best with the given input type.
+        """
+        AbstractNativeCompiler.save(model, path)
+
+    @staticmethod
+    def save(model, path: str):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(os.path.join(path, 'model_native.pkl'), 'wb') as fp:
+            fp.write(pickle.dumps(model))
+
+    @staticmethod
+    def load(path: str):
+        pkl = None
+        with open(os.path.join(path, 'model_native.pkl'), 'rb') as fp:
+            pkl = fp.read()
+        return pickle.loads(pkl)
+
+
+TabularNeuralNetTorchNativeCompiler = AbstractNativeCompiler

--- a/tabular/src/autogluon/tabular/models/tabular_nn/compilers/onnx.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/compilers/onnx.py
@@ -1,0 +1,301 @@
+import os
+import numpy as np
+
+
+
+def quantile_transformer_shape_calculator(operator):
+    op = operator.raw_operator
+    input_type = operator.inputs[0].type.__class__
+    input_dim = operator.inputs[0].type.shape[0]
+    output_type = input_type([input_dim, op.quantiles_.shape[1]])
+    operator.outputs[0].type = output_type
+
+
+def quantile_transformer_converter(scope, operator, container):
+    from scipy.stats import norm
+    from skl2onnx.algebra.onnx_ops import (
+        OnnxSub,
+        OnnxAbs,
+        OnnxSplit,
+        OnnxGatherElements,
+    )
+    from skl2onnx.algebra.onnx_ops import OnnxArgMin, OnnxConcat, OnnxMatMul, OnnxReshape
+    from skl2onnx.common.data_types import guess_numpy_type
+
+    op = operator.raw_operator
+    opv = container.target_opset
+    out = operator.outputs
+
+    # We retrieve the unique input.
+    X = operator.inputs[0]
+
+    # In most case, computation happen in floats.
+    # But it might be with double. ONNX is very strict
+    # about types, every constant should have the same
+    # type as the input.
+    dtype = guess_numpy_type(X.type)
+    batch_size = X.type.shape[0]
+    n_quantiles = op.n_quantiles_
+
+    # We tell in ONNX language how to compute the unique output.
+    # op_version=opv tells which opset is requested
+    C = op.quantiles_.astype(dtype)
+    C_col = OnnxSplit(C, axis=1, output_names=[f"C_col{x}" for x in range(op.n_features_in_)])
+    C_col.add_to(scope, container)
+    X_col = OnnxSplit(X, axis=1, output_names=[f"X_col{x}" for x in range(op.n_features_in_)])
+    X_col.add_to(scope, container)
+    Y_col = []
+    for feature_idx in range(op.n_features_in_):
+        # This implements
+        # > X_col[isfinite_mask] = np.interp(X_col_finite, self.references_, quantiles)
+        #
+        # Specifically, for yi = np.interp(xi, x, y), we implement
+        # > def nearest_interp(xi, x, y):
+        # >     idx = np.abs(x - xi[:,None])
+        # >     return y[idx.argmin(axis=1)]
+        # See https://stackoverflow.com/questions/21002799/extraploation-with-nearest-method-in-python
+        repeat = OnnxMatMul(
+            OnnxReshape(X_col.outputs[feature_idx], np.array([batch_size, 1])),
+            np.ones(shape=(1, n_quantiles)).astype(dtype),
+        )
+        sub = OnnxSub(
+            repeat,
+            OnnxReshape(C_col.outputs[feature_idx], np.array([1, n_quantiles])),
+            op_version=opv,
+            output_names=[f"sub_col{feature_idx}"],
+        )
+        idx = OnnxAbs(sub, op_version=opv, output_names=[f"idx_col{feature_idx}"])
+        argmin = OnnxArgMin(
+            OnnxReshape(idx, np.array([batch_size, n_quantiles])),
+            axis=1,
+            op_version=opv,
+            output_names=[f"argmin_col{feature_idx}"],
+        )
+        references = np.clip(norm.ppf(op.references_), -5.2, 5.2).astype(dtype)
+        cst = np.broadcast_to(references, (batch_size, n_quantiles))
+        argmin_reshaped = OnnxReshape(argmin, np.array([batch_size, 1]), output_names=[f"reshape_col{feature_idx}"])
+        ref = OnnxGatherElements(
+            cst, argmin_reshaped, axis=1, op_version=opv, output_names=[f"gathernd_col{feature_idx}"]
+        )
+        Y_col.append(OnnxReshape(ref, np.array([batch_size, 1]), output_names=[f"Y_col{feature_idx}"]))
+    Y = OnnxConcat(*Y_col, axis=1, op_version=opv, output_names=out[:1])
+    Y.add_to(scope, container)
+
+
+def ordinal_handle_unknown_transformer_shape_calculator(operator):
+    op = operator.raw_operator
+    input_type = operator.inputs[0].type.__class__
+    input_dim = operator.inputs[0].type.shape[0]
+    output_type = input_type([input_dim, len(op.categories_len_)])
+    operator.outputs[0].type = output_type
+
+
+def ordinal_handle_unknown_transformer_converter(scope, operator, container):
+    from skl2onnx.algebra.onnx_ops import (
+        OnnxSub,
+        OnnxAbs,
+        OnnxSplit,
+    )
+    from skl2onnx.algebra.onnx_ops import OnnxArgMin, OnnxConcat, OnnxMatMul, OnnxReshape
+    from skl2onnx.common.data_types import guess_numpy_type
+
+    op = operator.raw_operator
+    opv = container.target_opset
+    out = operator.outputs
+
+    # We retrieve the unique input.
+    X = operator.inputs[0]
+
+    # In most case, computation happen in floats.
+    # But it might be with double. ONNX is very strict
+    # about types, every constant should have the same
+    # type as the input.
+    dtype = guess_numpy_type(X.type)
+    batch_size = X.type.shape[0]
+    num_categories = len(op.categories_)
+    name_prefix = "ordinal_handle_unknown_"
+
+    C_col = op.categories_
+    X_col = OnnxSplit(X, axis=1, output_names=[f"{name_prefix}X_col{x}" for x in range(num_categories)])
+    X_col.add_to(scope, container)
+    Y_col = []
+    for feature_idx in range(num_categories):
+        # This implements
+        # > X_col = np.searchsorted(X_col_finite, self.references_)
+        #
+        # Specifically, for yi = np.searchsorted(xi, x), we implement
+        # > def searchsorted(xi, x, y):
+        # >     idx = np.abs(x - xi[:,None])
+        # >     return idx.argmin(axis=1)
+        num_classes = len(C_col[feature_idx])
+        repeat = OnnxMatMul(
+            OnnxReshape(X_col.outputs[feature_idx], np.array([batch_size, 1])),
+            np.ones(shape=(1, num_classes)).astype(dtype),
+        )
+        sub = OnnxSub(
+            repeat,
+            OnnxReshape(C_col[feature_idx].astype(dtype), np.array([1, num_classes])),
+            op_version=opv,
+            output_names=[f"{name_prefix}sub_col{feature_idx}"],
+        )
+        idx = OnnxAbs(sub, op_version=opv, output_names=[f"{name_prefix}idx_col{feature_idx}"])
+        argmin = OnnxArgMin(
+            OnnxReshape(idx, np.array([batch_size, num_classes])),
+            axis=1,
+            op_version=opv,
+            output_names=[f"{name_prefix}argmin_col{feature_idx}"],
+        )
+        Y_col.append(OnnxReshape(argmin, np.array([batch_size, 1]), output_names=[f"{name_prefix}Y_col{feature_idx}"]))
+    Y = OnnxConcat(*Y_col, axis=1, op_version=opv, output_names=out[:1])
+    Y.add_to(scope, container)
+
+
+class InferenceSessionWrapper:
+    """
+    Wrap around InferenceSession in onnxruntime, since it cannot be pickled.
+    See https://github.com/microsoft/onnxruntime/issues/10097
+    """
+
+    def __init__(self, onnx_bytes):
+        import onnxruntime as ort
+
+        self.sess = ort.InferenceSession(onnx_bytes.SerializeToString(), providers=["CPUExecutionProvider"])
+
+    def run(self, *args):
+        return self.sess.run(*args)
+
+    def get_inputs(self, *args):
+        return self.sess.get_inputs(*args)
+
+    def get_outputs(self, *args):
+        return self.sess.get_outputs(*args)
+
+    def __getstate__(self):
+        # No need to duplicate the model parameters here.
+        return {}
+
+    def __setstate__(self, values):
+        pass
+
+
+class TabularNeuralNetTorchOnnxTransformer:
+    def __init__(self, model):
+        self.sess = InferenceSessionWrapper(model)
+        self.batch_size = self.sess.get_inputs()[0].shape[0]
+
+    def transform(self, X):
+        """Run the model with the input and return the result."""
+        X.columns = [c.replace("-", "_") for c in X.columns]
+        inputs = self.sess.get_inputs()
+        input_names = [x.name for x in inputs]
+        input_dict = {}
+        input_arr = X[input_names].to_numpy().astype(np.float32)
+        input_size = input_arr.shape[0]
+        inputs = []
+        if input_size > self.batch_size:
+            indices = list(np.arange(self.batch_size, input_size, self.batch_size)) + [input_size]
+            inputs = np.split(input_arr, indices)
+        else:
+            inputs = [input_arr]
+        outputs = []
+        for input_arr in inputs:
+            input_size = input_arr.shape[0]
+            if input_size < self.batch_size:
+                # padding
+                pad_size = self.batch_size - input_size
+                pad_shape = list(input_arr.shape)
+                pad_shape[0] = pad_size
+                pad_arr = np.zeros(shape=tuple(pad_shape), dtype=np.float32)
+                input_arr = np.concatenate([input_arr, pad_arr])
+            for idx, name in enumerate(input_names):
+                input_dict[name] = input_arr[:, idx].reshape(self.batch_size, 1)
+            label_name = self.sess.get_outputs()[0].name
+            output_arr = self.sess.run([label_name], input_dict)[0]
+            if input_size < self.batch_size:
+                # remove padding
+                output_arr = output_arr[:input_size, :]
+            outputs.append(output_arr)
+        outputs = np.concatenate(outputs)
+        return outputs
+
+
+class TabularNeuralNetTorchOnnxCompiler:
+    name = "onnx"
+    save_in_pkl = False
+
+    @staticmethod
+    def can_compile():
+        """Verify whether the required package has been installed."""
+        try:
+            import skl2onnx
+            import onnxruntime
+
+            return True
+        except ImportError:
+            return False
+
+    @staticmethod
+    def compile(model, path: str, input_types=None):
+        """
+        Compile the trained model for faster inference.
+
+        Parameters
+        ----------
+        model
+            The native model that is expected to be compiled.
+        """
+        if isinstance(model, TabularNeuralNetTorchOnnxTransformer):
+            return model
+        from sklearn.pipeline import Pipeline
+        from skl2onnx import convert_sklearn
+        from skl2onnx.common.data_types import FloatTensorType
+        from skl2onnx import update_registered_converter
+        from sklearn.preprocessing import QuantileTransformer
+        from ..utils.categorical_encoders import OrdinalMergeRaresHandleUnknownEncoder
+
+        update_registered_converter(
+            QuantileTransformer,
+            "SklearnQuantileTransformer",
+            quantile_transformer_shape_calculator,
+            quantile_transformer_converter,
+        )
+        update_registered_converter(
+            OrdinalMergeRaresHandleUnknownEncoder,
+            "OrdinalMergeRaresHandleUnknownEncoder",
+            ordinal_handle_unknown_transformer_shape_calculator,
+            ordinal_handle_unknown_transformer_converter,
+        )
+
+        if input_types is None or not isinstance(input_types[0], tuple):
+            raise RuntimeError(
+                "input_types argument should contain at least one tuple, e.g. [((1, 14), np.float32)]"
+            )
+        pipeline = Pipeline(
+            steps=[
+                ("processor", model[0]),
+            ]
+        )
+
+        for idx, input_type in enumerate(input_types):
+            input_types[idx] = (input_type[0], FloatTensorType(input_type[1]))
+        onnx_model = convert_sklearn(pipeline, initial_types=input_types)
+
+        predictor = TabularNeuralNetTorchOnnxTransformer(model=onnx_model)
+        TabularNeuralNetTorchOnnxCompiler.save(onnx_model, path)
+        return predictor
+
+    @staticmethod
+    def save(model, path: str) -> str:
+        """Save the compiled model into onnx file format."""
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(os.path.join(path, "model.onnx"), "wb") as f:
+            f.write(model.SerializeToString())
+        return os.path.join(path, "model.onnx")
+
+    @staticmethod
+    def load(path: str) -> TabularNeuralNetTorchOnnxTransformer:
+        """Load from the path that contains an onnx file."""
+        import onnx
+
+        onnx_bytes = onnx.load(os.path.join(path, "model.onnx"))
+        return TabularNeuralNetTorchOnnxTransformer(model=onnx_bytes)

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -16,6 +16,8 @@ from autogluon.core.utils import try_import_torch
 from autogluon.core.utils.exceptions import TimeLimitExceeded
 from autogluon.core.models.abstract.abstract_nn_model import AbstractNeuralNetworkModel
 
+from ..compilers.native import TabularNeuralNetTorchNativeCompiler
+from ..compilers.onnx import TabularNeuralNetTorchOnnxCompiler
 from ..hyperparameters.parameters import get_default_param
 from ..hyperparameters.searchspaces import get_default_searchspace
 from ..utils.data_preprocessor import create_preprocessor, get_feature_arraycol_map, get_feature_type_map
@@ -253,7 +255,7 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
         logger.log(15, "Neural network architecture:")
         logger.log(15, str(self.model))
 
-        net_filename = self.path + self.temp_file_name
+        net_filename = os.path.join(self.path, self.temp_file_name)
         if num_epochs == 0:
             # use dummy training loop that stops immediately
             # useful for using NN just for data preprocessing / debugging
@@ -430,7 +432,7 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
             raise ValueError("new_data must of of type TabularTorchDataset if process=False")
         val_dataloader = new_data.build_loader(self.max_batch_size, self.num_dataloading_workers, is_test=True)
         preds_dataset = []
-        for batch_idx, data_batch in enumerate(val_dataloader):
+        for data_batch in val_dataloader:
             preds_batch = self.model.predict(data_batch)
             preds_dataset.append(preds_batch)
         preds_dataset = np.concatenate(preds_dataset, 0)
@@ -590,16 +592,11 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
         model: TabularNeuralNetTorchModel = super().load(path=path, reset_paths=reset_paths, verbose=verbose)
         if model._architecture_desc is not None:
             import torch
-            from .torch_network_modules import EmbedNet
-
-            # recreate network from architecture description
-            model.model = EmbedNet(problem_type=model.problem_type,
-                                   num_net_outputs=model._get_num_net_outputs(),
-                                   quantile_levels=model.quantile_levels,
-                                   architecture_desc=model._architecture_desc,
-                                   device=model.device)
             model._architecture_desc = None
-            model.model = torch.load(model.path + model.params_file_name)
+            model.model = torch.load(os.path.join(model.path, model.params_file_name))
+            if model._compiler:
+                model.model.eval()
+                model.processor = model._compiler.load(path=model.path)
         return model
     
     def _get_hpo_backend(self):
@@ -620,3 +617,40 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
         #  self.params_trained['batch_size'] = batch_size
         #  self.params_trained['num_epochs'] = best_epoch
         return {'can_refit_full': True}
+
+    def _valid_compilers(self):
+        return [TabularNeuralNetTorchNativeCompiler,
+                TabularNeuralNetTorchOnnxCompiler]
+
+    def _default_compiler(self):
+        return TabularNeuralNetTorchNativeCompiler
+
+    def _get_input_types(self, batch_size=None):
+        input_types = []
+        for f in self._features:
+            input_types.append((f, [batch_size, 1]))
+        return input_types
+
+    def compile(self, compiler_configs=None):
+        """
+        Compile the trained model for faster inference.
+
+        This completely overrides the compile() in AbstractModel, since we won't
+        overwrite self.model in the compilation process.
+        Instead, self.processor would be converted from sklearn ColumnTransformer
+        to its alternative counterpart.
+        """
+        assert self.is_fit(), "The model must be fit before calling the compile method."
+        if compiler_configs is None:
+            compiler_configs = {}
+        compiler = compiler_configs.get("compiler", "native")
+        batch_size = compiler_configs.get("batch_size", self.max_batch_size)
+        compiler_fallback_to_native = compiler_configs.get('compiler_fallback_to_native', False)
+
+        self._compiler = self._get_compiler(compiler=compiler,
+                                            compiler_fallback_to_native=compiler_fallback_to_native)
+        if self._compiler is not None:
+            input_types = self._get_input_types(batch_size=batch_size)
+            self.processor = self._compiler.compile(model=(self.processor, self.model),
+                                                    path=self.path,
+                                                    input_types=input_types)

--- a/tabular/src/autogluon/tabular/models/tabular_nn/utils/data_preprocessor.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/utils/data_preprocessor.py
@@ -23,8 +23,6 @@ def create_preprocessor(impute_strategy, max_category_levels, unique_category_st
         transformers.append( ('skewed', power_transformer, skewed_features) )
     if onehot_features:
         onehot_transformer = Pipeline(steps=[
-            # TODO: Consider avoiding converting to string for improved memory efficiency
-            ('to_str', FunctionTransformer(convert_df_dtype_to_str)),
             ('imputer', SimpleImputer(strategy='constant', fill_value=unique_category_str)),
             ('onehot', OneHotMergeRaresHandleUnknownEncoder(max_levels=max_category_levels, sparse=False))])  # test-time unknown values will be encoded as all zeros vector
         transformers.append( ('onehot', onehot_transformer, onehot_features) )

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -2009,6 +2009,7 @@ class TabularPredictor:
                 compiler_configs = {
                     "RF": {"compiler": "onnx"},
                     "XT": {"compiler": "onnx"},
+                    "NN_TORCH": {"compiler": "onnx"},
                 }
             Otherwise, specify a compiler_configs dictionary manually. Keys can be exact model names or model types.
             Exact model names take priority over types if both are valid for a model.
@@ -2032,6 +2033,7 @@ class TabularPredictor:
                 compiler_configs = {
                     "RF": {"compiler": "onnx"},
                     "XT": {"compiler": "onnx"},
+                    "NN_TORCH": {"compiler": "onnx"},
                 }
             else:
                 raise ValueError(f'Unknown compiler_configs preset: "{compiler_configs}"')

--- a/tabular/tests/unittests/models/test_tabular_nn.py
+++ b/tabular/tests/unittests/models/test_tabular_nn.py
@@ -1,3 +1,4 @@
+import pytest
 
 from autogluon.tabular.models.tabular_nn.torch.tabular_nn_torch import TabularNeuralNetTorchModel
 
@@ -25,3 +26,35 @@ def test_tabular_nn_regression(fit_helper):
     )
     dataset_name = 'ames'
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
+
+
+def test_tabular_nn_binary_compile_onnx(fit_helper):
+    fit_args = dict(
+        hyperparameters={TabularNeuralNetTorchModel: {}},
+    )
+    dataset_name = 'adult'
+    compiler_configs = {TabularNeuralNetTorchModel: {'compiler': 'onnx'}}
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args,
+                                        compile_models=True, compiler_configs=compiler_configs)
+
+
+def test_tabular_nn_multiclass_compile_onnx(fit_helper):
+    fit_args = dict(
+        hyperparameters={TabularNeuralNetTorchModel: {}},
+    )
+    dataset_name = 'covertype_small'
+    compiler_configs = {TabularNeuralNetTorchModel: {'compiler': 'onnx'}}
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args,
+                                        compile_models=True, compiler_configs=compiler_configs)
+
+
+@pytest.mark.skip(reason="FunctionTransformer is not supported unless the transform function is None (= identity).")
+def test_tabular_nn_regression_compile_onnx(fit_helper):
+    fit_args = dict(
+        hyperparameters={TabularNeuralNetTorchModel: {}},
+        time_limit=10,  # TabularNN trains for a long time on ames
+    )
+    dataset_name = 'ames'
+    compiler_configs = {TabularNeuralNetTorchModel: {'compiler': 'onnx'}}
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args,
+                                        compile_models=True, compiler_configs=compiler_configs)

--- a/tabular/tests/unittests/models/test_tabular_nn.py
+++ b/tabular/tests/unittests/models/test_tabular_nn.py
@@ -22,7 +22,7 @@ def test_tabular_nn_multiclass(fit_helper):
 def test_tabular_nn_regression(fit_helper):
     fit_args = dict(
         hyperparameters={TabularNeuralNetTorchModel: {}},
-        time_limit=10,  # TabularNN trains for a long time on ames
+        time_limit=20,  # TabularNN trains for a long time on ames
     )
     dataset_name = 'ames'
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
@@ -46,8 +46,8 @@ def test_tabular_nn_multiclass_compile_onnx(fit_helper):
     )
     dataset_name = 'covertype_small'
     compiler_configs = {TabularNeuralNetTorchModel: {'compiler': 'onnx'}}
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args,
-                                        compile_models=True, compiler_configs=compiler_configs)
+    predictor = fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args,
+                                                    compile_models=True, compiler_configs=compiler_configs)
     from autogluon.tabular.models.tabular_nn.compilers.onnx import TabularNeuralNetTorchOnnxTransformer
     assert isinstance(predictor._learner.trainer.models['NeuralNetTorch'].processor, TabularNeuralNetTorchOnnxTransformer)
 
@@ -55,11 +55,11 @@ def test_tabular_nn_multiclass_compile_onnx(fit_helper):
 def test_tabular_nn_regression_compile_onnx(fit_helper):
     fit_args = dict(
         hyperparameters={TabularNeuralNetTorchModel: {}},
-        time_limit=10,  # TabularNN trains for a long time on ames
+        time_limit=20,  # TabularNN trains for a long time on ames
     )
     dataset_name = 'ames'
     compiler_configs = {TabularNeuralNetTorchModel: {'compiler': 'onnx'}}
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args,
-                                        compile_models=True, compiler_configs=compiler_configs)
+    predictor = fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args,
+                                                    compile_models=True, compiler_configs=compiler_configs)
     from autogluon.tabular.models.tabular_nn.compilers.onnx import TabularNeuralNetTorchOnnxTransformer
     assert isinstance(predictor._learner.trainer.models['NeuralNetTorch'].processor, TabularNeuralNetTorchOnnxTransformer)

--- a/tabular/tests/unittests/models/test_tabular_nn.py
+++ b/tabular/tests/unittests/models/test_tabular_nn.py
@@ -34,8 +34,10 @@ def test_tabular_nn_binary_compile_onnx(fit_helper):
     )
     dataset_name = 'adult'
     compiler_configs = {TabularNeuralNetTorchModel: {'compiler': 'onnx'}}
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args,
-                                        compile_models=True, compiler_configs=compiler_configs)
+    predictor = fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args,
+                                                    compile_models=True, compiler_configs=compiler_configs)
+    from autogluon.tabular.models.tabular_nn.compilers.onnx import TabularNeuralNetTorchOnnxTransformer
+    assert isinstance(predictor._learner.trainer.models['NeuralNetTorch'].processor, TabularNeuralNetTorchOnnxTransformer)
 
 
 def test_tabular_nn_multiclass_compile_onnx(fit_helper):
@@ -46,9 +48,10 @@ def test_tabular_nn_multiclass_compile_onnx(fit_helper):
     compiler_configs = {TabularNeuralNetTorchModel: {'compiler': 'onnx'}}
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args,
                                         compile_models=True, compiler_configs=compiler_configs)
+    from autogluon.tabular.models.tabular_nn.compilers.onnx import TabularNeuralNetTorchOnnxTransformer
+    assert isinstance(predictor._learner.trainer.models['NeuralNetTorch'].processor, TabularNeuralNetTorchOnnxTransformer)
 
 
-@pytest.mark.skip(reason="FunctionTransformer is not supported unless the transform function is None (= identity).")
 def test_tabular_nn_regression_compile_onnx(fit_helper):
     fit_args = dict(
         hyperparameters={TabularNeuralNetTorchModel: {}},
@@ -58,3 +61,5 @@ def test_tabular_nn_regression_compile_onnx(fit_helper):
     compiler_configs = {TabularNeuralNetTorchModel: {'compiler': 'onnx'}}
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args,
                                         compile_models=True, compiler_configs=compiler_configs)
+    from autogluon.tabular.models.tabular_nn.compilers.onnx import TabularNeuralNetTorchOnnxTransformer
+    assert isinstance(predictor._learner.trainer.models['NeuralNetTorch'].processor, TabularNeuralNetTorchOnnxTransformer)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR converts the ColumnsTransformer in tabular NN model from sklearn to onnx, so that the processor in TabularNeuralNetTorchModel can be accelerated via onnxruntime.

While the impact to accuracy is minimal,
```
NeuralNetTorch:
{'accuracy': 0.8365236974101751, 'balanced_accuracy': 0.7532995553694549, 'mcc': 0.5305019485882506, 'roc_auc': 0.8815480292353528, 'f1': 0.6332950631458094, 'precision': 0.6769759450171822, 'recall': 0.594909404659189}
NeuralNetTorch_ONNX:
{'accuracy': 0.8362166035418159, 'balanced_accuracy': 0.7523552495805498, 'mcc': 0.5291951976581161, 'roc_auc': 0.8813204856717612, 'f1': 0.6320147194112237, 'precision': 0.6768472906403941, 'recall': 0.5927523727351165}
```
, the impact to overall online inference is significant.

The relative speedups comparing to sklearn baseline are shown in the following figure.

![image](https://user-images.githubusercontent.com/857821/205176134-db5782fe-b0b4-4333-96ad-607be7bb3e74.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
