### PR TITLE
Fix Tabular Ensemble Folding

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -485,9 +485,9 @@ class AbstractModel:
             user_specified_total_resource = math.inf
         
         # retrieve model level requirement when self is bagged model
-        user_specified_model_level_resource = self.model_base._user_params_aux.get(resource_type, None)
+        user_specified_model_level_resource = self._get_child_aux_val(key=resource_type, default=None)
         if user_specified_model_level_resource is not None:
-            assert user_specified_model_level_resource <= system_resource, f'Specified {resource_type} per {self.model_base.__class__.__name__} is more than the total: {system_resource}'
+            assert user_specified_model_level_resource <= system_resource, f'Specified {resource_type} per model base is more than the total: {system_resource}'
         user_specified_lower_level_resource = user_specified_ensemble_resource
         if user_specified_ensemble_resource is not None:
             if user_specified_model_level_resource is not None:

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -254,7 +254,7 @@ class BaggedEnsembleModel(AbstractModel):
                 return self
 
     def _get_child_aux_val(self, key: str, default=None):
-        assert self.is_initialized()
+        assert self.is_initialized(), "Model must be initialized before calling self._get_child_aux_val!"
         return self._params_aux_child.get(key, default)
 
     def _validate_bag_kwargs(self, *,

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -254,6 +254,7 @@ class BaggedEnsembleModel(AbstractModel):
                 return self
 
     def _get_child_aux_val(self, key: str, default=None):
+        assert self.is_initialized()
         return self._params_aux_child.get(key, default)
 
     def _validate_bag_kwargs(self, *,

--- a/tabular/tests/unittests/resource_allocation/test_total_resource_allocation.py
+++ b/tabular/tests/unittests/resource_allocation/test_total_resource_allocation.py
@@ -31,11 +31,13 @@ class DummyBaggedModel(BaggedEnsembleModel):
 def test_bagged_model_with_total_resources(mock_system_resources_ctx_mgr, mock_num_cpus, mock_num_gpus, k_fold):
     with mock_system_resources_ctx_mgr(num_cpus=mock_num_cpus, num_gpus=mock_num_gpus):
         model_base = DummyModel()
+        model_base.initialize()
         bagged_model = DummyBaggedModel(model_base)
         total_resources = {
             'num_cpus': 1,
             'num_gpus': 0,
         }
+        bagged_model.initialize()
         resources = bagged_model._preprocess_fit_resources(total_resources=total_resources, k_fold=k_fold)
         resources.pop('k_fold')
         assert resources == total_resources
@@ -57,6 +59,7 @@ def test_bagged_model_with_total_resources_and_ensemble_resources(mock_system_re
             'num_gpus': 1,
         }
         model_base = DummyModel()
+        model_base.initialize()
         bagged_model = DummyBaggedModel(
             model_base,
             hyperparameters={
@@ -66,6 +69,7 @@ def test_bagged_model_with_total_resources_and_ensemble_resources(mock_system_re
                 }
             }
         )
+        bagged_model.initialize()
         with pytest.raises(AssertionError) as e:
             bagged_model._preprocess_fit_resources(total_resources=total_resources, k_fold=k_fold)
         
@@ -78,24 +82,28 @@ def test_bagged_model_with_total_resources_and_ensemble_resources(mock_system_re
             'num_cpus': 4,
             'num_gpus': 1,
         }
+        model_base.initialize()
         bagged_model = DummyBaggedModel(
             model_base,
             hyperparameters={
                 'ag_args_fit': ensemble_ag_args_fit
             }
         )
+        bagged_model.initialize()
         resources = bagged_model._preprocess_fit_resources(total_resources=total_resources, k_fold=k_fold)
         resources.pop('k_fold')
         assert resources == ensemble_ag_args_fit
-    
+
 
 def test_bagged_model_with_total_resources_but_no_gpu_specified(mock_system_resources_ctx_mgr, mock_num_cpus, mock_num_gpus, k_fold):
     with mock_system_resources_ctx_mgr(num_cpus=mock_num_cpus, num_gpus=mock_num_gpus):
         model_base = DummyModel()
+        model_base.initialize()
         total_resources = {
             'num_cpus': 2,
         }
         bagged_model = DummyBaggedModel(model_base)
+        bagged_model.initialize()
         resources = bagged_model._preprocess_fit_resources(total_resources=total_resources, k_fold=k_fold)
         resources.pop('k_fold')
         default_model_resources = {'num_cpus': 2, 'num_gpus': ResourceManager.get_gpu_count_all()}  # return all gpu resources as default needs gpu
@@ -105,6 +113,7 @@ def test_bagged_model_with_total_resources_but_no_gpu_specified(mock_system_reso
 def test_bagged_model_without_total_resources_but_with_ensemble_resources(mock_system_resources_ctx_mgr, mock_num_cpus, mock_num_gpus, k_fold):
     with mock_system_resources_ctx_mgr(num_cpus=mock_num_cpus, num_gpus=mock_num_gpus):
         model_base = DummyModel()
+        model_base.initialize()
         bagged_model = DummyBaggedModel(
             model_base,
             hyperparameters={
@@ -114,10 +123,12 @@ def test_bagged_model_without_total_resources_but_with_ensemble_resources(mock_s
                 }
             }
         )
+        bagged_model.initialize()
         with pytest.raises(AssertionError) as e:
             bagged_model._preprocess_fit_resources(k_fold=k_fold)
         
         model_base = DummyModel()
+        model_base.initialize()
         ensemble_ag_args_fit = {
             'num_cpus': 1,
             'num_gpus': 0,
@@ -128,6 +139,7 @@ def test_bagged_model_without_total_resources_but_with_ensemble_resources(mock_s
                 'ag_args_fit': ensemble_ag_args_fit
             }
         )
+        bagged_model.initialize()
         resources = bagged_model._preprocess_fit_resources(k_fold=k_fold)
         resources.pop('k_fold')
         assert resources == ensemble_ag_args_fit
@@ -136,9 +148,11 @@ def test_bagged_model_without_total_resources_but_with_ensemble_resources(mock_s
 def test_bagged_model_without_total_resources_and_without_model_resources(mock_system_resources_ctx_mgr, mock_num_cpus, mock_num_gpus, k_fold):
     with mock_system_resources_ctx_mgr(num_cpus=mock_num_cpus, num_gpus=mock_num_gpus):
         model_base = DummyModel()
+        model_base.initialize()
         bagged_model = DummyBaggedModel(
             model_base
         )
+        bagged_model.initialize()
         resources = bagged_model._preprocess_fit_resources(k_fold=k_fold)
         resources.pop('k_fold')
         # Bagged model should take all resources and internally calculate correct resources given ag_args_ensemble and ag_args_fit


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/autogluon/autogluon/issues/2581

*Description of changes:*
* `model_base` is not available when doing repeated bagging. Use `_get_child_aux_val` to retrieve params instead.
* Added check of if `is_initialized()` check in `BaggedEnsembleModel._get_child_aux_val()`. @Innixma Let me know if it's missing intentionally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
