### PR TITLE
Tabular: Add max_sets

### DIFF
--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -506,6 +506,9 @@ class TabularPredictor:
                             use_orig_features: (bool) Whether a stack model will use the original features along with the stack features to train (akin to skip-connections). If the model has no stack features (no base models), this value is ignored and the stack model will use the original features.
                             max_base_models: (int, default=25) Maximum number of base models whose predictions form the features input to this stacker model. If more than `max_base_models` base models are available, only the top `max_base_models` models with highest validation score are used.
                             max_base_models_per_type: (int, default=5) Similar to `max_base_models`. If more than `max_base_models_per_type` of any particular model type are available, only the top `max_base_models_per_type` of that type are used. This occurs before the `max_base_models` filter.
+                            max_sets: (int, default=None) If specified, the maximum sets to fit in the bagged model.
+                                The lesser of `max_sets` and the predictor.fit `num_bag_sets` argument will be used for the given model.
+                                Useful if a particular model is expensive relative to others and you want to avoid repeated bagging of the expensive model while still repeated bagging the cheaper models.
                             save_bag_folds: (bool, default=True)
                                 If True, bagged models will save their fold models (the models from each individual fold of bagging). This is required to use bagged models for prediction.
                                 If False, bagged models will not save their fold models. This means that bagged models will not be valid models during inference.

--- a/tabular/tests/unittests/edgecases/test_edgecases.py
+++ b/tabular/tests/unittests/edgecases/test_edgecases.py
@@ -1,4 +1,6 @@
 
+import shutil
+
 from autogluon.core.constants import BINARY
 from autogluon.core.metrics import METRICS
 
@@ -16,3 +18,26 @@ def test_no_weighted_ensemble(fit_helper):
                                         fit_args=fit_args,
                                         extra_metrics=extra_metrics,
                                         expected_model_count=1)
+
+
+def test_max_sets(fit_helper):
+    """Tests that max_sets works"""
+    fit_args = dict(
+        hyperparameters={'GBM': {'ag_args_ensemble': {'max_sets': 3}}},
+        fit_weighted_ensemble=False,
+        num_bag_folds=2,
+        num_bag_sets=5,
+    )
+    dataset_name = 'adult'
+
+    predictor = fit_helper.fit_and_validate_dataset(
+        dataset_name=dataset_name,
+        fit_args=fit_args,
+        expected_model_count=1,
+        refit_full=False,
+        delete_directory=False,
+    )
+    leaderboard = predictor.leaderboard(extra_info=True)
+    # 2 folds * 3 sets = 6
+    assert leaderboard.iloc[0]['num_models'] == 6
+    shutil.rmtree(predictor.path, ignore_errors=True)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add max_sets as an ag_args_ensemble option
- For example, for AG_AUTOMM, it can be useful to set `max_sets=1`, while keeping the cheaper models as is to benefit from repeated bagging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
