### PR TITLE
Tabular: Add DummyModel

### DIFF
--- a/core/src/autogluon/core/models/__init__.py
+++ b/core/src/autogluon/core/models/__init__.py
@@ -1,4 +1,5 @@
 from .abstract.abstract_model import AbstractModel
+from .dummy.dummy_model import DummyModel
 from .greedy_ensemble.greedy_weighted_ensemble_model import GreedyWeightedEnsembleModel, SimpleWeightedEnsembleModel
 from .ensemble.bagged_ensemble_model import BaggedEnsembleModel
 from .ensemble.stacker_ensemble_model import StackerEnsembleModel

--- a/core/src/autogluon/core/models/dummy/_dummy_quantile_regressor.py
+++ b/core/src/autogluon/core/models/dummy/_dummy_quantile_regressor.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+
+class DummyQuantileRegressor:
+    """Adds support for quantile regression to dummy models"""
+    def __init__(self, quantile_levels: list):
+        self.quantile_levels = quantile_levels
+        self.models = []
+
+    def fit(self, X, y):
+        from sklearn.dummy import DummyRegressor
+        for quantile in self.quantile_levels:
+            m = DummyRegressor(quantile=quantile)
+            m.fit(X, y)
+            self.models.append(m)
+
+    def predict(self, X):
+        predictions = []
+        for m in self.models:
+            predictions.append(m.predict(X))
+        predictions = np.array(predictions).T
+        return predictions

--- a/core/src/autogluon/core/models/dummy/dummy_model.py
+++ b/core/src/autogluon/core/models/dummy/dummy_model.py
@@ -1,0 +1,34 @@
+import pandas as pd
+
+from ._dummy_quantile_regressor import DummyQuantileRegressor
+from .. import AbstractModel
+from ...constants import BINARY, MULTICLASS, REGRESSION, QUANTILE
+
+
+class DummyModel(AbstractModel):
+    """
+    A dummy model that ignores input features and predicts only a constant value.
+    Useful for tests and calculating worst-case performance.
+    """
+    def _get_model_type(self):
+        from sklearn.dummy import DummyClassifier, DummyRegressor
+        if self.problem_type == REGRESSION:
+            return DummyRegressor
+        elif self.problem_type == QUANTILE:
+            return DummyQuantileRegressor
+        elif self.problem_type in [BINARY, MULTICLASS]:
+            return DummyClassifier
+        else:
+            raise ValueError(f'DummyModel does not support problem_type={self.problem_type}')
+
+    def preprocess(self, X: pd.DataFrame, **kwargs):
+        return X
+
+    def _fit(self, X, y, **kwargs):
+        X = self.preprocess(X)
+        model_cls = self._get_model_type()
+        if model_cls == DummyQuantileRegressor:
+            self.model = model_cls(quantile_levels=self.quantile_levels)
+        else:
+            self.model = model_cls()
+        self.model.fit(X=X, y=y)

--- a/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
+++ b/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
@@ -4,7 +4,7 @@ import logging
 from collections import defaultdict
 
 from autogluon.core.constants import AG_ARGS, AG_ARGS_FIT, AG_ARGS_ENSEMBLE, BINARY, MULTICLASS, REGRESSION, SOFTCLASS, QUANTILE
-from autogluon.core.models import AbstractModel, GreedyWeightedEnsembleModel, StackerEnsembleModel, SimpleWeightedEnsembleModel
+from autogluon.core.models import AbstractModel, GreedyWeightedEnsembleModel, StackerEnsembleModel, SimpleWeightedEnsembleModel, DummyModel
 from autogluon.core.trainer.utils import process_hyperparameters
 
 from .presets_custom import get_preset_custom
