### PR TITLE
Support presets in AutoMM predictor initialization

### DIFF
--- a/multimodal/src/autogluon/multimodal/matcher.py
+++ b/multimodal/src/autogluon/multimodal/matcher.py
@@ -112,6 +112,7 @@ class MultiModalMatcher:
         label: Optional[str] = None,
         match_label: Optional[Union[int, str]] = None,
         problem_type: Optional[str] = None,
+        presets: Optional[str] = None,
         eval_metric: Optional[str] = None,
         hyperparameters: Optional[dict] = None,
         path: Optional[str] = None,
@@ -193,6 +194,7 @@ class MultiModalMatcher:
         self._label_column = label
         self._problem_type = None  # always infer problem type for matching.
         self._pipeline = problem_type.lower() if problem_type is not None else None
+        self._presets = presets.lower() if presets else None
         self._eval_metric_name = eval_metric
         self._validation_metric_name = None
         self._output_shape = None
@@ -226,7 +228,7 @@ class MultiModalMatcher:
                 self._response_model,
                 self._query_processors,
                 self._response_processors,
-            ) = init_pretrained_matcher(presets=self._pipeline, hyperparameters=hyperparameters)
+            ) = init_pretrained_matcher(pipeline=self._pipeline, presets=self._presets, hyperparameters=hyperparameters)
 
     @property
     def query(self):

--- a/multimodal/src/autogluon/multimodal/matcher.py
+++ b/multimodal/src/autogluon/multimodal/matcher.py
@@ -142,6 +142,8 @@ class MultiModalMatcher:
             if the label column contains binary, multiclass, or numeric labels.
             If `problem_type = None`, the prediction problem type is inferred
             based on the label-values in provided dataset.
+        presets
+            Presets regarding model quality, e.g., best_quality, high_quality_fast_inference, and medium_quality_faster_inference.
         eval_metric
             Evaluation metric name. If `eval_metric = None`, it is automatically chosen based on `problem_type`.
             Defaults to 'accuracy' for binary and multiclass classification, 'root_mean_squared_error' for regression.
@@ -309,7 +311,7 @@ class MultiModalMatcher:
              Id-to-content mappings. The contents can be text, image, etc.
              This is used when the dataframe contains the query/response identifiers instead of their contents.
         presets
-            Name of the presets. See the available presets in `presets.py`.
+            Presets regarding model quality, e.g., best_quality, high_quality_fast_inference, and medium_quality_faster_inference.
         tuning_data
             A dataframe containing validation data, which should have the same columns as the train_data.
             If `tuning_data = None`, `fit()` will automatically
@@ -600,6 +602,7 @@ class MultiModalMatcher:
         if presets == "siamese_network":
             config = self._config
             config = get_config(
+                problem_type=self._pipeline,
                 presets=presets,
                 config=config,
                 overrides=hyperparameters,

--- a/multimodal/src/autogluon/multimodal/matcher.py
+++ b/multimodal/src/autogluon/multimodal/matcher.py
@@ -228,7 +228,9 @@ class MultiModalMatcher:
                 self._response_model,
                 self._query_processors,
                 self._response_processors,
-            ) = init_pretrained_matcher(pipeline=self._pipeline, presets=self._presets, hyperparameters=hyperparameters)
+            ) = init_pretrained_matcher(
+                pipeline=self._pipeline, presets=self._presets, hyperparameters=hyperparameters
+            )
 
     @property
     def query(self):

--- a/multimodal/src/autogluon/multimodal/matcher.py
+++ b/multimodal/src/autogluon/multimodal/matcher.py
@@ -1734,6 +1734,7 @@ class MultiModalMatcher:
                     "label_column": self._label_column,
                     "problem_type": self._problem_type,
                     "pipeline": self._pipeline,
+                    "presets": self._presets,
                     "eval_metric_name": self._eval_metric_name,
                     "validation_metric_name": self._validation_metric_name,
                     "output_shape": self._output_shape,
@@ -1831,6 +1832,8 @@ class MultiModalMatcher:
         matcher._label_column = assets["label_column"]
         matcher._problem_type = assets["problem_type"]
         matcher._pipeline = assets["pipeline"]
+        if "presets" in assets:
+            matcher._presets = assets["presets"]
         matcher._eval_metric_name = assets["eval_metric_name"]
         matcher._verbosity = verbosity
         matcher._resume = resume

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -187,6 +187,7 @@ class MultiModalPredictor:
         response: Optional[Union[str, List[str]]] = None,
         match_label: Optional[Union[int, str]] = None,
         pipeline: Optional[str] = None,
