### PR TITLE
[tabular][bugfix] fix tabular NN working with _ray_predict_oof

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabular_nn/compilers/onnx.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/compilers/onnx.py
@@ -276,7 +276,7 @@ class TabularNeuralNetTorchOnnxTransformer:
 
 class TabularNeuralNetTorchOnnxCompiler:
     name = "onnx"
-    save_in_pkl = False
+    save_in_pkl = True
 
     @staticmethod
     def can_compile():


### PR DESCRIPTION
*Issue #, if available:*

```python
from autogluon.tabular import TabularDataset, TabularPredictor

# Training time:
train_data = TabularDataset('https://autogluon.s3.amazonaws.com/datasets/Inc/train.csv')
train_data = train_data.head(500)  # subsample for faster demo
print(train_data.head())
label = 'class'  # specifies which column do we want to predict
save_path = 'ag_models/'  # where to save trained models

if os.path.exists(save_path):
    shutil.rmtree(save_path, ignore_errors=True)

predictor = TabularPredictor(label=label, path=save_path). \
    fit(train_data, presets='good_quality', time_limit=120)
```

Training with `presets='good_quality'` will result in an error. 

The fundamental reason is that `_ray_predict_oof` would delete `fold_model.model`, see

```python
def _ray_predict_oof(fold_model, X_val_fold, y_val_fold, time_train_end_fold,
                     num_cpus=-1, save_bag_folds=True):
    pred_proba = fold_model.predict_proba(X_val_fold, num_cpus=num_cpus)
    time_pred_end_fold = time.time()
    fold_model.predict_time = time_pred_end_fold - time_train_end_fold
    fold_model.val_score = fold_model.score_with_y_pred_proba(y=y_val_fold,
                                                              y_pred_proba=pred_proba)
    fold_model.reduce_memory_size(remove_fit=True, remove_info=False, requires_save=True)
    if not save_bag_folds:
        fold_model.model = None
    return fold_model, pred_proba
```

Therefore, loading the PyTorch model with `torch.load(path + "net.params")` would result in an error.

*Description of changes:*

The proposed change is to include the PyTorch model inside the pickle file (`model.pkl`), just like other models.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
