### PR TITLE
[Cloud] Unify input of image modality in fit and inference apis

### DIFF
--- a/cloud/setup.py
+++ b/cloud/setup.py
@@ -33,14 +33,10 @@ install_requires = [
 
 extras_require = dict()
 
-test_requirements = [
-    'tox',
-    'pytest',
-    'pytest-cov'
-]
+test_requirements = ["tox", "pytest", "pytest-cov"]
 
 test_requirements = list(set(test_requirements))
-extras_require['tests'] = test_requirements
+extras_require["tests"] = test_requirements
 
 install_requires = ag.get_dependency_version_ranges(install_requires)
 for key in extras_require:

--- a/cloud/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -47,7 +47,6 @@ from ..utils.sagemaker_utils import (
 )
 from ..utils.utils import (
     convert_image_path_to_encoded_bytes_in_dataframe,
-    is_compressed_file,
     is_image_file,
     rename_file_with_uuid,
     unzip_file,

--- a/cloud/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -337,8 +337,6 @@ class CloudPredictor(ABC):
                 common_tune_data_path = os.path.commonpath(tune_data[image_column].tolist())
             common_path = os.path.commonpath([common_train_data_path, common_tune_data_path])
             common_path_head = os.path.split(common_path)[0]  # we keep the base dir to match zipping behavior
-            print(common_path)
-            print(common_path_head)
             train_data[image_column] = [os.path.relpath(path, common_path_head) for path in train_data[image_column]]
             if tune_data is not None:
                 tune_data[image_column] = [os.path.relpath(path, common_path_head) for path in tune_data[image_column]]

--- a/cloud/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -367,7 +367,9 @@ class CloudPredictor(ABC):
             path=serving_script, bucket=cloud_bucket, key_prefix=util_key_prefix
         )
 
-        images_input = self._upload_fit_image_artifact(images=common_path, bucket=cloud_bucket, key_prefix=util_key_prefix)
+        images_input = self._upload_fit_image_artifact(
+            images=common_path, bucket=cloud_bucket, key_prefix=util_key_prefix
+        )
         inputs = dict(train=train_input, config=config_input, serving=serving_input)
         if tune_input is not None:
             inputs["tune"] = tune_input
@@ -795,9 +797,7 @@ class CloudPredictor(ABC):
         if isinstance(test_data, pd.DataFrame):
             test_data = self._prepare_data(test_data, "test", output_type="csv")
         logger.log(20, "Uploading data...")
-        test_input = self.sagemaker_session.upload_data(
-            path=test_data, bucket=bucket, key_prefix=key_prefix + "/data"
-        )
+        test_input = self.sagemaker_session.upload_data(path=test_data, bucket=bucket, key_prefix=key_prefix + "/data")
         logger.log(20, "Data uploaded successfully")
 
         return test_input
@@ -888,8 +888,7 @@ class CloudPredictor(ABC):
             if isinstance(test_data, str):
                 test_data = load_pd.load(test_data)
             test_data = convert_image_path_to_encoded_bytes_in_dataframe(
-                dataframe=test_data,
-                image_column=test_data_image_column
+                dataframe=test_data, image_column=test_data_image_column
             )
         test_input = self._upload_batch_predict_data(test_data, cloud_bucket, cloud_key_prefix)
 

--- a/cloud/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -294,26 +294,18 @@ class CloudPredictor(ABC):
 
     def _upload_fit_image_artifact(self, images, bucket, key_prefix):
         if images is not None:
-            if is_s3_url(images):
-                fileexts = (".tar.gz", ".bz2", ".zip")  # More extensions?
-                assert images.endswith(fileexts), "Please provide a s3 path to a compressed file"
-            else:
-                image_zip_filename = images
-                if os.path.isdir(images):
-                    image_zip_filename = os.path.basename(os.path.normpath(images))
-                    zipfolder(image_zip_filename, images)
-                    image_zip_filename += ".zip"
-                else:
-                    assert is_compressed_file(
-                        images
-                    ), "Please provide a compressed file or a folder containing the images"
-                logger.log(20, "Uploading images ...")
-                images = self.sagemaker_session.upload_data(
-                    path=image_zip_filename,
-                    bucket=bucket,
-                    key_prefix=key_prefix,
-                )
-                logger.log(20, "Images uploaded successfully")
+            image_zip_filename = images
+            assert os.path.isdir(images), "Please provide a folder containing the images"
+            image_zip_filename = os.path.basename(os.path.normpath(images))
+            zipfolder(image_zip_filename, images)
+            image_zip_filename += ".zip"
+            logger.log(20, "Uploading images ...")
+            images = self.sagemaker_session.upload_data(
+                path=image_zip_filename,
+                bucket=bucket,
+                key_prefix=key_prefix,
+            )
+            logger.log(20, "Images uploaded successfully")
         return images
 
     def _upload_fit_artifact(
@@ -322,28 +314,48 @@ class CloudPredictor(ABC):
         tune_data,
         config,
         serving_script,
-        images=None,
+        image_column=None,
     ):
         cloud_bucket, cloud_key_prefix = s3_path_to_bucket_prefix(self.cloud_output_path)
         util_key_prefix = cloud_key_prefix + "/utils"
+
+        common_path = None
+        if image_column is not None:
+            # Find common path to zip and replace image column with relative path to be used in remote environment
+            if isinstance(train_data, str):
+                train_data = load_pd.load(train_data)
+            else:
+                train_data = copy.deepcopy(train_data)
+            if tune_data is not None:
+                if isinstance(tune_data, str):
+                    tune_data = load_pd.load(tune_data)
+                else:
+                    tune_data = copy.deepcopy(tune_data)
+            common_train_data_path = os.path.commonpath(train_data[image_column].tolist())
+            common_tune_data_path = common_train_data_path
+            if tune_data is not None:
+                common_tune_data_path = os.path.commonpath(tune_data[image_column].tolist())
+            common_path = os.path.commonpath([common_train_data_path, common_tune_data_path])
+            train_data[image_column] = [os.path.relpath(path, common_path) for path in train_data[image_column]]
+            if tune_data is not None:
+                tune_data[image_column] = [os.path.relpath(path, common_path) for path in tune_data[image_column]]
+
         train_input = train_data
-        if isinstance(train_data, pd.DataFrame) or not is_s3_url(train_data):
-            train_data = self._prepare_data(train_data, "train")
-            logger.log(20, "Uploading train data...")
-            train_input = self.sagemaker_session.upload_data(
-                path=train_data, bucket=cloud_bucket, key_prefix=util_key_prefix
-            )
-            logger.log(20, "Train data uploaded successfully")
+        train_data = self._prepare_data(train_data, "train")
+        logger.log(20, "Uploading train data...")
+        train_input = self.sagemaker_session.upload_data(
+            path=train_data, bucket=cloud_bucket, key_prefix=util_key_prefix
+        )
+        logger.log(20, "Train data uploaded successfully")
 
         tune_input = tune_data
         if tune_data is not None:
-            if isinstance(tune_data, pd.DataFrame) or not is_s3_url(tune_data):
-                tune_data = self._prepare_data(tune_data, "tune")
-                logger.log(20, "Uploading tune data...")
-                tune_input = self.sagemaker_session.upload_data(
-                    path=tune_data, bucket=cloud_bucket, key_prefix=util_key_prefix
-                )
-                logger.log(20, "Tune data uploaded successfully")
+            tune_data = self._prepare_data(tune_data, "tune")
+            logger.log(20, "Uploading tune data...")
+            tune_input = self.sagemaker_session.upload_data(
+                path=tune_data, bucket=cloud_bucket, key_prefix=util_key_prefix
+            )
+            logger.log(20, "Tune data uploaded successfully")
 
         config_input = self.sagemaker_session.upload_data(path=config, bucket=cloud_bucket, key_prefix=util_key_prefix)
 
@@ -351,7 +363,7 @@ class CloudPredictor(ABC):
             path=serving_script, bucket=cloud_bucket, key_prefix=util_key_prefix
         )
 
-        images_input = self._upload_fit_image_artifact(images=images, bucket=cloud_bucket, key_prefix=util_key_prefix)
+        images_input = self._upload_fit_image_artifact(images=common_path, bucket=cloud_bucket, key_prefix=util_key_prefix)
         inputs = dict(train=train_input, config=config_input, serving=serving_input)
         if tune_input is not None:
             inputs["tune"] = tune_input
@@ -365,7 +377,6 @@ class CloudPredictor(ABC):
         *,
         predictor_init_args,
         predictor_fit_args,
-        image_path=None,
         image_column=None,
         leaderboard=True,
         framework_version="latest",
@@ -389,19 +400,9 @@ class CloudPredictor(ABC):
             Init args for the predictor
         predictor_fit_args: dict
             Fit args for the predictor
-        image_path: str, default = None
-            A local path or s3 path to the images. This parameter is REQUIRED if you want to train predictor with image modality.
-            If you provided this parameter, the image path inside your train/tune data MUST be relative.
-            If local path, path needs to be either a compressed file containing the images or a folder containing the images.
-            If it's a folder, we will zip it for you and upload it to the s3.
-            If s3 path, the path needs to be a path to a compressed file containing the images
-
-            Example:
-            If your images live under a root directory `example_images/`, then you would provide `example_images` as the `image_path`.
-            And you want to make sure in your training/tuning file, the column corresponding to the images is a relative path prefix with the root directory.
-            For example, `example_images/train/image1.png`. An absolute path will NOT work as the file will be moved to a remote system.
         image_column: str, default = None
             The column name in the training/tuning data that contains the image paths.
+            The image paths MUST be absolute paths to you local system.
         leaderboard: bool, default = True
             Whether to include the leaderboard in the output artifact
         framework_version: str, default = `latest`
@@ -477,7 +478,7 @@ class CloudPredictor(ABC):
             train_data=train_data,
             tune_data=tune_data,
             config=config,
-            images=image_path,
+            image_column=image_column,
             serving_script=ScriptManager.get_serve_script(
                 self.predictor_type, framework_version
             ),  # Training and Inference should have the same framework_version
@@ -757,7 +758,7 @@ class CloudPredictor(ABC):
         Parameters
         ----------
         test_data: Union(str, pandas.DataFrame)
-            The test data to be inferenced. Can be a pandas.DataFrame, a local path or a s3 path.
+            The test data to be inferenced. Can be a pandas.DataFrame, or a local path to csv file.
         accept: str, default = application/x-parquet
             Type of accept output content.
             Valid options are application/x-parquet, text/csv, application/json