+        presets: Optional[str] = None,
         eval_metric: Optional[str] = None,
         hyperparameters: Optional[dict] = None,
         path: Optional[str] = None,
@@ -376,6 +377,7 @@ class MultiModalPredictor:
 
         self._label_column = label
         self._problem_type = problem_type
+        self._presets = presets.lower() if presets else None
         self._eval_metric_name = eval_metric
         self._validation_metric_name = None
         self._output_shape = num_classes
@@ -421,6 +423,7 @@ class MultiModalPredictor:
                 label=label,
                 match_label=match_label,
                 problem_type=self._problem_type,  # Ensure that matcher will always infer problem type.
+                presets=presets,
                 hyperparameters=hyperparameters,
                 eval_metric=eval_metric,
                 path=path,

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -422,7 +422,7 @@ class MultiModalPredictor:
                 response=response,
                 label=label,
                 match_label=match_label,
-                problem_type=self._problem_type,  # Ensure that matcher will always infer problem type.
+                problem_type=problem_type,
                 presets=presets,
                 hyperparameters=hyperparameters,
                 eval_metric=eval_metric,
@@ -442,9 +442,9 @@ class MultiModalPredictor:
         if self._problem_type is not None:
             if self.problem_property.support_zero_shot:
                 # Load pretrained model via the provided hyperparameters and presets
-                # FIXME!, Revise the logic to use presets and add problem_type in init_pretrained
                 self._config, self._model, self._data_processors = init_pretrained(
-                    presets=self._problem_type,
+                    problem_type=self._problem_type,
+                    presets=self._presets,
                     hyperparameters=hyperparameters,
                     num_classes=self._output_shape,
                     classes=self._classes,
@@ -748,6 +748,10 @@ class MultiModalPredictor:
             data=train_data,
             valid_data=tuning_data,
         )
+        if self._presets is not None:
+            presets = self._presets
+        else:
+            self._presets = presets
 
         if self._config is not None:  # continuous training
             config = self._config
@@ -1112,8 +1116,6 @@ class MultiModalPredictor:
         standalone: bool = True,
         **hpo_kwargs,
     ):
-        if self._config is not None:  # continuous training
-            config = self._config
 
         config = get_config(
             presets=presets,

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -2676,6 +2676,7 @@ class MultiModalPredictor:
                     "column_types": self._column_types,
                     "label_column": self._label_column,
                     "problem_type": self._problem_type,
+                    "presets": self._presets,
                     "eval_metric_name": self._eval_metric_name,
                     "validation_metric_name": self._validation_metric_name,
                     "output_shape": self._output_shape,
@@ -2884,6 +2885,8 @@ class MultiModalPredictor:
         predictor._problem_type = assets["problem_type"]
         if "pipeline" in assets:  # backward compatibility
             predictor._problem_type = assets["pipeline"]
+        if "presets" in assets:
+            predictor._presets = assets["presets"]
         if "best_score" in assets:  # backward compatibility
             predictor._best_score = assets["best_score"]
         if "total_train_time" in assets:  # backward compatibility

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -253,7 +253,7 @@ class MultiModalPredictor:
         pipeline
             Pipeline has been deprecated and merged in problem_type.
         presets
-            The presets for loading model parameters / training the model
+            Presets regarding model quality, e.g., best_quality, high_quality_fast_inference, and medium_quality_faster_inference.
         eval_metric
             Evaluation metric name. If `eval_metric = None`, it is automatically chosen based on `problem_type`.
             Defaults to 'accuracy' for binary and multiclass classification, 'root_mean_squared_error' for regression.
@@ -556,7 +556,7 @@ class MultiModalPredictor:
         train_data
             A dataframe containing training data.
         presets
-            Name of the presets. See the available presets in `presets.py`.
+            Presets regarding model quality, e.g., best_quality, high_quality_fast_inference, and medium_quality_faster_inference.
         config
             A dictionary with four keys "model", "data", "optimization", and "environment".
             Each key's value can be a string, yaml file path, or OmegaConf's DictConfig.
@@ -1118,6 +1118,7 @@ class MultiModalPredictor:
     ):
 
         config = get_config(
+            problem_type=self._problem_type,
             presets=presets,
             config=config,
             overrides=hyperparameters,

--- a/multimodal/src/autogluon/multimodal/presets.py
+++ b/multimodal/src/autogluon/multimodal/presets.py
@@ -543,3 +543,26 @@ def get_automm_presets(presets: str):
         )
 
     return overrides
