### PR TITLE
Tabular: Fixed crash during calibration in binary stacking

### DIFF
--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -2938,8 +2938,9 @@ class AbstractTrainer:
             y_val_probs = self.predict_proba(X_val, model_name_og)
             y_val = self.load_y_val().to_numpy()
 
-            if self.problem_type == BINARY:
-                y_val_probs = LabelCleanerMulticlassToBinary.convert_binary_proba_to_multiclass_proba(y_val_probs)
+        if self.problem_type == BINARY:
+            # Convert one-dimensional array to be in the form of a 2-class multiclass predict_proba output
+            y_val_probs = LabelCleanerMulticlassToBinary.convert_binary_proba_to_multiclass_proba(y_val_probs)
 
         model = self.load_model(model_name=model_name)
         if self.problem_type == QUANTILE:

--- a/tabular/src/autogluon/tabular/models/rf/rf_quantile.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_quantile.py
@@ -166,7 +166,7 @@ class BaseTreeQuantileRegressor(BaseDecisionTree):
             quantiles[X_leaves == leaf] = weighted_percentile(self.y_train_[self.y_train_leaves_ == leaf], quantile)
         return quantiles
 
-    def fit(self, X, y, sample_weight=None, check_input=True, X_idx_sorted=None):
+    def fit(self, X, y, sample_weight=None, check_input=True):
         """
         Build a decision tree classifier from the training set (X, y).
 
@@ -191,12 +191,6 @@ class BaseTreeQuantileRegressor(BaseDecisionTree):
             Allow to bypass several input checking.
             Don't use this parameter unless you know what you do.
 
-        X_idx_sorted : array-like, shape = [n_samples, n_features], optional
-            The indexes of the sorted training input samples. If many tree
-            are grown on the same dataset, this allows the ordering to be
-            cached between trees. If None, the data will be sorted here.
-            Don't use this parameter unless you know what to do.
-
         Returns
         -------
         self : object
@@ -210,9 +204,7 @@ class BaseTreeQuantileRegressor(BaseDecisionTree):
 
         # apply method requires X to be of dtype np.float32
         X, y = check_X_y(X, y, accept_sparse="csc", dtype=np.float32, multi_output=False)
-        super(BaseTreeQuantileRegressor, self).fit(
-            X, y, sample_weight=sample_weight, check_input=check_input, X_idx_sorted=X_idx_sorted
-        )
+        super(BaseTreeQuantileRegressor, self).fit(X, y, sample_weight=sample_weight, check_input=check_input)
         self.y_train_ = y
 
         # Stores the leaf nodes that the samples lie in.

--- a/tabular/tests/conftest.py
+++ b/tabular/tests/conftest.py
@@ -129,6 +129,7 @@ class FitHelper:
     @staticmethod
     def fit_and_validate_dataset(dataset_name,
                                  fit_args,
+                                 init_args=None,
                                  sample_size=1000,
                                  refit_full=True,
                                  delete_directory=True,
@@ -142,10 +143,15 @@ class FitHelper:
         train_data, test_data, dataset_info = DatasetLoaderHelper.load_dataset(name=dataset_name, directory_prefix=directory_prefix)
         label = dataset_info['label']
         save_path = os.path.join(directory_prefix, dataset_name, f'AutogluonOutput_{uuid.uuid4()}')
-        init_args = dict(
+        _init_args = dict(
             label=label,
             path=save_path,
         )
+        if init_args is None:
+            init_args = _init_args
+        else:
+            _init_args.update(init_args)
+            init_args = _init_args
         predictor = FitHelper.fit_dataset(train_data=train_data, init_args=init_args, fit_args=fit_args, sample_size=sample_size)
         if compile_models:
             predictor.compile_models(models="all", compiler_configs=compiler_configs)

--- a/tabular/tests/unittests/calibrate/test_calibrate.py
+++ b/tabular/tests/unittests/calibrate/test_calibrate.py
@@ -1,0 +1,70 @@
+
+def test_calibrate_binary(fit_helper):
+    """Tests that calibrate=True doesn't crash in binary"""
+    fit_args = dict(
+        hyperparameters={'GBM': {}},
+        calibrate=True,
+    )
+    dataset_name = 'adult'
+
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, sample_size=100)
+
+
+def test_calibrate_binary_bag(fit_helper):
+    """Tests that calibrate=True doesn't crash in binary w/ bagging"""
+    fit_args = dict(
+        hyperparameters={'GBM': {}},
+        calibrate=True,
+        num_bag_folds=3,
+    )
+    dataset_name = 'adult'
+
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, sample_size=100)
+
+
+def test_calibrate_multiclass(fit_helper):
+    """Tests that calibrate=True doesn't crash in multiclass"""
+    fit_args = dict(
+        hyperparameters={'GBM': {}},
+        calibrate=True,
+    )
+    dataset_name = 'covertype_small'
+
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, sample_size=100)
+
+
+def test_calibrate_multiclass_bag(fit_helper):
+    """Tests that calibrate=True doesn't crash in multiclass w/ bagging"""
+    fit_args = dict(
+        hyperparameters={'GBM': {}},
+        calibrate=True,
+        num_bag_folds=3,
+    )
+    dataset_name = 'covertype_small'
+
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, sample_size=100)
+
+
+def test_calibrate_quantile(fit_helper):
+    """Tests that calibrate=True doesn't crash in quantile"""
+    fit_args = dict(
+        hyperparameters={'RF': {}},
+        calibrate=True,
+    )
+    dataset_name = 'ames'
+    init_args = dict(problem_type='quantile', quantile_levels=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
+
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, init_args=init_args, sample_size=100)
+
+
+def test_calibrate_quantile_bag(fit_helper):
+    """Tests that calibrate=True doesn't crash in quantile w/ bagging"""
+    fit_args = dict(
+        hyperparameters={'RF': {}},
+        calibrate=True,
+        num_bag_folds=3,
+    )
+    dataset_name = 'ames'
+    init_args = dict(problem_type='quantile', quantile_levels=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
+
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, init_args=init_args, sample_size=100)

