### PR TITLE
[eda] shortcut for covariate shift detection

### DIFF
--- a/eda/src/autogluon/eda/analysis/shift.py
+++ b/eda/src/autogluon/eda/analysis/shift.py
@@ -124,9 +124,8 @@ class XShiftDetector(AbstractAnalysis, StateCheckMixin):
         else:
             fi_scores = None
         pvalue = self.C2ST.pvalue(num_permutations=self.num_permutations)
-        det_status = pvalue <= self.pvalue_thresh
         state.xshift_results = {
-            "detection_status": det_status,
+            "detection_status": bool(pvalue <= self.pvalue_thresh),  # numpy.bool_ -> bool
             "test_statistic": self.C2ST.test_stat,
             "pvalue": pvalue,
             "pvalue_threshold": self.pvalue_thresh,

--- a/eda/src/autogluon/eda/auto/__init__.py
+++ b/eda/src/autogluon/eda/auto/__init__.py
@@ -1,1 +1,1 @@
-from .simple import analyze, analyze_interaction, dataset_overview, quick_fit
+from .simple import analyze, analyze_interaction, covariate_shift_detection, dataset_overview, quick_fit

--- a/eda/src/autogluon/eda/auto/simple.py
+++ b/eda/src/autogluon/eda/auto/simple.py
@@ -479,9 +479,13 @@ def covariate_shift_detection(
 
     Examples
     --------
-    >>> import autogluon.eda.analysis as eda
+    >>> import autogluon.eda.auto as auto
     >>>
+    >>> # use default settings
     >>> auto.covariate_shift_detection(train_data=..., test_data=..., label=...)
+    >>>
+    >>> # customize classifier and verbosity level
+    >>> auto.covariate_shift_detection(train_data=..., test_data=..., label=..., verbosity=2, hyperparameters = {'GBM': {}})
 
     See Also
     --------

--- a/eda/tests/unittests/auto/test_simple.py
+++ b/eda/tests/unittests/auto/test_simple.py
@@ -4,11 +4,13 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from autogluon.eda import AnalysisState
 from autogluon.eda.analysis import Namespace
 from autogluon.eda.analysis.base import BaseAnalysis
-from autogluon.eda.auto import analyze, dataset_overview, quick_fit
+from autogluon.eda.auto import analyze, covariate_shift_detection, dataset_overview, quick_fit
+from autogluon.eda.auto.simple import get_default_estimator_if_not_specified, get_empty_dict_if_none
 from autogluon.eda.visualization import (
     ConfusionMatrix,
     DatasetStatistics,
@@ -17,6 +19,7 @@ from autogluon.eda.visualization import (
     MarkdownSectionComponent,
     ModelLeaderboard,
     RegressionEvaluation,
+    XShiftSummary,
 )
 from autogluon.eda.visualization.base import AbstractVisualization
 from autogluon.eda.visualization.interaction import FeatureDistanceAnalysisVisualization
@@ -146,3 +149,51 @@ def test_dataset_overview(monkeypatch):
     call_dtm_render.assert_called_once()
     call_md_render.assert_called_once()
     call_fdav_render.assert_called_once()
+
+
+def test_covariate_shift_detection(monkeypatch):
+    df_train = pd.read_csv(os.path.join(RESOURCE_PATH, "adult", "train_data.csv")).sample(100, random_state=0)
+    df_train["shift_col"] = np.random.rand(len(df_train))
+    df_test = pd.read_csv(os.path.join(RESOURCE_PATH, "adult", "test_data.csv")).sample(100, random_state=0)
+    df_test["shift_col"] = np.random.rand(len(df_test)) + 2
+
+    call_xss_render = MagicMock()
+    with monkeypatch.context() as m:
+        with tempfile.TemporaryDirectory() as path:
+            m.setattr(XShiftSummary, "render", call_xss_render)
+            state = covariate_shift_detection(
+                path=path, train_data=df_train, test_data=df_test, label="class", return_state=True, verbosity=2
+            )
+
+    call_xss_render.assert_called_once()
+    assert state.xshift_results.detection_status is True
+    assert state.xshift_results.test_statistic > 0.99
+    assert state.xshift_results.pvalue < 0.01
+    assert state.xshift_results.feature_importance.iloc[0].name == "shift_col"
+
+
+def test_get_empty_dict_if_none():
+    assert get_empty_dict_if_none(None) == {}
+    assert get_empty_dict_if_none({"q"}) == {"q"}
+
+
+@pytest.mark.parametrize(
+    "hyperparameters_present, presets_present",
+    [
+        (True, True),
+        (True, False),
+        (False, True),
+        (False, False),
+    ],
+)
+def test_get_default_estimator_if_not_specified(hyperparameters_present, presets_present):
+    fit_args = {}
+    if hyperparameters_present:
+        fit_args["hyperparameters"] = "some_params"
+    if presets_present:
+        fit_args["presets"] = "some_presets"
+
+    if (not hyperparameters_present) and (not presets_present):
+        assert "RF" in get_default_estimator_if_not_specified(fit_args)["hyperparameters"]
+    else:
+        assert get_default_estimator_if_not_specified(fit_args) == fit_args

--- a/eda/tests/unittests/test_shift.py
+++ b/eda/tests/unittests/test_shift.py
@@ -48,7 +48,6 @@ class TestShift(unittest.TestCase):
         train, test = load_adult_data()
         with tempfile.TemporaryDirectory() as path:
             shft_ana = eda.shift.XShiftDetector(
-                path=path,
                 train_data=train,
                 test_data=test,
                 label="class",


### PR DESCRIPTION
*Description of changes:*

### `auto.covariate_shift_detection()` shortcut for distributions shift detection

This is a shortcut for analyze and visualize steps encapsulated in a single call.

```
Parameters
----------
train_data: Optional[DataFrame]
    training dataset
test_data: Optional[DataFrame]
    test dataset
label: : Optional[str]
    target variable
state: Union[None, dict, AnalysisState], default = None
    pass prior state if necessary; the object will be updated during `anlz_facets` `fit` call.
sample: Union[None, int, float], default = None
    sample size; if `int`, then row number is used;
    `float` must be between 0.0 and 1.0 and represents fraction of dataset to sample;
    `None` means no sampling
    See also :func:`autogluon.eda.analysis.dataset.Sampler`
path: Optional[str], default = None,
    path for models saving
return_state: bool, default = False
    return state if `True`
verbosity: int, default = 0
    Verbosity levels range from 0 to 4 and control how much information is printed.
    Higher levels correspond to more detailed print statements (you can set verbosity = 0 to suppress warnings).
    If using logging, you can alternatively control amount of information printed via `logger.setLevel(L)`,
    where `L` ranges from 0 to 50 (Note: higher values of `L` correspond to fewer print statements, opposite of verbosity levels).
fit_args
    kwargs to pass into `TabularPredictor` fit
```

**Example**:

```python
import autogluon.eda.auto as auto

 # use defaults
auto.covariate_shift_detection(train_data=df_train, test_data=df_test, label=target_col)

# customize classifier and verbosity level
auto.covariate_shift_detection(train_data=..., test_data=..., label=..., verbosity=2, hyperparameters = {'GBM': {}})
```

![image](https://user-images.githubusercontent.com/10080307/210907197-1facfd56-1ec6-4ec3-9aae-60f5c161edf1.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
