### PR TITLE
[BUG] Fix broken tutorial index links

### DIFF
--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -74,19 +74,19 @@ Multimodal Prediction
 
    .. card::
       :title: Use AutoGluon Multimodal for Text Prediction: Quick Start
-      :link: multimodal/beginner_text.html
+      :link: multimodal/text_prediction/beginner_text.html
 
       How to train high-quality text prediction models with MultiModalPredictor in under 5 minutes.
 
    .. card::
       :title: Solving Multilingual Problems
-      :link: multimodal/multilingual_text.html
+      :link: multimodal/text_prediction/multilingual_text.html
 
       How to use MultiModalPredictor to build models on datasets with languages other than English.
 
    .. card::
       :title: Multimodal Data Tables with Text
-      :link: multimodal/multimodal_text_tabular.html
+      :link: multimodal/multimodal_prediction/multimodal_text_tabular.html
 
       How MultiModalPredictor can be applied to multimodal data tables with a mix of text, numerical, and categorical columns.
 
@@ -137,19 +137,19 @@ Time Series Forecasting
 
    .. card::
       :title: Quick Start
-      :link: forecasting-quickstart.html
+      :link: timeseries/forecasting-quickstart.html
 
       Quick start tutorial on fitting models with time series datasets.
 
    .. card::
       :title: In-depth Tutorial
-      :link: forecasting-indepth.html
+      :link: timeseries/forecasting-indepth.html
 
       Detailed discussion of the time series forecasting capabilities in AutoGluon.
 
    .. card::
       :title: FAQ
-      :link: forecasting-faq.html
+      :link: timeseries/forecasting-faq.html
 
       Frequently asked questions about AutoGluon-TimeSeries.
 


### PR DESCRIPTION
*Issue #, if available:* [2616](https://github.com/autogluon/autogluon/issues/2616)

*Description of changes:*
This change updates broken tutorial links for Multimodal and Time Series tutorials on the `tutorialslindex.html` page that moved.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