+
+
+def get_preset_str(problem_type: str, presets: str):
+    """
+    Concatenate problem type and presets to get a registered preset string.
+
+    Parameters
+    ----------
+    problem_type
+        Problem type.
+    presets
+        Presets regarding model quality, e.g., best_quality, high_quality_fast_inference, and medium_quality_faster_inference.
+
+    Returns
+    -------
+    A registered preset string.
+    """
+    if problem_type and presets:
+        return f"{presets}_{problem_type}"
+    elif problem_type:
+        return problem_type
+    else:
+        return presets

--- a/multimodal/src/autogluon/multimodal/presets.py
+++ b/multimodal/src/autogluon/multimodal/presets.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from .constants import DATA, DISTILLER, ENVIRONMENT, MATCHER, MODEL, OPTIMIZATION, QUERY, RESPONSE
+from .constants import BINARY, DATA, ENVIRONMENT, MODEL, MULTICLASS, OPTIMIZATION, REGRESSION
 from .registry import Registry
 
 automm_presets = Registry("automm_presets")
@@ -8,7 +8,7 @@ matcher_presets = Registry("matcher_presets")
 
 
 @automm_presets.register()
-def default():
+def high_quality_fast_inference():
     return {
         "model.names": [
             "categorical_mlp",
@@ -16,13 +16,16 @@ def default():
             "timm_image",
             "hf_text",
             "fusion_mlp",
-            "ner_text",
-            "fusion_ner",
         ],
         "model.hf_text.checkpoint_name": "google/electra-base-discriminator",
         "model.timm_image.checkpoint_name": "swin_base_patch4_window7_224",
         "env.num_workers": 2,
     }
+
+
+@automm_presets.register()
+def default():
+    return automm_presets.create("high_quality_fast_inference")
 
 
 @automm_presets.register()
@@ -34,12 +37,9 @@ def medium_quality_faster_train():
             "timm_image",
             "hf_text",
             "fusion_mlp",
-            "ner_text",
-            "fusion_ner",
         ],
         "model.hf_text.checkpoint_name": "google/electra-small-discriminator",
         "model.timm_image.checkpoint_name": "swin_small_patch4_window7_224",
-        "model.ner_text.checkpoint_name": "microsoft/deberta-v3-small",
         "optimization.learning_rate": 4e-4,
         "env.num_workers": 2,
     }
@@ -456,7 +456,13 @@ def medium_quality_faster_inference_image_text_similarity():
 @automm_presets.register()
 def best_quality_ner():
     return {
-        "model.names": ["ner_text"],
+        "model.names": [
+            "categorical_mlp",
+            "numerical_mlp",
+            "timm_image",
+            "ner_text",
+            "fusion_ner",
+        ],
         "model.ner_text.checkpoint_name": "microsoft/deberta-v3-large",
         "env.per_gpu_batch_size": 4,
     }
@@ -465,7 +471,13 @@ def best_quality_ner():
 @automm_presets.register()
 def medium_quality_faster_inference_ner():
     return {
-        "model.names": ["ner_text"],
+        "model.names": [
+            "categorical_mlp",
+            "numerical_mlp",
+            "timm_image",
+            "ner_text",
+            "fusion_ner",
+        ],
         "model.ner_text.checkpoint_name": "google/electra-small-discriminator",
     }
 
@@ -473,9 +485,20 @@ def medium_quality_faster_inference_ner():
 @automm_presets.register()
 def high_quality_fast_inference_ner():
     return {
-        "model.names": ["ner_text"],
+        "model.names": [
+            "categorical_mlp",
+            "numerical_mlp",
+            "timm_image",
+            "ner_text",
+            "fusion_ner",
+        ],
         "model.ner_text.checkpoint_name": "microsoft/deberta-v3-base",
     }
+
+
+@automm_presets.register()
+def ner():
+    return automm_presets.create("high_quality_fast_inference_ner")
 
 
 def list_automm_presets(verbose: bool = False):
