### PR TITLE
[timeseries] Speed up prediction for GluonTS models

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -406,7 +406,8 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         item_id_to_forecast = {f.item_id: f for f in forecasts}
         result_dfs = []
         for item_id in forecast_index.unique(level=ITEMID):
-            forecast = item_id_to_forecast[item_id]
+            # GluonTS always saves item_id as a string
+            forecast = item_id_to_forecast[str(item_id)]
             item_forecast_dict = {"mean": forecast.mean}
             for quantile in quantile_levels:
                 item_forecast_dict[str(quantile)] = forecast.quantile(str(quantile))

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -47,6 +47,7 @@ class SimpleGluonTSDataset(GluonTSDataset):
     ):
         assert target_df is not None
         assert target_df.freq, "Initializing GluonTS data sets without freq is not allowed"
+        assert len(target_df.columns) == 1
         # Convert TimeSeriesDataFrame to pd.Series for faster processing
         self.target_series = target_df.squeeze()
         self.item_ids = target_df.item_ids
@@ -367,7 +368,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
 
     @staticmethod
     def _sample_to_quantile_forecast(forecast: SampleForecast, quantile_levels: List[float]) -> QuantileForecast:
-        forecast_arrays = []
+        forecast_arrays = [forecast.mean]
 
         quantile_keys = [str(q) for q in quantile_levels]
         for q in quantile_keys:
@@ -376,7 +377,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         forecast_init_args = dict(
             forecast_arrays=np.array(forecast_arrays),
             start_date=forecast.start_date,
-            forecast_keys=quantile_keys,
+            forecast_keys=["mean"] + quantile_keys,
             item_id=forecast.item_id,
         )
         if isinstance(forecast.start_date, pd.Timestamp):  # GluonTS version is <0.10

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -380,7 +380,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
             forecast_arrays=np.array(forecast_arrays),
             start_date=forecast.start_date,
             forecast_keys=["mean"] + quantile_keys,
-            item_id=forecast.item_id,
+            item_id=str(forecast.item_id),
         )
         if isinstance(forecast.start_date, pd.Timestamp):  # GluonTS version is <0.10
             forecast_init_args.update({"freq": forecast.freq})

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -11,8 +11,8 @@ from gluonts.dataset.common import Dataset as GluonTSDataset
 from gluonts.dataset.field_names import FieldName
 from gluonts.model.estimator import Estimator as GluonTSEstimator
 from gluonts.model.forecast import Forecast, QuantileForecast, SampleForecast
-from gluonts.torch.model.forecast import DistributionForecast
 from gluonts.model.predictor import Predictor as GluonTSPredictor
+from gluonts.torch.model.forecast import DistributionForecast
 from pandas.tseries.frequencies import to_offset
 
 from autogluon.common.utils.log_utils import set_logger_verbosity

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -13,11 +13,11 @@ import numpy as np
 import pandas as pd
 import torch
 from gluonts.core.component import from_hyperparameters
+from gluonts.model.forecast import QuantileForecast
 from gluonts.torch.distributions import AffineTransformed, NormalOutput
 from gluonts.torch.model.deepar import DeepAREstimator
 from gluonts.torch.model.estimator import PyTorchLightningEstimator as GluonTSPyTorchLightningEstimator
 from gluonts.torch.model.forecast import DistributionForecast, Forecast
-from gluonts.model.forecast import QuantileForecast
 from gluonts.torch.model.predictor import PyTorchPredictor as GluonTSPyTorchPredictor
 from gluonts.torch.model.simple_feedforward import SimpleFeedForwardEstimator
 from pytorch_lightning.callbacks import Timer

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -133,6 +133,9 @@ class AbstractGluonTSPyTorchModel(AbstractGluonTSModel):
 
         quantile_keys = [str(q) for q in quantile_levels]
         if isinstance(forecast.distribution, AffineTransformed):
+            # FIXME: this is a hack to get around GluonTS not implementing quantiles for
+            # torch AffineTransformed. We hence force PyTorch SFF to always use Gaussian error.
+            # However, this leads to a ~2x regression in error compared to MXNet SFF.
             fdist = forecast.distribution
             quantiles_tensor = torch.tensor(quantile_levels, device=fdist.scale.device).unsqueeze(1)
             q_transformed = (fdist.scale * fdist.base_dist.icdf(quantiles_tensor) + fdist.loc).cpu().numpy().tolist()

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -147,7 +147,7 @@ class AbstractGluonTSPyTorchModel(AbstractGluonTSModel):
             forecast_arrays=np.array(forecast_arrays),
             start_date=forecast.start_date,
             forecast_keys=["mean"] + quantile_keys,
