### PR TITLE
[timeseries] Ensure that timestamps are sorted when creating a TimeSeriesDataFrame

### DIFF
--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -102,8 +102,10 @@ class TimeSeriesDataFrame(pd.DataFrame):
                 self._validate_multi_index_data_frame(data)
             else:
                 data = self._construct_pandas_frame_from_data_frame(data)
+            data = self._sort_timestamps(data)
         elif isinstance(data, Iterable):
             data = self._construct_pandas_frame_from_iterable_dataset(data)
+            data = self._sort_timestamps(data)
         else:
             raise ValueError("Data input type not recognized, must be DataFrame or iterable.")
         super().__init__(data=data, *args, **kwargs)
@@ -133,6 +135,11 @@ class TimeSeriesDataFrame(pd.DataFrame):
     @property
     def static_features(self):
         return self._static_features
+
+    @staticmethod
+    def _sort_timestamps(data: pd.DataFrame) -> pd.DataFrame:
+        item_ids = data.index.unique(level=ITEMID)
+        return data.sort_values(by=TIMESTAMP).loc[item_ids]
 
     @static_features.setter
     def static_features(self, value: Optional[pd.DataFrame]):

--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -102,10 +102,11 @@ class TimeSeriesDataFrame(pd.DataFrame):
                 self._validate_multi_index_data_frame(data)
             else:
                 data = self._construct_pandas_frame_from_data_frame(data)
-            data = self._sort_timestamps(data)
+            # Make sure that timestamps are sorted but item_id order is preserved
+            item_ids = data.index.unique(level=ITEMID)
+            data = data.sort_values(by=TIMESTAMP).loc[item_ids]
         elif isinstance(data, Iterable):
             data = self._construct_pandas_frame_from_iterable_dataset(data)
-            data = self._sort_timestamps(data)
         else:
             raise ValueError("Data input type not recognized, must be DataFrame or iterable.")
         super().__init__(data=data, *args, **kwargs)
@@ -135,11 +136,6 @@ class TimeSeriesDataFrame(pd.DataFrame):
     @property
     def static_features(self):
         return self._static_features
-
-    @staticmethod
-    def _sort_timestamps(data: pd.DataFrame) -> pd.DataFrame:
-        item_ids = data.index.unique(level=ITEMID)
-        return data.sort_values(by=TIMESTAMP).loc[item_ids]
 
     @static_features.setter
     def static_features(self, value: Optional[pd.DataFrame]):

--- a/timeseries/tests/unittests/models/test_sktime.py
+++ b/timeseries/tests/unittests/models/test_sktime.py
@@ -48,7 +48,7 @@ def test_when_sktime_converts_dataframe_then_data_not_duplicated_and_index_corre
     assert df.values.base is sktime_df.values.base
 
 
-def test_when_sktime_converts_from_dataframe_then_data_not_duplicated_and_index_correct():
+def test_when_sktime_converts_from_dataframe_then_index_correct():
     model = AutoETSSktimeModel()
 
     sktime_df = model._to_sktime_data_frame(DUMMY_TS_DATAFRAME.copy(deep=True))
@@ -63,9 +63,6 @@ def test_when_sktime_converts_from_dataframe_then_data_not_duplicated_and_index_
             df.index.get_level_values(-1),
         )
     )
-
-    # data is not copied
-    assert df.values.base is sktime_df.values.base
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -720,3 +720,29 @@ def test_when_static_features_are_modified_on_shallow_copy_then_original_df_does
     new_df = old_df.copy(deep=False)
     new_df.static_features = None
     assert old_df.static_features is not None
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        SAMPLE_DATAFRAME.sample(frac=1),
+        SAMPLE_TS_DATAFRAME.sample(frac=1),
+    ],
+)
+def test_when_raw_timestamps_are_not_sorted_then_ts_dataframe_has_sorted_timestamps(data):
+    tsdf = TimeSeriesDataFrame(data)
+    for item_id in tsdf.item_ids:
+        assert tsdf.loc[item_id].index.is_monotonic_increasing
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        SAMPLE_DATAFRAME.sample(frac=1),
+        SAMPLE_TS_DATAFRAME.sample(frac=1),
+    ],
+)
+def test_when_raw_timestamps_are_not_sorted_then_freq_inference_works(data):
+    tsdf = TimeSeriesDataFrame(data)
+    assert tsdf.freq is not None
+    assert tsdf.freq == SAMPLE_TS_DATAFRAME.freq


### PR DESCRIPTION
*Description of changes:*
- Ensures that the timestamps are always sorted chronologically inside a `TimeSeriesDataFrame`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
