### PR TITLE
[tabular] add tabular regression tests into CI

### DIFF
--- a/tabular/tests/regressiontests/test_tabular_regression.py
+++ b/tabular/tests/regressiontests/test_tabular_regression.py
@@ -390,7 +390,7 @@ def make_dataset(request, seed):
 def myfloor(x, base=.01):
   return round(base * math.floor(float(x)/base),8)
 
-@pytest.mark.regression
+@pytest.mark.slow
 def inner_test_tabular(testname):
 
     # Find the named test
@@ -497,6 +497,6 @@ def inner_test_tabular(testname):
 
 # These results have only been confirmed for Linux.  Windows is known to give different results for Pytorch.
 @pytest.mark.skipif(sys.platform != 'linux', reason='Scores only confirmed on Linux')
-@pytest.mark.regression
+@pytest.mark.slow
 def test_tabular_score(testname):
     inner_test_tabular(testname)


### PR DESCRIPTION
*Issue #, if available:*

Some failures are not captured since we didn't add tabular regression as part of our CI, e.g. #2650.

*Description of changes:*

We're currently have `--runslow` argument in pytest. Therefore, marking regression as slow would simply add regression tests into regular test cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
