### PR TITLE
[CI] fix typo in object detection tutorial CI

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -325,7 +325,7 @@ jobs:
   build_multimodal_tutorial:
     strategy:
       matrix:
-        SUB_DOC: ["advanced_topics", "image_prediction", "matching", "object_detectionm", "text_prediction", "multimodal_prediction"]
+        SUB_DOC: ["advanced_topics", "image_prediction", "matching", "object_detection", "text_prediction", "multimodal_prediction"]
     needs: [test_common, test_core, test_features, test_tabular, test_eda, test_fair, test_text, test_multimodal_predictor, test_multimodal_others, test_vision, test_timeseries, test_install]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
*Issue #, if available:*

Object Detection Tutorial 403 at [here](http://autogluon-staging.s3-website-us-west-2.amazonaws.com/split_multimodal_tutorial/276767d/tutorials/multimodal/object_detection/quick_start/quick_start_coco.html)

*Description of changes:*
 Fixed the typo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
