### PR TITLE
[Bug] Fix missing Predictor API docs on Website

### DIFF
--- a/.github/workflow_scripts/build_all_docs.sh
+++ b/.github/workflow_scripts/build_all_docs.sh
@@ -57,6 +57,7 @@ mkdir -p docs/_build/rst/tutorials/
 aws s3 cp $BUILD_DOCS_PATH docs/_build/rst/tutorials/ --recursive
 
 setup_build_contrib_env
+install_all_no_tests
 
 sed -i -e "s@###_PLACEHOLDER_WEB_CONTENT_ROOT_###@http://$site@g" docs/config.ini
 sed -i -e "s@###_OTHER_VERSIONS_DOCUMENTATION_LABEL_###@$other_doc_version_text@g" docs/config.ini

--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -24,87 +24,44 @@ function setup_torch_gpu {
     python3 -m pip install torch==1.12.0+cu113 torchvision==0.13.0+cu113 --extra-index-url https://download.pytorch.org/whl/cu113
 }
 
-function install_common {
-    python3 -m pip install --upgrade -e common/[tests]
-}
-
-function install_core {
-    install_common
-    python3 -m pip install --upgrade -e core/
-}
-
-function install_core_all {
-    install_common
-    python3 -m pip install --upgrade -e core/[all]
-}
-
-function install_core_all_tests {
-    install_common
-    python3 -m pip install --upgrade -e core/[all,tests]
-}
-
-function install_features {
-    python3 -m pip install --upgrade -e features/
-}
-
-function install_eda {
-    python3 -m pip install --upgrade -e eda/[tests]
-}
-
-function install_fair {
-    python3 -m pip install --upgrade -e fair/
-}
-
-function install_tabular {
-    python3 -m pip install --upgrade -e tabular/[tests]
-}
-
-function install_tabular_all {
-    python3 -m pip install --upgrade -e tabular/[all,tests]
+function install_local_packages {
+    while(($#)) ; do
+        python3 -m pip install --upgrade -e $1
+        shift
+    done
 }
 
 function install_multimodal {
     # launch different process for each test to make sure memory is released
     python3 -m pip install --upgrade pytest-xdist
-    python3 -m pip install --upgrade -e multimodal/[tests]
+    install_local_packages "multimodal/$1"
     mim install mmcv-full --timeout 60
     python3 -m pip install --upgrade mmdet
     python3 -m pip install --upgrade mmocr
 }
 
-function install_text {
-    python3 -m pip install --upgrade -e text/
-}
-
 function install_vision {
     python3 -m pip install --upgrade pytest-xdist  # launch different process for each test to avoid resource not being released by either mxnet or torch
-    python3 -m pip install --upgrade -e vision/
-}
-
-function install_timeseries {
-    python3 -m pip install --upgrade -e timeseries/[all,tests]
+    install_local_packages "vision/"
 }
 
 function install_cloud {
     python3 -m pip install --upgrade pytest-xdist # Enable running tests in parallel for speedup
-    python3 -m pip install --upgrade -e cloud/[tests]
-}
-
-function install_autogluon {
-    python3 -m pip install --upgrade -e autogluon/
+    install_local_packages "cloud/[tests]"
 }
 
 function install_all {
-    install_common
-    install_core_all
-    install_features
-    install_tabular_all
-    install_multimodal
-    install_text
+    install_local_packages "common/[tests]" "core/[all]" "features/" "tabular/[all,tests]" "timeseries/[all,tests]" "eda/[tests]"
+    install_multimodal "[tests]" # multimodal must be install before vision and text
     install_vision
-    install_timeseries
-    install_eda
-    install_autogluon
+    install_local_packages "text/" "autogluon/"
+}
+
+function install_all_no_tests {
+    install_local_packages "common/" "core/[all]" "features/" "tabular/[all]" "timeseries/[all]" "eda/"
+    install_multimodal # multimodal must be installed before vision and text
+    install_vision
+    install_local_packages "text/" "autogluon/"
 }
 
 function build_all {

--- a/.github/workflow_scripts/test_common.sh
+++ b/.github/workflow_scripts/test_common.sh
@@ -7,7 +7,7 @@ ADDITIONAL_TEST_ARGS=$1
 source $(dirname "$0")/env_setup.sh
 
 setup_build_env
-install_common
+install_local_packages "common/[tests]"
 
 cd common/
 if [ -n "$ADDITIONAL_TEST_ARGS" ]

--- a/.github/workflow_scripts/test_core.sh
+++ b/.github/workflow_scripts/test_core.sh
@@ -7,7 +7,7 @@ ADDITIONAL_TEST_ARGS=$1
 source $(dirname "$0")/env_setup.sh
 
 setup_build_env
-install_core_all_tests
+install_local_packages "common/[tests]" "core/[all,tests]"
 python3 -m pip install ray_lightning==0.2.0  # TODO Change this line once we support ray_lightning 0.3.0
 
 cd core/

--- a/.github/workflow_scripts/test_eda.sh
+++ b/.github/workflow_scripts/test_eda.sh
@@ -8,10 +8,7 @@ source $(dirname "$0")/env_setup.sh
 
 setup_build_env
 export CUDA_VISIBLE_DEVICES=0
-install_core_all_tests
-install_features
-install_tabular_all
-install_eda
+install_local_packages "common/[tests]" "core/[all,tests]" "features/" "tabular/[all,tests]" "eda/[tests]"
 
 cd eda/
 python3 -m tox -e lint

--- a/.github/workflow_scripts/test_fair.sh
+++ b/.github/workflow_scripts/test_fair.sh
@@ -10,11 +10,7 @@ then
 
     setup_build_env
     export CUDA_VISIBLE_DEVICES=0
-    install_core_all_tests
-    install_common
-    install_features
-    install_tabular_all
-    install_fair
+    install_local_packages "common/[tests]" "core/[all,tests]" "features/" "tabular/[all,tests]" "fair/"
 
     cd fair/
     if [ -n "$ADDITIONAL_TEST_ARGS" ]

--- a/.github/workflow_scripts/test_features.sh
+++ b/.github/workflow_scripts/test_features.sh
@@ -7,8 +7,7 @@ ADDITIONAL_TEST_ARGS=$1
 source $(dirname "$0")/env_setup.sh
 
 setup_build_env
-install_common
-install_features
+install_local_packages "common/[tests]" "features/"
 
 cd features/
 if [ -n "$ADDITIONAL_TEST_ARGS" ]

--- a/.github/workflow_scripts/test_multimodal_others.sh
+++ b/.github/workflow_scripts/test_multimodal_others.sh
@@ -8,9 +8,8 @@ source $(dirname "$0")/env_setup.sh
 
 setup_build_env
 export CUDA_VISIBLE_DEVICES=0
-install_core_all_tests
-install_features
-install_multimodal
+install_local_packages "common/[tests]" "core/[all,tests]" "features/"
+install_multimodal "[tests]"
 
 cd multimodal/
 if [ -n "$ADDITIONAL_TEST_ARGS" ]

--- a/.github/workflow_scripts/test_multimodal_predictor.sh
+++ b/.github/workflow_scripts/test_multimodal_predictor.sh
@@ -8,9 +8,8 @@ source $(dirname "$0")/env_setup.sh
 
 setup_build_env
 export CUDA_VISIBLE_DEVICES=0
-install_core_all_tests
-install_features
-install_multimodal
+install_local_packages "common/[tests]" "core/[all,tests]" "features/"
+install_multimodal "[tests]"
 
 cd multimodal/
 if [ -n "$ADDITIONAL_TEST_ARGS" ]

--- a/.github/workflow_scripts/test_tabular.sh
+++ b/.github/workflow_scripts/test_tabular.sh
@@ -8,11 +8,9 @@ source $(dirname "$0")/env_setup.sh
 
 setup_build_env
 export CUDA_VISIBLE_DEVICES=0
-install_core_all_tests
-install_features
-install_tabular_all
-install_multimodal
-install_text
+install_local_packages "common/[tests]" "core/[all,tests]" "features/" "tabular/[all,tests]"
+install_multimodal "[tests]"
+install_local_packages "text/"
 install_vision
 
 cd tabular/

--- a/.github/workflow_scripts/test_text.sh
+++ b/.github/workflow_scripts/test_text.sh
@@ -8,10 +8,9 @@ source $(dirname "$0")/env_setup.sh
 
 setup_build_env
 export CUDA_VISIBLE_DEVICES=0
-install_core_all_tests
-install_features
-install_multimodal
-install_text
+install_local_packages "common/[tests]" "core/[all,tests]" "features/"
+install_multimodal "[tests]"
+install_local_packages "text/"
 
 cd text/
 if [ -n "$ADDITIONAL_TEST_ARGS" ]

--- a/.github/workflow_scripts/test_timeseries.sh
+++ b/.github/workflow_scripts/test_timeseries.sh
@@ -9,10 +9,7 @@ source $(dirname "$0")/env_setup.sh
 setup_build_env
 setup_mxnet_gpu
 export CUDA_VISIBLE_DEVICES=0
-install_core_all_tests
-install_features
-install_tabular_all
-install_timeseries
+install_local_packages "common/[tests]" "core/[all,tests]" "features/" "tabular/[all,tests]" "timeseries/[all,tests]"
 
 cd timeseries/
 if [ -n "$ADDITIONAL_TEST_ARGS" ]

--- a/.github/workflow_scripts/test_vision.sh
+++ b/.github/workflow_scripts/test_vision.sh
@@ -10,9 +10,8 @@ setup_build_env
 setup_mxnet_gpu
 setup_torch_gpu
 export CUDA_VISIBLE_DEVICES=0
-install_core_all_tests
-install_features
-install_multimodal
+install_local_packages "common/[tests]" "core/[all,tests]" "features/"
+install_multimodal "[tests]"
 install_vision
 
 cd vision/


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/autogluon/autogluon/issues/2571

*Description of changes:*

The `install_all` bash call in `build_all_docs` was removed in [this commit](https://github.com/autogluon/autogluon/commit/dfa96254773017b1bd51038f62a9b21c3b20dafb) because of a package dependency conflict between `tox` for testing in `eda` module and dependencies of the `d2lbook` tool.

Unfortunately `install_all` call was required to install modules that are used during autogen of docs, resulting in the website API documentation problem described in [the issue](https://github.com/autogluon/autogluon/issues/2571).

The fix here is to create a new `install_all_no_tests` call that avoids installing tests including the `tox` dependency when `eda/[tests]` is installed. In order to do this, I cleaned up the bash scripts we use to install packages so that it is less pedantic and less code is repeated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