@@ -777,32 +778,30 @@ class CloudPredictor(ABC):
         return self._predict_real_time(test_data=test_data, accept=accept)
 
     def _upload_batch_predict_data(self, test_data, bucket, key_prefix):
-        if isinstance(test_data, str) and is_s3_url(test_data):
-            test_input = test_data
-        else:
-            # If a directory of images, upload directly
-            if isinstance(test_data, str) and not os.path.isdir(test_data):
-                # either a file to a dataframe, or a file to an image
-                if is_image_file(test_data):
-                    logger.warning(
-                        "Are you sure you want to do batch inference on a single image? You might want to try `deploy()` and `predict_realtime()` instead"
-                    )
-                else:
-                    test_data = load_pd.load(test_data)
+        # If a directory of images, upload directly
+        if isinstance(test_data, str) and not os.path.isdir(test_data):
+            # either a file to a dataframe, or a file to an image
+            if is_image_file(test_data):
+                logger.warning(
+                    "Are you sure you want to do batch inference on a single image? You might want to try `deploy()` and `predict_realtime()` instead"
+                )
+            else:
+                test_data = load_pd.load(test_data)
 
-            if isinstance(test_data, pd.DataFrame):
-                test_data = self._prepare_data(test_data, "test", output_type="csv")
-            logger.log(20, "Uploading data...")
-            test_input = self.sagemaker_session.upload_data(
-                path=test_data, bucket=bucket, key_prefix=key_prefix + "/data"
-            )
-            logger.log(20, "Data uploaded successfully")
+        if isinstance(test_data, pd.DataFrame):
+            test_data = self._prepare_data(test_data, "test", output_type="csv")
+        logger.log(20, "Uploading data...")
+        test_input = self.sagemaker_session.upload_data(
+            path=test_data, bucket=bucket, key_prefix=key_prefix + "/data"
+        )
+        logger.log(20, "Data uploaded successfully")
 
         return test_input
 
     def predict(
         self,
         test_data,
+        test_data_image_path=None,
         test_data_image_column=None,
         predictor_path=None,
         framework_version="latest",
@@ -825,8 +824,17 @@ class CloudPredictor(ABC):
         Parameters
         ----------
         test_data: Union(str, pandas.DataFrame)
-            The test data to be inferenced. Can be a pandas.DataFrame, a local path or a s3 path.
-        test_data_image_column: Optional(str)
+            The test data to be inferenced. Can be a pandas.DataFrame, or a local path to a csv.
+        test_data_image_path: str, default = None
+            A local path to the images. This parameter is REQUIRED if you want to inference with multimodality involving image modality.
+            If you provided this parameter, the image path inside your train/tune data MUST be relative.
+            Path needs to be a folder containing the images.
+
+            Example:
+            If your images live under a root directory `example_images/`, then you would provide `example_images` as the `image_path`.
+            And you want to make sure in your test file, the column corresponding to the images is a relative path prefix with the root directory.
+            For example, `example_images/test/image1.png`. An absolute path will NOT work.
+        test_data_image_column: str, default = None
             If test_data involves image modality, you must specify the column name corresponding to image paths.
             Images have to live in the same directory specified by the column.
         predictor_path: str
@@ -878,13 +886,19 @@ class CloudPredictor(ABC):
         if not job_name:
             job_name = sagemaker.utils.unique_name_from_base(SAGEMAKER_RESOURCE_PREFIX)
 
-        if test_data_image_column is not None:
+        if test_data_image_path is not None or test_data_image_column is not None:
+            assert test_data_image_path is not None and test_data_image_column is not None, \
+                "Please specify both `test_data_image_path` and `test_data_image_column` when involves image modality"
             logger.warning("Batch inference with image modality could be slow because of some technical details.")
             logger.warning(
                 "You can always retrieve the model trained with CloudPredictor and do batch inference using your custom solution."
             )
             test_data = load_pd.load(test_data)
-            test_data = convert_image_path_to_encoded_bytes_in_dataframe(test_data, test_data_image_column)
+            test_data = convert_image_path_to_encoded_bytes_in_dataframe(
+                dataframe=test_data,
+                image_root_path=test_data_image_path,
+                image_column=test_data_image_column
+            )
         test_input = self._upload_batch_predict_data(test_data, cloud_bucket, cloud_key_prefix)
 
         self._serve_script_path = ScriptManager.get_serve_script(self.predictor_type, framework_version)

--- a/cloud/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -805,7 +805,6 @@ class CloudPredictor(ABC):
     def predict(
         self,
         test_data,
-        test_data_image_path=None,
         test_data_image_column=None,
         predictor_path=None,
         framework_version="latest",

--- a/cloud/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -308,12 +308,12 @@ class CloudPredictor(ABC):
             )
             logger.log(20, "Images uploaded successfully")
         return upload_image_path
-    
+
     def _find_common_path_and_replace_image_column(self, data, image_column):
         common_path = os.path.commonpath(data[image_column].tolist())
         common_path_head = os.path.split(common_path)[0]  # we keep the base dir to match zipping behavior
         data[image_column] = [os.path.relpath(path, common_path_head) for path in data[image_column]]
-        
+
         return data, common_path
 
     def _upload_fit_artifact(
@@ -341,14 +341,12 @@ class CloudPredictor(ABC):
                 else:
                     tune_data = copy.deepcopy(tune_data)
             train_data, common_train_data_path = self._find_common_path_and_replace_image_column(
-                data=train_data,
-                image_column=image_column
+                data=train_data, image_column=image_column
             )
             if tune_data is not None:
                 tune_data, common_tune_data_path = self._find_common_path_and_replace_image_column(
-                data=train_data,
-                image_column=image_column
-            )
+                    data=train_data, image_column=image_column
+                )
 
         train_input = train_data
         train_data = self._prepare_data(train_data, "train")

--- a/cloud/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -312,7 +312,7 @@ class CloudPredictor(ABC):
     def _find_common_path_and_replace_image_column(self, data, image_column):
         common_path = os.path.commonpath(data[image_column].tolist())
         common_path_head = os.path.split(common_path)[0]  # we keep the base dir to match zipping behavior
-        data[image_column] = [os.path.relpath(path, common_path_head) for path in data[image_column]]
+        data[image_column] = data[image_column].apply(lambda path: os.path.relpath(path, common_path_head))
 
         return data, common_path
 
@@ -345,7 +345,7 @@ class CloudPredictor(ABC):
             )
             if tune_data is not None:
                 tune_data, common_tune_data_path = self._find_common_path_and_replace_image_column(
-                    data=train_data, image_column=image_column
+                    data=tune_data, image_column=image_column
                 )
 
         train_input = train_data

--- a/cloud/src/autogluon/cloud/predictor/image_cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/image_cloud_predictor.py
@@ -32,11 +32,7 @@ class ImageCloudPredictor(CloudPredictor):
             **kwargs,
         )
 
-    def predict_real_time(
-        self,
-        test_data,
-        accept="application/x-parquet"
-    ):
+    def predict_real_time(self, test_data, accept="application/x-parquet"):
         """
         Predict with the deployed SageMaker endpoint. A deployed SageMaker endpoint is required.
         This is intended to provide a low latency inference.

--- a/cloud/src/autogluon/cloud/predictor/image_cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/image_cloud_predictor.py
@@ -24,11 +24,11 @@ class ImageCloudPredictor(CloudPredictor):
         predictor_cls = ImagePredictor
         return predictor_cls
 
-    def fit(self, *, predictor_init_args, predictor_fit_args, image_path, **kwargs):
+    def fit(self, *, predictor_init_args, predictor_fit_args, image_column, **kwargs):
         super().fit(
             predictor_init_args=predictor_init_args,
             predictor_fit_args=predictor_fit_args,
-            image_path=image_path,
+            image_column=image_column,
             **kwargs,
         )
 

--- a/cloud/src/autogluon/cloud/predictor/image_cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/image_cloud_predictor.py
@@ -1,13 +1,8 @@
 import copy
 
-import pandas as pd
-
-from autogluon.common.loaders import load_pd
-from autogluon.common.utils.s3_utils import is_s3_url
-
 from ..utils.ag_sagemaker import AutoGluonImageRealtimePredictor
 from ..utils.constants import VALID_ACCEPT
-from ..utils.utils import is_image_file, read_image_bytes_and_encode
+from ..utils.utils import read_image_bytes_and_encode
 from .cloud_predictor import CloudPredictor
 
 
@@ -37,7 +32,11 @@ class ImageCloudPredictor(CloudPredictor):
             **kwargs,
         )
 
-    def predict_real_time(self, test_data, test_data_image_column=None, accept="application/x-parquet"):
+    def predict_real_time(
+        self,
+        test_data,
+        accept="application/x-parquet"
+    ):
         """
         Predict with the deployed SageMaker endpoint. A deployed SageMaker endpoint is required.
         This is intended to provide a low latency inference.
@@ -47,12 +46,9 @@ class ImageCloudPredictor(CloudPredictor):
         ----------
         test_data: Union(str, pandas.DataFrame)
             The test data to be inferenced.
-            Can be a pandas.DataFrame, a numpy.ndarray, a local path or a s3 path to a csv file containing paths of test images.
+            Can be an numpy.ndarray containing path to test images
             Or a local path to a single image file.
             Or a list of local paths to image files.
-        test_data_image_column: Optional(str)
-            If provided a pandas.DataFrame as the test_data, you must specify the column name corresponding to image paths.
-            Images have to live in the same directory specified by the column.
         accept: str, default = application/x-parquet
             Type of accept output content.
             Valid options are application/x-parquet, text/csv, application/json
@@ -68,24 +64,10 @@ class ImageCloudPredictor(CloudPredictor):
         import numpy as np
 
         if isinstance(test_data, str):
-            if is_s3_url(test_data):
-                test_data = load_pd.load(test_data)
-            else:
-                if is_image_file(test_data):
-                    test_data = np.array([read_image_bytes_and_encode(test_data)], dtype="object")
-                else:
-                    test_data = load_pd.load(test_data)
+            test_data = [test_data]
         if isinstance(test_data, list):
-            images = []
-            test_data = np.array([read_image_bytes_and_encode(image) for image in images], dtype="object")
-        if isinstance(test_data, pd.DataFrame):
-            assert test_data_image_column is not None, "Please specify an image column name"
-            assert test_data_image_column in test_data, "Please specify a valid image column name"
+            test_data = np.array([read_image_bytes_and_encode(image) for image in test_data], dtype="object")
 
-            # Convert test data to be numpy array for network transfer
-            test_data = np.asarray(
-                [read_image_bytes_and_encode(image_path) for image_path in test_data[test_data_image_column]]
-            )
         assert isinstance(test_data, np.ndarray), f"Invalid test data format {type(test_data)}"
 
         return self._predict_real_time(test_data=test_data, accept=accept)
