### PR TITLE
[eda] Quick Fit

### DIFF
--- a/.github/workflow_scripts/test_eda.sh
+++ b/.github/workflow_scripts/test_eda.sh
@@ -11,9 +11,7 @@ export CUDA_VISIBLE_DEVICES=0
 install_local_packages "common/[tests]" "core/[all,tests]" "features/" "tabular/[all,tests]" "eda/[tests]"
 
 cd eda/
-python3 -m tox -e lint
-python3 -m tox -e typecheck
-python3 -m tox -e format
+python3 -m tox -e lint,typecheck,format,testenv
 if [ -n "$ADDITIONAL_TEST_ARGS" ]
 then
     python3 -m pytest --junitxml=results.xml --runslow "$ADDITIONAL_TEST_ARGS" tests

--- a/eda/setup.cfg
+++ b/eda/setup.cfg
@@ -25,7 +25,7 @@ branch = True
 [coverage:report]
 show_missing = True
 skip_covered = True
-fail_under = 85
+fail_under = 90
 
 [coverage:paths]
 source =

--- a/eda/src/autogluon/eda/analysis/__init__.py
+++ b/eda/src/autogluon/eda/analysis/__init__.py
@@ -2,6 +2,6 @@ from .base import Namespace
 from .dataset import Sampler, TrainValidationSplit
 from .interaction import Correlation, CorrelationSignificance, DistributionFit, FeatureInteraction
 from .missing import MissingValuesAnalysis
-from .model import AutoGluonModelEvaluator
+from .model import AutoGluonModelEvaluator, AutoGluonModelQuickFit
 from .shift import XShiftDetector
 from .transform import ApplyFeatureGenerator

--- a/eda/src/autogluon/eda/analysis/interaction.py
+++ b/eda/src/autogluon/eda/analysis/interaction.py
@@ -19,6 +19,10 @@ class Correlation(AbstractAnalysis):
     """
     Correlation analysis.
 
+    Note: it is recommended to apply AutoGluon standard pre-processing - this will allow to include categorical variables into the analysis.
+    This can be done via wrapping analysis into :py:class:`~autogluon.eda.analysis.transform.ApplyFeatureGenerator`
+
+
     Parameters
     ----------
     method: str  {'pearson', 'kendall', 'spearman', 'phik'}, default='spearman'
@@ -43,9 +47,29 @@ class Correlation(AbstractAnalysis):
     children: List[AbstractAnalysis], default = []
         wrapped analyses; these will receive sampled `args` during `fit` call
 
+    Examples
+    --------
+    >>> import autogluon.eda.analysis as eda
+    >>> import autogluon.eda.visualization as viz
+    >>> import autogluon.eda.auto as auto
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> df_train = pd.DataFrame(...)
+    >>>
+    >>> auto.analyze(return_sttrain_data=df_train, label=target_col, anlz_facets=[
+    >>>     # Apply standard AutoGluon pre-processing to transform categorical variables to numbers to ensure correlation includes them.
+    >>>     eda.transform.ApplyFeatureGenerator(category_to_numbers=True, children=[
+    >>>         # We use `spearman` correlation to capture non-linear interactions because it is based on the order rank.
+    >>>         eda.interaction.Correlation(method='spearman', focus_field=target_col, focus_field_threshold=0.3),
+    >>>     ])
+    >>> ], viz_facets=[
+    >>>     viz.interaction.CorrelationVisualization(fig_args=dict(figsize=(12,8)), **common_args),
+    >>> ])
+
     See Also
     --------
     `phik <https://github.com/KaveIO/PhiK>`_ documentation
+    :py:class:`~autogluon.eda.analysis.transform.ApplyFeatureGenerator`
 
     """
 