@@ -560,6 +583,12 @@ def get_preset_str(problem_type: str, presets: str):
     -------
     A registered preset string.
     """
+    if problem_type in [
+        BINARY,
+        MULTICLASS,
+        REGRESSION,
+    ]:
+        problem_type = None
     if problem_type and presets:
         return f"{presets}_{problem_type}"
     elif problem_type:

--- a/multimodal/src/autogluon/multimodal/presets.py
+++ b/multimodal/src/autogluon/multimodal/presets.py
@@ -588,7 +588,8 @@ def get_preset_str(problem_type: str, presets: str):
         MULTICLASS,
         REGRESSION,
     ]:
-        problem_type = None
+        return presets
+
     if problem_type and presets:
         return f"{presets}_{problem_type}"
     elif problem_type:

--- a/multimodal/src/autogluon/multimodal/utils/config.py
+++ b/multimodal/src/autogluon/multimodal/utils/config.py
@@ -487,12 +487,6 @@ def update_config_by_rules(
                 "the loss_function automatically otherwise.",
                 UserWarning,
             )
-    if problem_type == NER:
-        if FUSION_MLP in config.model.names:
-            config.model.names.remove(FUSION_MLP)
-    else:
-        if FUSION_NER in config.model.names:
-            config.model.names.remove(FUSION_NER)
 
     return config
 

--- a/multimodal/src/autogluon/multimodal/utils/config.py
+++ b/multimodal/src/autogluon/multimodal/utils/config.py
@@ -20,7 +20,7 @@ from ..constants import (
     REGRESSION,
     VALID_CONFIG_KEYS,
 )
-from ..presets import get_automm_presets, get_basic_automm_config
+from ..presets import get_automm_presets, get_basic_automm_config, get_preset_str
 
 logger = logging.getLogger(AUTOMM)
 
@@ -61,6 +61,7 @@ def filter_search_space(hyperparameters: dict, keys_to_filter: Union[str, List[s
 
 
 def get_config(
+    problem_type: Optional[str] = None,
     presets: Optional[str] = None,
     config: Optional[Union[dict, DictConfig]] = None,
     overrides: Optional[Union[str, List[str], Dict]] = None,
@@ -72,8 +73,10 @@ def get_config(
 
     Parameters
     ----------
+    problem_type
+        Problem type.
     presets
-        Name of the presets.
+        Presets regarding model quality, e.g., best_quality, high_quality_fast_inference, and medium_quality_faster_inference.
     config
         A dictionary including four keys: "model", "data", "optimization", and "environment".
         If any key is not given, we will fill in with the default value.
@@ -123,6 +126,8 @@ def get_config(
     -------
     Configurations as a DictConfig object
     """
+    presets = get_preset_str(problem_type=problem_type, presets=presets)
+
     if config is None:
         config = {}
 

--- a/multimodal/src/autogluon/multimodal/utils/pipeline.py
+++ b/multimodal/src/autogluon/multimodal/utils/pipeline.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(AUTOMM)
 
 def get_registered_presets(problem_type: str, presets: str):
     if problem_type and presets:
-        return f"{problem_type}_{presets}"
+        return f"{presets}_{problem_type}"
     elif problem_type:
         return problem_type
     else:

--- a/multimodal/src/autogluon/multimodal/utils/pipeline.py
+++ b/multimodal/src/autogluon/multimodal/utils/pipeline.py
@@ -11,15 +11,6 @@ from .model import create_fusion_model
 logger = logging.getLogger(AUTOMM)
 
 