@@ -97,7 +79,7 @@ class ImageCloudPredictor(CloudPredictor):
     ):
         """
         test_data: str
-            The test data to be inferenced. Can be a local path or a s3 path to a directory containing the images.
+            The test data to be inferenced. Can be a local path to a directory containing the images.
         kwargs:
             Refer to `CloudPredictor.predict()`
         """

--- a/cloud/src/autogluon/cloud/predictor/multimodal_cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/multimodal_cloud_predictor.py
@@ -48,7 +48,6 @@ class MultiModalCloudPredictor(CloudPredictor):
     def predict_real_time(
         self,
         test_data,
-        test_data_image_path=None,
         test_data_image_column=None,
         accept="application/x-parquet"
     ):
@@ -63,10 +62,10 @@ class MultiModalCloudPredictor(CloudPredictor):
             The test data to be inferenced.
             Can be a pandas.DataFrame, a local path to a csv file.
             When predicting multimodality with image modality:
-                You need to specify `test_data_image_path` and `test_data_image_column`, and make sure the image column contains relative path to the image.
+                You need to specify `test_data_image_column`, and make sure the image column contains relative path to the image.
             When predicting with only images:
                 Can be a pandas.DataFrame, a local path to a csv file.
-                    Similarly, you need to specify `test_data_image_path` and `test_data_image_column`, and make sure the image column contains relative path to the image.
+                    Similarly, you need to specify `test_data_image_column`, and make sure the image column contains relative path to the image.
                 Or a local path to a single image file.
                 Or a list of local paths to image files.
         test_data_image_column: default = None

--- a/cloud/src/autogluon/cloud/predictor/multimodal_cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/multimodal_cloud_predictor.py
@@ -45,12 +45,7 @@ class MultiModalCloudPredictor(CloudPredictor):
         predictor_cls = multimodal_predictor_cls
         return predictor_cls
 
-    def predict_real_time(
-        self,
-        test_data,
-        test_data_image_column=None,
-        accept="application/x-parquet"
-    ):
+    def predict_real_time(self, test_data, test_data_image_column=None, accept="application/x-parquet"):
         """
         Predict with the deployed SageMaker endpoint. A deployed SageMaker endpoint is required.
         This is intended to provide a low latency inference.
@@ -97,8 +92,7 @@ class MultiModalCloudPredictor(CloudPredictor):
         if isinstance(test_data, pd.DataFrame):
             if test_data_image_column is not None:
                 test_data = convert_image_path_to_encoded_bytes_in_dataframe(
-                    dataframe=test_data,
-                    image_column=test_data_image_column
+                    dataframe=test_data, image_column=test_data_image_column
                 )
             content_type = "application/x-parquet"
 

--- a/cloud/src/autogluon/cloud/predictor/multimodal_cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/multimodal_cloud_predictor.py
@@ -69,19 +69,10 @@ class MultiModalCloudPredictor(CloudPredictor):
                     Similarly, you need to specify `test_data_image_path` and `test_data_image_column`, and make sure the image column contains relative path to the image.
                 Or a local path to a single image file.
                 Or a list of local paths to image files.
-        test_data_image_path: str, default = None
-            A local path to the images. This parameter is REQUIRED if you want to inference with multimodality involving image modality.
-            If you provided this parameter, the image path inside your train/tune data MUST be relative.
-            Path needs to be a folder containing the images.
-
-            Example:
-            If your images live under a root directory `example_images/`, then you would provide `example_images` as the `image_path`.
-            And you want to make sure in your test file, the column corresponding to the images is a relative path prefix with the root directory.
-            For example, `example_images/test/image1.png`. An absolute path will NOT work.
         test_data_image_column: default = None
             If provided a pandas.DataFrame as the test_data and test_data involves image modality,
             you must specify the column name corresponding to image paths.
-            Images have to live in the same directory specified by the column.
+            The path MUST be an abspath
         accept: str, default = application/x-parquet
             Type of accept output content.
             Valid options are application/x-parquet, text/csv, application/json
@@ -105,12 +96,9 @@ class MultiModalCloudPredictor(CloudPredictor):
             test_data = np.array([read_image_bytes_and_encode(image) for image in test_data], dtype="object")
             content_type = "application/x-npy"
         if isinstance(test_data, pd.DataFrame):
-            if test_data_image_path is not None or test_data_image_column is not None:
-                assert test_data_image_path is not None and test_data_image_column is not None, \
-                    "Please specify both `test_data_image_path` and `test_data_image_column` when involves image modality"
+            if test_data_image_column is not None:
                 test_data = convert_image_path_to_encoded_bytes_in_dataframe(
                     dataframe=test_data,
-                    image_root_path=test_data_image_path,
                     image_column=test_data_image_column
                 )
             content_type = "application/x-parquet"

--- a/cloud/src/autogluon/cloud/predictor/multimodal_cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/multimodal_cloud_predictor.py
@@ -45,7 +45,13 @@ class MultiModalCloudPredictor(CloudPredictor):
         predictor_cls = multimodal_predictor_cls
         return predictor_cls
 
-    def predict_real_time(self, test_data, test_data_image_column=None, accept="application/x-parquet"):
+    def predict_real_time(
+        self,
+        test_data,
+        test_data_image_path=None,
+        test_data_image_column=None,
+        accept="application/x-parquet"
+    ):
         """
         Predict with the deployed SageMaker endpoint. A deployed SageMaker endpoint is required.
         This is intended to provide a low latency inference.
@@ -55,15 +61,24 @@ class MultiModalCloudPredictor(CloudPredictor):
         ----------
         test_data: Union(str, pandas.DataFrame)
             The test data to be inferenced.
-            Can be a pandas.DataFrame, a local path or a s3 path to a csv file.
+            Can be a pandas.DataFrame, a local path to a csv file.
             When predicting multimodality with image modality:
-                You need to specify `test_data_image_column`, and make sure the image column contains relative path to the image.
+                You need to specify `test_data_image_path` and `test_data_image_column`, and make sure the image column contains relative path to the image.
             When predicting with only images:
-                Can be a pandas.DataFrame, a local path or a s3 path to a csv file.
-                    Similarly, You need to specify `test_data_image_column`, and make sure the image column contains relative path to the image.
+                Can be a pandas.DataFrame, a local path to a csv file.
+                    Similarly, you need to specify `test_data_image_path` and `test_data_image_column`, and make sure the image column contains relative path to the image.
                 Or a local path to a single image file.
                 Or a list of local paths to image files.
-        test_data_image_column: Optional(str)
+        test_data_image_path: str, default = None
+            A local path to the images. This parameter is REQUIRED if you want to inference with multimodality involving image modality.
+            If you provided this parameter, the image path inside your train/tune data MUST be relative.
+            Path needs to be a folder containing the images.
+
+            Example:
+            If your images live under a root directory `example_images/`, then you would provide `example_images` as the `image_path`.
+            And you want to make sure in your test file, the column corresponding to the images is a relative path prefix with the root directory.
+            For example, `example_images/test/image1.png`. An absolute path will NOT work.
+        test_data_image_column: default = None
             If provided a pandas.DataFrame as the test_data and test_data involves image modality,
             you must specify the column name corresponding to image paths.
             Images have to live in the same directory specified by the column.
@@ -82,21 +97,22 @@ class MultiModalCloudPredictor(CloudPredictor):
         import numpy as np
 
         if isinstance(test_data, str):
-            if is_s3_url(test_data):
-                test_data = load_pd.load(test_data)
+            if is_image_file(test_data):
+                test_data = [test_data]
             else:
-                if is_image_file(test_data):
-                    test_data = np.array([read_image_bytes_and_encode(test_data)], dtype="object")
-                    content_type = "application/x-npy"
-                else:
-                    test_data = load_pd.load(test_data)
+                test_data = load_pd.load(test_data)
         if isinstance(test_data, list):
-            images = []
-            test_data = np.array([read_image_bytes_and_encode(image) for image in images], dtype="object")
+            test_data = np.array([read_image_bytes_and_encode(image) for image in test_data], dtype="object")
             content_type = "application/x-npy"
         if isinstance(test_data, pd.DataFrame):
-            if test_data_image_column is not None:
-                test_data = convert_image_path_to_encoded_bytes_in_dataframe(test_data, test_data_image_column)
+            if test_data_image_path is not None or test_data_image_column is not None:
+                assert test_data_image_path is not None and test_data_image_column is not None, \
+                    "Please specify both `test_data_image_path` and `test_data_image_column` when involves image modality"
+                test_data = convert_image_path_to_encoded_bytes_in_dataframe(
+                    dataframe=test_data,
+                    image_root_path=test_data_image_path,
+                    image_column=test_data_image_column
+                )
             content_type = "application/x-parquet"
 
         # Providing content type here because sagemaker serializer doesn't support change content type dynamically.
@@ -112,12 +128,12 @@ class MultiModalCloudPredictor(CloudPredictor):
         """
         test_data: str
             The test data to be inferenced.
-            Can be a pandas.DataFrame, a local path or a s3 path to a csv file.
+            Can be a pandas.DataFrame, a local path to a csv file.
             When predicting multimodality with image modality:
                 You need to specify `test_data_image_column`, and make sure the image column contains relative path to the image.
             When predicting with only images:
-                Can be a local path or a s3 path to a directory containing the images.
-                or a local path or a s3 path to a single image.
+                Can be a local path to a directory containing the images.
+                or a local path to a single image.
         test_data_image_column: Optional(str)
             If test_data involves image modality, you must specify the column name corresponding to image paths.
             Images have to live in the same directory specified by the column.
@@ -126,17 +142,7 @@ class MultiModalCloudPredictor(CloudPredictor):
         """
         image_modality_only = False
         if isinstance(test_data, str):
-            if is_s3_url(test_data):
-                if is_s3_folder(test_data, session=self.sagemaker_session):
-                    image_modality_only = True
-                else:
-                    bucket, prefix = s3_path_to_bucket_prefix(test_data)
-                    utils_folder = "utils"
-                    self.sagemaker_session.download_data(utils_folder, bucket, key_prefix=prefix)
-                    filename = prefix.rsplit("/")[-1]
-                    if is_image_file(os.path.join(utils_folder, filename)):
-                        image_modality_only = True
-            elif os.path.isdir(test_data) or is_image_file(test_data):
+            if os.path.isdir(test_data) or is_image_file(test_data):
                 image_modality_only = True
 
         if image_modality_only:

