### PR TITLE
[timeseries] Fix several bottlenecks in the training procedure

### DIFF
--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -528,12 +528,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
             end_index = time_step_slice.stop
 
         time_step_slice = slice(start_index, end_index)
-        result = (
-            self.reset_index()
-            .groupby(ITEMID, sort=False, as_index=False)
-            .nth(time_step_slice)
-            .set_index([ITEMID, TIMESTAMP])
-        )
+        result = self.groupby(level=ITEMID, sort=False, as_index=False).nth(time_step_slice)
         result.static_features = self.static_features
         result._cached_freq = self._cached_freq
         return result

--- a/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
+++ b/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
@@ -107,7 +107,7 @@ class AbstractLocalModel(AbstractTimeSeriesModel):
         items_to_fit = [item_id for item_id, ts_hash in data_hash.items() if ts_hash not in self._cached_predictions]
         if len(items_to_fit) > 0:
             logger.debug(f"{self.name} received {len(items_to_fit)} new items to predict, generating predictions")
-            time_series_to_fit = [data.loc[item_id][self.target] for item_id in items_to_fit]
+            time_series_to_fit = (data.loc[item_id][self.target] for item_id in items_to_fit)
             with statsmodels_joblib_warning_filter():
                 predictions = Parallel(n_jobs=self.n_jobs)(
                     delayed(self._predict_with_local_model)(

--- a/timeseries/src/autogluon/timeseries/splitter.py
+++ b/timeseries/src/autogluon/timeseries/splitter.py
@@ -217,14 +217,19 @@ class MultiWindowSplitter(AbstractTimeSeriesSplitter):
         return train_data, val_data
 
 
-class LastWindowSplitter(MultiWindowSplitter):
+class LastWindowSplitter(AbstractTimeSeriesSplitter):
     """Reserves the last prediction_length steps of each time series for validation."""
-
-    def __init__(self):
-        super().__init__(num_windows=1)
 
     def describe_validation_strategy(self, prediction_length: int):
         return (
             f"Will use the last prediction_length = {prediction_length} time steps of each time series as a hold-out "
             "validation set."
         )
+
+    def _split(
+        self, ts_dataframe: TimeSeriesDataFrame, prediction_length: int
+    ) -> Tuple[TimeSeriesDataFrame, TimeSeriesDataFrame]:
+        train_data = ts_dataframe.slice_by_timestep(None, -prediction_length)
+        val_data = ts_dataframe
+        train_data._cached_freq = ts_dataframe._cached_freq
+        return train_data, val_data

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -730,7 +730,7 @@ def test_when_static_features_are_modified_on_shallow_copy_then_original_df_does
     ],
 )
 def test_when_raw_timestamps_are_not_sorted_then_ts_dataframe_has_sorted_timestamps(data):
-    tsdf = TimeSeriesDataFrame(data)
+    tsdf = TimeSeriesDataFrame(data, sort_timestamps=True)
     for item_id in tsdf.item_ids:
         assert tsdf.loc[item_id].index.is_monotonic_increasing
 
@@ -743,6 +743,6 @@ def test_when_raw_timestamps_are_not_sorted_then_ts_dataframe_has_sorted_timesta
     ],
 )
 def test_when_raw_timestamps_are_not_sorted_then_freq_inference_works(data):
-    tsdf = TimeSeriesDataFrame(data)
+    tsdf = TimeSeriesDataFrame(data, sort_timestamps=True)
     assert tsdf.freq is not None
     assert tsdf.freq == SAMPLE_TS_DATAFRAME.freq


### PR DESCRIPTION
*Description of changes:*
- Do not sort timestamps when creating a TimeSeriesDataFrame by default
- Speed up `TimeSeriesDataFrame.slice_by_timestep`
- Speed up `LastWindowSplitter`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
