### PR TITLE
[timeseries] Automatically convert timestamps to datetime & handle DataFrame inputs

### DIFF
--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -32,15 +32,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
     data : Any
         Time-series data to construct a ``TimeSeriesDataFrame``. The class currently supports four input formats.
 
-        1. Time-series data in Iterable format. For example::
-
-                iterable_dataset = [
-                    {"target": [0, 1, 2], "start": pd.Timestamp("01-01-2019", freq='D')},
-                    {"target": [3, 4, 5], "start": pd.Timestamp("01-01-2019", freq='D')},
-                    {"target": [6, 7, 8], "start": pd.Timestamp("01-01-2019", freq='D')}
-                ]
-
-        2. Time-series data in a pandas DataFrame format without multi-index. For example::
+        1. Time-series data in a pandas DataFrame format without multi-index. For example::
 
                    item_id  timestamp  target
                 0        0 2019-01-01       0
@@ -53,7 +45,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
                 7        2 2019-01-02       7
                 8        2 2019-01-03       8
 
-        3. Time-series data in pandas DataFrame format with multi-index on item_id and timestamp. For example::
+        2. Time-series data in pandas DataFrame format with multi-index on item_id and timestamp. For example::
 
                                         target
                 item_id timestamp
@@ -67,7 +59,15 @@ class TimeSeriesDataFrame(pd.DataFrame):
                         2019-01-02       7
                         2019-01-03       8
 
-        4. Path to a data file in CSV or Parquet format. The file must contain columns ``item_id`` and ``timestamp``, as well as columns with time series values. This is similar to Option 2 above (pandas DataFrame format without multi-index). Both remote (e.g., S3) and local paths are accepted.
+        3. Path to a data file in CSV or Parquet format. The file must contain columns ``item_id`` and ``timestamp``, as well as columns with time series values. This is similar to Option 2 above (pandas DataFrame format without multi-index). Both remote (e.g., S3) and local paths are accepted.
+
+        4. Time-series data in Iterable format. For example::
+
+                iterable_dataset = [
+                    {"target": [0, 1, 2], "start": pd.Timestamp("01-01-2019", freq='D')},
+                    {"target": [3, 4, 5], "start": pd.Timestamp("01-01-2019", freq='D')},
+                    {"target": [6, 7, 8], "start": pd.Timestamp("01-01-2019", freq='D')}
+                ]
 
     static_features : Optional[pd.DataFrame]
         An optional data frame describing the metadata attributes of individual items in the item index. These

--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -325,6 +325,9 @@ class TimeSeriesDataFrame(pd.DataFrame):
             assert timestamp_column in df.columns, f"Column {timestamp_column} not found!"
             df.rename(columns={timestamp_column: TIMESTAMP}, inplace=True)
 
+        if TIMESTAMP in df.columns:
+            df[TIMESTAMP] = pd.to_datetime(df[TIMESTAMP])
+
         cls._validate_data_frame(df)
         return df.set_index([ITEMID, TIMESTAMP])
 

--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -341,6 +341,47 @@ class TimeSeriesDataFrame(pd.DataFrame):
         return df.set_index([ITEMID, TIMESTAMP])
 
     @classmethod