--- a/cloud/src/autogluon/cloud/predictor/multimodal_cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/multimodal_cloud_predictor.py
@@ -69,7 +69,7 @@ class MultiModalCloudPredictor(CloudPredictor):
                 Or a local path to a single image file.
                 Or a list of local paths to image files.
         test_data_image_column: default = None
-            If provided a pandas.DataFrame as the test_data and test_data involves image modality,
+            If provided a csv file or pandas.DataFrame as the test_data and test_data involves image modality,
             you must specify the column name corresponding to image paths.
             The path MUST be an abspath
         accept: str, default = application/x-parquet
@@ -123,7 +123,7 @@ class MultiModalCloudPredictor(CloudPredictor):
                 or a local path to a single image.
         test_data_image_column: Optional(str)
             If test_data involves image modality, you must specify the column name corresponding to image paths.
-            Images have to live in the same directory specified by the column.
+            The path MUST be an abspath
         kwargs:
             Refer to `CloudPredictor.predict()`
         """

--- a/cloud/src/autogluon/cloud/predictor/multimodal_cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/multimodal_cloud_predictor.py
@@ -5,11 +5,9 @@ import os
 import pandas as pd
 
 from autogluon.common.loaders import load_pd
-from autogluon.common.utils.s3_utils import is_s3_url, s3_path_to_bucket_prefix
 
 from ..utils.ag_sagemaker import AutoGluonMultiModalRealtimePredictor
 from ..utils.constants import VALID_ACCEPT
-from ..utils.s3_utils import is_s3_folder
 from ..utils.utils import convert_image_path_to_encoded_bytes_in_dataframe, is_image_file, read_image_bytes_and_encode
 from .cloud_predictor import CloudPredictor
 

--- a/cloud/src/autogluon/cloud/predictor/multimodal_cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/multimodal_cloud_predictor.py
@@ -53,11 +53,11 @@ class MultiModalCloudPredictor(CloudPredictor):
         ----------
         test_data: Union(str, pandas.DataFrame)
             The test data to be inferenced.
-            Can be a pandas.DataFrame, a local path to a csv file.
+            Can be a pandas.DataFrame or a local path to a csv file.
             When predicting multimodality with image modality:
                 You need to specify `test_data_image_column`, and make sure the image column contains relative path to the image.
             When predicting with only images:
-                Can be a pandas.DataFrame, a local path to a csv file.
+                Can be a pandas.DataFrame or a local path to a csv file.
                     Similarly, you need to specify `test_data_image_column`, and make sure the image column contains relative path to the image.
                 Or a local path to a single image file.
                 Or a list of local paths to image files.
@@ -107,12 +107,11 @@ class MultiModalCloudPredictor(CloudPredictor):
         """
         test_data: str
             The test data to be inferenced.
-            Can be a pandas.DataFrame, a local path to a csv file.
+            Can be a pandas.DataFrame or a local path to a csv file.
             When predicting multimodality with image modality:
                 You need to specify `test_data_image_column`, and make sure the image column contains relative path to the image.
             When predicting with only images:
-                Can be a local path to a directory containing the images.
-                or a local path to a single image.
+                Can be a local path to a directory containing the images or a local path to a single image.
         test_data_image_column: Optional(str)
             If test_data involves image modality, you must specify the column name corresponding to image paths.
             The path MUST be an abspath

--- a/cloud/src/autogluon/cloud/predictor/tabular_cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/tabular_cloud_predictor.py
@@ -53,46 +53,6 @@ class TabularCloudPredictor(CloudPredictor):
             yaml.dump(config, f)
         return path
 