-            item_id=forecast.item_id,
+            item_id=str(forecast.item_id),
         )
         if isinstance(forecast.start_date, pd.Timestamp):  # GluonTS version is <0.10
             forecast_init_args.update({"freq": forecast.freq})

--- a/timeseries/tests/unittests/test_evaluator.py
+++ b/timeseries/tests/unittests/test_evaluator.py
@@ -55,11 +55,11 @@ def test_when_given_learned_model_when_evaluator_called_then_output_equal_to_glu
     )
     fcast_list, ts_list = list(forecast_iter), list(ts_iter)
     prediction_length = 2
-    past_data = DUMMY_TS_DATAFRAME.slice_by_timestep(None, -prediction_length)
+    forecast_index = DUMMY_TS_DATAFRAME.slice_by_timestep(-prediction_length, None).index
     forecast_df = model._gluonts_forecasts_to_data_frame(
         fcast_list,
         quantile_levels=model.quantile_levels,
-        data=past_data,
+        forecast_index=forecast_index,
     )
 
     ag_evaluator = TimeSeriesEvaluator(eval_metric=metric_name, prediction_length=prediction_length)
@@ -88,11 +88,11 @@ def test_when_given_all_zero_data_when_evaluator_called_then_output_equal_to_glu
     )
     fcast_list, ts_list = list(forecast_iter), list(ts_iter)
     prediction_length = 2
-    past_data = DUMMY_TS_DATAFRAME.slice_by_timestep(None, -prediction_length)
+    forecast_index = DUMMY_TS_DATAFRAME.slice_by_timestep(-prediction_length, None).index
     forecast_df = model._gluonts_forecasts_to_data_frame(
         fcast_list,
         quantile_levels=model.quantile_levels,
-        data=past_data,
+        forecast_index=forecast_index,
     )
 
     ag_evaluator = TimeSeriesEvaluator(eval_metric=metric_name, prediction_length=prediction_length)
@@ -124,11 +124,11 @@ def test_when_given_zero_forecasts_when_evaluator_called_then_output_equal_to_gl
             )
         )
     prediction_length = 2
-    past_data = DUMMY_TS_DATAFRAME.slice_by_timestep(None, -prediction_length)
+    forecast_index = DUMMY_TS_DATAFRAME.slice_by_timestep(-prediction_length, None).index
     forecast_df = model._gluonts_forecasts_to_data_frame(
         zero_forecast_list,
         quantile_levels=model.quantile_levels,
-        data=past_data,
+        forecast_index=forecast_index,
     )
 
     ag_evaluator = TimeSeriesEvaluator(eval_metric=metric_name, prediction_length=prediction_length)

--- a/timeseries/tests/unittests/test_evaluator.py
+++ b/timeseries/tests/unittests/test_evaluator.py
@@ -54,9 +54,15 @@ def test_when_given_learned_model_when_evaluator_called_then_output_equal_to_glu
         num_samples=100,
     )
     fcast_list, ts_list = list(forecast_iter), list(ts_iter)
-    forecast_df = model._gluonts_forecasts_to_data_frame(fcast_list, quantile_levels=model.quantile_levels)
+    prediction_length = 2
+    past_data = DUMMY_TS_DATAFRAME.slice_by_timestep(None, -prediction_length)
+    forecast_df = model._gluonts_forecasts_to_data_frame(
+        fcast_list,
+        quantile_levels=model.quantile_levels,
+        data=past_data,
+    )
 
-    ag_evaluator = TimeSeriesEvaluator(eval_metric=metric_name, prediction_length=2)
+    ag_evaluator = TimeSeriesEvaluator(eval_metric=metric_name, prediction_length=prediction_length)
     ag_value = ag_evaluator(DUMMY_TS_DATAFRAME, forecast_df)
 
     gts_evaluator = GluonTSEvaluator()
@@ -81,9 +87,15 @@ def test_when_given_all_zero_data_when_evaluator_called_then_output_equal_to_glu
         num_samples=100,
     )
     fcast_list, ts_list = list(forecast_iter), list(ts_iter)