@@ -96,15 +120,39 @@ class Correlation(AbstractAnalysis):
 class CorrelationSignificance(AbstractAnalysis):
     """
     Significance of correlation of all variable combinations in the DataFrame.
+
     See :py:meth:`~phik.significance.significance_matrix` for more details.
     This analysis requires :py:class:`~autogluon.eda.analysis.interaction.Correlation` results to be
     available in the state.
+
+    Note: it is recommended to apply AutoGluon standard pre-processing - this will allow to include categorical variables into the analysis.
+    This can be done via wrapping analysis into :py:class:`~autogluon.eda.analysis.transform.ApplyFeatureGenerator`
+
+    Examples
+    --------
+    >>> import autogluon.eda.analysis as eda
+    >>> import autogluon.eda.visualization as viz
+    >>> import autogluon.eda.auto as auto
+    >>> import pandas as pd
+    >>> df_train = pd.DataFrame(...)
+    >>>
+    >>> auto.analyze(return_sttrain_data=df_train, label=target_col, anlz_facets=[
+    >>>     # Apply standard AutoGluon pre-processing to transform categorical variables to numbers to ensure correlation includes them.
+    >>>     eda.transform.ApplyFeatureGenerator(category_to_numbers=True, children=[
+    >>>         # We use `spearman` correlation to capture non-linear interactions because it is based on the order rank.
+    >>>         eda.interaction.Correlation(method='spearman', focus_field=target_col, focus_field_threshold=0.3),
+    >>>         eda.interaction.CorrelationSignificance()
+    >>>     ])
+    >>> ], viz_facets=[
+    >>>     viz.interaction.CorrelationSignificanceVisualization(fig_args=dict(figsize=(12,8))),
+    >>> ])
 
     See Also
     --------
     `phik <https://github.com/KaveIO/PhiK>`_ documentation
     :py:meth:`~phik.significance.significance_matrix`
     :py:class:`~autogluon.eda.analysis.interaction.Correlation`
+    :py:class:`~autogluon.eda.analysis.transform.ApplyFeatureGenerator`
     """
 
     def can_handle(self, state: AnalysisState, args: AnalysisState) -> bool:

--- a/eda/src/autogluon/eda/analysis/model.py
+++ b/eda/src/autogluon/eda/analysis/model.py
@@ -19,13 +19,33 @@ class AutoGluonModelQuickFit(AbstractAnalysis):
     Note: this component can be wrapped into :py:class:`~autogluon.eda.analysis.dataset.TrainValidationSplit` and `~autogluon.eda.analysis.dataset.Sampler`
     to perform automated sampling and train-test split. This whole logic is implemented in :py:meth`~autogluon.eda.auto.simple.quick_fit` shortcut.
 
+    Examples
+    --------
+    >>> from autogluon.eda.analysis.base import BaseAnalysis
+    >>> from autogluon.eda.analysis import Sampler
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>>
+    >>> # Quick fit
+    >>> data = full_data[full_data['Age'].notna()]
+    >>> columns=['Pclass', 'Age', 'Embarked', 'SibSp', 'Parch', 'Fare', 'Cabin']
+    >>> state = auto.quick_fit(train_data=data[columns], label='Age', return_state=True, save_model_to_state=True, hyperparameters={'GBM': {}})
+    >>>
+    >>> # Using quick fit model as an imputer
+    >>> age_imputer = state.model
+    >>> na_data = all_data[all_data.Age.isna()].copy()
+    >>> na_data.Age = age_imputer.predict(na_data)
+
     Parameters
     ----------
     problem_type: str, default = 'auto'
         problem type to use. Valid problem_type values include ['auto', 'binary', 'multiclass', 'regression', 'quantile', 'softclass']
         auto means it will be Auto-detected using AutoGluon methods.
-    estimator_args
+    estimator_args: Optional[Dict[str, Any]], default = None,
         kwargs to pass into estimator constructor (`TabularPredictor`)
+    save_model_to_state: bool, default = False,
+        save fitted model into `state` under `model` key.
+        This functionality might be helpful in cases when the fitted model could be usable for other purposes (i.e. imputers)
     parent: Optional[AbstractAnalysis], default = None
         parent Analysis
     children: Optional[List[AbstractAnalysis]], default None