-    def fit(self, *, predictor_init_args, predictor_fit_args, image_path=None, image_column=None, **kwargs):
-        """
-        predictor_init_args: dict
-            Init args for the predictor
-        predictor_fit_args: dict
-            Fit args for the predictor
-        image_path: str, default = None
-            A local path or s3 path to the images. This parameter is REQUIRED if you want to train predictor with image modality.
-            If you provided this parameter, the image path inside your train/tune data MUST be relative.
-            If local path, path needs to be either a compressed file containing the images or a folder containing the images.
-            If it's a folder, we will zip it for you and upload it to the s3.
-            If s3 path, the path needs to be a path to a compressed file containing the images
-
-            Example:
-            If your images live under a root directory `example_images/`, then you would provide `example_images` as the `image_path`.
-            And you want to make sure in your training/tuning file, the column corresponding to the images is a relative path prefix with the root directory.
-            For example, `example_images/train/image1.png`. An absolute path will NOT work as the file will be moved to a remote system.
-        image_column: str, default = None
-            The column name in the training/tuning data that contains the image paths.
-            This is REQUIRED if you want to train multimodality with image modality with one exception:
-            If you pass in an `autogluon.tabular.FeatureMetadata` object that contains `image_path` special type to `predictor_fit_args`.
-        kwargs,
-            Refer to `CloudPredictor`
-        """
-        if image_path is not None:
-            assert (
-                image_column is not None or "feature_metadata" in predictor_fit_args
-            ), "Please provide `image_column` when training multimodality with image modality"
-        if image_column is not None:
-            assert (
-                image_path is not None
-            ), "Please provide `image_path` when training multimodality with image modality"
-        return super().fit(
-            predictor_init_args=predictor_init_args,
-            predictor_fit_args=predictor_fit_args,
-            image_path=image_path,
-            image_column=image_column,
-            **kwargs,
-        )
-
     def predict_real_time(self, test_data, test_data_image_column=None, accept="application/x-parquet"):
         """
         Predict with the deployed SageMaker endpoint. A deployed SageMaker endpoint is required.

--- a/cloud/src/autogluon/cloud/predictor/tabular_cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/tabular_cloud_predictor.py
@@ -103,7 +103,7 @@ class TabularCloudPredictor(CloudPredictor):
         ----------
         test_data: Union(str, pandas.DataFrame)
             The test data to be inferenced.
-            Can be a pandas.DataFrame, a local path or a s3 path to a csv file.
+            Can be a pandas.DataFrame, a local path to a csv file.
             When predicting multimodality with image modality:
                 You need to specify `test_data_image_column`, and make sure the image column contains relative path to the image.
         test_data_image_column: Optional(str)

--- a/cloud/src/autogluon/cloud/predictor/tabular_cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/tabular_cloud_predictor.py
@@ -106,10 +106,9 @@ class TabularCloudPredictor(CloudPredictor):
             Can be a pandas.DataFrame, a local path to a csv file.
             When predicting multimodality with image modality:
                 You need to specify `test_data_image_column`, and make sure the image column contains relative path to the image.
-        test_data_image_column: Optional(str)
-            If provided a pandas.DataFrame as the test_data and test_data involves image modality,
-            you must specify the column name corresponding to image paths.
-            Images have to live in the same directory specified by the column.
+        test_data_image_column: default = None
+            If test_data involves image modality, you must specify the column name corresponding to image paths.
+            The path MUST be an abspath
         accept: str, default = application/x-parquet
             Type of accept output content.
             Valid options are application/x-parquet, text/csv, application/json

--- a/cloud/src/autogluon/cloud/predictor/tabular_cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/tabular_cloud_predictor.py
@@ -63,7 +63,7 @@ class TabularCloudPredictor(CloudPredictor):
         ----------
         test_data: Union(str, pandas.DataFrame)
             The test data to be inferenced.
-            Can be a pandas.DataFrame, a local path to a csv file.
+            Can be a pandas.DataFrame or a local path to a csv file.
             When predicting multimodality with image modality:
                 You need to specify `test_data_image_column`, and make sure the image column contains relative path to the image.
         test_data_image_column: default = None

--- a/cloud/src/autogluon/cloud/scripts/train.py
+++ b/cloud/src/autogluon/cloud/scripts/train.py
@@ -114,7 +114,9 @@ if __name__ == "__main__":
         train_images_dir = "train_images"
         shutil.unpack_archive(train_image_compressed_file, train_images_dir)
         image_column = config["image_column"]
-        training_data[image_column] = training_data[image_column].apply(lambda path: os.path.join(train_images_dir, path))
+        training_data[image_column] = training_data[image_column].apply(
+            lambda path: os.path.join(train_images_dir, path)
+        )
 
     if args.tune_images:
         tune_image_compressed_file = get_input_path(args.tune_images)

--- a/cloud/src/autogluon/cloud/scripts/train.py
+++ b/cloud/src/autogluon/cloud/scripts/train.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
     parser.add_argument("--output-data-dir", type=str, default=get_env_if_present("SM_OUTPUT_DATA_DIR"))
     parser.add_argument("--model-dir", type=str, default=get_env_if_present("SM_MODEL_DIR"))
     parser.add_argument("--n_gpus", type=str, default=get_env_if_present("SM_NUM_GPUS"))
-    parser.add_argument("--training_dir", type=str, default=get_env_if_present("SM_CHANNEL_TRAIN"))
+    parser.add_argument("--train_dir", type=str, default=get_env_if_present("SM_CHANNEL_TRAIN"))
     parser.add_argument("--tune_dir", type=str, required=False, default=get_env_if_present("SM_CHANNEL_TUNE"))
     parser.add_argument(
         "--train_images", type=str, required=False, default=get_env_if_present("SM_CHANNEL_TRAIN_IMAGES")
@@ -95,7 +95,7 @@ if __name__ == "__main__":
 
         predictor_cls = MultiModalPredictor
 
-    train_file = get_input_path(args.training_dir)
+    train_file = get_input_path(args.train_dir)
     training_data = TabularDataset(train_file)
     if predictor_type == "tabular" and "image_column" in config:
         feature_metadata = predictor_fit_args.get("feature_metadata", None)
@@ -114,14 +114,14 @@ if __name__ == "__main__":
         train_images_dir = "train_images"
         shutil.unpack_archive(train_image_compressed_file, train_images_dir)
         image_column = config["image_column"]
-        training_data[image_column] = [os.path.join(train_images_dir, path) for path in training_data[image_column]]
+        training_data[image_column] = training_data[image_column].apply(lambda path: os.path.join(train_images_dir, path))
 
     if args.tune_images:
         tune_image_compressed_file = get_input_path(args.tune_images)
         tune_images_dir = "tune_images"
         shutil.unpack_archive(tune_image_compressed_file, tune_images_dir)
         image_column = config["image_column"]
-        tuning_data[image_column] = [os.path.join(tune_images_dir, path) for path in tune_images_dir[image_column]]
+        tuning_data[image_column] = tuning_data[image_column].apply(lambda path: os.path.join(tune_images_dir, path))
 
     predictor = predictor_cls(**predictor_init_args).fit(training_data, tuning_data=tuning_data, **predictor_fit_args)
 

--- a/cloud/src/autogluon/cloud/scripts/train.py
+++ b/cloud/src/autogluon/cloud/scripts/train.py
@@ -42,8 +42,12 @@ if __name__ == "__main__":
     parser.add_argument("--n_gpus", type=str, default=get_env_if_present("SM_NUM_GPUS"))
     parser.add_argument("--training_dir", type=str, default=get_env_if_present("SM_CHANNEL_TRAIN"))
     parser.add_argument("--tune_dir", type=str, required=False, default=get_env_if_present("SM_CHANNEL_TUNE"))
-    parser.add_argument("--train_images", type=str, required=False, default=get_env_if_present("SM_CHANNEL_TRAIN_IMAGES"))
-    parser.add_argument("--tune_images", type=str, required=False, default=get_env_if_present("SM_CHANNEL_TUNE_IMAGES"))
+    parser.add_argument(
+        "--train_images", type=str, required=False, default=get_env_if_present("SM_CHANNEL_TRAIN_IMAGES")
+    )
+    parser.add_argument(
+        "--tune_images", type=str, required=False, default=get_env_if_present("SM_CHANNEL_TUNE_IMAGES")
+    )
     parser.add_argument("--ag_config", type=str, default=get_env_if_present("SM_CHANNEL_CONFIG"))
     parser.add_argument("--serving_script", type=str, default=get_env_if_present("SM_CHANNEL_SERVING"))
 
@@ -111,7 +115,7 @@ if __name__ == "__main__":
         shutil.unpack_archive(train_image_compressed_file, train_images_dir)
         image_column = config["image_column"]
         training_data[image_column] = [os.path.join(train_images_dir, path) for path in training_data[image_column]]
-    
+
     if args.tune_images:
         tune_image_compressed_file = get_input_path(args.tune_images)
         tune_images_dir = "tune_images"

--- a/cloud/src/autogluon/cloud/scripts/train.py
+++ b/cloud/src/autogluon/cloud/scripts/train.py
@@ -42,7 +42,8 @@ if __name__ == "__main__":
     parser.add_argument("--n_gpus", type=str, default=get_env_if_present("SM_NUM_GPUS"))
     parser.add_argument("--training_dir", type=str, default=get_env_if_present("SM_CHANNEL_TRAIN"))
     parser.add_argument("--tune_dir", type=str, required=False, default=get_env_if_present("SM_CHANNEL_TUNE"))
-    parser.add_argument("--images_dir", type=str, required=False, default=get_env_if_present("SM_CHANNEL_IMAGES"))
+    parser.add_argument("--train_images", type=str, required=False, default=get_env_if_present("SM_CHANNEL_TRAIN_IMAGES"))
+    parser.add_argument("--tune_images", type=str, required=False, default=get_env_if_present("SM_CHANNEL_TUNE_IMAGES"))
     parser.add_argument("--ag_config", type=str, default=get_env_if_present("SM_CHANNEL_CONFIG"))
     parser.add_argument("--serving_script", type=str, default=get_env_if_present("SM_CHANNEL_SERVING"))
 
@@ -104,9 +105,19 @@ if __name__ == "__main__":
         tune_file = get_input_path(args.tune_dir)
         tuning_data = TabularDataset(tune_file)
 
-    if args.images_dir:
-        image_compressed_file = get_input_path(args.images_dir)
-        shutil.unpack_archive(image_compressed_file)
+    if args.train_images:
+        train_image_compressed_file = get_input_path(args.train_images)
+        train_images_dir = "train_images"
+        shutil.unpack_archive(train_image_compressed_file, train_images_dir)
+        image_column = config["image_column"]
+        training_data[image_column] = [os.path.join(train_images_dir, path) for path in training_data[image_column]]
+    
+    if args.tune_images:
+        tune_image_compressed_file = get_input_path(args.tune_images)
+        tune_images_dir = "tune_images"
+        shutil.unpack_archive(tune_image_compressed_file, tune_images_dir)
+        image_column = config["image_column"]
+        tuning_data[image_column] = [os.path.join(tune_images_dir, path) for path in tune_images_dir[image_column]]
 
     predictor = predictor_cls(**predictor_init_args).fit(training_data, tuning_data=tuning_data, **predictor_fit_args)
 

--- a/cloud/src/autogluon/cloud/utils/utils.py
+++ b/cloud/src/autogluon/cloud/utils/utils.py
@@ -13,28 +13,6 @@ from PIL import Image
 logger = logging.getLogger(__name__)
 
 
-def get_real_image_path_in_image_column(image_root_path, path):
-    """
-    Combine root path and path, where path contains root path's basename.
-    For example,
-        image_root_path = /home/user/example_images/
-        path = example_images/test/a.jpg
-        would return /home/user/example_images/test/a.jpg
-    This is needed to make sure the fit and predict api of CloudPredictor follows the same logic.
-    """
-    image_root_path = os.path.abspath(image_root_path)
-    path = path.split(os.path.sep)
-    while path[0] == "":
-        # Avoid cases like /foo/test
-        path.pop(0)
-    image_path_root_head, image_path_tail = os.path.split(image_root_path)
-    assert (
-        image_path_tail == path[0]
-    ), "Please make sure the image path inside your image column contains the root image directory"
-
-    return os.path.join(image_path_root_head, *path)
-
-
 def read_image_bytes_and_encode(image_path):
     image_obj = open(image_path, "rb")
     image_bytes = image_obj.read()

--- a/cloud/src/autogluon/cloud/utils/utils.py
+++ b/cloud/src/autogluon/cloud/utils/utils.py
@@ -42,10 +42,9 @@ def read_image_bytes_and_encode(image_path):
     return b85_image
 
 
-def convert_image_path_to_encoded_bytes_in_dataframe(dataframe, image_root_path, image_column):
+def convert_image_path_to_encoded_bytes_in_dataframe(dataframe, image_column):
     assert image_column in dataframe, "Please specify a valid image column name"
     dataframe = copy.deepcopy(dataframe)
-    dataframe[image_column] = [get_real_image_path_in_image_column(image_root_path, path) for path in dataframe[image_column]]
     dataframe[image_column] = [read_image_bytes_and_encode(path) for path in dataframe[image_column]]
 
     return dataframe

--- a/cloud/src/autogluon/cloud/utils/utils.py
+++ b/cloud/src/autogluon/cloud/utils/utils.py
@@ -13,12 +13,13 @@ logger = logging.getLogger(__name__)
 
 
 def read_image_bytes_and_encode(image_path):
+    image_path = os.path.abspath(image_path)
     image_obj = open(image_path, "rb")
     image_bytes = image_obj.read()
     image_obj.close()
-    b64_image = base64.b85encode(image_bytes).decode("utf-8")
+    b85_image = base64.b85encode(image_bytes).decode("utf-8")
 
-    return b64_image
+    return b85_image
 
 
 def convert_image_path_to_encoded_bytes_in_dataframe(dataframe, image_column):

--- a/cloud/src/autogluon/cloud/utils/utils.py
+++ b/cloud/src/autogluon/cloud/utils/utils.py
@@ -24,11 +24,13 @@ def get_real_image_path_in_image_column(image_root_path, path):
     """
     image_root_path = os.path.abspath(image_root_path)
     path = path.split(os.path.sep)
-    while path[0] == '':
+    while path[0] == "":
         # Avoid cases like /foo/test
         path.pop(0)
     image_path_root_head, image_path_tail = os.path.split(image_root_path)
-    assert image_path_tail == path[0], 'Please make sure the image path inside your image column contains the root image directory'
+    assert (
+        image_path_tail == path[0]
+    ), "Please make sure the image path inside your image column contains the root image directory"
 
     return os.path.join(image_path_root_head, *path)
 

--- a/cloud/tests/conftest.py
+++ b/cloud/tests/conftest.py
@@ -39,7 +39,7 @@ class CloudTestHelper:
     @staticmethod
     def replace_image_abspath(data, image_column):
         data = pd.read_csv(data)
-        data[image_column] = [os.path.abspath(path) for path in data[image_column]]
+        data[image_column] = data[image_column].apply(os.path.abspath)
         return data
 
     @staticmethod

--- a/cloud/tests/conftest.py
+++ b/cloud/tests/conftest.py
@@ -1,9 +1,10 @@
 import os
+import zipfile
 
 import boto3
 import pandas as pd
 import pytest
-import zipfile
+
 
 class CloudTestHelper:
 
@@ -24,12 +25,12 @@ class CloudTestHelper:
         s3 = boto3.client("s3")
         for arg in args:
             s3.download_file("autogluon-cloud", arg, os.path.basename(arg))
-            
+
     @staticmethod
     def extract_images(image_zip_file):
-        with zipfile.ZipFile(image_zip_file, 'r') as zip_ref:
-          zip_ref.extractall('.')
-            
+        with zipfile.ZipFile(image_zip_file, "r") as zip_ref:
+            zip_ref.extractall(".")
+
     @staticmethod
     def replace_image_abspath(data, image_column):
         data = pd.read_csv(data)

--- a/cloud/tests/conftest.py
+++ b/cloud/tests/conftest.py
@@ -1,11 +1,10 @@
 import os
 import zipfile
+from datetime import datetime, timezone
 
 import boto3
 import pandas as pd
 import pytest
-
-from datetime import datetime, timezone
 
 
 class CloudTestHelper:
@@ -61,7 +60,7 @@ class CloudTestHelper:
         fit_kwargs=None,
         deploy_kwargs=None,
         predict_real_time_kwargs=None,
-        predict_kwargs=None
+        predict_kwargs=None,
     ):
         if fit_kwargs is None:
             fit_kwargs = dict(instance_type="ml.m5.2xlarge")

