### PR TITLE
Export TIMM image models to onnx

### DIFF
--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -64,7 +64,9 @@ extras_require = {
         "black~=22.0,>=22.3",
         "isort>=5.10",
         "datasets>=2.3.2,<=2.3.2",
-        "onnxruntime-gpu>=1.13.1,<1.14.0;platform_system!='Darwin'",
+        "onnx>=1.13.0,<1.14.0",
+        "onnxruntime>=1.13.0,<1.14.0;platform_system=='Darwin'",
+        "onnxruntime-gpu>=1.13.0,<1.14.0;platform_system!='Darwin'",
     ]
 }
 

--- a/multimodal/src/autogluon/multimodal/__init__.py
+++ b/multimodal/src/autogluon/multimodal/__init__.py
@@ -4,5 +4,5 @@ except ImportError:
     pass
 
 from . import constants, data, models, optimization, predictor, problem_types, utils
-from .predictor import AutoMMPredictor, MultiModalPredictor
+from .predictor import AutoMMPredictor, MultiModalOnnxPredictor, MultiModalPredictor
 from .utils import download

--- a/multimodal/src/autogluon/multimodal/models/utils.py
+++ b/multimodal/src/autogluon/multimodal/models/utils.py
@@ -684,3 +684,21 @@ def update_mmdet_config(key, value, config):
             for subsubconfig in subconfig:
                 if isinstance(subsubconfig, dict):
                     update_mmdet_config(key, value, subsubconfig)
+
+
+def run_model(model: nn.Module, batch: dict):
+    from .timm_image import TimmAutoModelForImagePrediction
+
+    if isinstance(model, TimmAutoModelForImagePrediction):
+        input_vec = [batch[k] for k in model.input_keys]
+        column_names, column_values = [], []
+        for k in batch.keys():
+            if k.startswith(model.image_column_prefix):
+                column_names.append(k)
+                column_values.append(batch[k])
+        input_vec.append(column_names)
+        input_vec.append(column_values)
+        output = model(*tuple(input_vec))
+    else:
+        output = model(batch)
+    return output

--- a/multimodal/src/autogluon/multimodal/optimization/lit_matcher.py
+++ b/multimodal/src/autogluon/multimodal/optimization/lit_matcher.py
@@ -10,6 +10,7 @@ from torch.nn.modules.loss import _Loss
 from torchmetrics.aggregation import BaseAggregator
 
 from ..constants import AUTOMM, FEATURES, LOGIT_SCALE, PROBABILITY, QUERY, RESPONSE
+from ..models.utils import run_model
 from ..utils.matcher import compute_matching_probability
 from .losses import MultiNegativesSoftmaxLoss
 from .utils import (
@@ -230,10 +231,10 @@ class MatcherLitModule(pl.LightningModule):
         self,
         batch: Dict,
     ):
-        query_outputs = self.query_model(batch)[self.query_model.prefix]
+        query_outputs = run_model(self.query_model, batch)[self.query_model.prefix]
         query_embeddings = query_outputs[FEATURES]
 
-        response_outputs = self.response_model(batch)[self.response_model.prefix]
+        response_outputs = run_model(self.response_model, batch)[self.response_model.prefix]
         response_embeddings = response_outputs[FEATURES]
 
         logit_scale = (response_outputs[LOGIT_SCALE] if LOGIT_SCALE in response_outputs else None,)
@@ -330,14 +331,14 @@ class MatcherLitModule(pl.LightningModule):
         A dictionary with the mini-batch's logits and features.
         """
         if self.signature == QUERY:
-            embeddings = self.query_model(batch)[self.query_model.prefix][FEATURES]
+            embeddings = run_model(self.query_model, batch)[self.query_model.prefix][FEATURES]
             return {FEATURES: embeddings}
         elif self.signature == RESPONSE:
-            embeddings = self.response_model(batch)[self.response_model.prefix][FEATURES]
+            embeddings = run_model(self.response_model, batch)[self.response_model.prefix][FEATURES]
             return {FEATURES: embeddings}
         else:
-            query_embeddings = self.query_model(batch)[self.query_model.prefix][FEATURES]
-            response_embeddings = self.response_model(batch)[self.response_model.prefix][FEATURES]
+            query_embeddings = run_model(self.query_model, batch)[self.query_model.prefix][FEATURES]
+            response_embeddings = run_model(self.response_model, batch)[self.response_model.prefix][FEATURES]
 
         match_prob = compute_matching_probability(
             embeddings1=query_embeddings,

--- a/multimodal/src/autogluon/multimodal/optimization/lit_module.py
+++ b/multimodal/src/autogluon/multimodal/optimization/lit_module.py
@@ -11,6 +11,7 @@ from torchmetrics.aggregation import BaseAggregator
 
 from ..constants import AUTOMM, LM_TARGET, LOGITS, T_FEW, TEMPLATE_LOGITS, WEIGHT
 from ..data.mixup import MixupModule, multimodel_mixup
+from ..models.utils import run_model
 from .utils import apply_layerwise_lr_decay, apply_single_lr, apply_two_stages_lr, get_lr_scheduler, get_optimizer
 
 logger = logging.getLogger(AUTOMM)
@@ -205,7 +206,7 @@ class LitModule(pl.LightningModule):
         if self.mixup_fn is not None:
             self.mixup_fn.mixup_enabled = self.training & (self.current_epoch < self.hparams.mixup_off_epoch)
             batch, label = multimodel_mixup(batch=batch, model=self.model, mixup_fn=self.mixup_fn)
-        output = self.model(batch)
+        output = run_model(self.model, batch)
         loss = self._compute_loss(output=output, label=label)
         return output, loss
 
@@ -286,7 +287,7 @@ class LitModule(pl.LightningModule):
         -------
         A dictionary with the mini-batch's logits and features.
         """