--- a/tabular/tests/unittests/edgecases/test_edgecases.py
+++ b/tabular/tests/unittests/edgecases/test_edgecases.py
@@ -1,0 +1,18 @@
+
+from autogluon.core.constants import BINARY
+from autogluon.core.metrics import METRICS
+
+
+def test_no_weighted_ensemble(fit_helper):
+    """Tests that fit_weighted_ensemble=False works"""
+    fit_args = dict(
+        hyperparameters={'GBM': {}},
+        fit_weighted_ensemble=False,
+    )
+    dataset_name = 'adult'
+    extra_metrics = list(METRICS[BINARY])
+
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name,
+                                        fit_args=fit_args,
+                                        extra_metrics=extra_metrics,
+                                        expected_model_count=1)

--- a/tabular/tests/unittests/models/test_lightgbm.py
+++ b/tabular/tests/unittests/models/test_lightgbm.py
@@ -53,18 +53,3 @@ def test_lightgbm_regression_model(model_fit_helper):
     fit_args = dict()
     dataset_name = 'ames'
     model_fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, model=LGBModel(), fit_args=fit_args)
-
-
-def test_lightgbm_binary_no_weighted_ensemble(fit_helper):
-    """Additionally tests that fit_weighted_ensemble=False works"""
-    fit_args = dict(
-        hyperparameters={LGBModel: {}},
-        fit_weighted_ensemble=False,
-    )
-    dataset_name = 'adult'
-    extra_metrics = list(METRICS[BINARY])
-
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name,
-                                        fit_args=fit_args,
-                                        extra_metrics=extra_metrics,
-                                        expected_model_count=1)