--- a/cloud/tests/unittests/image/test_image.py
+++ b/cloud/tests/unittests/image/test_image.py
@@ -19,7 +19,8 @@ def test_image(test_helper):
         predictor_init_args = dict(label="label", eval_metric="acc")
         predictor_fit_args = dict(train_data=train_data, time_limit=time_limit)
         cloud_predictor = ImageCloudPredictor(
-            cloud_output_path=f"s3://autogluon-cloud-ci/test-image/{timestamp}", local_output_path="test_image_cloud_predictor"
+            cloud_output_path=f"s3://autogluon-cloud-ci/test-image/{timestamp}",
+            local_output_path="test_image_cloud_predictor",
         )
         cloud_predictor_no_train = ImageCloudPredictor(
             cloud_output_path=f"s3://autogluon-cloud-ci/test-image-no-train/{timestamp}",

--- a/cloud/tests/unittests/image/test_image.py
+++ b/cloud/tests/unittests/image/test_image.py
@@ -8,7 +8,7 @@ def test_image(test_helper):
     train_data = "image_train_relative.csv"
     train_image = "shopee-iet.zip"
     test_data = "test_images/BabyPants_1035.jpg"
-    image_column='Images'
+    image_column = "Images"
     with tempfile.TemporaryDirectory() as _:
         test_helper.prepare_data(train_data, train_image, test_data)
         test_helper.extract_images(train_image)
@@ -34,7 +34,7 @@ def test_image(test_helper):
             fit_kwargs=dict(
                 instance_type="ml.g4dn.2xlarge",
                 image_column=image_column,
-                custom_image_uri=test_helper.gpu_training_image
+                custom_image_uri=test_helper.gpu_training_image,
             ),
             deploy_kwargs=dict(custom_image_uri=test_helper.cpu_inference_image),
             predict_kwargs=dict(custom_image_uri=test_helper.cpu_inference_image),
@@ -45,7 +45,7 @@ def test_multimodal_image_only(test_helper):
     train_data = "image_train_relative.csv"
     train_image = "shopee-iet.zip"
     test_data = "test_images/BabyPants_1035.jpg"
-    image_column='Images'
+    image_column = "Images"
     with tempfile.TemporaryDirectory() as _:
         test_helper.prepare_data(train_data, train_image, test_data)
         test_helper.extract_images(train_image)
@@ -72,7 +72,7 @@ def test_multimodal_image_only(test_helper):
             fit_kwargs=dict(
                 instance_type="ml.g4dn.2xlarge",
                 image_column=image_column,
-                custom_image_uri=test_helper.gpu_training_image
+                custom_image_uri=test_helper.gpu_training_image,
             ),
             deploy_kwargs=dict(custom_image_uri=test_helper.cpu_inference_image),
             predict_kwargs=dict(custom_image_uri=test_helper.cpu_inference_image),

--- a/cloud/tests/unittests/image/test_image.py
+++ b/cloud/tests/unittests/image/test_image.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 
 from autogluon.cloud import ImageCloudPredictor, MultiModalCloudPredictor
@@ -7,8 +8,11 @@ def test_image(test_helper):
     train_data = "image_train_relative.csv"
     train_image = "shopee-iet.zip"
     test_data = "test_images/BabyPants_1035.jpg"
+    image_column='Images'
     with tempfile.TemporaryDirectory() as _:
         test_helper.prepare_data(train_data, train_image, test_data)
+        test_helper.extract_images(train_image)
+        train_data = test_helper.replace_image_abspath(train_data, image_column)
         test_data = "BabyPants_1035.jpg"
         time_limit = 60
 
@@ -27,9 +31,11 @@ def test_image(test_helper):
             predictor_fit_args,
             cloud_predictor_no_train,
             test_data,
-            image_path="shopee-iet.zip",
-            fit_instance_type="ml.g4dn.2xlarge",
-            fit_kwargs=dict(custom_image_uri=test_helper.gpu_training_image),
+            fit_kwargs=dict(
+                instance_type="ml.g4dn.2xlarge",
+                image_column=image_column,
+                custom_image_uri=test_helper.gpu_training_image
+            ),
             deploy_kwargs=dict(custom_image_uri=test_helper.cpu_inference_image),
             predict_kwargs=dict(custom_image_uri=test_helper.cpu_inference_image),
         )
@@ -39,8 +45,11 @@ def test_multimodal_image_only(test_helper):
     train_data = "image_train_relative.csv"
     train_image = "shopee-iet.zip"
     test_data = "test_images/BabyPants_1035.jpg"
+    image_column='Images'
     with tempfile.TemporaryDirectory() as _:
         test_helper.prepare_data(train_data, train_image, test_data)
+        test_helper.extract_images(train_image)
+        train_data = test_helper.replace_image_abspath(train_data, image_column)
         test_data = "BabyPants_1035.jpg"
         time_limit = 60
 
@@ -60,9 +69,11 @@ def test_multimodal_image_only(test_helper):
             predictor_fit_args,
             cloud_predictor_no_train,
             test_data,
-            image_path="shopee-iet.zip",
-            fit_instance_type="ml.g4dn.2xlarge",
-            fit_kwargs=dict(custom_image_uri=test_helper.gpu_training_image),
+            fit_kwargs=dict(
+                instance_type="ml.g4dn.2xlarge",
+                image_column=image_column,
+                custom_image_uri=test_helper.gpu_training_image
+            ),
             deploy_kwargs=dict(custom_image_uri=test_helper.cpu_inference_image),
             predict_kwargs=dict(custom_image_uri=test_helper.cpu_inference_image),
         )

--- a/cloud/tests/unittests/image/test_image.py
+++ b/cloud/tests/unittests/image/test_image.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 
 from autogluon.cloud import ImageCloudPredictor, MultiModalCloudPredictor

--- a/cloud/tests/unittests/image/test_image.py
+++ b/cloud/tests/unittests/image/test_image.py
@@ -8,6 +8,7 @@ def test_image(test_helper):
     train_image = "shopee-iet.zip"
     test_data = "test_images/BabyPants_1035.jpg"
     image_column = "image"
+    timestamp = test_helper.get_utc_timestamp_now()
     with tempfile.TemporaryDirectory() as _:
         test_helper.prepare_data(train_data, train_image, test_data)
         test_helper.extract_images(train_image)
@@ -18,10 +19,10 @@ def test_image(test_helper):
         predictor_init_args = dict(label="label", eval_metric="acc")
         predictor_fit_args = dict(train_data=train_data, time_limit=time_limit)
         cloud_predictor = ImageCloudPredictor(
-            cloud_output_path="s3://autogluon-cloud-ci/test-image", local_output_path="test_image_cloud_predictor"
+            cloud_output_path=f"s3://autogluon-cloud-ci/test-image/{timestamp}", local_output_path="test_image_cloud_predictor"
         )
         cloud_predictor_no_train = ImageCloudPredictor(
-            cloud_output_path="s3://autogluon-cloud-ci/test-image-no-train",
+            cloud_output_path=f"s3://autogluon-cloud-ci/test-image-no-train/{timestamp}",
             local_output_path="test_image_cloud_predictor_no_train",
         )
         test_helper.test_functionality(
@@ -45,6 +46,7 @@ def test_multimodal_image_only(test_helper):
     train_image = "shopee-iet.zip"
     test_data = "test_images/BabyPants_1035.jpg"
     image_column = "image"
+    timestamp = test_helper.get_utc_timestamp_now()
     with tempfile.TemporaryDirectory() as _:
         test_helper.prepare_data(train_data, train_image, test_data)
         test_helper.extract_images(train_image)
@@ -55,11 +57,11 @@ def test_multimodal_image_only(test_helper):
         predictor_init_args = dict(label="label", eval_metric="acc")
         predictor_fit_args = dict(train_data=train_data, time_limit=time_limit)
         cloud_predictor = MultiModalCloudPredictor(
-            cloud_output_path="s3://autogluon-cloud-ci/test-multimodal-image",
+            cloud_output_path=f"s3://autogluon-cloud-ci/test-multimodal-image/{timestamp}",
             local_output_path="test_multimodal_image_cloud_predictor",
         )
         cloud_predictor_no_train = MultiModalCloudPredictor(
-            cloud_output_path="s3://autogluon-cloud-ci/test-multimodal-image-no-train",
+            cloud_output_path=f"s3://autogluon-cloud-ci/test-multimodal-image-no-train/{timestamp}",
             local_output_path="test_multimodal_image_cloud_predictor_no_train",
         )
         test_helper.test_functionality(

--- a/cloud/tests/unittests/image/test_image.py
+++ b/cloud/tests/unittests/image/test_image.py
@@ -7,7 +7,7 @@ def test_image(test_helper):
     train_data = "image_train_relative.csv"
     train_image = "shopee-iet.zip"
     test_data = "test_images/BabyPants_1035.jpg"
-    image_column = "Images"
+    image_column = "image"
     with tempfile.TemporaryDirectory() as _:
         test_helper.prepare_data(train_data, train_image, test_data)
         test_helper.extract_images(train_image)
@@ -44,7 +44,7 @@ def test_multimodal_image_only(test_helper):
     train_data = "image_train_relative.csv"
     train_image = "shopee-iet.zip"
     test_data = "test_images/BabyPants_1035.jpg"
-    image_column = "Images"
+    image_column = "image"
     with tempfile.TemporaryDirectory() as _:
         test_helper.prepare_data(train_data, train_image, test_data)
         test_helper.extract_images(train_image)

--- a/cloud/tests/unittests/multimodal/test_multimodal.py
+++ b/cloud/tests/unittests/multimodal/test_multimodal.py
@@ -28,7 +28,6 @@ def test_multimodal_tabular_text(test_helper):
             predictor_fit_args,
             cloud_predictor_no_train,
             test_data,
-            fit_instance_type="ml.g4dn.2xlarge",
             fit_kwargs=dict(instance_type="ml.g4dn.2xlarge", custom_image_uri=test_helper.gpu_training_image),
             deploy_kwargs=dict(custom_image_uri=test_helper.cpu_inference_image),
             predict_kwargs=dict(custom_image_uri=test_helper.cpu_inference_image),

--- a/cloud/tests/unittests/multimodal/test_multimodal.py
+++ b/cloud/tests/unittests/multimodal/test_multimodal.py
@@ -1,5 +1,4 @@
 import tempfile
-import zipfile
 
 from autogluon.cloud import MultiModalCloudPredictor
 

--- a/cloud/tests/unittests/multimodal/test_multimodal.py
+++ b/cloud/tests/unittests/multimodal/test_multimodal.py
@@ -30,7 +30,10 @@ def test_multimodal_tabular_text(test_helper):
             cloud_predictor_no_train,
             test_data,
             fit_instance_type="ml.g4dn.2xlarge",
-            fit_kwargs=dict(custom_image_uri=test_helper.gpu_training_image),
+            fit_kwargs=dict(
+                instance_type="ml.g4dn.2xlarge",
+                custom_image_uri=test_helper.gpu_training_image
+            ),
             deploy_kwargs=dict(custom_image_uri=test_helper.cpu_inference_image),
             predict_kwargs=dict(custom_image_uri=test_helper.cpu_inference_image),
         )
@@ -40,10 +43,12 @@ def test_multimodal_tabular_text_image(test_helper):
     train_data = "tabular_text_image_train.csv"
     test_data = "tabular_text_image_test.csv"
     images = "tabular_text_image_images.zip"
+    image_column = 'Images'
     with tempfile.TemporaryDirectory() as _:
         test_helper.prepare_data(train_data, test_data, images)
-        with zipfile.ZipFile(images, "r") as zip_ref:
-            zip_ref.extractall(".")
+        test_helper.extract_images(images)
+        train_data = test_helper.replace_image_abspath(train_data, image_column)
+        test_data = test_helper.replace_image_abspath(test_data, image_column)
         time_limit = 120
 
         predictor_init_args = dict(
@@ -64,10 +69,14 @@ def test_multimodal_tabular_text_image(test_helper):
             predictor_fit_args,
             cloud_predictor_no_train,
             test_data,
-            image_path="tabular_text_image_images.zip",
-            fit_instance_type="ml.g4dn.2xlarge",
-            fit_kwargs=dict(custom_image_uri=test_helper.gpu_training_image),
+            fit_kwargs=dict(
+                instance_type="ml.g4dn.2xlarge",
+                image_column=image_column,
+                custom_image_uri=test_helper.gpu_training_image
+            ),
             deploy_kwargs=dict(custom_image_uri=test_helper.cpu_inference_image),
-            predict_real_time_kwargs=dict(test_data_image_column="Images"),
-            predict_kwargs=dict(test_data_image_column="Images", custom_image_uri=test_helper.cpu_inference_image),
-        )
+            predict_real_time_kwargs=dict(test_data_image_column=image_column),
+            predict_kwargs=dict(
+                test_data_image_column=image_column,
+                custom_image_uri=test_helper.cpu_inference_image),
+            )

