### PR TITLE
[CI] Fix build all docs

### DIFF
--- a/.github/workflow_scripts/build_all_docs.sh
+++ b/.github/workflow_scripts/build_all_docs.sh
@@ -57,9 +57,6 @@ mkdir -p docs/_build/rst/tutorials/
 aws s3 cp $BUILD_DOCS_PATH docs/_build/rst/tutorials/ --recursive
 
 setup_build_contrib_env
-install_all
-setup_mxnet_gpu
-# setup_torch
 
 sed -i -e "s@###_PLACEHOLDER_WEB_CONTENT_ROOT_###@http://$site@g" docs/config.ini
 sed -i -e "s@###_OTHER_VERSIONS_DOCUMENTATION_LABEL_###@$other_doc_version_text@g" docs/config.ini


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* The cause is that `d2lbook` depends on `awscli`, which got updated yesterday and have a conflict dependency with `tox` version we depend on in `eda` . We were previously installing all AG modules in the `build_all_docs` step, though I doubt it's needed. Removed for now to see if it solves the issue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
