### PR TITLE
Improve continuous training+HPO

### DIFF
--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -394,7 +394,6 @@ class MultiModalPredictor:
         self._model_postprocess_fn = None
         self._model = None
         self._resume = False
-        self._continuous_training = False
         self._verbosity = verbosity
         self._warn_if_exist = warn_if_exist
         self._enable_progress_bar = enable_progress_bar if enable_progress_bar is not None else True
@@ -689,7 +688,7 @@ class MultiModalPredictor:
                 assert isinstance(
                     teacher_predictor, str
                 ), "HPO with distillation only supports passing a path to the predictor"
-            if self._continuous_training:
+            if fit_called:
                 warnings.warn(
                     "HPO while continuous training."
                     "Hyperparameters related to Model and Data will NOT take effect."
@@ -2790,8 +2789,6 @@ class MultiModalPredictor:
 
         predictor._ckpt_path = ckpt_path
         predictor._model = model
-        if not resume:
-            predictor._continuous_training = True
 
         loss_func = get_loss_func(
             problem_type=predictor._problem_type,

--- a/multimodal/src/autogluon/multimodal/utils/config.py
+++ b/multimodal/src/autogluon/multimodal/utils/config.py
@@ -25,7 +25,7 @@ from ..presets import get_automm_presets, get_basic_automm_config, get_preset_st
 logger = logging.getLogger(AUTOMM)
 
 
-def filter_search_space(hyperparameters: dict, keys_to_filter: Union[str, List[str]]):
+def filter_search_space(hyperparameters: Dict, keys_to_filter: Union[str, List[str]]):
     """
     Filter search space within hyperparameters without the given keys as prefixes.
     Hyperparameters that are not search space will not be filtered.
@@ -41,6 +41,9 @@ def filter_search_space(hyperparameters: dict, keys_to_filter: Union[str, List[s
     -------
         hyperparameters being filtered
     """
+    if isinstance(keys_to_filter, str):
+        keys_to_filter = [keys_to_filter]
+
     assert any(
         key.startswith(valid_keys) for valid_keys in VALID_CONFIG_KEYS for key in keys_to_filter
     ), f"Invalid keys: {keys_to_filter}. Valid options are {VALID_CONFIG_KEYS}"
@@ -49,8 +52,6 @@ def filter_search_space(hyperparameters: dict, keys_to_filter: Union[str, List[s
     from autogluon.core.space import Space
 
     hyperparameters = copy.deepcopy(hyperparameters)
-    if isinstance(keys_to_filter, str):
-        keys_to_filter = [keys_to_filter]
     for hyperparameter, value in hyperparameters.copy().items():
         if not isinstance(value, (Space, Domain)):
             continue


### PR DESCRIPTION
*Issue #, if available:*

1. `_continuous_training` and `_fit_called` have duplicate functions.
2. Setting `_continuous_training`=True if resume=False is incorrect in the case that the predictor is saved without being fitted.

*Description of changes:*

1. Replace `_continuous_training` with `_fit_called`.
2. Add hyperparameter filtering in matcher HPO.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