-    forecast_df = model._gluonts_forecasts_to_data_frame(fcast_list, quantile_levels=model.quantile_levels)
+    prediction_length = 2
+    past_data = DUMMY_TS_DATAFRAME.slice_by_timestep(None, -prediction_length)
+    forecast_df = model._gluonts_forecasts_to_data_frame(
+        fcast_list,
+        quantile_levels=model.quantile_levels,
+        data=past_data,
+    )
 
-    ag_evaluator = TimeSeriesEvaluator(eval_metric=metric_name, prediction_length=2)
+    ag_evaluator = TimeSeriesEvaluator(eval_metric=metric_name, prediction_length=prediction_length)
     ag_value = ag_evaluator(data, forecast_df)
 
     gts_evaluator = GluonTSEvaluator()
@@ -111,9 +123,15 @@ def test_when_given_zero_forecasts_when_evaluator_called_then_output_equal_to_gl
                 item_id=s.item_id,
             )
         )
-    forecast_df = model._gluonts_forecasts_to_data_frame(zero_forecast_list, quantile_levels=model.quantile_levels)
+    prediction_length = 2
+    past_data = DUMMY_TS_DATAFRAME.slice_by_timestep(None, -prediction_length)
+    forecast_df = model._gluonts_forecasts_to_data_frame(
+        zero_forecast_list,
+        quantile_levels=model.quantile_levels,
+        data=past_data,
+    )
 
-    ag_evaluator = TimeSeriesEvaluator(eval_metric=metric_name, prediction_length=2)
+    ag_evaluator = TimeSeriesEvaluator(eval_metric=metric_name, prediction_length=prediction_length)
     ag_value = ag_evaluator(DUMMY_TS_DATAFRAME, forecast_df)
 
     gts_evaluator = GluonTSEvaluator()


### PR DESCRIPTION
*Description of changes:*
- Significantly speed up prediction for GluonTS models. The two main sources are:
  - Use of `pd.Series` instead of `TimeSeriesDataFrame` inside `SimpleGluonTSDataset` to avoid copying the static features.
  - Speed up `get_forecast_horizon_index_ts_dataframe` with a more efficient `groupby` operation
- Clean up redundant logic in `AbstractGluonTSModel. predict`.

### Benchmarking results on the M5 dataset
(only training for 1 epoch / 1 batch, so the training time/performance are meaningless here)

**With this PR**

5K items / 7M rows
```
Training timeseries model DeepAR.
        -0.9107       = Validation score (-mean_wQuantileLoss)
        5.99    s     = Training runtime
        47.57   s     = Validation (prediction) runtime
```

30K items / 47M rows
```
Training timeseries model DeepAR.
        -0.7019       = Validation score (-mean_wQuantileLoss)
        11.92   s     = Training runtime
        298.31  s     = Validation (prediction) runtime
```

**Current `master` branch**
5K items / 7M rows
```
Training timeseries model DeepAR.
        -0.8331       = Validation score (-mean_wQuantileLoss)
        6.61    s     = Training runtime
        81.16   s     = Validation (prediction) runtime
```

30K items / 47M rows
```
Training timeseries model DeepAR.
        -0.8672       = Validation score (-mean_wQuantileLoss)
        15.64   s     = Training runtime
        1107.97 s     = Validation (prediction) runtime
```

<details><summary>Code to reproduce the results</summary>

```python
import pandas as pd
from autogluon.timeseries import TimeSeriesDataFrame, TimeSeriesPredictor


prediction_length = 28
raw_data = pd.read_parquet("../m5/data/target.parquet")
static = pd.read_parquet("../m5/data/static.parquet")

raw_data["item_id"] = raw_data["item_id"].astype("str")
raw_data["timestamp"] = pd.to_datetime(raw_data["timestamp"])
static["item_id"] = static["item_id"].astype("str")
static.set_index("item_id", inplace=True)

print(f"Loaded dataset with {len(raw_data)} rows and {raw_data['item_id'].nunique()} items.")
df = TimeSeriesDataFrame(raw_data, static_features=static)

predictor = TimeSeriesPredictor(prediction_length=prediction_length, target="demand")
predictor.fit(
    train_data=df,
    hyperparameters={"DeepAR": {"epochs": 1, "num_batches_per_epoch": 1}},
)
```
</details>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
