### PR TITLE
Improve save_path in AutoMM

### DIFF
--- a/multimodal/src/autogluon/multimodal/matcher.py
+++ b/multimodal/src/autogluon/multimodal/matcher.py
@@ -96,6 +96,7 @@ from .utils import (
     save_pretrained_model_configs,
     save_text_tokenizers,
     select_model,
+    setup_save_path,
     try_to_infer_pos_label,
 )
 
@@ -180,9 +181,6 @@ class MultiModalMatcher:
         if verbosity is not None:
             set_logger_verbosity(verbosity, logger=logger)
 
-        if path is not None:
-            path = process_save_path(path=path)
-
         if isinstance(query, str):
             query = [query]
         if query:
@@ -220,6 +218,7 @@ class MultiModalMatcher:
         self._query_model = None
         self._response_model = None
         self._resume = False
+        self._fit_called = False
         self._continuous_training = False
         self._verbosity = verbosity
         self._warn_if_exist = warn_if_exist
@@ -364,24 +363,19 @@ class MultiModalMatcher:
         -------
         An "MultiModalMatcher" object (itself).
         """
+        fit_called = self._fit_called  # used in current function
+        self._fit_called = True
 
         pl.seed_everything(seed, workers=True)
 
-        if self._resume:
-            save_path = process_save_path(path=self._save_path, resume=True)
-        elif save_path is not None:
-            save_path = process_save_path(path=save_path)
-        elif self._save_path is not None:
-            save_path = process_save_path(path=self._save_path, raise_if_exist=False)
-
-        if not self._resume:
-            save_path = setup_outputdir(
-                path=save_path,
-                warn_if_exist=self._warn_if_exist,
-            )
-
-        save_path = os.path.abspath(os.path.expanduser(save_path))
-        logger.debug(f"save path: {save_path}")
+        self._save_path = setup_save_path(
+            resume=self._resume,
+            old_save_path=self._save_path,
+            proposed_save_path=save_path,
+            raise_if_exist=True,
+            warn_if_exist=False,
+            fit_called=fit_called,
+        )
 
         # Generate general info that's not config specific
         if tuning_data is None:
@@ -464,7 +458,6 @@ class MultiModalMatcher:
         self._problem_type = problem_type  # In case problem type isn't provided in __init__().
         self._eval_metric_name = eval_metric_name  # In case eval_metric isn't provided in __init__().
         self._validation_metric_name = validation_metric_name
-        self._save_path = save_path
         self._output_shape = output_shape
         self._column_types = column_types
 
@@ -475,7 +468,7 @@ class MultiModalMatcher:
             validation_metric_name=validation_metric_name,
             minmax_mode=minmax_mode,
             max_time=time_limit,
-            save_path=save_path,
+            save_path=self._save_path,
             ckpt_path=None if hyperparameter_tune_kwargs is not None else self._ckpt_path,
             resume=False if hyperparameter_tune_kwargs is not None else self._resume,
             enable_progress_bar=False if hyperparameter_tune_kwargs is not None else self._enable_progress_bar,
@@ -500,7 +493,7 @@ class MultiModalMatcher:
             return predictor
 
         self._fit(**_fit_args)
-        logger.info(f"Models and intermediate outputs are saved to {save_path} ")
+        logger.info(f"Models and intermediate outputs are saved to {self._save_path} ")
         return self
 
     def _get_matcher_df_preprocessor(
@@ -1819,6 +1812,7 @@ class MultiModalMatcher:
                     "output_shape": self._output_shape,
                     "save_path": self._save_path,
                     "pretrained_path": self._pretrained_path,
+                    "fit_called": self._fit_called,
                     "version": ag_version.__version__,
                 },
                 fp,
@@ -1918,6 +1912,10 @@ class MultiModalMatcher:
         matcher._resume = resume
         matcher._save_path = path  # in case the original exp dir is copied to somewhere else
         matcher._pretrain_path = path
+        if "fit_called" in assets:
+            matcher._fit_called = assets["fit_called"]
+        else:
+            matcher._fit_called = True  # backward compatible
         matcher._config = config
         matcher._query_config = query_config
         matcher._response_config = response_config

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -2439,6 +2439,7 @@ class MultiModalPredictor:
                     "classes": self._classes,
                     "save_path": self._save_path,
                     "pretrained_path": self._pretrained_path,
+                    "fit_called": self._fit_called,
                     "best_score": self._best_score,
                     "total_train_time": self._total_train_time,
                     "version": ag_version.__version__,
@@ -2651,6 +2652,10 @@ class MultiModalPredictor:
         predictor._resume = resume
         predictor._save_path = path  # in case the original exp dir is copied to somewhere else
         predictor._pretrain_path = path
+        if "fit_called" in assets:
+            predictor._fit_called = assets["fit_called"]
+        else:
+            predictor._fit_called = True  # backward compatible
         predictor._config = config
         predictor._output_shape = assets["output_shape"]
         if "classes" in assets:
@@ -2784,7 +2789,6 @@ class MultiModalPredictor:
             loss_func=loss_func,
         )
         predictor._model_postprocess_fn = model_postprocess_fn
-        predictor._fit_called = False
 
         return predictor
 

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -398,23 +398,12 @@ class MultiModalPredictor:
         self._init_scratch = init_scratch
         self._sample_data_path = sample_data_path
         self._fit_called = False  # While using ddp, after fit called, we can only use single gpu.
-        self._model_loaded = False  # Whether the model has been loaded
         self._matcher = None
+        self._save_path = path
 
         # Summary statistics used in fit summary. TODO: wrap it in a class.
         self._total_train_time = None
         self._best_score = None
-
-        if path is not None:
-            self._save_path = setup_save_path(
-                resume=self._resume,
-                proposed_save_path=path,
-                raise_if_exist=True,
-                warn_if_exist=self._warn_if_exist,
-                model_loaded=self._model_loaded,
-            )
-        else:
-            self._save_path = None
 
         if self.problem_property and self.problem_property.is_matching:
             self._matcher = MultiModalMatcher(
@@ -713,7 +702,6 @@ class MultiModalPredictor:
             proposed_save_path=save_path,
             raise_if_exist=True,
             warn_if_exist=False,
-            model_loaded=self._model_loaded,
             fit_called=fit_called,
         )
 
@@ -852,7 +840,7 @@ class MultiModalPredictor:
         return self
 
     def _verify_inference_ready(self):
-        if not self._fit_called and not self._model_loaded:
+        if not self._fit_called:
             if self._problem_type and not self.problem_property.support_zero_shot:
                 raise RuntimeError(
                     f"problem_type='{self._problem_type}' does not support running inference directly. "
@@ -1811,7 +1799,6 @@ class MultiModalPredictor:
         # Cache prediction results as COCO format # TODO: refactor this
         self._save_path = setup_save_path(
             old_save_path=self._save_path,
-            model_loaded=self._model_loaded,
             warn_if_exist=False,
         )
         cocoeval_cache_path = os.path.join(self._save_path, "object_detection_result_cache.json")
@@ -2156,7 +2143,6 @@ class MultiModalPredictor:
 
             self._save_path = setup_save_path(
                 old_save_path=self._save_path,
-                model_loaded=self._model_loaded,
                 warn_if_exist=False,
             )
 
@@ -2798,7 +2784,6 @@ class MultiModalPredictor:
             loss_func=loss_func,
         )
         predictor._model_postprocess_fn = model_postprocess_fn
-        predictor._model_loaded = True
         predictor._fit_called = False
 
         return predictor

--- a/multimodal/src/autogluon/multimodal/utils/save.py
+++ b/multimodal/src/autogluon/multimodal/utils/save.py
@@ -128,7 +128,6 @@ def setup_save_path(
     proposed_save_path: Optional[str] = None,
     warn_if_exist: Optional[bool] = True,
     raise_if_exist: Optional[bool] = False,
-    model_loaded: Optional[bool] = None,
     fit_called: Optional[bool] = None,
 ):
     # TODO: remove redundant folders in DDP mode
@@ -139,7 +138,7 @@ def setup_save_path(
     elif proposed_save_path is not None:  # TODO: distinguish DDP and existed predictor
         save_path = process_save_path(path=proposed_save_path, raise_if_exist=(raise_if_exist and rank == 0))
     elif old_save_path is not None:
-        if model_loaded or fit_called:
+        if fit_called:
             save_path = process_save_path(path=old_save_path, raise_if_exist=False)
         else:
             save_path = os.path.abspath(os.path.expanduser(old_save_path))

--- a/multimodal/src/autogluon/multimodal/utils/save.py
+++ b/multimodal/src/autogluon/multimodal/utils/save.py
@@ -141,7 +141,7 @@ def setup_save_path(
         if fit_called:
             save_path = process_save_path(path=old_save_path, raise_if_exist=False)
         else:
-            save_path = os.path.abspath(os.path.expanduser(old_save_path))
+            save_path = process_save_path(path=old_save_path, raise_if_exist=(raise_if_exist and rank == 0))
 
     if not resume:
         save_path = setup_outputdir(

--- a/multimodal/tests/unittests/others/test_save_path.py
+++ b/multimodal/tests/unittests/others/test_save_path.py
@@ -54,8 +54,6 @@ def test_existing_save_path_with_content_inside(save_path):
     dummy_file_path = os.path.join(abs_path, "dummy.txt")
     with open(dummy_file_path, "w") as f:
         f.write("dummy")
-    with pytest.raises(ValueError):
-        predictor = MultiModalPredictor(path=save_path)
 
     dataset = PetFinderDataset()
     predictor = MultiModalPredictor(

--- a/multimodal/tests/unittests/others/test_save_path.py
+++ b/multimodal/tests/unittests/others/test_save_path.py
@@ -54,6 +54,7 @@ def test_existing_save_path_with_content_inside(save_path):
     dummy_file_path = os.path.join(abs_path, "dummy.txt")
     with open(dummy_file_path, "w") as f:
         f.write("dummy")
+    predictor = MultiModalPredictor(path=save_path)
 
     dataset = PetFinderDataset()
     predictor = MultiModalPredictor(


### PR DESCRIPTION
*Issue #, if available:*

1. For object detection, if model_loaded=True, every time calling `.predict()`  would create a new save folder and change `_save_path`.
2. Creating saving folder in `init()` complicates the logic of save_path.
3. Predictor and matcher use different save_path logic.

*Description of changes:*

1. Remove the creation of saving folder from `init()`. Create saving folder only when it's used.
2. Remove the `_model_loaded` flag. For saving the prediction results of object detection, we can directly save to the path `_save_path`, whether the model is loaded or fitted.
3. Let matcher use the same save_path logic as predictor.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
