### PR TITLE
Error on non-finite values in label column

### DIFF
--- a/core/src/autogluon/core/constants.py
+++ b/core/src/autogluon/core/constants.py
@@ -25,6 +25,12 @@ OBJECTIVES_TO_NORMALIZE = ['log_loss', 'pac_score', 'soft_log_loss']  # do not l
 AUTO_WEIGHT = 'auto_weight'
 BALANCE_WEIGHT = 'balance_weight'
 
+# Constants used to infer problem type
+MULTICLASS_UPPER_LIMIT = 1000  # assume regression if dtype is numeric and unique label count is above this limit
+LARGE_DATA_THRESHOLD = 1000
+REGRESS_THRESHOLD_LARGE_DATA = 0.05
+REGRESS_THRESHOLD_SMALL_DATA = 0.1
+
 # TODO: Add docs to dedicated page, or should it live in AbstractModel?
 # TODO: How to reference correct version of docs?
 # TODO: Add error in AG_ARGS if unknown key present

--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -18,7 +18,10 @@ from sklearn.model_selection import RepeatedKFold, RepeatedStratifiedKFold, Leav
 from sklearn.model_selection import train_test_split
 
 from .miscs import warning_filter
-from ..constants import BINARY, REGRESSION, MULTICLASS, SOFTCLASS, QUANTILE
+from ..constants import (
+    BINARY, LARGE_DATA_THRESHOLD, MULTICLASS, MULTICLASS_UPPER_LIMIT, QUANTILE,
+    REGRESS_THRESHOLD_LARGE_DATA, REGRESS_THRESHOLD_SMALL_DATA, REGRESSION, SOFTCLASS
+)
 from ..metrics import accuracy, root_mean_squared_error, pinball_loss, Scorer
 
 
@@ -572,18 +575,19 @@ def infer_problem_type(y: Series, silent=False) -> str:
     """ Identifies which type of prediction problem we are interested in (if user has not specified).
         Ie. binary classification, multi-class classification, or regression.
     """
-    if len(y) == 0:
-        raise ValueError("provided labels cannot have length = 0")
-    y = y.dropna()  # Remove missing values from y (there should not be any though as they were removed in Learner.general_data_processing())
+    with pd.option_context('mode.use_inf_as_na', True): # treat None, NaN, INF, NINF as NA
+        y = y.dropna()
     num_rows = len(y)
+
+    if num_rows == 0:
+        raise ValueError("Label column cannot have 0 valid values")
 
     unique_values = y.unique()
 
-    MULTICLASS_LIMIT = 1000  # if numeric and class count would be above this amount, assume it is regression
-    if num_rows > 1000:
-        REGRESS_THRESHOLD = 0.05  # if the unique-ratio is less than this, we assume multiclass classification, even when labels are integers
+    if num_rows > LARGE_DATA_THRESHOLD:
+        regression_threshold = REGRESS_THRESHOLD_LARGE_DATA  # if the unique-ratio is less than this, we assume multiclass classification, even when labels are integers
     else:
-        REGRESS_THRESHOLD = 0.1
+        regression_threshold = REGRESS_THRESHOLD_SMALL_DATA
 
     unique_count = len(unique_values)
     if unique_count == 2:
@@ -594,7 +598,7 @@ def infer_problem_type(y: Series, silent=False) -> str:
         reason = f"dtype of label-column == {y.dtype.name}"
     elif np.issubdtype(y.dtype, np.floating):
         unique_ratio = unique_count / float(num_rows)
-        if (unique_ratio <= REGRESS_THRESHOLD) and (unique_count <= MULTICLASS_LIMIT):
+        if (unique_ratio <= regression_threshold) and (unique_count <= MULTICLASS_UPPER_LIMIT):
             try:
                 can_convert_to_int = np.array_equal(y, y.astype(int))
                 if can_convert_to_int:
@@ -611,7 +615,7 @@ def infer_problem_type(y: Series, silent=False) -> str:
             reason = "dtype of label-column == float and many unique label-values observed"
     elif np.issubdtype(y.dtype, np.integer):
         unique_ratio = unique_count / float(num_rows)