-def get_registered_presets(problem_type: str, presets: str):
-    if problem_type and presets:
-        return f"{presets}_{problem_type}"
-    elif problem_type:
-        return problem_type
-    else:
-        return presets
-
-
 def init_pretrained(
     problem_type: Optional[str] = None,
     presets: Optional[str] = None,
@@ -33,8 +24,10 @@ def init_pretrained(
 
     Parameters
     ----------
+    problem_type
+        Problem type.
     presets
-        The preset to load
+        Presets regarding model quality, e.g., best_quality, high_quality_fast_inference, and medium_quality_faster_inference.
     hyperparameters
         The customized hyperparameters used to override the default.
 
@@ -47,8 +40,7 @@ def init_pretrained(
     data_processors
         The data processors associated with the pre-trained model.
     """
-    presets = get_registered_presets(problem_type=problem_type, presets=presets)
-    config = get_config(presets=presets, overrides=hyperparameters)
+    config = get_config(problem_type=problem_type, presets=presets, overrides=hyperparameters)
     assert (
         len(config.model.names) == 1
     ), f"Zero shot mode only supports using one model, but detects multiple models {config.model.names}"
@@ -72,8 +64,10 @@ def init_pretrained_matcher(
 
     Parameters
     ----------
+    pipeline
+        Matching pipeline.
     presets
-        Name of the pipeline.
+        Presets regarding model quality, e.g., best_quality, high_quality_fast_inference, and medium_quality_faster_inference.
     hyperparameters
         The customized hyperparameters used to override the default.
 
@@ -94,8 +88,8 @@ def init_pretrained_matcher(
     response_processors
         The data processors associated with the response model.
     """
-    presets = get_registered_presets(problem_type=pipeline, presets=presets)
     config = get_config(
+        problem_type=pipeline,
         presets=presets,
         overrides=hyperparameters,
         extra=["matcher"],

--- a/multimodal/src/autogluon/multimodal/utils/pipeline.py
+++ b/multimodal/src/autogluon/multimodal/utils/pipeline.py
@@ -11,8 +11,18 @@ from .model import create_fusion_model
 logger = logging.getLogger(AUTOMM)
 
 
+def get_registered_presets(problem_type: str, presets: str):
+    if problem_type and presets:
+        return f"{problem_type}_{presets}"
+    elif problem_type:
+        return problem_type
+    else:
+        return presets
+
+
 def init_pretrained(
-    presets: Optional[str],
+    problem_type: Optional[str] = None,
+    presets: Optional[str] = None,
     hyperparameters: Optional[Union[str, Dict, List[str]]] = None,
     num_classes: Optional[int] = None,
     classes: Optional[list] = None,
@@ -37,7 +47,7 @@ def init_pretrained(
     data_processors
         The data processors associated with the pre-trained model.
     """
-    # TODO: Fix the logic and add presets
+    presets = get_registered_presets(problem_type=problem_type, presets=presets)
     config = get_config(presets=presets, overrides=hyperparameters)
     assert (
         len(config.model.names) == 1
@@ -53,7 +63,8 @@ def init_pretrained(
 
 
 def init_pretrained_matcher(
-    presets: Optional[str],
+    pipeline: Optional[str] = None,
+    presets: Optional[str] = None,
     hyperparameters: Optional[Union[str, Dict, List[str]]] = None,
 ):
     """
@@ -83,6 +94,7 @@ def init_pretrained_matcher(
     response_processors
         The data processors associated with the response model.
     """
+    presets = get_registered_presets(problem_type=pipeline, presets=presets)
     config = get_config(
         presets=presets,
         overrides=hyperparameters,

--- a/multimodal/tests/unittests/others/test_presets.py
+++ b/multimodal/tests/unittests/others/test_presets.py
@@ -1,8 +1,21 @@
 import pytest
 from omegaconf import OmegaConf
 
-from autogluon.multimodal.constants import DATA, DISTILLER, ENVIRONMENT, MODEL, OPTIMIZATION
+from autogluon.multimodal import MultiModalPredictor
+from autogluon.multimodal.constants import (
+    DATA,
+    DISTILLER,
+    ENVIRONMENT,
+    FEATURE_EXTRACTION,
+    FEW_SHOT_TEXT_CLASSIFICATION,
+    MODEL,
+    OCR_TEXT_DETECTION,
+    OCR_TEXT_RECOGNITION,
+    OPTIMIZATION,
+    ZERO_SHOT_IMAGE_CLASSIFICATION,
+)
 from autogluon.multimodal.presets import get_automm_presets, get_basic_automm_config, list_automm_presets
+from autogluon.multimodal.problem_types import PROBLEM_TYPES_REG
 from autogluon.multimodal.utils import get_config
 
 
@@ -36,3 +49,21 @@ def test_basic_config():
 
     basic_config = get_basic_automm_config(extra=[DISTILLER])
     assert list(basic_config.keys()).sort() == [MODEL, DATA, OPTIMIZATION, ENVIRONMENT, DISTILLER].sort()
+
+
+@pytest.mark.parametrize("problem_type", list(PROBLEM_TYPES_REG.list_keys()))
+@pytest.mark.parametrize("presets", ["medium_quality_faster_inference", "high_quality_fast_inference", "best_quality"])
+def test_preset_in_init(problem_type, presets):
+    if problem_type in [
+        OCR_TEXT_DETECTION,
+        OCR_TEXT_RECOGNITION,
+    ]:
+        pytest.skip(reason="Need to fix these presets before testing them.")
+
+    predictor = MultiModalPredictor(problem_type=problem_type)
+    if problem_type not in [
+        FEATURE_EXTRACTION,
+        FEW_SHOT_TEXT_CLASSIFICATION,
+        ZERO_SHOT_IMAGE_CLASSIFICATION,
+    ]:
+        predictor = MultiModalPredictor(problem_type=problem_type, presets=presets)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Let users use `presets` in predictor initialization. The presets is to control model quality: `best_quality`, `high_quality_fast_inference`, and `medium_quality_faster_inference`.
2. Fix ner presets. Use the registered ner presets rather than the default.
3. Add unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
