### PR TITLE
[timeseries] Save AutoGluonTabular model to the correct folder

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
@@ -85,6 +85,7 @@ class AutoGluonTabularModel(AbstractTimeSeriesModel):
         self.residuals_std = 0.0
 
         self.tabular_predictor = TabularPredictor(
+            path=self.path,
             label=self.target,
             problem_type=ag.constants.REGRESSION,
             eval_metric=self.TIMESERIES_METRIC_TO_TABULAR_METRIC.get(self.eval_metric),


### PR DESCRIPTION
*Description of changes:*
- Save the `AutoGluonTabular` model to the correct model folder instead of the automatically generated folder in `AutogluonModels`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