-        if (unique_ratio <= REGRESS_THRESHOLD) and (unique_count <= MULTICLASS_LIMIT):
+        if (unique_ratio <= regression_threshold) and (unique_count <= MULTICLASS_UPPER_LIMIT):
             problem_type = MULTICLASS  # TODO: Check if integers are from 0 to n-1 for n unique values, if they have a wide spread, it could still be regression
             reason = "dtype of label-column == int, but few unique label-values observed"
         else:

--- a/core/tests/unittests/utils/test_utils.py
+++ b/core/tests/unittests/utils/test_utils.py
@@ -1,0 +1,80 @@
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from autogluon.core.utils import infer_problem_type
+from autogluon.core.constants import BINARY, MULTICLASS, MULTICLASS_UPPER_LIMIT, REGRESSION
+
+
+class TestInferProblemType(unittest.TestCase):
+
+    def test_infer_problem_type_empty(self):
+        with self.assertRaises(ValueError):
+            infer_problem_type(pd.Series([], dtype="float"))
+
+    def test_infer_problem_type_nan(self):
+        with self.assertRaises(ValueError):
+            infer_problem_type(pd.Series([np.nan]))
+
+    def test_infer_problem_type_inf(self):
+        with self.assertRaises(ValueError):
+            infer_problem_type(pd.Series([np.inf]))
+
+    def test_infer_problem_type_ninf(self):
+        with self.assertRaises(ValueError):
+            infer_problem_type(pd.Series([np.NINF]))
+
+    def test_infer_problem_type_binary(self):
+        inferred_problem_type = infer_problem_type(pd.Series([-1, -1, 99, -1, -1, 99]))
+        assert inferred_problem_type == BINARY
+
+    def test_infer_problem_type_binary_with_nan(self):
+        inferred_problem_type = infer_problem_type(pd.Series([-1, -1, 99, -1, -1, 99, np.nan]))
+        assert inferred_problem_type == BINARY
+
+    def test_infer_problem_type_str(self):
+        inferred_problem_type = infer_problem_type(pd.Series(["a", "b", "c"], dtype=str))
+        assert inferred_problem_type == MULTICLASS
+
+    def test_infer_problem_type_category(self):
+        inferred_problem_type = infer_problem_type(pd.Series(["a", "b", "c"], dtype='category'))
+        assert inferred_problem_type == MULTICLASS
+
+    def test_infer_problem_type_object(self):
+        inferred_problem_type = infer_problem_type(pd.Series(["a", "b", "c"], dtype='object'))
+        assert inferred_problem_type == MULTICLASS
+
+    def test_infer_problem_type_multiclass_with_nan(self):
+        inferred_problem_type = infer_problem_type(pd.Series(["a", "b", "c", np.nan]))
+        assert inferred_problem_type == MULTICLASS
+
+    def test_infer_problem_type_big_float_data_regression(self):
+        big_float_regression_series = pd.Series(np.repeat(np.linspace(0.0, 1.0, MULTICLASS_UPPER_LIMIT+1), 2))
+        inferred_problem_type = infer_problem_type(big_float_regression_series)
+        assert inferred_problem_type == REGRESSION
+
+    def test_infer_problem_type_small_float_data_multiclass(self):
+        big_float_multiclass_series = pd.Series(np.repeat([1.0, 2.0, 3.0], MULTICLASS_UPPER_LIMIT-1))
+        inferred_problem_type = infer_problem_type(big_float_multiclass_series)
+        assert inferred_problem_type == MULTICLASS
+
+    def test_infer_problem_type_small_float_data_regression(self):
+        small_float_regression_series = pd.Series(np.linspace(0.0, 1.0, MULTICLASS_UPPER_LIMIT-1))
+        inferred_problem_type = infer_problem_type(small_float_regression_series)
+        assert inferred_problem_type == REGRESSION
+
+    def test_infer_problem_type_big_integer_data_regression(self):
+        big_integer_regression_series = pd.Series(np.repeat(np.arange(MULTICLASS_UPPER_LIMIT+1), 2), dtype=np.int64)
+        inferred_problem_type = infer_problem_type(big_integer_regression_series)
+        assert inferred_problem_type == REGRESSION
+
+    def test_infer_problem_type_small_integer_data_multiclass(self):
+        small_integer_multiclass_series = pd.Series(np.repeat(np.arange(3), MULTICLASS_UPPER_LIMIT-1), dtype=np.int64)
+        inferred_problem_type = infer_problem_type(small_integer_multiclass_series)
+        assert inferred_problem_type == MULTICLASS
+
+    def test_infer_problem_type_small_integer_data_regression(self):
+        small_integer_regression_series = pd.Series(np.arange(MULTICLASS_UPPER_LIMIT-1), dtype=np.int64)
+        inferred_problem_type = infer_problem_type(small_integer_regression_series)
+        assert inferred_problem_type == REGRESSION

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -974,3 +974,34 @@ def test_tabular_bagstack_use_bag_holdout():
     ###################################################################
     run_tabular_benchmarks(fast_benchmark=fast_benchmark, subsample_size=subsample_size, perf_threshold=perf_threshold,
                            seed_val=seed_val, fit_args=fit_args, run_distill=True, crash_in_oof=True)
