### PR TITLE
[Tabular] Resource Allocation Fix

### DIFF
--- a/core/src/autogluon/core/hpo/executors.py
+++ b/core/src/autogluon/core/hpo/executors.py
@@ -194,7 +194,6 @@ class HpoExecutor(ABC):
             if minimum_model_num_gpus > 0:
                 num_jobs_in_parallel_with_gpu = num_gpus // minimum_model_num_gpus
             num_jobs_in_parallel = min(num_jobs_in_parallel_with_mem, num_jobs_in_parallel_with_cpu, num_jobs_in_parallel_with_gpu)
-
             if model_base != initialized_model:
                 # bagged model
                 if num_jobs_in_parallel // k_fold < 1:

--- a/core/src/autogluon/core/hpo/executors.py
+++ b/core/src/autogluon/core/hpo/executors.py
@@ -208,9 +208,12 @@ class HpoExecutor(ABC):
                 gpu_per_trial = num_gpus // num_trials_in_parallel
             else:
                 num_trials = self.hyperparameter_tune_kwargs.get('num_trials', math.inf)
+                if self.executor_type == 'custom':
+                    # custom backend runs sequentially
+                    num_jobs_in_parallel = 1
                 cpu_per_trial = int(num_cpus // min(num_jobs_in_parallel, num_trials))
                 gpu_per_trial = num_gpus / min(num_jobs_in_parallel, num_trials)
-
+                
             self.hyperparameter_tune_kwargs['resources_per_trial'] = {
                 'num_cpus': cpu_per_trial,
                 'num_gpus': gpu_per_trial

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -508,7 +508,7 @@ class AbstractModel:
             # bagged model's default resources should be resources * k_fold if the amount is available
             default_num_cpus = min(default_num_cpus * k_fold, system_num_cpus)
             default_num_gpus = min(default_num_gpus * k_fold, system_num_gpus)
-            # initialize the model base to check if there's user specified resources requirements
+            # retrieve model level requirement when self is bagged model
             user_specified_model_level_num_cpus = self.model_base._user_params_aux.get('num_cpus', None)
             user_specified_model_level_num_gpus = self.model_base._user_params_aux.get('num_gpus', None)
             if user_specified_model_level_num_cpus is not None:

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -530,7 +530,7 @@ class AbstractModel:
             # bagged model will look ag_args_ensemble and ag_args_fit internally to determine resources
             # pass all resources here by default
             default_num_cpus = system_num_cpus
-            default_num_gpus = system_num_gpus
+            default_num_gpus = system_num_gpus if default_num_gpus > 0 else 0
             user_specified_lower_level_num_cpus = self._process_user_provided_resource_requirement_to_calculate_total_resource_when_ensemble(
                 system_resource=system_num_cpus,
                 user_specified_total_resource=num_cpus,

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -519,9 +519,10 @@ class AbstractModel:
             assert user_specified_lower_level_num_gpus <= system_num_cpus, f'Specified num_gpus per {self.__class__.__name__} is more than the total: {system_num_cpus}'
         k_fold = kwargs.get('k_fold', None)
         if k_fold is not None and k_fold > 0:
-            # bagged model's default resources should be resources * k_fold if the amount is available
-            default_num_cpus = min(default_num_cpus * k_fold, system_num_cpus)
-            default_num_gpus = min(default_num_gpus * k_fold, system_num_gpus)
+            # bagged model will look ag_args_ensemble and ag_args_fit internally to determine resources
+            # pass all resources here by default
+            default_num_cpus = system_num_cpus
+            default_num_gpus = system_num_gpus
             user_specified_lower_level_num_cpus = self._process_user_provided_resource_requirement_to_calculate_total_resource_when_ensemble(
                 system_resource=system_num_cpus,
                 user_specified_ensemble_resource=user_specified_lower_level_num_cpus,

--- a/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
+++ b/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
@@ -197,7 +197,6 @@ class LocalFoldFittingStrategy(AbstractFoldFittingStrategy):
             user_resources_per_job['num_gpus'] = user_gpu_per_job
         self.user_ensemble_resources = user_ensemble_resources
         self.user_resources_per_job = user_resources_per_job
-        print(user_ensemble_resources, user_resources_per_job)
 
     def _get_fold_time_limit(self, fold_ctx):
         _, folds_finished, folds_left, folds_to_fit, _, _ = self._get_fold_properties(fold_ctx)

--- a/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
+++ b/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
@@ -137,8 +137,18 @@ class LocalFoldFittingStrategy(AbstractFoldFittingStrategy):
         self.time_limit_fold_ratio = time_limit_fold_ratio
         self.num_cpus = num_cpus
         self.num_gpus = num_gpus
-        logger.debug(f'Bagging total_num_cpus, num_gpus {self.num_cpus} | {self.num_gpus}')
+        logger.debug(f'Upper level total_num_cpus, num_gpus {self.num_cpus} | {self.num_gpus}')
+        self._validate_user_specified_resources()
+
+    def schedule_fold_model_fit(self, fold_ctx):
+        raise NotImplementedError
+
+    def after_all_folds_scheduled(self):
+        raise NotImplementedError
+    
+    def _validate_user_specified_resources(self):
         # User specified value through ag_args_fit means they want this individual model to use this amount of resources
+        user_ensemble_resources = None
         user_resources_per_job = None
         # initialize the model base to get necessary info for estimating memory usage and getting resources
         self._initialized_model_base = copy.deepcopy(self.model_base)
@@ -152,6 +162,25 @@ class LocalFoldFittingStrategy(AbstractFoldFittingStrategy):
         minimum_model_num_gpus = minimum_model_resources.get('num_gpus', 0)
         logger.debug(f'minimum_model_resources: {minimum_model_resources}')
         logger.debug(f'user_cpu_per_job, user_gpu_per_job {user_cpu_per_job} | {user_gpu_per_job}')
+        user_ensemble_cpu = self.bagged_ensemble_model._user_params_aux.get('num_cpus', None)
+        user_ensemble_gpu = self.bagged_ensemble_model._user_params_aux.get('num_gpus', None)
+        logger.debug(f'user_ensemble_cpu, user_ensemble_gpu {user_ensemble_cpu} | {user_ensemble_gpu}')
+        if user_ensemble_cpu is not None or user_ensemble_gpu is not None:
+            user_ensemble_resources = dict()
+        if user_ensemble_cpu is not None:
+            assert user_ensemble_cpu <= self.num_cpus, \
+                f"Detected ensemble cpu requirement = {user_ensemble_cpu} > total cpu granted = {self.num_cpus}"
+            assert user_ensemble_cpu >= minimum_model_num_cpus, \
+                f"Detected ensenble cpu requirement = {user_ensemble_cpu} < minimum cpu required by the model = {minimum_model_num_cpus}"
+            user_ensemble_resources['num_cpus'] = user_ensemble_cpu
+            self.num_cpus = user_ensemble_cpu
+        if user_ensemble_gpu is not None:
+            assert user_ensemble_gpu <= self.num_gpus, \
+                f"Detected ensemble gpu requirement = {user_ensemble_gpu} > total gpu granted = {self.num_gpus}"
+            assert user_ensemble_gpu >= minimum_model_num_gpus, \
+                f"Detected ensenble gpu requirement = {user_ensemble_cpu} < minimum gpu required by the model = {minimum_model_num_gpus}"
+            user_ensemble_resources['num_gpus'] = user_ensemble_gpu
+            self.num_gpus = user_ensemble_gpu
         if user_cpu_per_job is not None or user_gpu_per_job is not None:
             user_resources_per_job = dict()
         if user_cpu_per_job is not None:
@@ -166,13 +195,9 @@ class LocalFoldFittingStrategy(AbstractFoldFittingStrategy):
             assert user_gpu_per_job >= minimum_model_num_gpus, \
                 f"Detected model level gpu requirement = {user_gpu_per_job} < minimum gpu required by the model = {minimum_model_num_gpus}"
             user_resources_per_job['num_gpus'] = user_gpu_per_job
+        self.user_ensemble_resources = user_ensemble_resources
         self.user_resources_per_job = user_resources_per_job
-
-    def schedule_fold_model_fit(self, fold_ctx):
-        raise NotImplementedError
-
-    def after_all_folds_scheduled(self):
-        raise NotImplementedError
+        print(user_ensemble_resources, user_resources_per_job)
 
     def _get_fold_time_limit(self, fold_ctx):
         _, folds_finished, folds_left, folds_to_fit, _, _ = self._get_fold_properties(fold_ctx)
@@ -243,6 +268,20 @@ class SequentialLocalFoldFittingStrategy(LocalFoldFittingStrategy):
     """
     This strategy fits the folds locally in a sequence.
     """
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        if self.user_ensemble_resources is None:
+            if self.user_resources_per_job is None:
+                self.num_cpus, self.num_gpus = self.model_base._get_default_resources()
+            else:
+                self.num_cpus = self.user_resources_per_job.get('num_cpus', self.num_cpus)
+                self.num_gpus = self.user_resources_per_job.get('num_gpus', self.num_gpus)
+        else:
+            if self.user_resources_per_job is not None:
+                self.num_cpus = self.user_resources_per_job.get('num_cpus', self.num_cpus)
+                self.num_gpus = self.user_resources_per_job.get('num_gpus', self.num_gpus)
+        self.resources = {'num_cpus': self.num_cpus, 'num_gpus': self.num_gpus}
+        
     def schedule_fold_model_fit(self, fold_ctx):
         self.jobs.append(fold_ctx)
 

--- a/tabular/tests/conftest.py
+++ b/tabular/tests/conftest.py
@@ -286,3 +286,7 @@ def mock_num_cpus():
 @pytest.fixture
 def mock_num_gpus():
     return 2
+
+@pytest.fixture
+def k_fold():
+    return 2

--- a/tabular/tests/unittests/resource_allocation/test_resource_allocation_combined.py
+++ b/tabular/tests/unittests/resource_allocation/test_resource_allocation_combined.py
@@ -184,16 +184,57 @@ tests_dict = {
                 }
             }
         ),
-        'total_resources_with_valid_ag_args_fit': (
+        'valid_ag_args_ensemble_and_ag_args_fit': (
             {
-                'total_resources': {'num_cpus': 16, 'num_gpus': 4},
-                'ag_args_fit': {'num_cpus': 8, 'num_gpus': 2},
+                'ag_args_ensemble': {'num_cpus': 8, 'num_gpus': 2},
+                'ag_args_fit': {'num_cpus': 4, 'num_gpus': 1},
+                'expected_answer': {
+                    'resources_per_model': {'num_cpus': 4, 'num_gpus': 1}
+                }
+            }
+        ),
+        'valid_ag_args_ensemble': (
+            {
+                'ag_args_ensemble': {'num_cpus': 8, 'num_gpus': 2},  # should be ignored
+                'model_default_resources': {'num_cpus': 2, 'num_gpus': 1},
+                'expected_answer': {
+                    'resources_per_model': {'num_cpus': 2, 'num_gpus': 1}
+                }
+            }
+        ),
+        'total_resources_with_valid_ag_args_ensemble_and_ag_args_fit': (
+            {
+                'system_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'total_resources': {'num_cpus': 8, 'num_gpus': 2},
+                'ag_args_ensemble': {'num_cpus': 4, 'num_gpus': 1},
+                'ag_args_fit': {'num_cpus': 2, 'num_gpus': 0.5},
+                'expected_answer': {
+                    'resources_per_model': {'num_cpus': 2, 'num_gpus': 0.5}
+                }
+            }
+        ),
+        'total_resources_with_valid_ag_args_ensemble': (
+            {
+                'system_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'total_resources': {'num_cpus': 8, 'num_gpus': 2},
+                'ag_args_ensemble': {'num_cpus': 4, 'num_gpus': 1},  # should be ignored
+                'model_default_resources': {'num_cpus': 2, 'num_gpus': 1},
                 'expected_answer': {
                     'resources_per_model': {'num_cpus': 8, 'num_gpus': 2}
                 }
             }
         ),
-        'total_resources_without_ag_args_fit': (
+        'total_resources_with_valid_ag_args_fit': (
+            {
+                'system_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'total_resources': {'num_cpus': 8, 'num_gpus': 2},
+                'ag_args_fit': {'num_cpus': 4, 'num_gpus': 1},
+                'expected_answer': {
+                    'resources_per_model': {'num_cpus': 4, 'num_gpus': 1}
+                }
+            }
+        ),
+        'total_resources': (
             {
                 'system_resources': {'num_cpus': 16, 'num_gpus': 4},
                 'total_resources': {'num_cpus': 8, 'num_gpus': 2},
@@ -210,7 +251,7 @@ tests_dict = {
                 }
             }
         ),
-        'total_resources_with_valid_ag_args_ensemble_and_valid_ag_args_fit': (
+        'bagging_with_total_resources_and_valid_ag_args_ensemble_and_valid_ag_args_fit': (
             {
                 'system_resources': {'num_cpus': 16, 'num_gpus': 4},
                 'total_resources': {'num_cpus': 8, 'num_gpus': 2},
@@ -223,7 +264,7 @@ tests_dict = {
                 }
             }
         ),
-        'valid_ag_args_ensemble_and_valid_ag_args_fit': (
+        'bagging_with_valid_ag_args_ensemble_and_valid_ag_args_fit': (
             {
                 'system_resources': {'num_cpus': 16, 'num_gpus': 4},
                 'ag_args_fit': {'num_cpus': 2, 'num_gpus': 1},
@@ -235,7 +276,7 @@ tests_dict = {
                 }
             }
         ),
-        'valid_ag_args_ensemble_without_ag_args_fit': (
+        'bagging_with_valid_ag_args_ensemble': (
             {
                 'system_resources': {'num_cpus': 16, 'num_gpus': 4},
                 'ag_args_ensemble': {'num_cpus': 8, 'num_gpus': 4},
@@ -247,7 +288,7 @@ tests_dict = {
                 }
             }
         ),
-        'valid_ag_args_fit_without_ag_args_ensemble': (
+        'bagging_with_valid_ag_args_fit': (
             {
                 'system_resources': {'num_cpus': 16, 'num_gpus': 4},
                 'ag_args_fit': {'num_cpus': 2, 'num_gpus': 1},
@@ -270,7 +311,7 @@ tests_dict = {
                 }
             }
         ),
-        'total_resources_with_valid_ag_args_ensemble_and_valid_ag_args_fit_sequential': (
+        'sequential_bagging_with_total_resources_and_valid_ag_args_ensemble_and_valid_ag_args_fit': (
             {
                 'system_resources': {'num_cpus': 16, 'num_gpus': 4},
                 'total_resources': {'num_cpus': 8, 'num_gpus': 2},
@@ -283,7 +324,7 @@ tests_dict = {
                 }
             }
         ),
-        'valid_ag_args_ensemble_with_ag_args_fit_sequential': (
+        'sequential_bagging_with_valid_ag_args_ensemble_and_ag_args_fit': (
             {
                 'system_resources': {'num_cpus': 16, 'num_gpus': 4},
                 'ag_args_ensemble': {'num_cpus': 8, 'num_gpus': 2},
@@ -295,7 +336,7 @@ tests_dict = {
                 }
             }
         ),
-        'valid_ag_args_ensemble_without_ag_args_fit_sequential': (
+        'sequential_bagging_with_valid_ag_args_ensemble': (
             {
                 'system_resources': {'num_cpus': 16, 'num_gpus': 4},
                 'ag_args_ensemble': {'num_cpus': 2, 'num_gpus': 1},
@@ -306,7 +347,7 @@ tests_dict = {
                 }
             }
         ),
-        'valid_ag_args_fit_with_ag_args_ensemble_sequential': (
+        'sequential_bagging_with_valid_ag_args_fit_and_ag_args_ensemble': (
             {
                 'system_resources': {'num_cpus': 16, 'num_gpus': 4},
                 'ag_args_fit': {'num_cpus': 2, 'num_gpus': 1},

--- a/tabular/tests/unittests/resource_allocation/test_resource_allocation_combined.py
+++ b/tabular/tests/unittests/resource_allocation/test_resource_allocation_combined.py
@@ -320,6 +320,18 @@ tests_dict = {
         'bagging_without_anything': (
             {
                 'system_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'model_minimum_resources': {'num_cpus': 2, 'num_gpus': 0},
+                'model_default_resources': {'num_cpus': 1, 'num_gpus': 0},
+                'num_bag_folds': 8,
+                'expected_answer': {
+                    'resources_per_model': {'num_cpus': 2, 'num_gpus': 0},
+                    'model_in_parallel': 8
+                }
+            }
+        ),
+        'bagging_without_anything_with_gpu': (
+            {
+                'system_resources': {'num_cpus': 16, 'num_gpus': 4},
                 'model_minimum_resources': {'num_cpus': 2, 'num_gpus': 0.5},
                 'model_default_resources': {'num_cpus': 2, 'num_gpus': 1},
                 'num_bag_folds': 8,
@@ -446,6 +458,16 @@ tests_dict = {
         'hpo_without_anything': (
             {
                 'system_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'model_default_resources': {'num_cpus': 2, 'num_gpus': 0},
+                'num_trials': 2,
+                'expected_answer': {
+                    'resources_per_trial': {'num_cpus': 8, 'num_gpus': 0}
+                }
+            }
+        ),
+        'hpo_without_anything_with_gpu': (
+            {
+                'system_resources': {'num_cpus': 16, 'num_gpus': 4},
                 'model_default_resources': {'num_cpus': 2, 'num_gpus': 1},
                 'num_trials': 2,
                 'expected_answer': {
@@ -515,6 +537,17 @@ tests_dict = {
             }
         ),
         'custom_hpo_without_anything': (
+            {
+                'system_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'model_default_resources': {'num_cpus': 1, 'num_gpus': 0},
+                'num_trials': 2,
+                'executor_cls': CustomHpoExecutor,
+                'expected_answer': {
+                    'resources_per_trial': {'num_cpus': 1, 'num_gpus': 0}
+                }
+            }
+        ),
+        'custom_hpo_without_anything_with_gpu': (
             {
                 'system_resources': {'num_cpus': 16, 'num_gpus': 4},
                 'model_default_resources': {'num_cpus': 1, 'num_gpus': 1},
@@ -630,6 +663,20 @@ tests_dict = {
             }
         ),
         'hpo_and_bagging_without_anything': (
+            {
+                'system_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'model_default_resources': {'num_cpus': 1, 'num_gpus': 0},
+                'model_minimum_resources': {'num_cpus': 2, 'num_gpus': 0},
+                'num_trials': 2,
+                'num_bag_folds': 4,
+                'expected_answer': {
+                    'resources_per_trial': {'num_cpus': 8, 'num_gpus': 0},
+                    'resources_per_model': {'num_cpus': 2, 'num_gpus': 0},
+                    'model_in_parallel': 4  # This is models running in parallel in a bagged model
+                }
+            }
+        ),
+        'hpo_and_bagging_without_anything_with_gpu': (
             {
                 'system_resources': {'num_cpus': 16, 'num_gpus': 4},
                 'model_default_resources': {'num_cpus': 1, 'num_gpus': 1},

--- a/tabular/tests/unittests/resource_allocation/test_resource_allocation_combined.py
+++ b/tabular/tests/unittests/resource_allocation/test_resource_allocation_combined.py
@@ -471,7 +471,6 @@ tests_dict = {
                 'system_resources': {'num_cpus': 16, 'num_gpus': 4},
                 'total_resources': {'num_cpus': 8, 'num_gpus': 2},
                 'model_minimum_resources': {'num_cpus': 2, 'num_gpus': 1},
-                'model_default_resources': {'num_cpus': 1, 'num_gpus': 0.5},
                 'num_trials': 2,
                 'num_bag_folds': 2,
                 'expected_answer': {
@@ -486,7 +485,6 @@ tests_dict = {
                 'system_resources': {'num_cpus': 16, 'num_gpus': 4},
                 'total_resources': {'num_cpus': 8, 'num_gpus': 2},
                 'model_minimum_resources': {'num_cpus': 2, 'num_gpus': 0.5},
-                'model_default_resources': {'num_cpus': 1, 'num_gpus': 0.5},
                 'ag_args_ensemble': {'num_cpus': 4, 'num_gpus': 1},
                 'ag_args_fit': {'num_cpus': 2, 'num_gpus': 0.5},
                 'num_trials': 2,
@@ -503,7 +501,6 @@ tests_dict = {
                 'system_resources': {'num_cpus': 16, 'num_gpus': 4},
                 'total_resources': {'num_cpus': 8, 'num_gpus': 2},
                 'model_minimum_resources': {'num_cpus': 1, 'num_gpus': 0.5},
-                'model_default_resources': {'num_cpus': 1, 'num_gpus': 0.5},
                 'ag_args_ensemble': {'num_cpus': 4, 'num_gpus': 1},
                 'num_trials': 2,
                 'num_bag_folds': 4,
@@ -519,7 +516,6 @@ tests_dict = {
                 'system_resources': {'num_cpus': 16, 'num_gpus': 4},
                 'total_resources': {'num_cpus': 8, 'num_gpus': 2},
                 'model_minimum_resources': {'num_cpus': 1, 'num_gpus': 0.5},
-                'model_default_resources': {'num_cpus': 1, 'num_gpus': 0.5},
                 'ag_args_fit': {'num_cpus': 2, 'num_gpus': 0.5},
                 'num_trials': 2,
                 'num_bag_folds': 4,
@@ -534,7 +530,6 @@ tests_dict = {
             {
                 'system_resources': {'num_cpus': 16, 'num_gpus': 4},
                 'model_minimum_resources': {'num_cpus': 2, 'num_gpus': 0.5},
-                'model_default_resources': {'num_cpus': 1, 'num_gpus': 0.5},
                 'ag_args_ensemble': {'num_cpus': 4, 'num_gpus': 1},
                 'ag_args_fit': {'num_cpus': 2, 'num_gpus': 0.5},
                 'num_trials': 2,
@@ -550,7 +545,6 @@ tests_dict = {
             {
                 'system_resources': {'num_cpus': 16, 'num_gpus': 4},
                 'model_minimum_resources': {'num_cpus': 2, 'num_gpus': 0.5},
-                'model_default_resources': {'num_cpus': 1, 'num_gpus': 0.5},
                 'ag_args_ensemble': {'num_cpus': 4, 'num_gpus': 1},
                 'ag_args_fit': {'num_cpus': 2, 'num_gpus': 0.5},
                 'num_trials': 2,
@@ -566,7 +560,6 @@ tests_dict = {
             {
                 'system_resources': {'num_cpus': 16, 'num_gpus': 4},
                 'model_minimum_resources': {'num_cpus': 2, 'num_gpus': 0.5},
-                'model_default_resources': {'num_cpus': 1, 'num_gpus': 0.5},
                 'ag_args_fit': {'num_cpus': 2, 'num_gpus': 0.5},
                 'num_trials': 2,
                 'num_bag_folds': 4,
@@ -581,13 +574,216 @@ tests_dict = {
             {
                 'system_resources': {'num_cpus': 16, 'num_gpus': 4},
                 'model_minimum_resources': {'num_cpus': 2, 'num_gpus': 1},
-                'model_default_resources': {'num_cpus': 1, 'num_gpus': 0.5},
                 'num_trials': 2,
                 'num_bag_folds': 4,
                 'expected_answer': {
                     'resources_per_trial': {'num_cpus': 16, 'num_gpus': 4},
                     'resources_per_model': {'num_cpus': 4, 'num_gpus': 1},
                     'model_in_parallel': 4  # This is models running in parallel in a bagged model
+                }
+            }
+        ),
+        'hpo_and_sequential_bagging_with_total_resources_and_ag_args_ensemble_and_ag_args_fit': (
+            {
+                'system_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'total_resources': {'num_cpus': 8, 'num_gpus': 2},
+                'model_minimum_resources': {'num_cpus': 2, 'num_gpus': 0.5},
+                'ag_args_ensemble': {'num_cpus': 4, 'num_gpus': 1},
+                'ag_args_fit': {'num_cpus': 2, 'num_gpus': 0.5},
+                'num_trials': 2,
+                'num_bag_folds': 4,
+                'fold_strategy_cls': SequentialLocalFoldFittingStrategy,
+                'expected_answer': {
+                    'resources_per_trial': {'num_cpus': 4, 'num_gpus': 1},
+                    'resources_per_model': {'num_cpus': 2, 'num_gpus': 0.5},
+                }
+            }
+        ),
+        'hpo_and_sequential_bagging_with_total_resources_and_ag_args_ensemble': (
+            {
+                'system_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'total_resources': {'num_cpus': 8, 'num_gpus': 2},
+                'model_minimum_resources': {'num_cpus': 2, 'num_gpus': 0.5},
+                'ag_args_ensemble': {'num_cpus': 4, 'num_gpus': 1},
+                'num_trials': 2,
+                'num_bag_folds': 4,
+                'fold_strategy_cls': SequentialLocalFoldFittingStrategy,
+                'expected_answer': {
+                    'resources_per_trial': {'num_cpus': 4, 'num_gpus': 1},
+                    'resources_per_model': {'num_cpus': 4, 'num_gpus': 1},
+                }
+            }
+        ),
+        'hpo_and_sequential_bagging_with_total_resources_and_ag_args_fit': (
+            {
+                'system_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'total_resources': {'num_cpus': 8, 'num_gpus': 2},
+                'model_minimum_resources': {'num_cpus': 2, 'num_gpus': 0.5},
+                'ag_args_fit': {'num_cpus': 4, 'num_gpus': 1},
+                'num_trials': 2,
+                'num_bag_folds': 4,
+                'fold_strategy_cls': SequentialLocalFoldFittingStrategy,
+                'expected_answer': {
+                    # TODO: This is incorrect but doesn't cause big enough issue...
+                    # hpo resource calculator needs to know which folding strategy will be used, which is only being inferred later...
+                    # we calculate parallel folding for now...
+                    'resources_per_trial': {'num_cpus': 8, 'num_gpus': 2},
+                    'resources_per_model': {'num_cpus': 4, 'num_gpus': 1},
+                }
+            }
+        ),
+        'hpo_and_sequential_bagging_with_total_resources': (
+            {
+                'system_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'total_resources': {'num_cpus': 8, 'num_gpus': 2},
+                'model_minimum_resources': {'num_cpus': 2, 'num_gpus': 0.5},
+                'model_default_resources': {'num_cpus': 2, 'num_gpus': 0.5},
+                'num_trials': 2,
+                'num_bag_folds': 4,
+                'fold_strategy_cls': SequentialLocalFoldFittingStrategy,
+                'expected_answer': {
+                    # TODO: This is incorrect but doesn't cause big enough issue...
+                    # hpo resource calculator needs to know which folding strategy will be used, which is only being inferred later...
+                    # we calculate parallel folding for now...
+                    'resources_per_trial': {'num_cpus': 8, 'num_gpus': 2},
+                    'resources_per_model': {'num_cpus': 2, 'num_gpus': 0.5},
+                }
+            }
+        ),
+        'custom_hpo_and_bagging_with_total_resources_and_ag_args_ensemble_and_ag_args_fit': (
+            {
+                'system_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'total_resources': {'num_cpus': 8, 'num_gpus': 2},
+                'model_minimum_resources': {'num_cpus': 2, 'num_gpus': 0.5},
+                'ag_args_ensemble': {'num_cpus': 4, 'num_gpus': 1},
+                'ag_args_fit': {'num_cpus': 2, 'num_gpus': 0.5},
+                'num_trials': 2,
+                'executor_cls': CustomHpoExecutor,
+                'num_bag_folds': 4,
+                'expected_answer': {
+                    'resources_per_trial': {'num_cpus': 4, 'num_gpus': 1},
+                    'resources_per_model': {'num_cpus': 2, 'num_gpus': 0.5},
+                    'model_in_parallel': 2
+                }
+            }
+        ),
+        'custom_hpo_and_bagging_with_total_resources_and_ag_args_ensemble': (
+            {
+                'system_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'total_resources': {'num_cpus': 8, 'num_gpus': 2},
+                'model_minimum_resources': {'num_cpus': 2, 'num_gpus': 0.5},
+                'ag_args_ensemble': {'num_cpus': 4, 'num_gpus': 1},
+                'num_trials': 2,
+                'executor_cls': CustomHpoExecutor,
+                'num_bag_folds': 4,
+                'expected_answer': {
+                    'resources_per_trial': {'num_cpus': 4, 'num_gpus': 1},
+                    'resources_per_model': {'num_cpus': 2, 'num_gpus': 0.5},
+                    'model_in_parallel': 2
+                }
+            }
+        ),
+        'custom_hpo_and_bagging_with_total_resources_and_ag_args_fit': (
+            {
+                'system_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'total_resources': {'num_cpus': 8, 'num_gpus': 2},
+                'model_minimum_resources': {'num_cpus': 2, 'num_gpus': 0.5},
+                'ag_args_fit': {'num_cpus': 4, 'num_gpus': 1},
+                'num_trials': 2,
+                'executor_cls': CustomHpoExecutor,
+                'num_bag_folds': 4,
+                'expected_answer': {
+                    'resources_per_trial': {'num_cpus': 8, 'num_gpus': 2},
+                    'resources_per_model': {'num_cpus': 4, 'num_gpus': 1},
+                    'model_in_parallel': 2
+                }
+            }
+        ),
+        'custom_hpo_and_bagging_with_total_resources': (
+            {
+                'system_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'total_resources': {'num_cpus': 8, 'num_gpus': 2},
+                'model_minimum_resources': {'num_cpus': 2, 'num_gpus': 0.5},
+                'num_trials': 2,
+                'executor_cls': CustomHpoExecutor,
+                'num_bag_folds': 4,
+                'expected_answer': {
+                    'resources_per_trial': {'num_cpus': 8, 'num_gpus': 2},
+                    'resources_per_model': {'num_cpus': 2, 'num_gpus': 0.5},
+                    'model_in_parallel': 4
+                }
+            }
+        ),
+        'custom_hpo_and_sequential_bagging_with_total_resources_and_ag_args_ensemble_and_ag_args_fit': (
+            {
+                'system_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'total_resources': {'num_cpus': 8, 'num_gpus': 2},
+                'model_minimum_resources': {'num_cpus': 2, 'num_gpus': 0.5},
+                'ag_args_ensemble': {'num_cpus': 4, 'num_gpus': 1},
+                'ag_args_fit': {'num_cpus': 2, 'num_gpus': 0.5},
+                'num_trials': 2,
+                'executor_cls': CustomHpoExecutor,
+                'num_bag_folds': 4,
+                'fold_strategy_cls': SequentialLocalFoldFittingStrategy,
+                'expected_answer': {
+                    'resources_per_trial': {'num_cpus': 4, 'num_gpus': 1},
+                    'resources_per_model': {'num_cpus': 2, 'num_gpus': 0.5},
+                }
+            }
+        ),
+        'custom_hpo_and_sequential_bagging_with_total_resources_and_ag_args_ensemble': (
+            {
+                'system_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'total_resources': {'num_cpus': 8, 'num_gpus': 2},
+                'model_minimum_resources': {'num_cpus': 2, 'num_gpus': 0.5},
+                'ag_args_ensemble': {'num_cpus': 4, 'num_gpus': 1},
+                'num_trials': 2,
+                'executor_cls': CustomHpoExecutor,
+                'num_bag_folds': 4,
+                'fold_strategy_cls': SequentialLocalFoldFittingStrategy,
+                'expected_answer': {
+                    'resources_per_trial': {'num_cpus': 4, 'num_gpus': 1},
+                    'resources_per_model': {'num_cpus': 4, 'num_gpus': 1},
+                }
+            }
+        ),
+        'custom_hpo_and_sequential_bagging_with_total_resources_and_ag_args_fit': (
+            {
+                'system_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'total_resources': {'num_cpus': 8, 'num_gpus': 2},
+                'model_minimum_resources': {'num_cpus': 2, 'num_gpus': 0.5},
+                'ag_args_fit': {'num_cpus': 4, 'num_gpus': 1},
+                'num_trials': 2,
+                'executor_cls': CustomHpoExecutor,
+                'num_bag_folds': 4,
+                'fold_strategy_cls': SequentialLocalFoldFittingStrategy,
+                'expected_answer': {
+                    # TODO: This is incorrect but doesn't cause big enough issue...
+                    # hpo resource calculator needs to know which folding strategy will be used to determine if need to consider num_folds
+                    # but folding strategy is only being decided later...
+                    # we calculate parallel folding for now...
+                    'resources_per_trial': {'num_cpus': 8, 'num_gpus': 2},
+                    'resources_per_model': {'num_cpus': 4, 'num_gpus': 1},
+                }
+            }
+        ),
+        'custom_hpo_and_sequential_bagging_with_total_resources': (
+            {
+                'system_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'total_resources': {'num_cpus': 8, 'num_gpus': 2},
+                'model_minimum_resources': {'num_cpus': 2, 'num_gpus': 0.5},
+                'model_default_resources': {'num_cpus': 2, 'num_gpus': 0.5},
+                'num_trials': 2,
+                'executor_cls': CustomHpoExecutor,
+                'num_bag_folds': 4,
+                'fold_strategy_cls': SequentialLocalFoldFittingStrategy,
+                'expected_answer': {
+                    # TODO: This is incorrect but doesn't cause big enough issue...
+                    # hpo resource calculator needs to know which folding strategy will be used to determine if need to consider num_folds
+                    # but folding strategy is only being decided later...
+                    # we calculate parallel folding for now...
+                    'resources_per_trial': {'num_cpus': 8, 'num_gpus': 2},
+                    'resources_per_model': {'num_cpus': 2, 'num_gpus': 0.5},
                 }
             }
         ),

--- a/tabular/tests/unittests/resource_allocation/test_resource_allocation_combined.py
+++ b/tabular/tests/unittests/resource_allocation/test_resource_allocation_combined.py
@@ -184,6 +184,24 @@ tests_dict = {
                 }
             }
         ),
+        'valid_ag_args_fit_without_gpu_default_no_gpu': (
+            {
+                'ag_args_fit': {'num_cpus': 8},
+                'model_default_resources': {'num_cpus': 1, 'num_gpus': 0},
+                'expected_answer': {
+                    'resources_per_model': {'num_cpus': 8, 'num_gpus': 0}
+                }
+            }
+        ),
+        'valid_ag_args_fit_without_gpu_default_gpu': (
+            {
+                'ag_args_fit': {'num_cpus': 8},
+                'model_default_resources': {'num_cpus': 1, 'num_gpus': 1},
+                'expected_answer': {
+                    'resources_per_model': {'num_cpus': 8, 'num_gpus': 1}
+                }
+            }
+        ),
         'valid_ag_args_ensemble_and_ag_args_fit': (
             {
                 'ag_args_ensemble': {'num_cpus': 8, 'num_gpus': 2},
@@ -614,6 +632,7 @@ tests_dict = {
         'hpo_and_bagging_without_anything': (
             {
                 'system_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'model_default_resources': {'num_cpus': 1, 'num_gpus': 1},
                 'model_minimum_resources': {'num_cpus': 2, 'num_gpus': 1},
                 'num_trials': 2,
                 'num_bag_folds': 4,

--- a/tabular/tests/unittests/resource_allocation/test_resource_allocation_combined.py
+++ b/tabular/tests/unittests/resource_allocation/test_resource_allocation_combined.py
@@ -942,6 +942,16 @@ tests_dict = {
                 'should_raise': True
             }
         ),
+        'custom_hpo_invalid_ag_args_fit_more_than_total':(
+            {
+                'system_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'total_resources': {'num_cpus': 8, 'num_gpus': 2},
+                'ag_args_fit': {'num_cpus': 99, 'num_gpus': 1},
+                'num_trials': 2,
+                'executor_cls': CustomHpoExecutor,
+                'should_raise': True
+            }
+        ),
         'sequential_bagging_invalid_ag_args_ensemble_more_than_total': (
             {
                 'system_resources': {'num_cpus': 16, 'num_gpus': 4},
@@ -1043,6 +1053,26 @@ tests_dict = {
                 'model_minimum_resources': {'num_cpus': 16, 'num_gpus': 4},
                 'ag_args_fit': {'num_cpus': 4, 'num_gpus': 1},
                 'num_trials': 2,
+                'should_raise': True
+            }
+        ),
+        'custom_hpo_invalid_ag_args_ensemble_less_than_min': (
+            {
+                'system_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'model_minimum_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'ag_args_ensemble': {'num_cpus': 4, 'num_gpus': 1},
+                'num_trials': 2,
+                'executor_cls': CustomHpoExecutor,
+                'should_raise': True
+            }
+        ),
+        'custom_hpo_invalid_ag_args_fit_less_than_min': (
+            {
+                'system_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'model_minimum_resources': {'num_cpus': 16, 'num_gpus': 4},
+                'ag_args_ensemble': {'num_cpus': 4, 'num_gpus': 1},
+                'num_trials': 2,
+                'executor_cls': CustomHpoExecutor,
                 'should_raise': True
             }
         ),

--- a/tabular/tests/unittests/resource_allocation/test_total_resource_allocation.py
+++ b/tabular/tests/unittests/resource_allocation/test_total_resource_allocation.py
@@ -98,8 +98,7 @@ def test_bagged_model_with_total_resources_but_no_gpu_specified(mock_system_reso
         bagged_model = DummyBaggedModel(model_base)
         resources = bagged_model._preprocess_fit_resources(total_resources=total_resources, k_fold=k_fold)
         resources.pop('k_fold')
-        _, default_model_num_gpus = model_base._get_default_resources()
-        default_model_resources = {'num_cpus': 2, 'num_gpus': default_model_num_gpus * k_fold}
+        default_model_resources = {'num_cpus': 2, 'num_gpus': ResourceManager.get_gpu_count_all()}  # return all gpu resources as default needs gpu
         assert resources == default_model_resources
     
     

--- a/tabular/tests/unittests/resource_allocation/test_total_resource_allocation.py
+++ b/tabular/tests/unittests/resource_allocation/test_total_resource_allocation.py
@@ -89,17 +89,6 @@ def test_bagged_model_with_total_resources_and_ensemble_resources(mock_system_re
         assert resources == ensemble_ag_args_fit
     
 
-def test_bagged_model_without_total_resources(mock_system_resources_ctx_mgr, mock_num_cpus, mock_num_gpus, k_fold):
-    with mock_system_resources_ctx_mgr(num_cpus=mock_num_cpus, num_gpus=mock_num_gpus):
-        model_base = DummyModel()
-        bagged_model = DummyBaggedModel(model_base)
-        resources = bagged_model._preprocess_fit_resources(k_fold=k_fold)
-        resources.pop('k_fold')
-        default_model_num_cpus, default_model_num_gpus = model_base._get_default_resources()
-        default_model_resources = {'num_cpus': default_model_num_cpus * k_fold, 'num_gpus': default_model_num_gpus * k_fold}
-        assert resources == default_model_resources
-    
-
 def test_bagged_model_with_total_resources_but_no_gpu_specified(mock_system_resources_ctx_mgr, mock_num_cpus, mock_num_gpus, k_fold):
     with mock_system_resources_ctx_mgr(num_cpus=mock_num_cpus, num_gpus=mock_num_gpus):
         model_base = DummyModel()
@@ -153,12 +142,12 @@ def test_bagged_model_without_total_resources_and_without_model_resources(mock_s
         )
         resources = bagged_model._preprocess_fit_resources(k_fold=k_fold)
         resources.pop('k_fold')
-        default_model_num_cpus, default_model_num_gpus = model_base._get_default_resources()
-        default_model_resources = {
-            'num_cpus': min(default_model_num_cpus * k_fold, ResourceManager.get_cpu_count()),
-            'num_gpus': min(default_model_num_gpus * k_fold, ResourceManager.get_gpu_count_all()),
+        # Bagged model should take all resources and internally calculate correct resources given ag_args_ensemble and ag_args_fit
+        expected_model_resources = {
+            'num_cpus': ResourceManager.get_cpu_count(),
+            'num_gpus': ResourceManager.get_gpu_count_all(),
         }
-        assert resources == default_model_resources
+        assert resources == expected_model_resources
 
 
 def test_nonbagged_model_with_total_resources(mock_system_resources_ctx_mgr, mock_num_cpus, mock_num_gpus):

--- a/tabular/tests/unittests/resource_allocation/test_total_resource_allocation.py
+++ b/tabular/tests/unittests/resource_allocation/test_total_resource_allocation.py
@@ -74,19 +74,19 @@ def test_bagged_model_with_total_resources_and_ensemble_resources(mock_system_re
             'num_gpus': 1,
         }
         model_base = DummyModel()
+        ensemble_ag_args_fit = {
+            'num_cpus': 4,
+            'num_gpus': 1,
+        }
         bagged_model = DummyBaggedModel(
             model_base,
             hyperparameters={
-                'ag_args_fit': {
-                    'num_cpus': 4,
-                    'num_gpus': 1,
-                }
+                'ag_args_fit': ensemble_ag_args_fit
             }
         )
         resources = bagged_model._preprocess_fit_resources(total_resources=total_resources, k_fold=k_fold)
         resources.pop('k_fold')
-        # Total resources should not be affected by ensemble resources.
-        assert resources == total_resources
+        assert resources == ensemble_ag_args_fit
     
 
 def test_bagged_model_without_total_resources(mock_system_resources_ctx_mgr, mock_num_cpus, mock_num_gpus, k_fold):


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/autogluon/autogluon/issues/2446

*Description of changes:*
* Fixed the case when user didn't specify total resources, but specified lower level resources. Previously would pass default value based on the model to the lower value as the total resources, which is incorrect. Now will check if user passed lower level requirements, and use those.
* Added a special case when user provide both `num_resource` and `ag_args_fit` when not doing bagging nor hpo. Might think about better way to handle it in the future...
* Updated unit tests and added two more tests to cover cases when no resource requirement is specified, we should be using the default value based on the model.
* Added end-to-end tests...

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
