### PR TITLE
[CI]Fix torch install on platform tests

### DIFF
--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -41,7 +41,7 @@ function setup_torch_gpu_non_linux {
 }
 
 function setup_torch_cpu_non_linux {
-    pip3 install torch==1.12.1+cpu torchvision==0.13.1+cpu torchtext==0.13.1 -f https://download.pytorch.org/whl/cpu/torch_stable.html
+    pip3 install torch==1.12.1 torchvision==0.13.1 torchtext==0.13.1
 }
 
 function install_local_packages {

--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -36,6 +36,14 @@ function setup_torch_cpu {
     python3 -m pip install --no-cache-dir -U ${TORCH_URL} ${TORCHVISION_URL}
 }
 
+function setup_torch_gpu_non_linux {
+    pip3 install torch==1.12.1+cu113 torchvision==0.13.1+cu113 torchtext==0.13.1 --extra-index-url https://download.pytorch.org/whl/cu113
+}
+
+function setup_torch_cpu_non_linux {
+    pip3 install torch==1.12.1+cpu torchvision==0.13.1+cpu torchtext==0.13.1 -f https://download.pytorch.org/whl/cpu/torch_stable.html
+}
+
 function install_local_packages {
     while(($#)) ; do
         python3 -m pip install --upgrade -e $1

--- a/.github/workflow_scripts/test_tabular.sh
+++ b/.github/workflow_scripts/test_tabular.sh
@@ -3,12 +3,19 @@
 set -ex
 
 ADDITIONAL_TEST_ARGS=$1
+IS_PLATFORM_TEST=$2
 
 source $(dirname "$0")/env_setup.sh
 
 setup_build_env
-setup_torch_gpu
-export CUDA_VISIBLE_DEVICES=0
+
+if [ "${IS_PLATFORM_TEST,,}" = "true" ]
+then
+    setup_torch_cpu_non_linux
+else
+    setup_torch_gpu
+fi
+
 install_local_packages "common/[tests]" "core/[all,tests]" "features/" "tabular/[all,tests]"
 install_multimodal "[tests]"
 install_local_packages "text/"

--- a/.github/workflow_scripts/test_tabular.sh
+++ b/.github/workflow_scripts/test_tabular.sh
@@ -14,6 +14,8 @@ then
     setup_torch_cpu_non_linux
 else
     setup_torch_gpu
+    export CUDA_VISIBLE_DEVICES=0
+
 fi
 
 install_local_packages "common/[tests]" "core/[all,tests]" "features/" "tabular/[all,tests]"

--- a/.github/workflow_scripts/test_tabular.sh
+++ b/.github/workflow_scripts/test_tabular.sh
@@ -15,7 +15,6 @@ then
 else
     setup_torch_gpu
     export CUDA_VISIBLE_DEVICES=0
-
 fi
 
 install_local_packages "common/[tests]" "core/[all,tests]" "features/" "tabular/[all,tests]"

--- a/.github/workflow_scripts/test_tabular.sh
+++ b/.github/workflow_scripts/test_tabular.sh
@@ -9,7 +9,7 @@ source $(dirname "$0")/env_setup.sh
 
 setup_build_env
 
-if [ "${IS_PLATFORM_TEST,,}" = "true" ]
+if [ "$IS_PLATFORM_TEST" = "true" ]
 then
     setup_torch_cpu_non_linux
 else

--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -197,7 +197,7 @@ jobs:
       - name: unit-test
         shell: bash -l {0}
         run: |
-          chmod +x ./.github/workflow_scripts/test_tabular.sh && ./.github/workflow_scripts/test_tabular.sh "-m not gpu"
+          chmod +x ./.github/workflow_scripts/test_tabular.sh && ./.github/workflow_scripts/test_tabular.sh "-m not gpu" "true"
 
   install:
     needs: setup


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Security patches applied in https://github.com/autogluon/autogluon/pull/2588 is linux specific. For our platform tests, we install default torch.
* Platform tests are running in github hosted machine and doesn't contain credentials. Should be fine


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