--- a/tabular/tests/unittests/models/test_rf.py
+++ b/tabular/tests/unittests/models/test_rf.py
@@ -27,6 +27,15 @@ def test_rf_regression(fit_helper):
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
 
 
+def test_rf_quantile(fit_helper):
+    fit_args = dict(
+        hyperparameters={'RF': {}},
+    )
+    dataset_name = 'ames'
+    init_args = dict(problem_type='quantile', quantile_levels=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, init_args=init_args)
+
+
 def test_rf_binary_compile_onnx(fit_helper):
     fit_args = dict(
         hyperparameters={RFModel: {}},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixed crash during calibration due to incorrect predict_proba dimensions when problem_type='binary', eval_metric='log_loss', num_bag_folds>1

- This bug was first introduced in 0.6 release and impacts 0.6 and 0.6.1 releases.
- Bug caused due to making out-of-fold predictions and predict_proba outputs consistent in v0.6 (previously they had different dimensions in binary by default), however the calibrate code still treated them inconsistently in binary classification, leading to the error.
- Workaround prior to this fix: set `calibrate=False` in `predictor.fit(...)`
- Also fixed a bug that made quantile regression on RF crash due to removed fit parameter in sklearn & added unit tests

*Code to Reproduce*

```python3
from autogluon.tabular import TabularPredictor, TabularDataset


if __name__ == '__main__':
    path_prefix = 'https://autogluon.s3.amazonaws.com/datasets/AdultIncomeBinaryClassification/'
    path_train = path_prefix + 'train_data.csv'
    path_test = path_prefix + 'test_data.csv'

    label = 'class'
    train_data = TabularDataset(path_train)
    test_data = TabularDataset(path_test)
    sample = 1000  # Number of rows to use to train / infer

    if sample is not None and (sample < len(train_data)):
        train_data = train_data.sample(n=sample, random_state=0).reset_index(drop=True)

    hyperparameters = {
        'GBM': [
            {},
        ]
    }

    predictor = TabularPredictor(label=label, eval_metric='log_loss')
    predictor.fit(
        train_data=train_data,
        hyperparameters=hyperparameters,
        presets='best_quality',
    )
    leaderboard = predictor.leaderboard(test_data)

```

Error prior to fix:

```
Traceback (most recent call last):
  File "/Users/neerick/workspace/virtual/autogluon38/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 3433, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-2-68ebe127e745>", line 1, in <module>
    runfile('/Users/neerick/workspace/code/autogluon-scratch/scripts/run_adult_zs.py', wdir='/Users/neerick/workspace/code/autogluon-scratch/scripts')
  File "/Users/neerick/Library/Application Support/JetBrains/Toolbox/apps/PyCharm-P/ch-1/223.7571.64/PyCharm 2022.3 EAP.app/Contents/plugins/python/helpers/pydev/_pydev_bundle/pydev_umd.py", line 198, in runfile
    pydev_imports.execfile(filename, global_vars, local_vars)  # execute the script
  File "/Users/neerick/Library/Application Support/JetBrains/Toolbox/apps/PyCharm-P/ch-1/223.7571.64/PyCharm 2022.3 EAP.app/Contents/plugins/python/helpers/pydev/_pydev_imps/_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
  File "/Users/neerick/workspace/code/autogluon-scratch/scripts/run_adult_zs.py", line 24, in <module>
    predictor.fit(
  File "/Users/neerick/workspace/code/autogluon/core/src/autogluon/core/utils/decorators.py", line 30, in _call
    return f(*gargs, **gkwargs)
  File "/Users/neerick/workspace/code/autogluon/tabular/src/autogluon/tabular/predictor/predictor.py", line 868, in fit
    self._post_fit(
  File "/Users/neerick/workspace/code/autogluon/tabular/src/autogluon/tabular/predictor/predictor.py", line 921, in _post_fit
    self._trainer.calibrate_model()
  File "/Users/neerick/workspace/code/autogluon/core/src/autogluon/core/trainer/abstract_trainer.py", line 2953, in calibrate_model
    temp_scalar = tune_temperature_scaling(y_val_probs=y_val_probs, y_val=y_val,
  File "/Users/neerick/workspace/code/autogluon/core/src/autogluon/core/calibrate/temperature_scaling.py", line 57, in tune_temperature_scaling
    optimizer.step(temperature_scale_step)
  File "/Users/neerick/workspace/virtual/autogluon38/lib/python3.8/site-packages/torch/optim/lr_scheduler.py", line 65, in wrapper
    return wrapped(*args, **kwargs)
  File "/Users/neerick/workspace/virtual/autogluon38/lib/python3.8/site-packages/torch/optim/optimizer.py", line 113, in wrapper
    return func(*args, **kwargs)
  File "/Users/neerick/workspace/virtual/autogluon38/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/Users/neerick/workspace/virtual/autogluon38/lib/python3.8/site-packages/torch/optim/lbfgs.py", line 311, in step
    orig_loss = closure()
  File "/Users/neerick/workspace/virtual/autogluon38/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/Users/neerick/workspace/code/autogluon/core/src/autogluon/core/calibrate/temperature_scaling.py", line 50, in temperature_scale_step
    temp = temperature_param.unsqueeze(1).expand(logits.size(0), logits.size(1))
IndexError: Dimension out of range (expected to be in range of [-1, 0], but got 1)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