--- a/cloud/tests/unittests/multimodal/test_multimodal.py
+++ b/cloud/tests/unittests/multimodal/test_multimodal.py
@@ -30,10 +30,7 @@ def test_multimodal_tabular_text(test_helper):
             cloud_predictor_no_train,
             test_data,
             fit_instance_type="ml.g4dn.2xlarge",
-            fit_kwargs=dict(
-                instance_type="ml.g4dn.2xlarge",
-                custom_image_uri=test_helper.gpu_training_image
-            ),
+            fit_kwargs=dict(instance_type="ml.g4dn.2xlarge", custom_image_uri=test_helper.gpu_training_image),
             deploy_kwargs=dict(custom_image_uri=test_helper.cpu_inference_image),
             predict_kwargs=dict(custom_image_uri=test_helper.cpu_inference_image),
         )
@@ -43,7 +40,7 @@ def test_multimodal_tabular_text_image(test_helper):
     train_data = "tabular_text_image_train.csv"
     test_data = "tabular_text_image_test.csv"
     images = "tabular_text_image_images.zip"
-    image_column = 'Images'
+    image_column = "Images"
     with tempfile.TemporaryDirectory() as _:
         test_helper.prepare_data(train_data, test_data, images)
         test_helper.extract_images(images)
@@ -72,11 +69,9 @@ def test_multimodal_tabular_text_image(test_helper):
             fit_kwargs=dict(
                 instance_type="ml.g4dn.2xlarge",
                 image_column=image_column,
-                custom_image_uri=test_helper.gpu_training_image
+                custom_image_uri=test_helper.gpu_training_image,
             ),
             deploy_kwargs=dict(custom_image_uri=test_helper.cpu_inference_image),
             predict_real_time_kwargs=dict(test_data_image_column=image_column),
-            predict_kwargs=dict(
-                test_data_image_column=image_column,
-                custom_image_uri=test_helper.cpu_inference_image),
-            )
+            predict_kwargs=dict(test_data_image_column=image_column, custom_image_uri=test_helper.cpu_inference_image),
+        )

--- a/cloud/tests/unittests/multimodal/test_multimodal.py
+++ b/cloud/tests/unittests/multimodal/test_multimodal.py
@@ -6,6 +6,7 @@ from autogluon.cloud import MultiModalCloudPredictor
 def test_multimodal_tabular_text(test_helper):
     train_data = "tabular_text_train.csv"
     test_data = "tabular_text_test.csv"
+    timestamp = test_helper.get_utc_timestamp_now()
     with tempfile.TemporaryDirectory() as _:
         test_helper.prepare_data(train_data, test_data)
         time_limit = 60
@@ -15,11 +16,11 @@ def test_multimodal_tabular_text(test_helper):
         )
         predictor_fit_args = dict(train_data=train_data, time_limit=time_limit)
         cloud_predictor = MultiModalCloudPredictor(
-            cloud_output_path="s3://autogluon-cloud-ci/test-multimodal-tabular-text",
+            cloud_output_path=f"s3://autogluon-cloud-ci/test-multimodal-tabular-text/{timestamp}",
             local_output_path="test_multimodal_tabular_text_cloud_predictor",
         )
         cloud_predictor_no_train = MultiModalCloudPredictor(
-            cloud_output_path="s3://autogluon-cloud-ci/test-multimodal-tabular-text-no-train",
+            cloud_output_path=f"s3://autogluon-cloud-ci/test-multimodal-tabular-text-no-train/{timestamp}",
             local_output_path="test_multimodal_tabular_text_cloud_predictor_no_train",
         )
         test_helper.test_functionality(
@@ -39,6 +40,7 @@ def test_multimodal_tabular_text_image(test_helper):
     test_data = "tabular_text_image_test.csv"
     images = "tabular_text_image_images.zip"
     image_column = "Images"
+    timestamp = test_helper.get_utc_timestamp_now()
     with tempfile.TemporaryDirectory() as _:
         test_helper.prepare_data(train_data, test_data, images)
         test_helper.extract_images(images)
@@ -51,11 +53,11 @@ def test_multimodal_tabular_text_image(test_helper):
         )
         predictor_fit_args = dict(train_data=train_data, time_limit=time_limit)
         cloud_predictor = MultiModalCloudPredictor(
-            cloud_output_path="s3://autogluon-cloud-ci/test-multimodal-tabular-text-image",
+            cloud_output_path=f"s3://autogluon-cloud-ci/test-multimodal-tabular-text-image/{timestamp}",
             local_output_path="test_multimodal_tabular_text_image_cloud_predictor",
         )
         cloud_predictor_no_train = MultiModalCloudPredictor(
-            cloud_output_path="s3://autogluon-cloud-ci/test-multimodal-tabular-text-image-no-train",
+            cloud_output_path=f"s3://autogluon-cloud-ci/test-multimodal-tabular-text-image-no-train/{timestamp}",
             local_output_path="test_multimodal_tabular_text_image_cloud_predictor_no_train",
         )
         test_helper.test_functionality(

--- a/cloud/tests/unittests/tabular/test_tabular.py
+++ b/cloud/tests/unittests/tabular/test_tabular.py
@@ -78,7 +78,7 @@ def test_tabular_tabular_text_image(test_helper):
             fit_kwargs=dict(
                 instance_type="ml.g4dn.2xlarge",
                 image_column=image_column,
-                custom_image_uri=test_helper.gpu_training_image
+                custom_image_uri=test_helper.gpu_training_image,
             ),
             deploy_kwargs=dict(custom_image_uri=test_helper.gpu_inference_image),
             predict_real_time_kwargs=dict(

--- a/cloud/tests/unittests/tabular/test_tabular.py
+++ b/cloud/tests/unittests/tabular/test_tabular.py
@@ -41,10 +41,12 @@ def test_tabular_tabular_text_image(test_helper):
     train_data = "tabular_text_image_train.csv"
     test_data = "tabular_text_image_test.csv"
     images = "tabular_text_image_images.zip"
+    image_column = "Images"
     with tempfile.TemporaryDirectory() as _:
         test_helper.prepare_data(train_data, test_data, images)
-        with zipfile.ZipFile(images, "r") as zip_ref:
-            zip_ref.extractall(".")
+        test_helper.extract_images(images)
+        train_data = test_helper.replace_image_abspath(train_data, image_column)
+        test_data = test_helper.replace_image_abspath(test_data, image_column)
         time_limit = 600
 
         predictor_init_args = dict(
@@ -73,15 +75,16 @@ def test_tabular_tabular_text_image(test_helper):
             predictor_fit_args,
             cloud_predictor_no_train,
             test_data,
-            image_path="tabular_text_image_images.zip",
-            fit_instance_type="ml.g4dn.2xlarge",
-            fit_kwargs=dict(image_column="Images", custom_image_uri=test_helper.gpu_training_image),
-            deploy_kwargs=dict(instance_type="ml.g4dn.2xlarge", custom_image_uri=test_helper.gpu_inference_image),
+            fit_kwargs=dict(
+                instance_type="ml.g4dn.2xlarge",
+                image_column=image_column,
+                custom_image_uri=test_helper.gpu_training_image
+            ),
+            deploy_kwargs=dict(custom_image_uri=test_helper.gpu_inference_image),
             predict_real_time_kwargs=dict(
                 test_data_image_column="Images",
             ),
             predict_kwargs=dict(
-                instance_type="ml.g4dn.2xlarge",
                 test_data_image_column="Images",
                 custom_image_uri=test_helper.gpu_inference_image,
             ),
@@ -120,8 +123,10 @@ def test_tabular_tabular_text(test_helper):
             predictor_fit_args,
             cloud_predictor_no_train,
             test_data,
-            fit_instance_type="ml.g4dn.2xlarge",
-            fit_kwargs=dict(custom_image_uri=test_helper.cpu_training_image),
-            deploy_kwargs=dict(instance_type="ml.g4dn.2xlarge", custom_image_uri=test_helper.gpu_inference_image),
-            predict_kwargs=dict(instance_type="ml.g4dn.2xlarge", custom_image_uri=test_helper.gpu_inference_image),
+            fit_kwargs=dict(
+                instance_type="ml.g4dn.2xlarge",
+                custom_image_uri=test_helper.gpu_training_image,
+            ),
+            deploy_kwargs=dict(custom_image_uri=test_helper.gpu_inference_image),
+            predict_kwargs=dict(custom_image_uri=test_helper.gpu_inference_image),
         )

--- a/cloud/tests/unittests/tabular/test_tabular.py
+++ b/cloud/tests/unittests/tabular/test_tabular.py
@@ -7,6 +7,7 @@ def test_tabular(test_helper):
     train_data = "tabular_train.csv"
     tune_data = "tabular_tune.csv"
     test_data = "tabular_test.csv"
+    timestamp = test_helper.get_utc_timestamp_now()
     with tempfile.TemporaryDirectory() as _:
         test_helper.prepare_data(train_data, tune_data, test_data)
         time_limit = 60
@@ -18,10 +19,11 @@ def test_tabular(test_helper):
             time_limit=time_limit,
         )
         cloud_predictor = TabularCloudPredictor(
-            cloud_output_path="s3://autogluon-cloud-ci/test-tabular", local_output_path="test_tabular_cloud_predictor"
+            cloud_output_path=f"s3://autogluon-cloud-ci/test-tabular/{timestamp}",
+            local_output_path="test_tabular_cloud_predictor"
         )
         cloud_predictor_no_train = TabularCloudPredictor(
-            cloud_output_path="s3://autogluon-cloud-ci/test-tabular-no-train",
+            cloud_output_path=f"s3://autogluon-cloud-ci/test-tabular-no-train/{timestamp}",
             local_output_path="test_tabular_cloud_predictor_no_train",
         )
         test_helper.test_functionality(
@@ -41,6 +43,7 @@ def test_tabular_tabular_text_image(test_helper):
     test_data = "tabular_text_image_test.csv"
     images = "tabular_text_image_images.zip"
     image_column = "Images"
+    timestamp = test_helper.get_utc_timestamp_now()
     with tempfile.TemporaryDirectory() as _:
         test_helper.prepare_data(train_data, test_data, images)
         test_helper.extract_images(images)
@@ -61,11 +64,11 @@ def test_tabular_tabular_text_image(test_helper):
             },
         )
         cloud_predictor = TabularCloudPredictor(
-            cloud_output_path="s3://autogluon-cloud-ci/test-tabular-tabular-text-image",
+            cloud_output_path=f"s3://autogluon-cloud-ci/test-tabular-tabular-text-image/{timestamp}",
             local_output_path="test_tabular_tabular_text_image_cloud_predictor",
         )
         cloud_predictor_no_train = TabularCloudPredictor(
-            cloud_output_path="s3://autogluon-cloud-ci/test-tabular-tabular-text-image-no-train",
+            cloud_output_path=f"s3://autogluon-cloud-ci/test-tabular-tabular-text-image-no-train/{timestamp}",
             local_output_path="test_tabular_tabular_text_image_cloud_predictor_no_train",
         )
         test_helper.test_functionality(
@@ -79,13 +82,13 @@ def test_tabular_tabular_text_image(test_helper):
                 image_column=image_column,
                 custom_image_uri=test_helper.gpu_training_image,
             ),
