### PR TITLE
Remove pycocotools

### DIFF
--- a/docs/install-include.rst
+++ b/docs/install-include.rst
@@ -170,7 +170,7 @@ AutoGluon is modularized into `sub-modules <https://packaging.python.org/guides/
     - Optional Dependency: `vowpalwabbit`. This will install the VowpalWabbit package and allow you to fit VowpalWabbit in TabularPredictor.
     - Optional Dependency: `imodels`. This will install the imodels package and allow you to fit interpretable models in TabularPredictor.
 - `autogluon.multimodal` - functionality for image, text, and multimodal problems. Focus on deep learning models.
-    - To try object detection functionality using `MultiModalPredictor`, please install additional dependencies via `mim install mmcv-full` and `pip install mmdet`. Note that Windows users should also install `pycocotools`` by: `pip install pycocotools-windows`, but it only supports python 3.6/3.7/3.8.
+    - To try object detection functionality using `MultiModalPredictor`, please install additional dependencies via `mim install mmcv-full`, `pip install mmdet` and `pip install pycocotools`. Note that Windows users should also install `pycocotools`` by: `pip install pycocotools-windows`, but it only supports python 3.6/3.7/3.8.
 - `autogluon.vision` - only functionality for computer vision (ImagePredictor, ObjectDetector)
 - `autogluon.text` - only functionality for natural language processing (TextPredictor)
 - `autogluon.timeseries` - only functionality for time series data (TimeSeriesPredictor)

--- a/docs/tutorials/multimodal/object_detection/index.rst
+++ b/docs/tutorials/multimodal/object_detection/index.rst
@@ -3,7 +3,7 @@ Object Detection
 
 Pre-requisite
 -------------
-All detection modules depend on ``mmcv-full`` and ``mmdet`` packages.
+All detection modules depend on ``mmcv-full``, ``mmdet`` and ``pycocotools`` packages.
 
 
 To install ``mmcv-full``, run:
@@ -14,10 +14,18 @@ To install ``mmdet``, run:
 
     ``pip install mmdet``
 
+To install ``pycocotools``, run:
+
+    ``pip install pycocotools``
+
+We suggest to install the version between ``pycocotools>=2.0.5,<2.0.7``.
+Note that Windows users should install ``pycocotools`` by: ``pip install pycocotools-windows``, but it only supports python 3.6/3.7/3.8.
+
 For additional support, please refer to official instructions for mmdet_ and mmcv-full_
 
 .. _mmdet: https://mmdetection.readthedocs.io/en/v2.2.1/install.html
 .. _mmcv-full: https://mmcv.readthedocs.io/en/latest/get_started/installation.html
+
 
 
 Quick Start

--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -53,7 +53,6 @@ install_requires = [
     "nlpaug>=1.1.10,<=1.1.10",
     "nltk>=3.4.5,<4.0.0",
     "openmim>0.1.5,<=0.2.1",
-    "pycocotools>=2.0.5,<2.0.7;platform_system!='Windows'",
     "defusedxml>=0.7.1,<=0.7.1",
     "albumentations>=1.1.0,<=1.2.0",
 ]

--- a/multimodal/src/autogluon/multimodal/utils/object_detection.py
+++ b/multimodal/src/autogluon/multimodal/utils/object_detection.py
@@ -640,6 +640,7 @@ def cocoeval_torchmetrics(outputs):
 
 
 def cocoeval_pycocotools(outputs, data, anno_file, cache_path, metrics):
+    try_import_pycocotools()
     from pycocotools.coco import COCO
     from pycocotools.cocoeval import COCOeval
 


### PR DESCRIPTION
*Issue #, if available:*
AutoGluon installation issue. #2494 #2521 
pycocotools can't be easily built in some linux and windows distribution.

*Description of changes:*
Remove pycocotools from setup.py. Given this is only used for object detection model evaluation, it is better to lazy import rather than effecting AG installation. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
