### PR TITLE
[Tabular] Avoid copying identical dataframes

### DIFF
--- a/features/src/autogluon/features/generators/abstract.py
+++ b/features/src/autogluon/features/generators/abstract.py
@@ -323,7 +323,10 @@ class AbstractFeatureGenerator:
         if self.column_names_as_str:
             X.columns = X.columns.astype(str)  # Ensure all column names are strings
         try:
-            X = X[self.features_in]
+            if list(X.columns) != self.features_in:
+                # It comes at a cost when making a copy of the DataFrame,
+                # therefore, try avoid copying by checking the expected features first.
+                X = X[self.features_in]
         except KeyError:
             missing_cols = []
             for col in self.features_in:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Avoid copying DataFrame when they are identical. This brings about 10% speedup of single-batch prediction on tabular models.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
