### PR TITLE
Fix AutoMM usage of text in TabularPredictor

### DIFF
--- a/core/src/autogluon/core/models/abstract/_tags.py
+++ b/core/src/autogluon/core/models/abstract/_tags.py
@@ -22,3 +22,10 @@ _DEFAULT_TAGS = {
     #  It is recommended in these scenarios to set `can_refit_full` to False until a correct implementation is added.
     'can_refit_full': False,
 }
+
+
+_DEFAULT_CLASS_TAGS = {
+    # Whether the model can handle raw text input features.
+    #  Used for informing the global feature preprocessor on if it should keep raw text features.
+    'handles_text': False,
+}

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -22,7 +22,7 @@ from autogluon.common.utils.log_utils import DuplicateFilter
 from autogluon.common.utils.resource_utils import ResourceManager
 
 from .model_trial import model_trial, skip_hpo
-from ._tags import _DEFAULT_TAGS
+from ._tags import _DEFAULT_CLASS_TAGS, _DEFAULT_TAGS
 from ... import metrics, Space
 from ...constants import AG_ARGS_FIT, BINARY, REGRESSION, QUANTILE, REFIT_FULL_SUFFIX, OBJECTIVES_TO_NORMALIZE
 from ...data.label_cleaner import LabelCleaner, LabelCleanerMulticlassToBinary
@@ -1606,8 +1606,14 @@ class AbstractModel:
     def _features(self):
         return self._features_internal
 
-    def _get_tags(self):
-        collected_tags = {}
+    def _get_tags(self) -> dict:
+        """
+        Tags are key-value pairs assigned to an object.
+        These can be accessed after initializing an object.
+        Tags are used for identifying if an object supports certain functionality.
+        """
+        # first get class tags, which are overwritten by any object tags
+        collected_tags = self._get_class_tags()
         for base_class in reversed(inspect.getmro(self.__class__)):
             if hasattr(base_class, '_more_tags'):
                 # need the if because mixins might not have _more_tags
@@ -1617,7 +1623,31 @@ class AbstractModel:
                 collected_tags.update(more_tags)
         return collected_tags
 
-    def _more_tags(self):
+    @classmethod
+    def _get_class_tags(cls) -> dict:
+        """
+        Class tags are tags assigned to a class that are fixed.
+        These can be accessed prior to initializing an object.
+        Tags are used for identifying if an object supports certain functionality.
+        """
+        collected_tags = {}
+        for base_class in reversed(inspect.getmro(cls)):
+            if hasattr(base_class, '_class_tags'):
+                # need the if because mixins might not have _class_tags
+                # but might do redundant work in estimators
+                # (i.e. calling more tags on BaseEstimator multiple times)
+                more_tags = base_class._class_tags()
+                collected_tags.update(more_tags)
+        return collected_tags
+
+    @classmethod
+    def _class_tags(cls) -> dict:
+        """
+        [Advanced] Optional tags used to communicate model capabilities to AutoML systems, such as if the model supports text features.
+        """
+        return _DEFAULT_CLASS_TAGS
+
+    def _more_tags(self) -> dict:
         return _DEFAULT_TAGS
     
     def _get_model_base(self):

