### PR TITLE
Fix AutoMM Tokenizer

### DIFF
--- a/multimodal/src/autogluon/multimodal/data/process_text.py
+++ b/multimodal/src/autogluon/multimodal/data/process_text.py
@@ -435,8 +435,18 @@ class TextProcessor:
         -------
         A tokenizer instance.
         """
-        tokenizer_class = ALL_TOKENIZERS[tokenizer_name]
-        return tokenizer_class.from_pretrained(checkpoint_name)
+        try:
+            tokenizer_class = ALL_TOKENIZERS[tokenizer_name]
+            return tokenizer_class.from_pretrained(checkpoint_name)
+        except TypeError as e:
+            try:
+                tokenizer_class = ALL_TOKENIZERS["bert"]
+                tokenizer = tokenizer_class.from_pretrained(checkpoint_name)
+                logger.warning(f"Current checkpoint {checkpoint_name} does not support AutoTokenizer. "
+                               "Switch to BertTokenizer instead.")
+                return tokenizer
+            except:
+                raise e
 
     @staticmethod
     def get_trimmed_lengths(

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -417,12 +417,16 @@ class MultiModalPredictor:
         self._model_loaded = False  # Whether the model has been loaded
         self._matcher = None
 
-        self._save_path = setup_save_path(
-            resume=self._resume,
-            proposed_save_path=path,
-            raise_if_exist=True,
-            warn_if_exist=self._warn_if_exist,
-        )
+        if path is not None:
+            self._save_path = setup_save_path(
+                resume=self._resume,
+                proposed_save_path=path,
+                raise_if_exist=True,
+                warn_if_exist=self._warn_if_exist,
+                model_loaded=self._model_loaded,
+            )
+        else:
+            self._save_path = None
 
         if self._problem_type == OBJECT_DETECTION:
             warnings.warn(

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -417,16 +417,13 @@ class MultiModalPredictor:
         self._model_loaded = False  # Whether the model has been loaded
         self._matcher = None
 
-        if path is not None:
-            self._save_path = setup_save_path(
-                resume=self._resume,
-                proposed_save_path=path,
-                raise_if_exist=True,
-                warn_if_exist=self._warn_if_exist,
-                model_loaded=self._model_loaded,
-            )
-        else:
-            self._save_path = None
+        self._save_path = setup_save_path(
+            resume=self._resume,
+            proposed_save_path=path,
+            raise_if_exist=True,
+            warn_if_exist=self._warn_if_exist,
+            model_loaded=self._model_loaded,
+        )
 
         if self._problem_type == OBJECT_DETECTION:
             warnings.warn(

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -422,7 +422,6 @@ class MultiModalPredictor:
             proposed_save_path=path,
             raise_if_exist=True,
             warn_if_exist=self._warn_if_exist,
-            model_loaded=self._model_loaded,
         )
 
         if self._problem_type == OBJECT_DETECTION:


### PR DESCRIPTION
Fix for #2449.

Try `BertTokenizer` if `AutoTokenizer` doesn't work for current checkpoint.

Reference:
https://clay-atlas.com/us/blog/2022/08/09/solved-typeerror-not-a-string-at-using-autotokenizer-from_pretrained/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
