### PR TITLE
[timeseries] Speed up the train/val splitter

### DIFF
--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -517,15 +517,9 @@ class TimeSeriesDataFrame(pd.DataFrame):
             start_index = time_step_slice.start
             end_index = time_step_slice.stop
 
-        num_timesteps_per_item = self.num_timesteps_per_item()
-        # Create a boolean index that selects the correct slice in each timeseries
-        boolean_indicators = []
-        for length in num_timesteps_per_item:
-            indicator = np.zeros(length, dtype=bool)
-            indicator[start_index:end_index] = True
-            boolean_indicators.append(indicator)
-        index = np.concatenate(boolean_indicators)
-        result = TimeSeriesDataFrame(self[index].copy(), static_features=self.static_features)
+        time_step_slice = slice(start_index, end_index)
+        result = self.groupby(level=ITEMID, sort=False, as_index=False).nth(time_step_slice)
+        result.static_features = self.static_features
         result._cached_freq = self._cached_freq
         return result
 

--- a/timeseries/src/autogluon/timeseries/splitter.py
+++ b/timeseries/src/autogluon/timeseries/splitter.py
@@ -54,18 +54,18 @@ class AbstractTimeSeriesSplitter:
     def __repr__(self):
         return f"{self.name}()"
 
-
-def append_suffix_to_item_id(
-    ts_dataframe: Union[TimeSeriesDataFrame, pd.DataFrame], suffix: str
-) -> TimeSeriesDataFrame:
-    """Append a suffix to each item_id in a TimeSeriesDataFrame."""
-    result = ts_dataframe.copy(deep=False)
-    if result.index.nlevels == 1:
-        result.index = result.index.astype(str) + suffix
-    elif result.index.nlevels == 2:
-        new_item_id = result.index.levels[0].astype(str) + suffix
-        result.index = result.index.set_levels(levels=new_item_id, level=0)
-    return result
+    @staticmethod
+    def _append_suffix_to_item_id(
+        ts_dataframe: Union[TimeSeriesDataFrame, pd.DataFrame], suffix: str
+    ) -> TimeSeriesDataFrame:
+        """Append a suffix to each item_id in a TimeSeriesDataFrame."""
+        result = ts_dataframe.copy(deep=False)
+        if result.index.nlevels == 1:
+            result.index = result.index.astype(str) + suffix
+        elif result.index.nlevels == 2:
+            new_item_id = result.index.levels[0].astype(str) + suffix
+            result.index = result.index.set_levels(levels=new_item_id, level=0)
+        return result
 
 
 class MultiWindowSplitter(AbstractTimeSeriesSplitter):
@@ -193,9 +193,9 @@ class MultiWindowSplitter(AbstractTimeSeriesSplitter):
                 if len(can_be_split) == 0:
                     break
 
-            validation_dataframes.append(append_suffix_to_item_id(ts_dataframe, suffix))
+            validation_dataframes.append(self._append_suffix_to_item_id(ts_dataframe, suffix))
             if static_features_available:
-                validation_static_features.append(append_suffix_to_item_id(ts_dataframe.static_features, suffix))
+                validation_static_features.append(self._append_suffix_to_item_id(ts_dataframe.static_features, suffix))
 
             ts_dataframe = ts_dataframe.slice_by_timestep(None, -prediction_length)
 

--- a/timeseries/tests/unittests/test_splitter.py
+++ b/timeseries/tests/unittests/test_splitter.py
@@ -1,5 +1,7 @@
 from ast import literal_eval
 
+import numpy as np
+import pandas as pd
 import pytest
 
 from autogluon.timeseries.splitter import MultiWindowSplitter
@@ -72,6 +74,19 @@ def test_when_splitter_adds_suffix_to_index_then_data_is_not_copied():
     splitter = MultiWindowSplitter()
     ts_df_with_suffix = splitter._append_suffix_to_item_id(ts_dataframe=ts_df, suffix="_[None:None]")
     assert ts_df.values.base is ts_df_with_suffix.values.base