+
+
+def test_tabular_raise_on_nonfinite_float_labels():
+    predictor = TabularPredictor(label='y')
+    nonfinite_values = [np.nan, np.inf, np.NINF]
+
+    for idx, nonfinite_value in enumerate(nonfinite_values):
+        train_data = TabularDataset({
+            'x': [0.0, 1.0, 2.0, 3.0, 4.0],
+            'y': [0.0, 1.0, 2.0, 3.0, 4.0]
+            })
+        train_data.loc[idx, 'y'] = nonfinite_value
+
+        with pytest.raises(ValueError) as ex_info:
+            predictor.fit(train_data)
+        assert str(ex_info.value).split()[-1] == str(idx)
+
+def test_tabular_raise_on_nonfinite_class_labels():
+    predictor = TabularPredictor(label='y')
+    nonfinite_values = [np.nan, np.inf, np.NINF]
+
+    for idx, nonfinite_value in enumerate(nonfinite_values):
+        train_data = TabularDataset({
+            'x': [0.0, 1.0, 2.0, 3.0, 4.0],
+            'y': ["a", "b", "c", "d", "e"]
+            })
+        train_data.loc[idx, 'y'] = nonfinite_value
+
+        with pytest.raises(ValueError) as ex_info:
+            predictor.fit(train_data)
+        assert str(ex_info.value).split()[-1] == str(idx)


### PR DESCRIPTION
*Issue #, if available:* [2443](https://github.com/autogluon/autogluon/issues/2443)

*Description of changes:*
After discussion with a customer, we decided that AutoGluon should crash if any un-representable value (`NaN`, `Inf`, `NINF`) is present in the label column, because prediction behavior is not well specified for these rows. Infinite values don't make sense for regression problems but could be treated as additional classes or ignored for classification problems. `NaN` values could be ignored for regression problems but could be treated as a separate class or ignored in regression problems. 

This set of commit changes the behavior of AutoGluon to always raise an Error if these values are present in the label column of `train_data` or `tune_data` so that the user has to explicitly handle these values ahead of time. *This could cause AutoGluon runs that executed successful before this change to fail*.

Previously Behavior:
- If a `NaN` value was passed in the label column of `train_data`, the record was dropped and a warning was logged.
- If an infinite value was passed in a label column of `train_data`, it would get passed on to predictors in the ensemble. Some handled it, some failed.
- If `NaN` values or infinite values were in the label column of the tuning_data, the data would get passed on as-is to predictors in the ensemble.

New Behavior:
- If a `NaN`, `Inf`, or `NINF` value is present in the label column for `train_data` or `tune_data`,  a `ValueError` is raised stating "Label column cannot contain non-finite values (NaN, Inf, Ninf)".

I also added unit testing for the "infer_probem_type" utility function and moved constants to a separate file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
