### PR TITLE
[timeseries] Speed up data preparation for local models

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
+++ b/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
@@ -107,8 +107,8 @@ class AbstractLocalModel(AbstractTimeSeriesModel):
         items_to_fit = [item_id for item_id, ts_hash in data_hash.items() if ts_hash not in self._cached_predictions]
         if len(items_to_fit) > 0:
             logger.debug(f"{self.name} received {len(items_to_fit)} new items to predict, generating predictions")
-            target = data[self.target]
-            time_series_to_fit = [target.loc[item_id] for item_id in items_to_fit]
+            target_series = data[self.target]
+            time_series_to_fit = (target_series.loc[item_id] for item_id in items_to_fit)
             with statsmodels_joblib_warning_filter():
                 predictions = Parallel(n_jobs=self.n_jobs)(
                     delayed(self._predict_with_local_model)(

--- a/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
+++ b/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
@@ -107,7 +107,8 @@ class AbstractLocalModel(AbstractTimeSeriesModel):
         items_to_fit = [item_id for item_id, ts_hash in data_hash.items() if ts_hash not in self._cached_predictions]
         if len(items_to_fit) > 0:
             logger.debug(f"{self.name} received {len(items_to_fit)} new items to predict, generating predictions")
-            time_series_to_fit = [data.loc[item_id][self.target] for item_id in items_to_fit]
+            target = data[self.target]
+            time_series_to_fit = [target.loc[item_id] for item_id in items_to_fit]
             with statsmodels_joblib_warning_filter():
                 predictions = Parallel(n_jobs=self.n_jobs)(
                     delayed(self._predict_with_local_model)(


### PR DESCRIPTION
*Description of changes:*
- Convert the target column into a `pd.Series` before splitting individual time series. This is much faster than calling `.loc` on a `TimeSeriesDataFrame`. For TSDF we end up subsetting the `static_features` for each iteration in the loop, but these static features aren't used by the underlying models.


Testing on a subset of 5000 items from the M5 competition dataset:

Using code currently on `master`:
```
Loaded dataset with 7559974 rows and 5000 items.
Fitting Naive: 35.2s
```

After current PR:
```
Loaded dataset with 7559974 rows and 5000 items.
Fitting Naive: 19.9s
```

<details>
  <summary>Code for reproducing the results</summary>

```python
import time
import pandas as pd
from autogluon.timeseries import TimeSeriesDataFrame
from autogluon.timeseries.models import NaiveModel


prediction_length = 28
raw_data = pd.read_parquet("../m5/data/subset.parquet")
static = pd.read_parquet("../m5/data/static.parquet")

raw_data["item_id"] = raw_data["item_id"].astype("str")
static["item_id"] = static["item_id"].astype("str")
static.set_index("item_id", inplace=True)

print(f"Loaded dataset with {len(raw_data)} rows and {raw_data['item_id'].nunique()} items.")
df = TimeSeriesDataFrame(raw_data, static_features=static)

model = NaiveModel(prediction_length=28, target="demand")
start_time = time.time()
model.fit(train_data=df)
preds = model.predict(data=df)
print(f"Fitting Naive: {time.time() - start_time:.1f}s")
```

</details>



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
