### PR TITLE
[timeseries] Speed up TimeSeriesEnsembleSelection.fit

### DIFF
--- a/timeseries/src/autogluon/timeseries/evaluator.py
+++ b/timeseries/src/autogluon/timeseries/evaluator.py
@@ -198,14 +198,16 @@ class TimeSeriesEvaluator:
     def save_past_metrics(self, data_past: TimeSeriesDataFrame):
         self._past_naive_1_error = in_sample_naive_1_error(y_past=data_past[self.target_column])
 
-    def score_with_saved_past_data(self, data_future: TimeSeriesDataFrame, predictions: TimeSeriesDataFrame) -> float:
+    def score_with_saved_past_metrics(
+        self, data_future: TimeSeriesDataFrame, predictions: TimeSeriesDataFrame
+    ) -> float:
         """Compute the metric assuming that the historic metrics have already been computed.
 
         This method should be preferred to TimeSeriesEvaluator.__call__ if the metrics are computed multiple times, as
         it doesn't require splitting the test data into past/future portions each time (e.g., when fitting ensembles).
         """
         assert (predictions.num_timesteps_per_item() == self.prediction_length).all()
-        assert self._past_naive_1_error is not None, "Call save_past_metrics before score_with_saved_past_data"
+        assert self._past_naive_1_error is not None, "Call save_past_metrics before score_with_saved_past_metrics"
         assert data_future.index.equals(predictions.index), "Prediction and data indices do not match."
 
         with evaluator_warning_filter(), warnings.catch_warnings():
@@ -222,4 +224,4 @@ class TimeSeriesEvaluator:
         data_past = data.slice_by_timestep(None, -self.prediction_length)
         data_future = data.slice_by_timestep(-self.prediction_length, None)
         self.save_past_metrics(data_past=data_past)
-        return self.score_with_saved_past_data(data_future=data_future, predictions=predictions)
+        return self.score_with_saved_past_metrics(data_future=data_future, predictions=predictions)

--- a/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
+++ b/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
@@ -49,7 +49,7 @@ class TimeSeriesEnsembleSelection(EnsembleSelection):
         # Split the observed time series once to avoid repeated computations inside the evaluator
         data_past = labels.slice_by_timestep(None, -self.metric.prediction_length)
         data_future = labels.slice_by_timestep(-self.metric.prediction_length, None)
-        self.metric.cache_historic_metrics(data_past)
+        self.metric.save_past_metrics(data_past)
         super()._fit(
             predictions=[d.values for d in predictions],
             labels=data_future,
@@ -60,7 +60,7 @@ class TimeSeriesEnsembleSelection(EnsembleSelection):
     def _calculate_regret(self, y_true, y_pred_proba, metric, dummy_pred=None, sample_weight=None):  # noqa
         dummy_pred = copy.deepcopy(self.dummy_pred if dummy_pred is None else dummy_pred)
         dummy_pred[list(dummy_pred.columns)] = y_pred_proba
-        score = metric.score_with_cached_history(y_true, dummy_pred) * metric.coefficient
+        score = metric.score_with_saved_past_metrics(y_true, dummy_pred) * metric.coefficient
         # score: higher is better, regret: lower is better, so we flip the sign
         return -score
 

--- a/timeseries/tests/unittests/test_evaluator.py
+++ b/timeseries/tests/unittests/test_evaluator.py
@@ -175,3 +175,13 @@ def test_given_unavailable_input_and_no_raise_check_get_eval_metric_output_defau
     assert TimeSeriesEvaluator.DEFAULT_METRIC == TimeSeriesEvaluator.check_get_evaluation_metric(
         "some_nonsense_eval_metric", raise_if_not_available=False
     )
+
+
+@pytest.mark.parametrize("eval_metric", ["MASE", "sMAPE"])
+def test_given_historic_data_not_cached_when_scoring_then_exception_is_raised(eval_metric):
+    prediction_length = 3
+    evaluator = TimeSeriesEvaluator(eval_metric=eval_metric, prediction_length=prediction_length)
+    data_future = DUMMY_TS_DATAFRAME.slice_by_timestep(-prediction_length, None)
+    predictions = data_future.rename({"target": "mean"}, axis=1)
+    with pytest.raises(AssertionError, match="Call cache_historic_metrics"):
+        evaluator.score_with_cached_history(data_future=data_future, predictions=predictions)

--- a/timeseries/tests/unittests/test_evaluator.py
+++ b/timeseries/tests/unittests/test_evaluator.py
@@ -184,4 +184,4 @@ def test_given_historic_data_not_cached_when_scoring_then_exception_is_raised(ev
     data_future = DUMMY_TS_DATAFRAME.slice_by_timestep(-prediction_length, None)
     predictions = data_future.rename({"target": "mean"}, axis=1)
     with pytest.raises(AssertionError, match="Call save_past_metrics before"):
-        evaluator.score_with_saved_past_data(data_future=data_future, predictions=predictions)
+        evaluator.score_with_saved_past_metrics(data_future=data_future, predictions=predictions)

--- a/timeseries/tests/unittests/test_evaluator.py
+++ b/timeseries/tests/unittests/test_evaluator.py
@@ -183,5 +183,5 @@ def test_given_historic_data_not_cached_when_scoring_then_exception_is_raised(ev
     evaluator = TimeSeriesEvaluator(eval_metric=eval_metric, prediction_length=prediction_length)
     data_future = DUMMY_TS_DATAFRAME.slice_by_timestep(-prediction_length, None)
     predictions = data_future.rename({"target": "mean"}, axis=1)
-    with pytest.raises(AssertionError, match="Call save_past_metrics before score_with_saved_past_data"):
+    with pytest.raises(AssertionError, match="Call save_past_metrics before"):
         evaluator.score_with_saved_past_data(data_future=data_future, predictions=predictions)

--- a/timeseries/tests/unittests/test_evaluator.py
+++ b/timeseries/tests/unittests/test_evaluator.py
@@ -183,5 +183,5 @@ def test_given_historic_data_not_cached_when_scoring_then_exception_is_raised(ev
     evaluator = TimeSeriesEvaluator(eval_metric=eval_metric, prediction_length=prediction_length)
     data_future = DUMMY_TS_DATAFRAME.slice_by_timestep(-prediction_length, None)
     predictions = data_future.rename({"target": "mean"}, axis=1)
-    with pytest.raises(AssertionError, match="Call cache_historic_metrics"):
-        evaluator.score_with_cached_history(data_future=data_future, predictions=predictions)
+    with pytest.raises(AssertionError, match="Call save_past_metrics before score_with_saved_past_data"):
+        evaluator.score_with_saved_past_data(data_future=data_future, predictions=predictions)


### PR DESCRIPTION
*Description of changes:*
- Avoid the costly `TimeSeriesDataFrame.slice_by_timestep` operation when computing the metrics while fitting an ensemble.

### Runtime comparison of `fit_ensemble()` with 2 base models
**M4-hourly (350K rows, 414 items)**
- Current `master` branch
```
Fitting simple weighted ensemble.
        33.31   s     = Training runtime
```
- This PR
```
Fitting simple weighted ensemble.
        4.59    s     = Training runtime
```

**M4-daily (10M rows, 4227 items)**
- Current `master` branch
```
Fitting simple weighted ensemble.
        1120.93 s     = Training runtime
```
- This PR
```
Fitting simple weighted ensemble.
        18.20   s     = Training runtime
```




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