@@ -61,7 +61,8 @@ DEFAULT_SOFTCLASS_PRIORITY = dict(
 
 DEFAULT_CUSTOM_MODEL_PRIORITY = 0
 
-DEFAULT_QUANTILE_MODEL = ['RF', 'XT', 'FASTAI', 'NN_TORCH', 'ENS_WEIGHTED']  # TODO: OTHERS will be added
+# FIXME: v0.7 : Remove this, it is a hack. Model classes should define what problem types they support instead of using this
+DEFAULT_QUANTILE_MODEL = ['DUMMY', 'RF', 'XT', 'FASTAI', 'NN_TORCH', 'ENS_WEIGHTED']  # TODO: OTHERS will be added
 
 MODEL_TYPES = dict(
     RF=RFModel,
@@ -89,7 +90,9 @@ MODEL_TYPES = dict(
     IM_FIGS=FigsModel,
     IM_HSTREE=HSTreeModel,
     IM_BOOSTEDRULES=BoostedRulesModel,
-    VW=VowpalWabbitModel
+    VW=VowpalWabbitModel,
+
+    DUMMY=DummyModel,
 )
 
 
@@ -185,7 +188,7 @@ def get_preset_models(path, problem_type, eval_metric, hyperparameters,
     model_cfg_priority_dict = defaultdict(list)
     model_type_list = list(hp_level.keys())
     if 'NN' in model_type_list:
-        # TODO: Remove in v0.6.0
+        # TODO: Remove in v0.7.0
         logger.log(30, '\tWARNING: "NN" model has been deprecated in v0.4.0 and renamed to "NN_MXNET". '
                        'Starting in v0.6.0, specifying "NN" or "NN_MXNET" will raise an exception. Consider instead specifying "NN_TORCH".')
     for model_type in model_type_list:

--- a/tabular/tests/unittests/configs/test_config_helper.py
+++ b/tabular/tests/unittests/configs/test_config_helper.py
@@ -60,7 +60,7 @@ def test_excluded_model_types_invalid_option():
 def test_included_model_types():
     expected_config = dict(excluded_model_types=['XT', 'KNN', 'GBM', 'CAT', 'XGB', 'NN_MXNET', 'NN_TORCH', 'LR', 'FASTAI', 'TRANSF',
                                                  'AG_TEXT_NN', 'AG_IMAGE_NN', 'AG_AUTOMM', 'FT_TRANSFORMER', 'FASTTEXT',
-                                                 'IM_RULEFIT', 'IM_GREEDYTREE', 'IM_FIGS', 'IM_HSTREE', 'IM_BOOSTEDRULES', 'VW'])
+                                                 'IM_RULEFIT', 'IM_GREEDYTREE', 'IM_FIGS', 'IM_HSTREE', 'IM_BOOSTEDRULES', 'VW', 'DUMMY'])
     actual_config = ConfigBuilder().included_model_types('RF').build()
     assert actual_config == expected_config
 
@@ -72,7 +72,7 @@ def test_included_model_types():
 
     expected_config = dict(excluded_model_types=['XT', 'KNN', 'GBM', 'CAT', 'XGB', 'NN_MXNET', 'NN_TORCH', 'FASTAI', 'TRANSF',
                                                  'AG_TEXT_NN', 'AG_IMAGE_NN', 'AG_AUTOMM', 'FT_TRANSFORMER', 'FASTTEXT',
-                                                 'IM_RULEFIT', 'IM_GREEDYTREE', 'IM_FIGS', 'IM_HSTREE', 'IM_BOOSTEDRULES', 'VW'])
+                                                 'IM_RULEFIT', 'IM_GREEDYTREE', 'IM_FIGS', 'IM_HSTREE', 'IM_BOOSTEDRULES', 'VW', 'DUMMY'])
     actual_config = ConfigBuilder().included_model_types(['RF', 'LR']).build()
     assert actual_config == expected_config
 
@@ -81,7 +81,7 @@ def test_included_model_types():
 
     expected_config = dict(excluded_model_types=['XT', 'KNN', 'GBM', 'CAT', 'XGB', 'NN_MXNET', 'NN_TORCH', 'LR', 'FASTAI', 'TRANSF',
                                                  'AG_TEXT_NN', 'AG_IMAGE_NN', 'AG_AUTOMM', 'FT_TRANSFORMER', 'FASTTEXT',
-                                                 'IM_RULEFIT', 'IM_GREEDYTREE', 'IM_FIGS', 'IM_HSTREE', 'IM_BOOSTEDRULES', 'VW'])
+                                                 'IM_RULEFIT', 'IM_GREEDYTREE', 'IM_FIGS', 'IM_HSTREE', 'IM_BOOSTEDRULES', 'VW', 'DUMMY'])
     actual_config = ConfigBuilder().included_model_types([CustomKNN, 'RF']).build()
     assert actual_config == expected_config
 