--- a/eda/src/autogluon/eda/analysis/model.py
+++ b/eda/src/autogluon/eda/analysis/model.py
@@ -117,7 +117,7 @@ class AutoGluonModelEvaluator(AbstractAnalysis):
         label = predictor.label
         y_true = val_data[label]
         y_pred = predictor.predict(val_data)
-        importance = predictor.feature_importance(val_data.reset_index(drop=True))
+        importance = predictor.feature_importance(val_data.reset_index(drop=True), silent=True)
         leaderboard = predictor.leaderboard(val_data, silent=True)
 
         s = {

--- a/eda/src/autogluon/eda/analysis/model.py
+++ b/eda/src/autogluon/eda/analysis/model.py
@@ -11,12 +11,69 @@ __all__ = ["AutoGluonModelEvaluator", "AutoGluonModelQuickFit"]
 
 
 class AutoGluonModelQuickFit(AbstractAnalysis):
+    """
+    Fit a quick model using AutoGluon.
+
+    `train_data`, `val_data` and `label` must be present in args.
+
+    Note: this component can be wrapped into :py:class:`~autogluon.eda.analysis.dataset.TrainValidationSplit` and `~autogluon.eda.analysis.dataset.Sampler`
+    to perform automated sampling and train-test split. This whole logic is implemented in :py:meth`~autogluon.eda.auto.simple.quick_fit` shortcut.
+
+    Parameters
+    ----------
+    problem_type: str, default = 'auto'
+        problem type to use. Valid problem_type values include ['auto', 'binary', 'multiclass', 'regression', 'quantile', 'softclass']
+        auto means it will be Auto-detected using AutoGluon methods.
+    estimator_args
+        kwargs to pass into estimator constructor (`TabularPredictor`)
+    parent: Optional[AbstractAnalysis], default = None
+        parent Analysis
+    children: Optional[List[AbstractAnalysis]], default None
+        wrapped analyses; these will receive sampled `args` during `fit` call
+    kwargs
+
+    Examples
+    --------
+    >>> import autogluon.eda.analysis as eda
+    >>> import autogluon.eda.visualization as viz
+    >>> import autogluon.eda.auto as auto
+    >>> auto.analyze(
+    >>>     train_data=df_train,
+    >>>     label=label,
+    >>>     anlz_facets=[
+    >>>         eda.dataset.TrainValidationSplit(children=[
+    >>>             eda.model.AutoGluonModelQuickFit(
+    >>>                 estimator_args=dict(path=path),
+    >>>                 verbosity=0,
+    >>>                 hyperparameters={
+    >>>                     "RF": {
+    >>>                         "criterion": "entropy",
+    >>>                         "max_depth": 15,
+    >>>                         "ag_args": {"name_suffix": "Entr", "problem_types": ["binary", "multiclass"]},
+    >>>                     }
+    >>>                 },
+    >>>                 children=[
+    >>>                     eda.model.AutoGluonModelEvaluator()
+    >>>                 ],
+    >>>             )
+    >>>         ])
+    >>>     ],
+    >>> )
+
+    See Also
+    --------
+    :py:meth`~autogluon.eda.auto.simple.quick_fit`
+    :py:class:`~autogluon.eda.analysis.dataset.TrainValidationSplit`
+    :py:class:`~autogluon.eda.analysis.dataset.Sampler`
+
+    """
+
     def __init__(
         self,
+        problem_type: str = "auto",
         estimator_args: Optional[Dict[str, Any]] = None,
         parent: Optional[AbstractAnalysis] = None,
         children: Optional[List[AbstractAnalysis]] = None,
-        problem_type: str = "auto",
         **kwargs,
     ) -> None:
         super().__init__(parent, children, **kwargs)

--- a/eda/src/autogluon/eda/auto/__init__.py
+++ b/eda/src/autogluon/eda/auto/__init__.py
@@ -1,1 +1,1 @@
-from .simple import analyze, analyze_interaction, quick_fit
+from .simple import analyze, analyze_interaction, dataset_overview, quick_fit

--- a/eda/src/autogluon/eda/auto/__init__.py
+++ b/eda/src/autogluon/eda/auto/__init__.py
@@ -1,1 +1,1 @@
-from .simple import analyze, analyze_interaction
+from .simple import analyze, analyze_interaction, quick_fit

--- a/eda/src/autogluon/eda/auto/simple.py
+++ b/eda/src/autogluon/eda/auto/simple.py
@@ -177,6 +177,7 @@ def analyze_interaction(
 def quick_fit(
     train_data: pd.DataFrame,
     label: str,
+    path: Optional[str] = None,
     val_size: float = 0.3,
     problem_type: str = "auto",
     sample: Union[None, int, float] = None,
@@ -207,6 +208,8 @@ def quick_fit(
         training dataset
     label: str
         target variable
+    path: Optional[str], default = None,
+        path for models saving
     problem_type: str, default = 'auto'
         problem type to use. Valid problem_type values include ['auto', 'binary', 'multiclass', 'regression', 'quantile', 'softclass']
         auto means it will be Auto-detected using AutoGluon methods.
@@ -278,6 +281,7 @@ def quick_fit(
                 problem_type=problem_type,
                 children=[
                     AutoGluonModelQuickFit(
+                        estimator_args={"path": path},
                         verbosity=verbosity,
                         problem_type=problem_type,
                         children=[

--- a/eda/src/autogluon/eda/auto/simple.py
+++ b/eda/src/autogluon/eda/auto/simple.py
@@ -1,17 +1,26 @@
 import logging
 from typing import Any, Dict, List, Optional, Union
 
+import pandas as pd
+
 from autogluon.common.utils.log_utils import verbosity2loglevel
 
 from .. import AnalysisState
-from ..analysis import FeatureInteraction
+from ..analysis import AutoGluonModelEvaluator, AutoGluonModelQuickFit, FeatureInteraction, TrainValidationSplit
 from ..analysis.base import AbstractAnalysis, BaseAnalysis
 from ..analysis.dataset import RawTypesAnalysis, Sampler
-from ..visualization import FeatureInteractionVisualization
+from ..visualization import (
+    ConfusionMatrix,
+    FeatureImportance,
+    FeatureInteractionVisualization,
+    MarkdownSectionComponent,
+    ModelLeaderboard,
+    RegressionEvaluation,
+)
 from ..visualization.base import AbstractVisualization
 from ..visualization.layouts import SimpleVerticalLinearLayout
 
-__all__ = ["analyze", "analyze_interaction"]
+__all__ = ["analyze", "analyze_interaction", "quick_fit"]
 
 
 def analyze(
@@ -161,5 +170,131 @@ def analyze_interaction(
         ],
         viz_facets=[
             FeatureInteractionVisualization(key=key, fig_args=fig_args, **viz_args),
+        ],
+    )
+
+
+def quick_fit(
+    train_data: pd.DataFrame,
+    label: str,
+    val_size: float = 0.3,
+    problem_type: str = "auto",
+    sample: Union[None, int, float] = None,
+    state: Union[None, dict, AnalysisState] = None,
+    return_state: bool = False,
+    verbosity: int = 0,
+    show_feature_importance_barplots: bool = False,
+    **fit_args,
+):
+    """
+    This helper performs quick model fit analysis and then produces a composite report of the results.
+
+    The analysis is structured in a sequence of operations:
+        - Sample if `sample` is specified.
+        - Perform train-test split using `val_size` ratio
+        - Fit AutoGluon estimator given `fit_args`; if `hyperparameters` not present in args, then use default ones
+            (Random Forest by default - because it is interpretable)
+        - Display report
+
+    The reports include:
+        - confusion matrix for classification problems; predictions vs actual for regression problems
+        - model leaderboard
+        - feature importance
+
+    Parameters
+    ----------
+    train_data: DataFrame
+        training dataset
+    label: str
+        target variable
+    problem_type: str, default = 'auto'
+        problem type to use. Valid problem_type values include ['auto', 'binary', 'multiclass', 'regression', 'quantile', 'softclass']
+        auto means it will be Auto-detected using AutoGluon methods.
+    sample: Union[None, int, float], default = None
+        sample size; if `int`, then row number is used;
+        `float` must be between 0.0 and 1.0 and represents fraction of dataset to sample;
+        `None` means no sampling
+        See also :func:`autogluon.eda.analysis.dataset.Sampler`
+    val_size: float, default = 0.3
+        fraction of training set to be assigned as validation set during the split.
+    state: Union[None, dict, AnalysisState], default = None
+        pass prior state if necessary; the object will be updated during `anlz_facets` `fit` call.
+    return_state: bool, default = False
+        return state if `True`
+    verbosity: int, default = 0
+        Verbosity levels range from 0 to 4 and control how much information is printed.
+        Higher levels correspond to more detailed print statements (you can set verbosity = 0 to suppress warnings).
+        If using logging, you can alternatively control amount of information printed via `logger.setLevel(L)`,
+        where `L` ranges from 0 to 50 (Note: higher values of `L` correspond to fewer print statements, opposite of verbosity levels).
+    show_feature_importance_barplots: bool, default = False
+        if `True`, then barplot char will ba added with feature importance visualization
+    fit_args
+        kwargs to pass into `TabularPredictor` fit
+
+    Returns
+    -------
+        state after `fit` call if `return_state` is `True`; `None` otherwise
+
+    See Also
+    --------
+    :py:class:`~autogluon.eda.visualization.model.ConfusionMatrix`
+    :py:class:`~autogluon.eda.visualization.model.RegressionEvaluation`
+    :py:class:`~autogluon.eda.visualization.model.ModelLeaderboard`
+    :py:class:`~autogluon.eda.visualization.model.FeatureImportance`
+
+    """
+    if state is not None:
+        assert isinstance(state, (dict, AnalysisState))
+
+    if not isinstance(state, AnalysisState):
+        state = AnalysisState(state)
+
+    if "hyperparameters" not in fit_args:
+        fit_args = fit_args.copy()
+        fit_args["hyperparameters"] = {
+            "RF": [
+                {
+                    "criterion": "entropy",
+                    "max_depth": 15,
+                    "ag_args": {"name_suffix": "Entr", "problem_types": ["binary", "multiclass"]},
+                },
+                {
+                    "criterion": "squared_error",
+                    "max_depth": 15,
+                    "ag_args": {"name_suffix": "MSE", "problem_types": ["regression", "quantile"]},
+                },
+            ],
+        }
+
+    return analyze(
+        train_data=train_data,
+        label=label,
+        sample=sample,
+        state=state,
+        return_state=return_state,
+        anlz_facets=[
+            TrainValidationSplit(
+                val_size=val_size,
+                problem_type=problem_type,
+                children=[
+                    AutoGluonModelQuickFit(
+                        verbosity=verbosity,
+                        problem_type=problem_type,
+                        children=[
+                            AutoGluonModelEvaluator(),
+                        ],
+                        **fit_args,
+                    ),
+                ],
+            )
+        ],
+        viz_facets=[
+            MarkdownSectionComponent(markdown=f"### Model Prediction for {label}"),
+            ConfusionMatrix(fig_args=dict(figsize=(3, 3)), annot_kws={"size": 12}),
+            RegressionEvaluation(fig_args=dict(figsize=(6, 6)), marker="o", scatter_kws={"s": 5}),
+            MarkdownSectionComponent(markdown="### Model Leaderboard"),
+            ModelLeaderboard(),
+            MarkdownSectionComponent(markdown="### Feature Importance for Trained Model"),
+            FeatureImportance(show_barplots=show_feature_importance_barplots),
         ],
     )

--- a/eda/src/autogluon/eda/visualization/__init__.py
+++ b/eda/src/autogluon/eda/visualization/__init__.py
@@ -6,5 +6,5 @@ from .interaction import (
 )
 from .layouts import MarkdownSectionComponent, SimpleHorizontalLayout, SimpleVerticalLinearLayout, TabLayout
 from .missing import MissingValues
-from .model import ConfusionMatrix, FeatureImportance, RegressionEvaluation
+from .model import ConfusionMatrix, FeatureImportance, ModelLeaderboard, RegressionEvaluation
 from .shift import XShiftSummary

--- a/eda/src/autogluon/eda/visualization/model.py
+++ b/eda/src/autogluon/eda/visualization/model.py
@@ -68,7 +68,8 @@ class ConfusionMatrix(AbstractVisualization, JupyterMixin):
 
     def _render(self, state: AnalysisState) -> None:
         self.render_header_if_needed(state, "Confusion Matrix")
-        cm = pd.DataFrame(state.model_evaluation.confusion_matrix)
+        labels = state.model_evaluation.labels
+        cm = pd.DataFrame(state.model_evaluation.confusion_matrix, columns=labels, index=labels)
         cm.index.name = "Actual"
         cm.columns.name = "Predicted"
         normalized = state.model_evaluation.confusion_matrix_normalized

--- a/eda/src/autogluon/eda/visualization/model.py
+++ b/eda/src/autogluon/eda/visualization/model.py
@@ -240,19 +240,9 @@ class ModelLeaderboard(AbstractVisualization, JupyterMixin):
     :py:class:`~autogluon.eda.analysis.model.AutoGluonModelEvaluator`
     """
 
-    def __init__(
-        self,
-        fig_args: Optional[Dict[str, Any]] = None,
-        headers: bool = False,
-        namespace: Optional[str] = None,
-        **kwargs,
-    ) -> None:
+    def __init__(self, namespace: Optional[str] = None, headers: bool = False, **kwargs) -> None:
         super().__init__(namespace, **kwargs)
         self.headers = headers
-
-        if fig_args is None:
-            fig_args = {}
-        self.fig_args = fig_args
 
     def can_handle(self, state: AnalysisState) -> bool:
         return "model_evaluation" in state and "leaderboard" in state.model_evaluation

--- a/eda/src/autogluon/eda/visualization/model.py
+++ b/eda/src/autogluon/eda/visualization/model.py
@@ -209,7 +209,6 @@ class FeatureImportance(AbstractVisualization, JupyterMixin):
 
 class ModelLeaderboard(AbstractVisualization, JupyterMixin):
     """
-
     Render model leaderboard for trained model ensemble.
 
     Parameters

--- a/eda/tests/unittests/analysis/test_model.py
+++ b/eda/tests/unittests/analysis/test_model.py
@@ -41,14 +41,7 @@ def test_AutoGluonModelEvaluator_regression():
     assert len(state.model_evaluation.y_pred) == len(df_test)
     expected = [c for c in df_train.columns if c not in ["Street", "Utilities", "SalePrice"]]
     assert sorted(state.model_evaluation.importance.index.to_list()) == sorted(expected)
-    assert state.model_evaluation.importance.columns.to_list() == [
-        "importance",
-        "stddev",
-        "p_value",
-        "n",
-        "p99_high",
-        "p99_low",
-    ]
+    _assert_importance_is_present(state)
     assert state.model_evaluation.confusion_matrix is None
     assert state.model_evaluation.confusion_matrix_normalized is None
 
@@ -73,6 +66,51 @@ def test_AutoGluonModelEvaluator_classification():
     assert len(state.model_evaluation.y_pred) == len(df_test)
     expected = [c for c in df_train.columns if c not in ["class"]]
     assert sorted(state.model_evaluation.importance.index.to_list()) == sorted(expected)
+    _assert_importance_is_present(state)
+
+
+def test_AutoGluonModelQuickFit():
+    df_train = pd.read_csv(os.path.join(RESOURCE_PATH, "adult", "train_data.csv")).sample(100, random_state=0)
+    target_col = "class"
+
+    with tempfile.TemporaryDirectory() as path:
+        state = auto.analyze(
+            train_data=df_train,
+            label=target_col,
+            return_state=True,
+            anlz_facets=[
+                eda.dataset.TrainValidationSplit(
+                    children=[
+                        eda.model.AutoGluonModelQuickFit(
+                            estimator_args=dict(path=path),
+                            verbosity=0,
+                            hyperparameters={
+                                "RF": {
+                                    "criterion": "entropy",
+                                    "max_depth": 15,
+                                    "ag_args": {"name_suffix": "Entr", "problem_types": ["binary", "multiclass"]},
+                                }
+                            },
+                            children=[eda.model.AutoGluonModelEvaluator()],
+                        )
+                    ]
+                )
+            ],
+        )
+
+    assert state.model_evaluation.problem_type == "binary"
+    assert len(state.model_evaluation.y_true) == int(len(df_train) * 0.3)
+    assert len(state.model_evaluation.y_pred) == int(len(df_train) * 0.3)
+    expected = [c for c in df_train.columns if c not in ["class"]]
+    assert sorted(state.model_evaluation.importance.index.to_list()) == sorted(expected)
+    _assert_importance_is_present(state)
+
+
+def test_AutoGluonModelQuickFit__constructor_defaults():
+    assert eda.model.AutoGluonModelQuickFit().estimator_args == {}
+
+
+def _assert_importance_is_present(state):
     assert state.model_evaluation.importance.columns.to_list() == [
         "importance",
         "stddev",

--- a/eda/tests/unittests/visualization/test_model.py
+++ b/eda/tests/unittests/visualization/test_model.py
@@ -7,7 +7,7 @@ import pytest
 import seaborn as sns
 
 from autogluon.eda import AnalysisState
-from autogluon.eda.visualization import ConfusionMatrix, FeatureImportance, RegressionEvaluation
+from autogluon.eda.visualization import ConfusionMatrix, FeatureImportance, ModelLeaderboard, RegressionEvaluation
 
 
 @pytest.mark.parametrize("confusion_matrix_normalized,expected_fmt", [(True, ",.2%"), (False, "d")])
@@ -190,3 +190,18 @@ def test_FeatureImportance(monkeypatch, show_barplots):
         call_plt_subplots.assert_not_called()
         call_plt_show.assert_not_called()
         call_sns_barplot.assert_not_called()
+
+
+def test_ModelLeaderboard():
+    assert ModelLeaderboard().can_handle(state=AnalysisState(model_evaluation={})) is False
+
+    state = AnalysisState(model_evaluation={"leaderboard": "some_leaderboard"})
+
+    viz = ModelLeaderboard(headers=True)
+    assert viz.can_handle(state=state) is True
+
+    viz.render_text = MagicMock()
+    viz.display_obj = MagicMock()
+    viz.render(state)
+    viz.render_text.assert_called_with("Model Leaderboard", text_type="h3")
+    viz.display_obj.assert_called_with("some_leaderboard")


### PR DESCRIPTION
*Description of changes:*

## `AutoGluonModelQuickFit`

The component allows to fit a quick model using AutoGluon. `train_data`, `val_data` and `label` must be present in args.
Note: this component can be wrapped into :`TrainValidationSplit` and `Sampler` to perform automated sampling and train-test split. This whole logic is implemented in `quick_fit()` shortcut (see below).

```
    Parameters
    ----------
    problem_type: str, default = 'auto'
        problem type to use. Valid problem_type values include ['auto', 'binary', 'multiclass', 'regression', 'quantile', 'softclass']
        auto means it will be Auto-detected using AutoGluon methods.
    estimator_args
        kwargs to pass into estimator constructor (`TabularPredictor`)
    parent: Optional[AbstractAnalysis], default = None
        parent Analysis
    children: Optional[List[AbstractAnalysis]], default None
        wrapped analyses; these will receive sampled `args` during `fit` call
```

Usage:
```python
auto.analyze(
    train_data=df_train,
    label=label,
    anlz_facets=[
        eda.dataset.TrainValidationSplit(children=[  # Creates train-test split using train_data above
            eda.model.AutoGluonModelQuickFit(  # Fits the model
                estimator_args=dict(path=path),
                verbosity=0,
                hyperparameters={
                    "RF": {
                        "criterion": "entropy",
                        "max_depth": 15,
                        "ag_args": {"name_suffix": "Entr", "problem_types": ["binary", "multiclass"]},
                    }
                },
                children=[
                    eda.model.AutoGluonModelEvaluator()  # Fitted model is evaluated
                ],
            )
        ])
    ],
)
```

## `auto.quick_fit()`
This helper performs quick model fit analysis and then produces a composite report of the results.

The analysis is structured in a sequence of operations:
- Sample if `sample` is specified.
- Perform train-test split using `val_size` ratio
- Fit AutoGluon estimator given `fit_args`; if `hyperparameters` not present in args, then use default ones
    (Random Forest by default - because it is interpretable)
- Display report

The reports include:
- confusion matrix for classification problems; predictions vs actual for regression problems
- model leaderboard
- feature importance

```
    Parameters
    ----------
    train_data: DataFrame
        training dataset
    label: str
        target variable
    path: Optional[str], default = None,
        path for models saving
    problem_type: str, default = 'auto'
        problem type to use. Valid problem_type values include ['auto', 'binary', 'multiclass', 'regression', 'quantile', 'softclass']
        auto means it will be Auto-detected using AutoGluon methods.
    sample: Union[None, int, float], default = None
        sample size; if `int`, then row number is used;
        `float` must be between 0.0 and 1.0 and represents fraction of dataset to sample;
        `None` means no sampling
        See also :func:`autogluon.eda.analysis.dataset.Sampler`
    val_size: float, default = 0.3
        fraction of training set to be assigned as validation set during the split.
    state: Union[None, dict, AnalysisState], default = None
        pass prior state if necessary; the object will be updated during `anlz_facets` `fit` call.
    return_state: bool, default = False
        return state if `True`
    verbosity: int, default = 0
        Verbosity levels range from 0 to 4 and control how much information is printed.
        Higher levels correspond to more detailed print statements (you can set verbosity = 0 to suppress warnings).
        If using logging, you can alternatively control amount of information printed via `logger.setLevel(L)`,
        where `L` ranges from 0 to 50 (Note: higher values of `L` correspond to fewer print statements, opposite of verbosity levels).
    show_feature_importance_barplots: bool, default = False
        if `True`, then barplot char will ba added with feature importance visualization
    fit_args
        kwargs to pass into `TabularPredictor` fit

    Returns
    -------
        state after `fit` call if `return_state` is `True`; `None` otherwise
```

**Usage:**
```python
import autogluon.eda.auto as auto

auto.quick_fit(train_data=df_train, label=label, show_feature_importance_barplots=True, hyperparameters='toy')
```

![image](https://user-images.githubusercontent.com/10080307/210467449-471264ed-8dbd-4c1e-80c6-daa1bc6ed9cf.png)

## `auto.dataset_overview()`

Shortcut to perform high-level datasets summary overview (counts, frequencies, missing statistics, types info).

```
Parameters
----------
train_data: Optional[DataFrame], default = None
    training dataset
test_data: Optional[DataFrame], default = None
    test dataset
val_data: Optional[DataFrame], default = None
    validation dataset
label: : Optional[str], default = None
    target variable
state: Union[None, dict, AnalysisState], default = None
    pass prior state if necessary; the object will be updated during `anlz_facets` `fit` call.
sample: Union[None, int, float], default = None
    sample size; if `int`, then row number is used;
    `float` must be between 0.0 and 1.0 and represents fraction of dataset to sample;
    `None` means no sampling
    See also :func:`autogluon.eda.analysis.dataset.Sampler`
```

**Usage:**
```python
auto.dataset_overview(train_data=df_train, test_data=df_test, label=target_col)
```

![image](https://user-images.githubusercontent.com/10080307/210648741-ad891fbe-0e65-4273-8884-592957ed38c2.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
