### PR TITLE
[timeseries] Fix inconsistent item_id handling by GluonTS

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -409,7 +409,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
             "Some forecast quantiles are missing from GluonTS forecast outputs. Was"
             " the model trained to forecast all quantiles?"
         )
-        item_id_to_forecast = {f.item_id: f for f in forecasts}
+        item_id_to_forecast = {str(f.item_id): f for f in forecasts}
         result_dfs = []
         for item_id in forecast_index.unique(level=ITEMID):
             # GluonTS always saves item_id as a string


### PR DESCRIPTION
*Description of changes:*
- This PR fixes a bug introduced by the refactoring of `AbstractGluonTSModel` introduced by #2593 that caused, e.g., `TemporalFusionTransformerMXNet` model to fail. 

Background: Some GluonTS models always convert `item_id` to a string, while others keep the original dtype (e.g., int). With this PR, we ensure that we always convert `item_id` to a string internally, but return the correct dtype to the user.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
