### PR TITLE
[timeseries] Check if the timestamps are sorted inside the TimeSeriesPredictor

### DIFF
--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -720,29 +720,3 @@ def test_when_static_features_are_modified_on_shallow_copy_then_original_df_does
     new_df = old_df.copy(deep=False)
     new_df.static_features = None
     assert old_df.static_features is not None
-
-
-@pytest.mark.parametrize(
-    "data",
-    [
-        SAMPLE_DATAFRAME.sample(frac=1),
-        SAMPLE_TS_DATAFRAME.sample(frac=1),
-    ],
-)
-def test_when_raw_timestamps_are_not_sorted_then_ts_dataframe_has_sorted_timestamps(data):
-    tsdf = TimeSeriesDataFrame(data)
-    for item_id in tsdf.item_ids:
-        assert tsdf.loc[item_id].index.is_monotonic_increasing
-
-
-@pytest.mark.parametrize(
-    "data",
-    [
-        SAMPLE_DATAFRAME.sample(frac=1),
-        SAMPLE_TS_DATAFRAME.sample(frac=1),
-    ],
-)
-def test_when_raw_timestamps_are_not_sorted_then_freq_inference_works(data):
-    tsdf = TimeSeriesDataFrame(data)
-    assert tsdf.freq is not None
-    assert tsdf.freq == SAMPLE_TS_DATAFRAME.freq


### PR DESCRIPTION
*Description of changes:*
- Current solution, where we always sort the timestamps when creating a `TimeSeriesDataFrame` introduces a significant overhead when dealing with large datasets. With this PR, we delegate the task of ensuring that the timestamps are sorted chronologically to the user with a check inside the `TimeSeriesPredictor`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
