### PR TITLE
Fix image properties in df preprocessor

### DIFF
--- a/multimodal/src/autogluon/multimodal/data/preprocess_dataframe.py
+++ b/multimodal/src/autogluon/multimodal/data/preprocess_dataframe.py
@@ -146,21 +146,11 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
 
     @property
     def image_bytearray_names(self):
-        if hasattr(self, "_image_bytearray_names"):
-            return self._image_bytearray_names
-        else:
-            return [
-                col_name for col_name in self._image_feature_names if self._column_types[col_name] == IMAGE_BYTEARRAY
-            ]
+        return [col_name for col_name in self._image_feature_names if self._column_types[col_name] == IMAGE_BYTEARRAY]
 
     @property
     def image_feature_names(self):
-        if hasattr(self, "_image_path_names"):
-            return self._image_path_names
-        elif hasattr(self, "_image_bytearray_names"):
-            return self._image_bytearray_names
-        else:
-            return self._image_feature_names
+        return self._image_path_names if hasattr(self, "_image_path_names") else self._image_feature_names
 
     @property
     def text_feature_names(self):
@@ -176,12 +166,9 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
 
     @property
     def required_feature_names(self):
-        if hasattr(self, "_image_path_names"):
-            image_feature_names = self._image_path_names
-        elif hasattr(self, "_image_bytearray_names"):
-            image_feature_names = self._image_bytearray_names
-        else:
-            image_feature_names = self._image_feature_names
+        image_feature_names = (
+            self._image_path_names if hasattr(self, "_image_path_names") else self._image_feature_names
+        )
 
         return (
             image_feature_names
@@ -231,8 +218,6 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
         if modality.startswith(IMAGE) or modality == ROIS:
             if hasattr(self, "_image_path_names"):
                 return self._image_path_names
-            elif hasattr(self, "_image_bytearray_names"):
-                return self._image_bytearray_names
             else:
                 return self._image_feature_names
         elif modality.startswith(TEXT):


### PR DESCRIPTION
*Issue #, if available:*
`_image_bytearray_names` attribute doesn't exist in df preprocessor. So, `hasattr(self, "_image_bytearray_names")` is always False.  `hasattr(self, "_image_path_names")` is for backward compatibility since we used `_image_path_names` in the initial AutoMM versions. The image_bytearray is new and doesn't have backward compatible issues.

*Description of changes:*
Removed the `hasattr(self, "_image_bytearray_names")` checks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