--- a/tabular/tests/unittests/edgecases/test_edgecases.py
+++ b/tabular/tests/unittests/edgecases/test_edgecases.py
@@ -8,7 +8,7 @@ from autogluon.core.metrics import METRICS
 def test_no_weighted_ensemble(fit_helper):
     """Tests that fit_weighted_ensemble=False works"""
     fit_args = dict(
-        hyperparameters={'GBM': {}},
+        hyperparameters={'DUMMY': {}},
         fit_weighted_ensemble=False,
     )
     dataset_name = 'adult'
@@ -23,7 +23,7 @@ def test_no_weighted_ensemble(fit_helper):
 def test_max_sets(fit_helper):
     """Tests that max_sets works"""
     fit_args = dict(
-        hyperparameters={'GBM': {'ag_args_ensemble': {'max_sets': 3}}},
+        hyperparameters={'DUMMY': {'ag_args_ensemble': {'max_sets': 3}}},
         fit_weighted_ensemble=False,
         num_bag_folds=2,
         num_bag_sets=5,
@@ -46,7 +46,7 @@ def test_max_sets(fit_helper):
 def test_num_folds(fit_helper):
     """Tests that num_folds works"""
     fit_args = dict(
-        hyperparameters={'GBM': {'ag_args_ensemble': {'num_folds': 3}}},
+        hyperparameters={'DUMMY': {'ag_args_ensemble': {'num_folds': 3}}},
         fit_weighted_ensemble=False,
         num_bag_folds=7,
         num_bag_sets=2,

--- a/tabular/tests/unittests/models/test_dummy.py
+++ b/tabular/tests/unittests/models/test_dummy.py
@@ -1,0 +1,64 @@
+
+from autogluon.core.models.dummy.dummy_model import DummyModel
+from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION
+from autogluon.core.metrics import METRICS
+
+
+def test_dummy_binary(fit_helper):
+    """Additionally tests that all binary metrics work"""
+    fit_args = dict(
+        hyperparameters={DummyModel: {}},
+    )
+    dataset_name = 'adult'
+    extra_metrics = list(METRICS[BINARY])
+
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics)
+
+
+def test_dummy_multiclass(fit_helper):
+    """Additionally tests that all multiclass metrics work"""
+    fit_args = dict(
+        hyperparameters={DummyModel: {}},
+    )
+    extra_metrics = list(METRICS[MULTICLASS])
+
+    dataset_name = 'covertype_small'
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics)
+
+
+def test_dummy_regression(fit_helper):
+    """Additionally tests that all regression metrics work"""
+    fit_args = dict(
+        hyperparameters={DummyModel: {}},
+    )
+    extra_metrics = list(METRICS[REGRESSION])
+
+    dataset_name = 'ames'
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics)
+
+
+def test_dummy_quantile(fit_helper):
+    fit_args = dict(
+        hyperparameters={'DUMMY': {}},
+    )
+    dataset_name = 'ames'
+    init_args = dict(problem_type='quantile', quantile_levels=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, init_args=init_args)
+
+
+def test_dummy_binary_model(model_fit_helper):
+    fit_args = dict()
+    dataset_name = 'adult'
+    model_fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, model=DummyModel(), fit_args=fit_args)
+
+
+def test_dummy_multiclass_model(model_fit_helper):
+    fit_args = dict()
+    dataset_name = 'covertype_small'
+    model_fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, model=DummyModel(), fit_args=fit_args)
+
+
+def test_dummy_regression_model(model_fit_helper):
+    fit_args = dict()
+    dataset_name = 'ames'
+    model_fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, model=DummyModel(), fit_args=fit_args)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add DummyModel
- DummyModel allows us to test new functionality without having to wait for model training to occur or have to worry about model training interacting with the new functionality during debugging.
- Also helps speed up unit tests for logic that requires going through the predictor.fit path, but that doesn't care about the model quality.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