-            deploy_kwargs=dict(custom_image_uri=test_helper.gpu_inference_image),
+            deploy_kwargs=dict(custom_image_uri=test_helper.cpu_inference_image),
             predict_real_time_kwargs=dict(
                 test_data_image_column="Images",
             ),
             predict_kwargs=dict(
                 test_data_image_column="Images",
-                custom_image_uri=test_helper.gpu_inference_image,
+                custom_image_uri=test_helper.cpu_inference_image,
             ),
         )
 
@@ -93,6 +96,7 @@ def test_tabular_tabular_text_image(test_helper):
 def test_tabular_tabular_text(test_helper):
     train_data = "tabular_text_train.csv"
     test_data = "tabular_text_test.csv"
+    timestamp = test_helper.get_utc_timestamp_now()
     with tempfile.TemporaryDirectory() as _:
         test_helper.prepare_data(train_data, test_data)
         time_limit = 120
@@ -109,11 +113,11 @@ def test_tabular_tabular_text(test_helper):
             },
         )
         cloud_predictor = TabularCloudPredictor(
-            cloud_output_path="s3://autogluon-cloud-ci/test-tabular-tabular-text",
+            cloud_output_path=f"s3://autogluon-cloud-ci/test-tabular-tabular-text/{timestamp}",
             local_output_path="test_tabular_tabular_text_cloud_predictor",
         )
         cloud_predictor_no_train = TabularCloudPredictor(
-            cloud_output_path="s3://autogluon-cloud-ci/test-tabular-tabular-text-no-train",
+            cloud_output_path=f"s3://autogluon-cloud-ci/test-tabular-tabular-text-no-train/{timestamp}",
             local_output_path="test_tabular_tabular_text_cloud_predictor_no_train",
         )
         test_helper.test_functionality(
@@ -126,6 +130,6 @@ def test_tabular_tabular_text(test_helper):
                 instance_type="ml.g4dn.2xlarge",
                 custom_image_uri=test_helper.gpu_training_image,
             ),
-            deploy_kwargs=dict(custom_image_uri=test_helper.gpu_inference_image),
-            predict_kwargs=dict(custom_image_uri=test_helper.gpu_inference_image),
+            deploy_kwargs=dict(custom_image_uri=test_helper.cpu_inference_image),
+            predict_kwargs=dict(custom_image_uri=test_helper.cpu_inference_image),
         )

--- a/cloud/tests/unittests/tabular/test_tabular.py
+++ b/cloud/tests/unittests/tabular/test_tabular.py
@@ -20,7 +20,7 @@ def test_tabular(test_helper):
         )
         cloud_predictor = TabularCloudPredictor(
             cloud_output_path=f"s3://autogluon-cloud-ci/test-tabular/{timestamp}",
-            local_output_path="test_tabular_cloud_predictor"
+            local_output_path="test_tabular_cloud_predictor",
         )
         cloud_predictor_no_train = TabularCloudPredictor(
             cloud_output_path=f"s3://autogluon-cloud-ci/test-tabular-no-train/{timestamp}",

--- a/cloud/tests/unittests/tabular/test_tabular.py
+++ b/cloud/tests/unittests/tabular/test_tabular.py
@@ -1,5 +1,4 @@
 import tempfile
-import zipfile
 
 from autogluon.cloud import TabularCloudPredictor
 

--- a/cloud/tests/unittests/text/test_text.py
+++ b/cloud/tests/unittests/text/test_text.py
@@ -7,6 +7,7 @@ def test_text(test_helper):
     train_data = "text_train.csv"
     tune_data = "text_tune.csv"
     test_data = "text_test.csv"
+    timestamp = test_helper.get_utc_timestamp_now()
     with tempfile.TemporaryDirectory() as _:
         test_helper.prepare_data(train_data, tune_data, test_data)
         time_limit = 60
@@ -14,10 +15,11 @@ def test_text(test_helper):
         predictor_init_args = dict(label="label", eval_metric="acc")
         predictor_fit_args = dict(train_data=train_data, tuning_data=tune_data, time_limit=time_limit)
         cloud_predictor = TextCloudPredictor(
-            cloud_output_path="s3://autogluon-cloud-ci/test-text", local_output_path="test_text_cloud_predictor"
+            cloud_output_path=f"s3://autogluon-cloud-ci/test-text/{timestamp}",
+            local_output_path="test_text_cloud_predictor"
         )
         cloud_predictor_no_train = TextCloudPredictor(
-            cloud_output_path="s3://autogluon-cloud-ci/test-text-no-train",
+            cloud_output_path=f"s3://autogluon-cloud-ci/test-text-no-train/{timestamp}",
             local_output_path="test_text_cloud_predictor_no_train",
         )
         test_helper.test_functionality(
@@ -39,6 +41,7 @@ def test_multimodal_text_only(test_helper):
     train_data = "text_train.csv"
     tune_data = "text_tune.csv"
     test_data = "text_test.csv"
+    timestamp = test_helper.get_utc_timestamp_now()
     with tempfile.TemporaryDirectory() as _:
         test_helper.prepare_data(train_data, tune_data, test_data)
         time_limit = 60
@@ -46,11 +49,11 @@ def test_multimodal_text_only(test_helper):
         predictor_init_args = dict(label="label", eval_metric="acc")
         predictor_fit_args = dict(train_data=train_data, tuning_data=tune_data, time_limit=time_limit)
         cloud_predictor = MultiModalCloudPredictor(
-            cloud_output_path="s3://autogluon-cloud-ci/test-multimodal-text",
+            cloud_output_path=f"s3://autogluon-cloud-ci/test-multimodal-text/{timestamp}",
             local_output_path="test_multimodal_text_cloud_predictor",
         )
         cloud_predictor_no_train = MultiModalCloudPredictor(
-            cloud_output_path="s3://autogluon-cloud-ci/test-multimodal-text-no-train",
+            cloud_output_path=f"s3://autogluon-cloud-ci/test-multimodal-text-no-train/{timestamp}",
             local_output_path="test_multimodal_text_cloud_predictor_no_train",
         )
         test_helper.test_functionality(

--- a/cloud/tests/unittests/text/test_text.py
+++ b/cloud/tests/unittests/text/test_text.py
@@ -16,7 +16,7 @@ def test_text(test_helper):
         predictor_fit_args = dict(train_data=train_data, tuning_data=tune_data, time_limit=time_limit)
         cloud_predictor = TextCloudPredictor(
             cloud_output_path=f"s3://autogluon-cloud-ci/test-text/{timestamp}",
-            local_output_path="test_text_cloud_predictor"
+            local_output_path="test_text_cloud_predictor",
         )
         cloud_predictor_no_train = TextCloudPredictor(
             cloud_output_path=f"s3://autogluon-cloud-ci/test-text-no-train/{timestamp}",

--- a/cloud/tests/unittests/text/test_text.py
+++ b/cloud/tests/unittests/text/test_text.py
@@ -26,8 +26,10 @@ def test_text(test_helper):
             predictor_fit_args,
             cloud_predictor_no_train,
             test_data,
-            fit_instance_type="ml.g4dn.2xlarge",
-            fit_kwargs=dict(custom_image_uri=test_helper.gpu_training_image),
+            fit_kwargs=dict(
+                instance_type="ml.g4dn.2xlarge",
+                custom_image_uri=test_helper.gpu_training_image,
+            ),
             deploy_kwargs=dict(custom_image_uri=test_helper.cpu_inference_image),
             predict_kwargs=dict(custom_image_uri=test_helper.cpu_inference_image),
         )
@@ -57,8 +59,10 @@ def test_multimodal_text_only(test_helper):
             predictor_fit_args,
             cloud_predictor_no_train,
             test_data,
-            fit_instance_type="ml.g4dn.2xlarge",
-            fit_kwargs=dict(custom_image_uri=test_helper.gpu_training_image),
+            fit_kwargs=dict(
+                instance_type="ml.g4dn.2xlarge",
+                custom_image_uri=test_helper.gpu_training_image,
+            ),
             deploy_kwargs=dict(custom_image_uri=test_helper.cpu_inference_image),
             predict_kwargs=dict(custom_image_uri=test_helper.cpu_inference_image),
         )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* As discussed with @tonyhoo, we decide to unify the api for fit and inference when image modality is involved. Now we only ask for `image_column` for both cases, and we require user to have the `image_path` inside the csv file to be an absolute path in both cases.
* We've removed support for files in s3 as it would be extremely complicated when image modality is involved. This also makes sense as tabular/multimodal predictor doesn't support images living in s3 as well.
* Updated unit tests accordingly


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