-        output = self.model(batch)
+        output = run_model(self.model, batch)
         if self.model_postprocess_fn:
             output = self.model_postprocess_fn(output)
 

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -12,7 +12,7 @@ import shutil
 import sys
 import time
 import warnings
-from collections import OrderedDict
+from collections import OrderedDict, namedtuple
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Dict, List, Optional, Union
@@ -140,6 +140,7 @@ from .utils import (
     get_minmax_mode,
     get_mixup,
     get_onnx_input,
+    get_precision_context,
     hyperparameter_tune,
     infer_batch,
     infer_dtypes_by_model_names,
@@ -152,6 +153,7 @@ from .utils import (
     load_text_tokenizers,
     logits_to_prob,
     modify_duplicate_model_names,
+    move_to_device,
     predict,
     process_batch,
     save_pretrained_model_configs,
@@ -2476,11 +2478,11 @@ class MultiModalPredictor:
 
     def export_onnx(
         self,
-        onnx_path: Optional[str] = None,
         data: Optional[pd.DataFrame] = None,
+        onnx_path: Optional[str] = None,
         batch_size: Optional[int] = None,
         verbose: Optional[bool] = False,
-        opset_version: Optional[int] = 13,
+        opset_version: Optional[int] = 16,
     ):
         """
         Export this predictor's model to ONNX file.
@@ -2502,6 +2504,10 @@ class MultiModalPredictor:
         """
         # TODO: Support CLIP
         # TODO: Add test
+        from .models.timm_image import TimmAutoModelForImagePrediction
+
+        if not isinstance(self._model, TimmAutoModelForImagePrediction):
+            raise NotImplementedError(f"export_onnx doesn't support model type {type(self._model)}")
         warnings.warn("Currently, the functionality of exporting to ONNX is experimental.")
 
         valid_input, dynamic_axes, default_onnx_path, batch = get_onnx_input(
@@ -2516,21 +2522,35 @@ class MultiModalPredictor:
             )
 
         if not onnx_path:
-            onnx_path = default_onnx_path
+            onnx_path = os.path.join(self.path, default_onnx_path)
 
-        torch.onnx.export(
-            self._model.eval(),
-            batch,
-            onnx_path,
-            opset_version=opset_version,
-            verbose=verbose,
-            input_names=valid_input,
-            dynamic_axes=dynamic_axes,
-        )
+        device_type = "cuda" if torch.cuda.is_available() else "cpu"
+        device = torch.device(device_type)
+        self._model.to(device).eval()
+        batch = move_to_device(batch, device=device)
+
+        InputBatch = namedtuple("InputBatch", self._model.input_keys)
+        input_vec = InputBatch(**batch)
+
+        strategy = "dp"  # default used in inference.
+        num_gpus = compute_num_gpus(config_num_gpus=self._config.env.num_gpus, strategy=strategy)
+        precision = infer_precision(num_gpus=num_gpus, precision=self._config.env.precision, cpu_only_warning=False)
+        precision_context = get_precision_context(precision=precision, device_type=device_type)
+
+        with precision_context, torch.no_grad():
+            torch.onnx.export(
+                self._model.eval(),
+                args=input_vec,
+                f=onnx_path,
+                opset_version=opset_version,
+                verbose=verbose,
+                input_names=valid_input,
+                dynamic_axes=dynamic_axes,
+            )
 
     def get_processed_batch_for_deployment(
         self,
-        data: pd.DataFrame,
+        data: Union[pd.DataFrame, dict],
         valid_input: Optional[List] = None,
         onnx_tracing: bool = False,
         batch_size: int = None,
@@ -2559,13 +2579,6 @@ class MultiModalPredictor:
         Tensor or numpy array.
         The output processed batch could be used for export/evaluate deployed model.
         """
-        # TODO: add support for data = dict or list
-        if onnx_tracing:
-            if batch_size:
-                data = data[:batch_size]
-            else:
-                data = data[:2]
-
         data, df_preprocessor, data_processors = self._on_predict_start(
             data=data,
             requires_label=requires_label,
@@ -2910,3 +2923,49 @@ class AutoMMPredictor(MultiModalPredictor):
             "raise an exception starting in v0.7."
         )
         super(AutoMMPredictor, self).__init__(**kwargs)
+
+
+class MultiModalOnnxPredictor:
+    def __init__(self, base_predictor, model):
+        self._predictor = base_predictor
+        import onnxruntime as ort
+
+        self.sess = ort.InferenceSession(model.SerializeToString(), providers=["CUDAExecutionProvider"])
+
+    def predict(self, data: Union[pd.DataFrame, dict, list, str]):
+        raise NotImplementedError()
+
+    def predict_proba(self, data: Union[pd.DataFrame, dict, list, str]):
+        data, df_preprocessor, data_processors = self._predictor._on_predict_start(
+            data=data,
+            requires_label=False,
+        )
+        data = process_batch(
+            data=data,
+            df_preprocessor=df_preprocessor,
+            data_processors=data_processors,
+        )
+
+        inputs = self.sess.get_inputs()
+        outputs = self.sess.get_outputs()
+        input_names = [i.name for i in inputs]
+        input_dict = {k: data[k].numpy() for k in input_names}
+
+        # Taking second output, since outputs are (feature, logits)
+        # TODO: Make output consistent. Currently relying on keys of the output dict.
+        assert len(outputs) == 2, "expecting two outputs from the model."
+        label_name = outputs[1].name
+        onnx_logits = self.sess.run([label_name], input_dict)[0]
+        onnx_proba = logits_to_prob(onnx_logits)
+
+        return onnx_proba
+
+    @staticmethod
+    def load(path):
+        import onnx
+
+        base_predictor = MultiModalPredictor.load(path=path)
+        onnx_path = os.path.join(path, "model.onnx")
+        onnx_bytes = onnx.load(onnx_path)
+
+        return MultiModalOnnxPredictor(base_predictor=base_predictor, model=onnx_bytes)

--- a/multimodal/src/autogluon/multimodal/utils/__init__.py
+++ b/multimodal/src/autogluon/multimodal/utils/__init__.py
@@ -27,6 +27,7 @@ from .environment import (
     check_if_packages_installed,
     compute_inference_batch_size,
     compute_num_gpus,
+    get_precision_context,
     infer_precision,
     is_interactive,
     move_to_device,

--- a/multimodal/src/autogluon/multimodal/utils/inference.py
+++ b/multimodal/src/autogluon/multimodal/utils/inference.py
@@ -29,6 +29,7 @@ from ..constants import (
 )
 from ..data.preprocess_dataframe import MultiModalFeaturePreprocessor
 from ..data.utils import apply_data_processor, apply_df_preprocessor, get_collate_fn, get_per_sample_features
+from ..models.utils import run_model
 from .environment import (
     compute_inference_batch_size,
     compute_num_gpus,
@@ -154,7 +155,7 @@ def infer_batch(
     batch = move_to_device(batch, device=device)
     precision_context = get_precision_context(precision=precision, device_type=device_type)
     with precision_context, torch.no_grad():
-        output = model(batch)
+        output = run_model(model, batch)
         if model_postprocess_fn:
             output = model_postprocess_fn(output)
 

--- a/multimodal/src/autogluon/multimodal/utils/onnx.py
+++ b/multimodal/src/autogluon/multimodal/utils/onnx.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional, Tuple, Union
 
 from torch import tensor
 
-from ..constants import AUTOMM, FEATURE_EXTRACTION
+from ..constants import AUTOMM, FEATURE_EXTRACTION, MULTICLASS
 
 logger = logging.getLogger(AUTOMM)
 
@@ -89,6 +89,16 @@ def get_onnx_input(pipeline: str, config: Optional[Dict] = None):
                 ],
             ),
         }
+    elif pipeline == MULTICLASS:
+        valid_input = ["timm_image_image", "timm_image_image_valid_num"]
+        dynamic_axes = {
+            "timm_image_image": {
+                0: "batch_size",
+            },
+            "timm_image_image_valid_num": {},
+        }
+        default_onnx_path = "./model.onnx"
+        default_batch = None
     else:
         raise ValueError(f"ONNX export is not supported in current pipeline {pipeline}")
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. This PR exports the TIMM image models to onnx, and it's been tested on onnxruntime for checking correctness.
2. Downgrades onnx to 1.12.x (since https://github.com/autogluon/autogluon/pull/2567), due to conflict version range of protobuf against tensorboardx:
  a. onnx 1.13.x requires protobuf >=3.12.2,<=3.20.1, (onnx 1.12.x requires protobuf >=3.12.2,<=3.20.1)
  b. tensorboardx 2.5.1 requires protobuf >=3.8.0,<=3.20.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