+
+
+def test_when_static_features_are_present_then_static_features_index_is_aligned_with_data():
+    item_id_to_length = {"B": 15, "A": 7, "Z": 22, "1": 10}
+    ts_dataframe = get_data_frame_with_variable_lengths(item_id_to_length=item_id_to_length)
+    ts_dataframe.static_features = pd.DataFrame(
+        np.random.normal(size=len(item_id_to_length)), index=item_id_to_length.keys()
+    )
+    splitter = MultiWindowSplitter()
+    prediction_length = 7
+    train, val = splitter.split(ts_dataframe, prediction_length)
+    assert (train.item_ids == train.static_features.index).all()
+    assert (val.item_ids == val.static_features.index).all()
 
 
 def test_when_static_features_are_present_then_splitter_correctly_splits_them():

--- a/timeseries/tests/unittests/test_splitter.py
+++ b/timeseries/tests/unittests/test_splitter.py
@@ -2,7 +2,7 @@ from ast import literal_eval
 
 import pytest
 
-from autogluon.timeseries.splitter import MultiWindowSplitter, append_suffix_to_item_id
+from autogluon.timeseries.splitter import MultiWindowSplitter
 
 from .common import (
     DATAFRAME_WITH_COVARIATES,
@@ -69,7 +69,8 @@ def test_when_all_series_too_short_then_multi_window_splitter_raises_value_error
 
 def test_when_splitter_adds_suffix_to_index_then_data_is_not_copied():
     ts_df = DUMMY_VARIABLE_LENGTH_TS_DATAFRAME.copy()
-    ts_df_with_suffix = append_suffix_to_item_id(ts_dataframe=ts_df, suffix="_[None:None]")
+    splitter = MultiWindowSplitter()
+    ts_df_with_suffix = splitter._append_suffix_to_item_id(ts_dataframe=ts_df, suffix="_[None:None]")
     assert ts_df.values.base is ts_df_with_suffix.values.base
 
 


### PR DESCRIPTION
*Description of changes:*
- Speed up the `append_suffix_to_item_id` function
- Replace the surprisingly slow `DataFrame.loc[index]` operation with `DataFrame.query("item_id in @index")`.

Testing on a subset of 5000 items from the M5 competition dataset:

Using code currently on `master`:
```
Loaded dataset with 7559974 rows and 5000 items.
df.slice_by_timestep(None, -prediction_length): 5.75s
LastWindowSplitter.split(df, prediction_length): 63.83s
```

After current PR:
```
Loaded dataset with 7559974 rows and 5000 items.
df.slice_by_timestep(None, -prediction_length): 1.38s
LastWindowSplitter.split(df, prediction_length): 8.30s
```

<details>
  <summary>Code for reproducing the results</summary>

```python
import time
import pandas as pd
from autogluon.timeseries import TimeSeriesDataFrame
from autogluon.timeseries.splitter import LastWindowSplitter

prediction_length = 28
# Dataset consists of the first 5000 items of the M5 competition dataset
raw_data = pd.read_parquet("../m5/data/subset.parquet")
static = pd.read_parquet("../m5/data/static.parquet")

raw_data["item_id"] = raw_data["item_id"].astype("str")
static["item_id"] = static["item_id"].astype("str")
static.set_index("item_id", inplace=True)

print(f"Loaded dataset with {len(raw_data)} rows and {raw_data['item_id'].nunique()} items.")
df = TimeSeriesDataFrame(raw_data, static_features=static)

start = time.time()
df.slice_by_timestep(None, -prediction_length)
print(f"df.slice_by_timestep(None, -prediction_length): {time.time() - start:.2f}s")

start = time.time()
splitter = LastWindowSplitter()
train_data, val_data = splitter.split(df, prediction_length)
print(f"LastWindowSplitter.split(df, prediction_length): {time.time() - start:.2f}s")
```

</details>



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
