### PR TITLE
[timeseries] Pass known_covariates to component models of the WeightedEnsemble

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
@@ -86,7 +86,6 @@ class AutoGluonTabularModel(AbstractTimeSeriesModel):
 
         self.tabular_predictor = TabularPredictor(
             label=self.target,
-            path=self.path,
             problem_type=ag.constants.REGRESSION,
             eval_metric=self.TIMESERIES_METRIC_TO_TABULAR_METRIC.get(self.eval_metric),
         )

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
@@ -86,6 +86,7 @@ class AutoGluonTabularModel(AbstractTimeSeriesModel):
 
         self.tabular_predictor = TabularPredictor(
             label=self.target,
+            path=self.path,
             problem_type=ag.constants.REGRESSION,
             eval_metric=self.TIMESERIES_METRIC_TO_TABULAR_METRIC.get(self.eval_metric),
         )

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -180,14 +180,16 @@ class SimpleAbstractTrainer:
 
     # TODO: This is horribly inefficient beyond simple weighted ensembling.
     #  Refactor to Tabular's implementation if doing stacking / multiple ensembles
-    def get_inputs_to_model(self, model, X, model_pred_proba_dict=None):
+    def get_inputs_to_model(
+        self, model, X, model_pred_proba_dict=None, known_covariates: Optional[TimeSeriesDataFrame] = None
+    ):
         if model_pred_proba_dict is None:
             model_pred_proba_dict = {}
         model_set = self.get_minimum_model_set(model, include_self=False)
         if model_set:
             for m in model_set:
                 if m not in model_pred_proba_dict:
-                    model_pred_proba_dict[m] = self.predict(model=m, data=X)
+                    model_pred_proba_dict[m] = self.predict(model=m, data=X, known_covariates=known_covariates)
             return model_pred_proba_dict
         else:
             return X
@@ -823,6 +825,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
             return self._predict_model(data, model, known_covariates=known_covariates, **kwargs)
         except Exception as err:
             logger.error(f"Warning: Model {model.name} failed during prediction with exception: {err}")
+            logger.debug(traceback.format_exc())
             other_models = [m for m in self.get_model_names() if m != model.name]
             if len(other_models) > 0 and model_was_selected_automatically:
                 logger.info(f"\tYou can call predict(data, model) with one of other available models: {other_models}")
@@ -869,7 +872,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
     ) -> TimeSeriesDataFrame:
         if isinstance(model, str):
             model = self.load_model(model)
-        data = self.get_inputs_to_model(model=model, X=data)
+        data = self.get_inputs_to_model(model=model, X=data, known_covariates=known_covariates)
         return model.predict(data, known_covariates=known_covariates, **kwargs)
 
     # TODO: experimental

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -825,7 +825,6 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
             return self._predict_model(data, model, known_covariates=known_covariates, **kwargs)
         except Exception as err:
             logger.error(f"Warning: Model {model.name} failed during prediction with exception: {err}")
-            logger.debug(traceback.format_exc())
             other_models = [m for m in self.get_model_names() if m != model.name]
             if len(other_models) > 0 and model_was_selected_automatically:
                 logger.info(f"\tYou can call predict(data, model) with one of other available models: {other_models}")

--- a/timeseries/src/autogluon/timeseries/utils/features.py
+++ b/timeseries/src/autogluon/timeseries/utils/features.py
@@ -19,7 +19,7 @@ class ContinuousAndCategoricalFeatureGenerator(PipelineFeatureGenerator):
 
     def __init__(self, feature_metadata: Optional[FeatureMetadata] = None, verbosity: int = 0, **kwargs):
         generators = [
-            CategoryFeatureGenerator(minimum_cat_count=1),
+            CategoryFeatureGenerator(minimum_cat_count=1, fillna="mode"),
             IdentityFeatureGenerator(infer_features_in_args={"valid_raw_types": [R_INT, R_FLOAT]}),
         ]
         super().__init__(

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -16,7 +16,7 @@ from autogluon.timeseries.models import DeepARModel, ETSModel
 from autogluon.timeseries.models.ensemble.greedy_ensemble import TimeSeriesEnsembleWrapper
 from autogluon.timeseries.trainer.auto_trainer import AutoTimeSeriesTrainer
 
-from .common import DUMMY_TS_DATAFRAME, get_data_frame_with_item_index, DATAFRAME_WITH_COVARIATES
+from .common import DATAFRAME_WITH_COVARIATES, DUMMY_TS_DATAFRAME, get_data_frame_with_item_index
 
 DUMMY_TRAINER_HYPERPARAMETERS = {"SimpleFeedForward": {"epochs": 1}}
 TEST_HYPERPARAMETER_SETTINGS = [

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -16,7 +16,7 @@ from autogluon.timeseries.models import DeepARModel, ETSModel
 from autogluon.timeseries.models.ensemble.greedy_ensemble import TimeSeriesEnsembleWrapper
 from autogluon.timeseries.trainer.auto_trainer import AutoTimeSeriesTrainer
 
-from .common import DUMMY_TS_DATAFRAME, get_data_frame_with_item_index
+from .common import DUMMY_TS_DATAFRAME, get_data_frame_with_item_index, DATAFRAME_WITH_COVARIATES
 
 DUMMY_TRAINER_HYPERPARAMETERS = {"SimpleFeedForward": {"epochs": 1}}
 TEST_HYPERPARAMETER_SETTINGS = [
@@ -419,3 +419,26 @@ def test_given_base_model_fails_when_trainer_scores_then_weighted_ensemble_can_s
         score = trainer.score(DUMMY_TS_DATAFRAME, model="WeightedEnsemble")
         fail_predict.assert_called()
         assert isinstance(score, float)
+
+
+def test_when_known_covariates_present_then_all_ensemble_base_models_can_predict(temp_model_path):
+    df = DATAFRAME_WITH_COVARIATES.copy()
+    prediction_length = 2
+    df_train = df.slice_by_timestep(None, -prediction_length)
+    df_future = df.slice_by_timestep(-prediction_length, None)
+    known_covariates = df_future.drop("target", axis=1)
+
+    trainer = AutoTimeSeriesTrainer(path=temp_model_path, prediction_length=prediction_length, enable_ensemble=False)
+    trainer.fit(df_train, hyperparameters={"ETS": {"maxiter": 1}, "DeepAR": {"epochs": 1, "num_batches_per_epoch": 1}})
+
+    # Manually add ensemble to ensure that both models have non-zero weight
+    ensemble = TimeSeriesEnsembleWrapper(weights={"DeepAR": 0.5, "ETS": 0.5}, name="WeightedEnsemble")
+    trainer._add_model(model=ensemble, base_models=["DeepAR", "ETS"])
+    with mock.patch(
+        "autogluon.timeseries.models.ensemble.greedy_ensemble.TimeSeriesEnsembleWrapper.predict"
+    ) as mock_predict:
+        trainer.predict(df_train, model="WeightedEnsemble", known_covariates=known_covariates)
+        inputs = mock_predict.call_args[0][0]
+        # No models failed during prediction
+        assert inputs["DeepAR"] is not None
+        assert inputs["ETS"] is not None


### PR DESCRIPTION
*Description of changes:*
- Fix a bug where prediction with `WeightedEnsemble` fails if component models use `known_covariates` + add a test case for this
- Make sure that static feature preprocessing doesn't introduce NaNs to the `static_features` dataframe

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