+    def from_path(
+        cls,
+        path: str,
+        id_column: Optional[str] = None,
+        timestamp_column: Optional[str] = None,
+    ) -> TimeSeriesDataFrame:
+        """Construct a ``TimeSeriesDataFrame`` from a CSV or Parquet file.
+
+        Parameters
+        ----------
+        path : str
+            Path to a local or remote (e.g., S3) file containing the time series data in CSV or Parquet format.
+            Example file contents::
+
+            .. code-block::
+
+                item_id,timestamp,target
+                0,2019-01-01,0
+                0,2019-01-02,1
+                0,2019-01-03,2
+                1,2019-01-01,3
+                1,2019-01-02,4
+                1,2019-01-03,5
+                2,2019-01-01,6
+                2,2019-01-02,7
+                2,2019-01-03,8
+
+        id_column: str
+            Name of the 'item_id' column if column name is different
+        timestamp_column: str
+            Name of the 'timestamp' column if column name is different
+
+        Returns
+        -------
+        ts_df: TimeSeriesDataFrame
+            A data frame in TimeSeriesDataFrame format.
+        """
+        df = load_pd.load(path)
+        return cls.from_data_frame(df, id_column=id_column, timestamp_column=timestamp_column)
+
+    @classmethod
     def from_data_frame(
         cls,
         df: pd.DataFrame,

--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -59,7 +59,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
                         2019-01-02       7
                         2019-01-03       8
 
-        3. Path to a data file in CSV or Parquet format. The file must contain columns ``item_id`` and ``timestamp``, as well as columns with time series values. This is similar to Option 2 above (pandas DataFrame format without multi-index). Both remote (e.g., S3) and local paths are accepted.
+        3. Path to a data file in CSV or Parquet format. The file must contain columns ``item_id`` and ``timestamp``, as well as columns with time series values. This is similar to Option 1 above (pandas DataFrame format without multi-index). Both remote (e.g., S3) and local paths are accepted.
 
         4. Time-series data in Iterable format. For example::
 

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -1,13 +1,13 @@
 import logging
 import pprint
 import time
+import traceback
 import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Type, Union
 
 import pandas as pd
 
-from autogluon.common.features.feature_metadata import FeatureMetadata
 from autogluon.common.utils.log_utils import set_logger_verbosity
 from autogluon.common.utils.utils import setup_outputdir
 from autogluon.core.utils.decorators import apply_presets
@@ -209,7 +209,9 @@ class TimeSeriesPredictor:
             try:
                 df = TimeSeriesDataFrame(df)
             except:
-                raise ValueError(f"Provided data of type {type(df)} cannot be interpreted as a TimeSeriesDataFrame.")
+                raise ValueError(
+                    f"Provided data of type {type(df)} cannot be automatically converted to a TimeSeriesDataFrame."
+                )
         if self.ignore_time_index:
             df = df.get_reindexed_view(freq="S")
         timestamps = df.reset_index(level=TIMESTAMP)[TIMESTAMP]

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -205,6 +205,11 @@ class TimeSeriesPredictor:
         """
         if df is None:
             return df
+        if not isinstance(df, TimeSeriesDataFrame):
+            try:
+                df = TimeSeriesDataFrame(df)
+            except:
+                raise ValueError(f"Provided data of type {type(df)} cannot be interpreted as a TimeSeriesDataFrame.")
         if self.ignore_time_index:
             df = df.get_reindexed_view(freq="S")
         timestamps = df.reset_index(level=TIMESTAMP)[TIMESTAMP]

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -199,18 +199,23 @@ class TimeSeriesPredictor:
     def validation_splitter(self) -> AbstractTimeSeriesSplitter:
         return self._learner.validation_splitter
 
-    def _check_and_prepare_data_frame(self, df: TimeSeriesDataFrame) -> TimeSeriesDataFrame:
+    def _check_and_prepare_data_frame(self, df: Union[TimeSeriesDataFrame, pd.DataFrame]) -> TimeSeriesDataFrame:
         """Ensure that TimeSeriesDataFrame has a frequency, or replace its time index with a dummy if
         ``self.ignore_time_index`` is True.
         """
         if df is None:
             return df
         if not isinstance(df, TimeSeriesDataFrame):
-            try:
-                df = TimeSeriesDataFrame(df)
-            except:
+            if isinstance(df, pd.DataFrame):
+                try:
+                    df = TimeSeriesDataFrame(df)
+                except:
+                    raise ValueError(
+                        f"Provided data of type {type(df)} cannot be automatically converted to a TimeSeriesDataFrame."
+                    )
+            else:
                 raise ValueError(
-                    f"Provided data of type {type(df)} cannot be automatically converted to a TimeSeriesDataFrame."
+                    f"Please provide data in TimeSeriesDataFrame format (received an object of type {type(df)})."
                 )
         if self.ignore_time_index:
             df = df.get_reindexed_view(freq="S")
@@ -254,8 +259,8 @@ class TimeSeriesPredictor:
     @apply_presets(TIMESERIES_PRESETS_CONFIGS)
     def fit(
         self,
-        train_data: TimeSeriesDataFrame,
-        tuning_data: Optional[TimeSeriesDataFrame] = None,
+        train_data: Union[TimeSeriesDataFrame, pd.DataFrame],
+        tuning_data: Optional[Union[TimeSeriesDataFrame, pd.DataFrame]] = None,
         time_limit: Optional[int] = None,
         presets: Optional[str] = None,
         hyperparameters: Dict[Union[str, Type], Any] = None,
@@ -268,7 +273,7 @@ class TimeSeriesPredictor:
 
         Parameters
         ----------
-        train_data : TimeSeriesDataFrame
+        train_data : Union[TimeSeriesDataFrame, pd.DataFrame]
             Training data in the :class:`~autogluon.timeseries.TimeSeriesDataFrame` format. For best performance, all
             time series should have length ``> 2 * prediction_length``.
 
@@ -286,7 +291,10 @@ class TimeSeriesPredictor:
 
                 data.static_features["store_id"] = data.static_features["store_id"].astype("category")
 
-        tuning_data : TimeSeriesDataFrame, optional
+            If provided data is an instance of pandas DataFrame, AutoGluon will attempt to automatically convert it
+            to a ``TimeSeriesDataFrame``.
+
+        tuning_data : Union[TimeSeriesDataFrame, pd.DataFrame], optional
             Data reserved for model selection and hyperparameter tuning, rather than training individual models. Also
             used to compute the validation scores. Note that only the last ``prediction_length`` time steps of each
             time series are used for computing the validation score.
@@ -305,6 +313,10 @@ class TimeSeriesPredictor:
 
             If ``train_data`` has static features, ``tuning_data`` must have also have static features with the same
             column names and dtypes.
+
+            If provided data is an instance of pandas DataFrame, AutoGluon will attempt to automatically convert it
+            to a ``TimeSeriesDataFrame``.
+
         time_limit : int, optional
             Approximately how long :meth:`~autogluon.timeseries.TimeSeriesPredictor.fit` will run (wall-clock time in
             seconds). If not specified, :meth:`~autogluon.timeseries.TimeSeriesPredictor.fit` will run until all models
@@ -493,7 +505,7 @@ class TimeSeriesPredictor:
 
     def predict(
         self,
-        data: TimeSeriesDataFrame,
+        data: Union[TimeSeriesDataFrame, pd.DataFrame],
         known_covariates: Optional[TimeSeriesDataFrame] = None,
         model: Optional[str] = None,
         random_seed: Optional[int] = 123,
@@ -503,7 +515,7 @@ class TimeSeriesPredictor:
 
         Parameters
         ----------
-        data : TimeSeriesDataFrame
+        data : Union[TimeSeriesDataFrame, pd.DataFrame]
             Time series data to forecast with.
 
             If ``known_covariates_names`` were specified when creating the predictor, ``data`` must include the columns
@@ -511,6 +523,9 @@ class TimeSeriesPredictor:
 
             If ``train_data`` used to train the predictor contained static features, then ``data`` must also contain
             static features that have the same columns and dtypes.
+
+            If provided data is an instance of pandas DataFrame, AutoGluon will attempt to automatically convert it
+            to a ``TimeSeriesDataFrame``.
         known_covariates : TimeSeriesDataFrame, optional
             If ``known_covariates_names`` were specified when creating the predictor, it is necessary to provide the
             values of the known covariates for each time series during the forecast horizon. That is:
@@ -568,13 +583,13 @@ class TimeSeriesPredictor:
         data = self._check_and_prepare_data_frame(data)
         return self._learner.predict(data, known_covariates=known_covariates, model=model, **kwargs)
 
-    def evaluate(self, data: TimeSeriesDataFrame, **kwargs):
+    def evaluate(self, data: Union[TimeSeriesDataFrame, pd.DataFrame], **kwargs):
         """Evaluate the performance for given dataset, computing the score determined by ``self.eval_metric``
         on the given data set, and with the same ``prediction_length`` used when training models.
 
         Parameters
         ----------
-        data : TimeSeriesDataFrame
+        data : Union[TimeSeriesDataFrame, pd.DataFrame]
             The data to evaluate the best model on. The last ``prediction_length`` time steps of the data set, for each
             item, will be held out for prediction and forecast accuracy will be calculated on these time steps.
 
@@ -583,6 +598,9 @@ class TimeSeriesPredictor:
 
             If ``train_data`` used to train the predictor contained static features, then ``data`` must also contain
             static features that have the same columns and dtypes.
+
+            If provided data is an instance of pandas DataFrame, AutoGluon will attempt to automatically convert it
+            to a ``TimeSeriesDataFrame``.
 
         Other Parameters
         ----------------
@@ -601,7 +619,7 @@ class TimeSeriesPredictor:
         data = self._check_and_prepare_data_frame(data)
         return self._learner.score(data, **kwargs)
 
-    def score(self, data: TimeSeriesDataFrame, **kwargs):
+    def score(self, data: Union[TimeSeriesDataFrame, pd.DataFrame], **kwargs):
         """See, :meth:`~autogluon.timeseries.TimeSeriesPredictor.evaluate`."""
         return self.evaluate(data, **kwargs)
 
@@ -647,7 +665,9 @@ class TimeSeriesPredictor:
         """Returns the name of the best model from trainer."""
         return self._trainer.get_model_best()
 
-    def leaderboard(self, data: Optional[TimeSeriesDataFrame] = None, silent=False) -> pd.DataFrame:
+    def leaderboard(
+        self, data: Optional[Union[TimeSeriesDataFrame, pd.DataFrame]] = None, silent=False
+    ) -> pd.DataFrame:
         """Return a leaderboard showing the performance of every trained model, the output is a
         pandas data frame with columns:
 
@@ -667,7 +687,7 @@ class TimeSeriesPredictor:
 
         Parameters
         ----------
-        data : TimeSeriesDataFrame, optional
+        data : Union[TimeSeriesDataFrame, pd.DataFrame], optional
             dataset used for additional evaluation. If not provided, the validation set used during training will be
             used.
 
@@ -676,6 +696,9 @@ class TimeSeriesPredictor:
 
             If ``train_data`` used to train the predictor contained static features, then ``data`` must also contain
             static features that have the same columns and dtypes.
+
+            If provided data is an instance of pandas DataFrame, AutoGluon will attempt to automatically convert it
+            to a ``TimeSeriesDataFrame``.
 
         silent : bool, default = False
             If False, the leaderboard DataFrame will be printed.

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -594,5 +594,5 @@ def test_given_data_cannot_be_interpreted_as_tsdf_then_exception_raised(temp_mod
     df = pd.DataFrame(DUMMY_TS_DATAFRAME.reset_index())
     df = df.rename(columns=rename_columns)
     predictor = TimeSeriesPredictor(path_context=temp_model_path)
-    with pytest.raises(ValueError, match="cannot be interpreted as a TimeSeriesDataFrame"):
+    with pytest.raises(ValueError, match="cannot be automatically converted to a TimeSeriesDataFrame"):
         predictor.fit(df, hyperparameters={"Naive": {}})

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -13,7 +13,7 @@ from autogluon.timeseries.models import DeepARModel, SimpleFeedForwardModel
 from autogluon.timeseries.predictor import TimeSeriesPredictor
 from autogluon.timeseries.splitter import LastWindowSplitter, MultiWindowSplitter
 
-from .common import DATAFRAME_WITH_COVARIATES, DUMMY_TS_DATAFRAME
+from .common import DUMMY_TS_DATAFRAME
 
 TEST_HYPERPARAMETER_SETTINGS = [
     {"SimpleFeedForward": {"epochs": 1}},

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -577,3 +577,22 @@ def test_when_prediction_data_contains_nans_then_exception_is_raised(temp_model_
     df.iloc[5] = np.nan
     with pytest.raises(ValueError, match="missing values"):
         predictor.predict(df)
+
+
+def test_given_data_is_in_dataframe_format_then_predictor_works(temp_model_path):
+    df = pd.DataFrame(DUMMY_TS_DATAFRAME.reset_index())
+    predictor = TimeSeriesPredictor(path_context=temp_model_path)
+    predictor.fit(df, hyperparameters={"Naive": {}})
+    predictor.leaderboard(df)
+    predictor.score(df)
+    predictions = predictor.predict(df)
+    assert isinstance(predictions, TimeSeriesDataFrame)
+
+
+@pytest.mark.parametrize("rename_columns", [{TIMESTAMP: "custom_timestamp"}, {ITEMID: "custom_item_id"}])
+def test_given_data_cannot_be_interpreted_as_tsdf_then_exception_raised(temp_model_path, rename_columns):
+    df = pd.DataFrame(DUMMY_TS_DATAFRAME.reset_index())
+    df = df.rename(columns=rename_columns)
+    predictor = TimeSeriesPredictor(path_context=temp_model_path)
+    with pytest.raises(ValueError, match="cannot be interpreted as a TimeSeriesDataFrame"):
+        predictor.fit(df, hyperparameters={"Naive": {}})

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -734,3 +734,10 @@ def test_when_dataset_constructed_from_dataframe_then_timestamp_column_is_conver
     )
     ts_df = TimeSeriesDataFrame.from_data_frame(df, timestamp_column=timestamp_column)
     assert ts_df.index.get_level_values(level=TIMESTAMP).dtype == "datetime64[ns]"
+
+
+def test_when_path_is_given_to_constructor_then_tsdf_is_constructed_correctly():
+    df = TimeSeriesDataFrame("https://autogluon.s3.amazonaws.com/datasets/timeseries/dummy/dummy.csv")
+    assert isinstance(df.index, pd.MultiIndex)
+    assert df.index.names == [ITEMID, TIMESTAMP]
+    assert len(df) > 0

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -737,16 +737,11 @@ def test_when_dataset_constructed_from_dataframe_then_timestamp_column_is_conver
     assert ts_df.index.get_level_values(level=TIMESTAMP).dtype == "datetime64[ns]"
 
 
-@pytest.mark.parametrize("use_parquet", [True, False])
-def test_when_path_is_given_to_constructor_then_tsdf_is_constructed_correctly(use_parquet):
+def test_when_path_is_given_to_constructor_then_tsdf_is_constructed_correctly():
     df = SAMPLE_TS_DATAFRAME.reset_index()
     with TemporaryDirectory() as temp_dir:
-        if use_parquet:
-            temp_file = str(Path(temp_dir) / f"temp.parquet")
-            df.to_parquet(temp_file)
-        else:
-            temp_file = str(Path(temp_dir) / f"temp.csv")
-            df.to_csv(temp_file)
+        temp_file = str(Path(temp_dir) / f"temp.csv")
+        df.to_csv(temp_file)
 
         ts_df = TimeSeriesDataFrame(temp_file)
         assert isinstance(ts_df.index, pd.MultiIndex)

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -720,3 +720,17 @@ def test_when_static_features_are_modified_on_shallow_copy_then_original_df_does
     new_df = old_df.copy(deep=False)
     new_df.static_features = None
     assert old_df.static_features is not None
+
+
+@pytest.mark.parametrize("timestamp_column", ["timestamp", None, "custom_ts_column"])
+def test_when_dataset_constructed_from_dataframe_then_timestamp_column_is_converted_to_datetime(timestamp_column):
+    timestamps = ["2020-01-01", "2020-01-02", "2020-01-03"]
+    df = pd.DataFrame(
+        {
+            "item_id": np.ones(len(timestamps), dtype=np.int64),
+            timestamp_column or "timestamp": timestamps,
+            "target": np.ones(len(timestamps)),
+        }
+    )
+    ts_df = TimeSeriesDataFrame.from_data_frame(df, timestamp_column=timestamp_column)
+    assert ts_df.index.get_level_values(level=TIMESTAMP).dtype == "datetime64[ns]"


### PR DESCRIPTION
*Description of changes:*

This PR contains several potential improvements to the data loading process in `autogluon.timeseries`:
1. Automatically convert the `timestamp` columns to the `datetime64` format when constructing a `TimeSeriesDataFrame` from `pd.DataFrame` without multiindex.
2. Load a `TimeSeriesDataFrame` from path (local or remote), similar to `autogluon.tabular.TabularDataset`.
3. Accept `pd.DataFrame` as input to `TimeSeriesPredictor` and automatically convert to `TimeSeriesDataFrame` under the hood.


These changes make it possible to significantly shorten the code for training AGTS on a dataset. 
- Current minimal example
```python
import pandas as pd
from autogluon.timeseries import TimeSeriesPredictor, TimeSeriesDataFrame

raw_df = pd.read_csv(
    "https://autogluon.s3.amazonaws.com/datasets/timeseries/dummy/dummy.csv", 
    parse_dates=["timestamp"],
)
data = TimeSeriesDataFrame(raw_df)
predictor = TimeSeriesPredictor().fit(data)
```
- Using Option 2 from this PR
```python
from autogluon.timeseries import TimeSeriesPredictor, TimeSeriesDataFrame

data = TimeSeriesDataFrame("https://autogluon.s3.amazonaws.com/datasets/timeseries/dummy/dummy.csv")
predictor = TimeSeriesPredictor().fit(data)
```
- Using Option 3 from this PR
```python
import pandas as pd
from autogluon.timeseries import TimeSeriesPredictor

data = pd.read_csv("https://autogluon.s3.amazonaws.com/datasets/timeseries/dummy/dummy.csv")
predictor = TimeSeriesPredictor().fit(data)
```




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