--- a/core/src/autogluon/core/utils/try_import.py
+++ b/core/src/autogluon/core/utils/try_import.py
@@ -15,6 +15,7 @@ __all__ = [
     'try_import_fastai',
     'try_import_torch',
     'try_import_d8',
+    'try_import_autogluon_multimodal',
     'try_import_autogluon_text',
     'try_import_autogluon_vision',
     'try_import_rapids_cuml',
@@ -215,6 +216,14 @@ def try_import_d8():
     except ImportError as e:
         raise ImportError("`import d8` failed. d8 is an optional dependency.\n"
                           "A quick tip is to install via `pip install d8`.\n")
+
+
+def try_import_autogluon_multimodal():
+    try:
+        import autogluon.multimodal
+    except ImportError:
+        raise ImportError("`import autogluon.multimodal` failed.\n"
+                          f"A quick tip is to install via `pip install autogluon.multimodal=={__version__}`.\n")
 
 
 def try_import_autogluon_text():

--- a/tabular/src/autogluon/tabular/models/automm/automm_model.py
+++ b/tabular/src/autogluon/tabular/models/automm/automm_model.py
@@ -10,7 +10,7 @@ from autogluon.common.features.types import R_OBJECT, R_INT, R_FLOAT, R_CATEGORY
     S_TEXT_NGRAM, S_TEXT_AS_CATEGORY, S_TEXT_SPECIAL, S_IMAGE_PATH
 from autogluon.core.constants import REGRESSION
 from autogluon.common.utils.resource_utils import ResourceManager
-from autogluon.core.utils import try_import_autogluon_text
+from autogluon.core.utils import try_import_autogluon_multimodal
 from autogluon.core.models import AbstractModel
 
 logger = logging.getLogger(__name__)
@@ -84,7 +84,7 @@ class MultiModalPredictorModel(AbstractModel):
 
     def _set_default_params(self):
         super()._set_default_params()
-        try_import_autogluon_text()
+        try_import_autogluon_multimodal()
 
     def _fit(self,
              X: pd.DataFrame,
@@ -114,7 +114,7 @@ class MultiModalPredictorModel(AbstractModel):
             Other keyword arguments
 
         """
-        try_import_autogluon_text()
+        try_import_autogluon_multimodal()
         from autogluon.multimodal import MultiModalPredictor
 
         # Decide name of the label column
@@ -218,7 +218,7 @@ class MultiModalPredictorModel(AbstractModel):
     def load(cls, path: str, reset_paths=True, verbose=True):
         model = super().load(path=path, reset_paths=reset_paths, verbose=verbose)
         if model._load_model:
-            try_import_autogluon_text()
+            try_import_autogluon_multimodal()
             from autogluon.multimodal import MultiModalPredictor
             model.model = MultiModalPredictor.load(os.path.join(path, cls._NN_MODEL_NAME))
         model._load_model = None
@@ -250,3 +250,7 @@ class MultiModalPredictorModel(AbstractModel):
     def _more_tags(self):
         # `can_refit_full=False` because MultiModalPredictor does not communicate how to train until the best epoch in refit_full.
         return {'can_refit_full': False}
+
+    @classmethod
+    def _class_tags(cls):
+        return {'handles_text': True}

--- a/tabular/src/autogluon/tabular/models/automm/ft_transformer.py
+++ b/tabular/src/autogluon/tabular/models/automm/ft_transformer.py
@@ -98,3 +98,7 @@ class FTTransformerModel(MultiModalPredictorModel):
         }
         default_ag_args_ensemble.update(extra_ag_args_ensemble)
         return default_ag_args_ensemble
+
+    @classmethod
+    def _class_tags(cls):
+        return {'handles_text': False}

--- a/tabular/src/autogluon/tabular/models/fasttext/fasttext_model.py
+++ b/tabular/src/autogluon/tabular/models/fasttext/fasttext_model.py
@@ -188,3 +188,7 @@ class FastTextModel(AbstractModel):
     def _more_tags(self):
         # `can_refit_full=True` because validation data is not used and there is no form of early stopping implemented.
         return {'can_refit_full': True}
+
+    @classmethod
+    def _class_tags(cls):
+        return {'handles_text': True}

--- a/tabular/src/autogluon/tabular/models/text_prediction/text_prediction_v1_model.py
+++ b/tabular/src/autogluon/tabular/models/text_prediction/text_prediction_v1_model.py
@@ -210,3 +210,7 @@ class TextPredictorModel(AbstractModel):
     def _more_tags(self):
         # `can_refit_full=False` because TextPredictor does not communicate how to train until the best epoch in refit_full.
         return {'can_refit_full': False}
+
+    @classmethod
+    def _class_tags(cls):
+        return {'handles_text': True}

--- a/tabular/src/autogluon/tabular/models/vowpalwabbit/vowpalwabbit_model.py
+++ b/tabular/src/autogluon/tabular/models/vowpalwabbit/vowpalwabbit_model.py
@@ -252,3 +252,7 @@ class VowpalWabbitModel(AbstractModel):
     def _more_tags(self):
         # `can_refit_full=True` because best epoch is communicated at end of `_fit`: `self.params_trained['passes'] = epoch`
         return {'can_refit_full': True}
+
+    @classmethod
+    def _class_tags(cls):
+        return {'handles_text': True}

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -3496,6 +3496,7 @@ class TabularPredictor:
         for key in hyperparameters:
             if isinstance(key, int) or key == 'default':
                 is_advanced_hyperparameter_type = True
+                break
         if is_advanced_hyperparameter_type:
             for key in hyperparameters:
                 for m in hyperparameters[key]:

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -35,6 +35,7 @@ from ..configs.feature_generator_presets import get_default_feature_generator
 from ..configs.hyperparameter_configs import get_hyperparameter_config
 from ..configs.presets_configs import tabular_presets_dict, tabular_presets_alias
 from ..learner import AbstractTabularLearner, DefaultLearner
+from ..trainer.model_presets.presets import MODEL_TYPES
 
 logger = logging.getLogger(__name__)  # return autogluon root logger
 
@@ -392,13 +393,15 @@ class TabularPredictor:
                     'XT' (extremely randomized trees)
                     'KNN' (k-nearest neighbors)
                     'LR' (linear regression)
-                    'NN_MXNET' (neural network implemented in MXNet)
                     'NN_TORCH' (neural network implemented in Pytorch)
                     'FASTAI' (neural network with FastAI backend)
+                    'AG_AUTOMM' (`MultimodalPredictor` from `autogluon.multimodal`. Supports Tabular, Text, and Image modalities. GPU is required.)
                 Experimental model options include:
+                    'FT_TRANSFORMER' (Tabular Transformer, GPU is recommended. Does not scale well to >100 features.)
                     'FASTTEXT' (FastText)
-                    'AG_TEXT_NN' (Multimodal Text+Tabular model, GPU is required)
-                    'TRANSF' (Tabular Transformer, GPU is recommended)
+                    'VW' (VowpalWabbit)
+                    'AG_TEXT_NN' (Multimodal Text+Tabular model, GPU is required. Recommended to instead use its successor, 'AG_AUTOMM'.)
+                    'AG_IMAGE_NN' (Image model, GPU is required. Recommended to instead use its successor, 'AG_AUTOMM'.)
                 If a certain key is missing from hyperparameters, then `fit()` will not train any models of that type. Omitting a model key from hyperparameters is equivalent to including this model key in `excluded_model_types`.
                 For example, set `hyperparameters = { 'NN_TORCH':{...} }` if say you only want to train (PyTorch) neural networks and no other types of models.
             Values = dict of hyperparameter settings for each model type, or list of dicts.
@@ -789,18 +792,9 @@ class TabularPredictor:
         # in case the hyperprams are large in memory
         self.fit_hyperparameters_ = hyperparameters
 
-        ###################################
-        # FIXME: v0.1 This section is a hack
         if 'enable_raw_text_features' not in feature_generator_init_kwargs:
-            if 'AG_TEXT_NN' in hyperparameters or 'VW' in hyperparameters:
+            if self._check_if_hyperparameters_handle_text(hyperparameters=hyperparameters):
                 feature_generator_init_kwargs['enable_raw_text_features'] = True
-            else:
-                for key in hyperparameters:
-                    if isinstance(key, int) or key == 'default':
-                        if 'AG_TEXT_NN' in hyperparameters[key] or 'VW' in hyperparameters[key]:
-                            feature_generator_init_kwargs['enable_raw_text_features'] = True
-                            break
-        ###################################
 
         if feature_metadata is not None and isinstance(feature_metadata, str) and feature_metadata == 'infer':
             feature_metadata = None
@@ -3494,6 +3488,38 @@ class TabularPredictor:
         predictor_clone.save_space()
         return predictor_clone if return_clone else predictor_clone.path
 
+    @staticmethod
+    def _check_if_hyperparameters_handle_text(hyperparameters: dict) -> bool:
+        """Check if hyperparameters contain a model that supports raw text features as input"""
+        models_in_hyperparameters = set()
+        is_advanced_hyperparameter_type = False
+        for key in hyperparameters:
+            if isinstance(key, int) or key == 'default':
+                is_advanced_hyperparameter_type = True
+        if is_advanced_hyperparameter_type:
+            for key in hyperparameters:
+                for m in hyperparameters[key]:
+                    models_in_hyperparameters.add(m)
+        else:
+            for key in hyperparameters:
+                models_in_hyperparameters.add(key)
+        models_in_hyperparameters_raw_text_compatible = []
+        for m in models_in_hyperparameters:
+            if isinstance(m, str):
+                # TODO: Technically the use of MODEL_TYPES here is a hack since we should derive valid types from trainer,
+                #  but this is required prior to trainer existing.
+                if m in MODEL_TYPES:
+                    m = MODEL_TYPES[m]
+                else:
+                    continue
+            if m._get_class_tags().get('handles_text', False):
+                models_in_hyperparameters_raw_text_compatible.append(m)
+
+        if models_in_hyperparameters_raw_text_compatible:
+            return True
+        else:
+            return False
+
     def _assert_is_fit(self, message_suffix: str = None):
         if not self._learner.is_fit:
             error_message = "Predictor is not fit. Call `.fit` before calling"
@@ -3502,6 +3528,7 @@ class TabularPredictor:
             else:
                 error_message = f"{error_message} `.{message_suffix}`."
             raise AssertionError(error_message)
+
 
 # Location to store WIP functionality that will be later added to TabularPredictor
 class _TabularPredictorExperimental(TabularPredictor):

--- a/tabular/tests/unittests/models/test_automm.py
+++ b/tabular/tests/unittests/models/test_automm.py
@@ -1,0 +1,20 @@
+import pytest
+
+
+@pytest.mark.gpu
+def test_automm_sts(fit_helper):
+    pytest.skip("Temporary skip the unittest")
+    fit_args = dict(
+        hyperparameters={'AG_AUTOMM': {}},
+    )
+    dataset_name = 'sts'
+    fit_helper.fit_and_validate_dataset(
+        dataset_name=dataset_name, fit_args=fit_args, sample_size=1000,
+        refit_full=True,
+    )
+
+
+def test_handle_text_automm():
+    hyperparameters = {'AG_AUTOMM': {}}
+    from autogluon.tabular import TabularPredictor
+    assert TabularPredictor._check_if_hyperparameters_handle_text(hyperparameters)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fixed case where AutoMM is specified as a model in TabularPredictor, but the global preprocessor does not keep raw text features in output, leading AutoMM to not use text features.
- Now this situation is fixed for all future models so long as they specify `handles_text=True` in `_class_tags`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
