### PR TITLE
[eda] Added target_analysis - target variable composite analysis

### DIFF
--- a/eda/src/autogluon/eda/analysis/interaction.py
+++ b/eda/src/autogluon/eda/analysis/interaction.py
@@ -336,7 +336,16 @@ class DistributionFit(AbstractAnalysis):
     """
 
     # Getting the list of distributions: https://docs.scipy.org/doc/scipy/tutorial/stats.html#getting-help
-    AVAILABLE_DISTRIBUTIONS = sorted([d for d in dir(stats) if isinstance(getattr(stats, d), stats.rv_continuous)])
+    AVAILABLE_DISTRIBUTIONS = sorted(
+        [
+            dist
+            for dist in dir(stats)
+            if isinstance(getattr(stats, dist), stats.rv_continuous)
+            # kstwo can't be fit on a single variable
+            # levy_stable, studentized_range are too slow
+            and dist not in ["kstwo", "levy_stable", "studentized_range"]
+        ]
+    )
 
     def __init__(
         self,

--- a/eda/src/autogluon/eda/analysis/interaction.py
+++ b/eda/src/autogluon/eda/analysis/interaction.py
@@ -386,6 +386,7 @@ class DistributionFit(AbstractAnalysis):
 
     def _fit(self, state: AnalysisState, args: AnalysisState, **fit_kwargs) -> None:
         state.distributions_fit = {}
+        state.distributions_fit_pvalue_min = self.pvalue_min
         for (ds, df) in self.available_datasets(args):
             state.distributions_fit[ds] = {}
             for c in self.columns:
@@ -410,19 +411,36 @@ class DistributionFit(AbstractAnalysis):
                 if pvalue >= pvalue_min:
                     results[i] = {
                         "param": param,
+                        "shapes": self._list_parameters(dist),
                         "statistic": statistic,
                         "pvalue": pvalue,
                     }
             if len(results) == 0:
-                self.logger.warning(
-                    f"{series.name}: none of the distributions were able to fit to satisfy specified pvalue_min: {self.pvalue_min}"
-                )
                 return None
             df = pd.DataFrame(results).T.sort_values("pvalue", ascending=False)
             if self.keep_top_n is not None:
                 df = df[: self.keep_top_n]
             results = df.T.to_dict()
             return results
+
+    def _list_parameters(self, distribution):
+        """List parameters for scipy.stats.distribution.
+        # Arguments
+            distribution: a string or scipy.stats distribution object.
+        # Returns
+            A list of distribution parameter strings.
+        """
+        if isinstance(distribution, str):
+            distribution = getattr(stats, distribution)
+        if distribution.shapes:
+            parameters = [name.strip() for name in distribution.shapes.split(",")]
+        else:
+            parameters = []
+        if distribution.name in stats._discrete_distns._distn_names:
+            parameters += ["loc"]
+        elif distribution.name in stats._continuous_distns._distn_names:
+            parameters += ["loc", "scale"]
+        return parameters
 
 
 class FeatureDistanceAnalysis(AbstractAnalysis):

--- a/eda/src/autogluon/eda/analysis/interaction.py
+++ b/eda/src/autogluon/eda/analysis/interaction.py
@@ -14,6 +14,8 @@ from .base import AbstractAnalysis
 
 __all__ = ["Correlation", "CorrelationSignificance", "FeatureInteraction", "DistributionFit"]
 
+from autogluon.common.features.types import R_FLOAT, R_INT
+
 
 class Correlation(AbstractAnalysis):
     """
@@ -95,6 +97,10 @@ class Correlation(AbstractAnalysis):
         state.correlations = {}
         state.correlations_method = self.method
         for (ds, df) in self.available_datasets(args):
+
+            if args.label in df.columns and df[args.label].dtype not in [R_INT, R_FLOAT]:
+                df[args.label] = df[args.label].astype("category").cat.codes
+
             if self.method == "phik":
                 state.correlations[ds] = df.phik_matrix(**self.args, verbose=False)
             else:

--- a/eda/src/autogluon/eda/auto/__init__.py
+++ b/eda/src/autogluon/eda/auto/__init__.py
@@ -1,1 +1,8 @@
-from .simple import analyze, analyze_interaction, covariate_shift_detection, dataset_overview, quick_fit
+from .simple import (
+    analyze,
+    analyze_interaction,
+    covariate_shift_detection,
+    dataset_overview,
+    quick_fit,
+    target_analysis,
+)

--- a/eda/src/autogluon/eda/auto/simple.py
+++ b/eda/src/autogluon/eda/auto/simple.py
@@ -632,6 +632,42 @@ def target_analysis(
     state: Union[None, dict, AnalysisState] = None,
     return_state: bool = False,
 ) -> Optional[AnalysisState]:
+    """
+    Target variable composite analysis.
+
+    Performs the following analysis components of the label field:
+     - basic summary stats
+     - feature values distribution charts; adds fitted distributions for numeric targets
+     - target correlations analysis; with interaction charts of target vs high-correlated features
+
+    Parameters
+    ----------
+    train_data: Optional[DataFrame]
+        training dataset
+    label: : Optional[str]
+        target variable
+    state: Union[None, dict, AnalysisState], default = None
+        pass prior state if necessary; the object will be updated during `anlz_facets` `fit` call.
+    sample: Union[None, int, float], default = None
+        sample size; if `int`, then row number is used;
+        `float` must be between 0.0 and 1.0 and represents fraction of dataset to sample;
+        `None` means no sampling
+        See also :func:`autogluon.eda.analysis.dataset.Sampler`
+    return_state: bool, default = False
+        return state if `True`
+
+    Returns
+    -------
+        state after `fit` call if `return_state` is `True`; `None` otherwise
+
+    Examples
+    --------
+    >>> import autogluon.eda.analysis as eda
+    >>>
+    >>> auto.target_analysis(train_data=..., label=...)
+
+
+    """
 
     assert label in train_data.columns, f"label `{label}` is not in `train_data` columns: `{train_data.columns}`"
 

--- a/eda/src/autogluon/eda/visualization/dataset.py
+++ b/eda/src/autogluon/eda/visualization/dataset.py
@@ -99,7 +99,8 @@ class DatasetStatistics(AbstractVisualization, JupyterMixin):
             self.render_header_if_needed(state, f"{ds} dataset summary")
             if self.sort_by in df.columns:
                 df = df.sort_values(by=self.sort_by, ascending=self.sort_asc)
-            self.display_obj(df)
+            with pd.option_context("display.max_rows", 100 if len(df) <= 100 else 20):
+                self.display_obj(df)
 
     @staticmethod
     def _merge_analysis_facets(ds: str, state: AnalysisState):

--- a/eda/src/autogluon/eda/visualization/interaction.py
+++ b/eda/src/autogluon/eda/visualization/interaction.py
@@ -34,8 +34,13 @@ class _AbstractCorrelationChart(AbstractVisualization, JupyterMixin, ABC):
     def _render_internal(self, state: AnalysisState, render_key: str, header: str, chart_args: Dict[str, Any]) -> None:
         for ds, corr in state[render_key].items():
             # Don't render single cell
-            if len(state.correlations[ds]) <= 1:
+            cells_num = len(state.correlations[ds])
+            if cells_num <= 1:
                 continue
+
+            fig_args = self.fig_args.copy()
+            if "figsize" not in fig_args:
+                fig_args["figsize"] = (cells_num, cells_num)
 
             if state.correlations_focus_field is not None:
                 focus_field_header = f"; focus: absolute correlation for {state.correlations_focus_field} >= {state.correlations_focus_field_threshold}"
@@ -43,13 +48,13 @@ class _AbstractCorrelationChart(AbstractVisualization, JupyterMixin, ABC):
                 focus_field_header = ""
             self.render_header_if_needed(state, f"{ds} - {state.correlations_method} {header}{focus_field_header}")
 
-            fig, ax = plt.subplots(**self.fig_args)
+            fig, ax = plt.subplots(**fig_args)
             sns.heatmap(
                 corr,
                 annot=True,
                 ax=ax,
-                linewidths=0.9,
-                linecolor="white",
+                linewidths=0.5,
+                linecolor="lightgrey",
                 fmt=".2f",
                 square=True,
                 cbar_kws={"shrink": 0.5},
@@ -163,13 +168,18 @@ class FeatureDistanceAnalysisVisualization(AbstractVisualization, JupyterMixin):
         return self.all_keys_must_be_present(state, "feature_distance")
 
     def _render(self, state: AnalysisState) -> None:
-        fig, ax = plt.subplots(**self.fig_args)
+        fig_args = self.fig_args.copy()
+        if "figsize" not in fig_args:
+            fig_args["figsize"] = (12, len(state.feature_distance.columns) / 4)
+
+        fig, ax = plt.subplots(**fig_args)
         default_args = dict(orientation="left")
         ax.grid(False)
         hc.dendrogram(
             ax=ax,
             Z=state.feature_distance.linkage,
             labels=state.feature_distance.columns,
+            leaf_font_size=10,
             **{**default_args, **self._kwargs},
         )
         plt.show(fig)
@@ -216,7 +226,8 @@ class FeatureInteractionVisualization(AbstractVisualization, JupyterMixin):
     def __init__(
         self,
         key: str,
-        numeric_as_categorical_threshold=20,
+        numeric_as_categorical_threshold: int = 20,
+        max_categories_to_consider_render: int = 30,
         headers: bool = False,
         namespace: Optional[str] = None,
         fig_args: Optional[Dict[str, Any]] = None,
@@ -226,6 +237,7 @@ class FeatureInteractionVisualization(AbstractVisualization, JupyterMixin):
         self.key = key
         self.headers = headers
         self.numeric_as_categorical_threshold = numeric_as_categorical_threshold
+        self.max_categories_to_consider_render = max_categories_to_consider_render
         if fig_args is None:
             fig_args = {}
         self.fig_args = fig_args
@@ -244,6 +256,17 @@ class FeatureInteractionVisualization(AbstractVisualization, JupyterMixin):
             y, y_type = self._get_value_and_type(ds, df, state, interaction_features, "y")
             hue, hue_type = self._get_value_and_type(ds, df, state, interaction_features, "hue")
 
+            # Don't render high-cardinality category variables
+            features = "/".join([interaction_features[k] for k in ["x", "y", "hue"] if k in interaction_features])
+            for f, t in [(x, x_type), (y, y_type), (hue, hue_type)]:
+                if t == "category" and df[f].nunique() > self.max_categories_to_consider_render:
+                    self.render_markdown(
+                        f"Interaction `{features}` is not rendered due to `{f}` "
+                        f"having too many categories (`{df[f].nunique()}` > `{self.max_categories_to_consider_render}`) "
+                        f"for comfortable read."
+                    )
+                    return
+
             y, y_type, hue, hue_type = self._swap_y_and_hue_if_necessary(x_type, y, y_type, hue, hue_type)
 
             renderer_cls: Optional[Type[_AbstractFeatureInteractionPlotRenderer]] = self._get_chart_renderer(
@@ -257,9 +280,12 @@ class FeatureInteractionVisualization(AbstractVisualization, JupyterMixin):
             chart_args, data, is_single_var = self._prepare_chart_args(df, x, x_type, y, y_type, hue)
 
             if self.headers:
-                features = "/".join([interaction_features[k] for k in ["x", "y", "hue"] if k in interaction_features])
                 prefix = "" if is_single_var else "Feature interaction between "
                 self.render_header_if_needed(state, f"{prefix}{features} in {ds}")
+
+            fig_args = self.fig_args.copy()
+            if "figsize" not in fig_args:
+                fig_args["figsize"] = (12, 6)
 
             renderer.render(
                 state=state,
@@ -267,7 +293,7 @@ class FeatureInteractionVisualization(AbstractVisualization, JupyterMixin):
                 params=(x, y, hue),
                 param_types=(x_type, y_type, hue_type),
                 data=data,
-                fig_args=self.fig_args,
+                fig_args=fig_args,
                 chart_args=chart_args,
             )
 

--- a/eda/src/autogluon/eda/visualization/layouts.py
+++ b/eda/src/autogluon/eda/visualization/layouts.py
@@ -1,10 +1,11 @@
 from typing import Dict, List, Optional, Union
 
-from IPython.display import Markdown, display
+from IPython.display import display
 from ipywidgets import HBox, Layout, Output, Tab
 
 from .. import AnalysisState
 from .base import AbstractVisualization
+from .jupyter import JupyterMixin
 
 __all__ = ["MarkdownSectionComponent", "SimpleVerticalLinearLayout", "SimpleHorizontalLayout", "TabLayout"]
 
@@ -72,7 +73,7 @@ class TabLayout(SimpleVerticalLinearLayout):
                 facet.render(state)
 
 
-class MarkdownSectionComponent(AbstractVisualization):
+class MarkdownSectionComponent(AbstractVisualization, JupyterMixin):
     """
     Render provided string as a Markdown cell.
     See `Jupyter Markdown cell <https://jupyter-notebook.readthedocs.io/en/stable/examples/Notebook/Working%20With%20Markdown%20Cells.html>`_
@@ -87,4 +88,4 @@ class MarkdownSectionComponent(AbstractVisualization):
         return True
 
     def _render(self, state: AnalysisState) -> None:
-        display(Markdown(self.markdown))
+        self.render_markdown(self.markdown)

--- a/eda/src/autogluon/eda/visualization/missing.py
+++ b/eda/src/autogluon/eda/visualization/missing.py
@@ -90,7 +90,7 @@ class MissingValues(AbstractVisualization, JupyterMixin):
 
     @staticmethod
     def _internal_render(widget, data, **kwargs):
-        fig = widget(data, **kwargs)
+        fig = widget(data, fontsize=10, **kwargs)
         plt.show(fig)
 
     def _get_operation(self, graph_type):

--- a/eda/src/autogluon/eda/visualization/model.py
+++ b/eda/src/autogluon/eda/visualization/model.py
@@ -74,8 +74,24 @@ class ConfusionMatrix(AbstractVisualization, JupyterMixin):
         cm.columns.name = "Predicted"
         normalized = state.model_evaluation.confusion_matrix_normalized
         fmt = ",.2%" if normalized else "d"
-        fig, ax = plt.subplots(**self.fig_args)
-        sns.heatmap(cm, ax=ax, cmap="Blues", annot=True, fmt=fmt, cbar=False, **self._kwargs)
+
+        cells_num = len(cm)
+        fig_args = self.fig_args.copy()
+        if "figsize" not in fig_args:
+            fig_args["figsize"] = (cells_num, cells_num)
+
+        fig, ax = plt.subplots(**fig_args)
+        sns.heatmap(
+            cm,
+            ax=ax,
+            cmap="Blues",
+            annot=True,
+            linewidths=0.5,
+            linecolor="lightgrey",
+            fmt=fmt,
+            cbar=False,
+            **self._kwargs,
+        )
         plt.show(fig)
 
 
@@ -203,7 +219,11 @@ class FeatureImportance(AbstractVisualization, JupyterMixin):
         importance = state.model_evaluation.importance
         self.display_obj(importance)
         if self.show_barplots:
-            fig, ax = plt.subplots(**self.fig_args)
+            fig_args = self.fig_args.copy()
+            if "figsize" not in fig_args:
+                fig_args["figsize"] = (12, len(importance) / 4)
+
+            fig, ax = plt.subplots(**fig_args)
             sns.barplot(ax=ax, data=importance.reset_index(), y="index", x="importance", **self._kwargs)
             plt.show(fig)
 

--- a/eda/src/autogluon/eda/visualization/shift.py
+++ b/eda/src/autogluon/eda/visualization/shift.py
@@ -29,17 +29,19 @@ class XShiftSummary(AbstractVisualization, JupyterMixin):
                 f"a type of distribution shift.\n"
                 f"\n"
                 f"**Test results**: "
-                f"We can predict whether a sample is in the test vs. training set with a {results['eval_metric']} of\n"
-                f"{results['test_statistic']:.4f} with a p-value of {results['pvalue']:.4f} "
-                f"(smaller than the threshold of {results['pvalue_threshold']:.4f}).\n"
+                f"We can predict whether a sample is in the test vs. training set with a `{results['eval_metric']}` of\n"
+                f"`{results['test_statistic']:.4f}` with a p-value of `{results['pvalue']:.4f}` "
+                f"(smaller than the threshold of `{results['pvalue_threshold']:.4f})`.\n"
                 f"\n"
             )
         if "feature_importance" in results:
+            fi = results["feature_importance"]
+            fi = fi[fi.p_value <= results["pvalue_threshold"]]
             fi_md = (
                 f"**Feature importances**: "
                 f"The variables that are the most responsible for this shift are those with high feature "
                 f"importance:\n\n"
-                f"{results['feature_importance'].to_markdown()}"
+                f"{fi.to_markdown()}"
             )
             return ret_md + fi_md
         return ret_md

--- a/eda/tests/unittests/analysis/test_interaction.py
+++ b/eda/tests/unittests/analysis/test_interaction.py
@@ -289,20 +289,23 @@ def test_DistributionFit__happy_path():
         ],
     )
     assert state.distributions_fit.train_data.a == {
-        "dweibull": {
-            "param": (1.9212313611673846, 3.5000360875942134, 1.6939405342565321),
-            "statistic": 0.12094344045455918,
-            "pvalue": 0.9998695812922455,
-        },
         "dgamma": {
             "param": (2.7071122240167984, 3.4999828973430622, 0.5541010748597517),
-            "statistic": 0.12375823666401586,
             "pvalue": 0.9997989026208239,
+            "shapes": ["a", "loc", "scale"],
+            "statistic": 0.12375823666401586,
+        },
+        "dweibull": {
+            "param": (1.9212313611673846, 3.5000360875942134, 1.6939405342565321),
+            "pvalue": 0.9998695812922455,
+            "shapes": ["c", "loc", "scale"],
+            "statistic": 0.12094344045455918,
         },
         "logistic": {
             "param": (3.5, 1.0421523470240495),
-            "statistic": 0.14168404087671216,
             "pvalue": 0.9981811820582718,
+            "shapes": ["loc", "scale"],
+            "statistic": 0.14168404087671216,
         },
     }
 
@@ -312,7 +315,6 @@ def test_DistributionFit__happy_path():
         pvalue_min=0.9,
         distributions_to_fit=["dweibull", "dgamma", "logistic", "lognorm"],
     )
-    a.logger.warning = MagicMock()
 
     state = auto.analyze(
         train_data=df,
@@ -320,9 +322,6 @@ def test_DistributionFit__happy_path():
         anlz_facets=[a],
     )
     assert state.distributions_fit.train_data.e is None
-    a.logger.warning.assert_called_with(
-        "e: none of the distributions were able to fit to satisfy specified pvalue_min: 0.9"
-    )
 
 
 def test_DistributionFit__constructor_defaults():

--- a/eda/tests/unittests/auto/test_simple.py
+++ b/eda/tests/unittests/auto/test_simple.py
@@ -1,4 +1,5 @@
 import os
+import re
 import tempfile
 from unittest.mock import MagicMock, call
 
@@ -344,36 +345,33 @@ def test_target_analysis__regression(monkeypatch):
 
         state = target_analysis(train_data=df_train, label="fnlwgt", return_state=True)
 
-    call_md_render.assert_has_calls(
-        [
-            call("## Target variable analysis"),
-            call(
-                "\n".join(
-                    [
-                        "### Distribution fits for target variable",
-                        " - [kstwobign](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.kstwobign.html)",
-                        "   - p-value: 0.976",
-                        "   - Parameters: (loc: -134163.8474064017, scale: 377621.2391000401)",
-                        " - [gumbel_r](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.gumbel_r.html)",
-                        "   - p-value: 0.966",
-                        "   - Parameters: (loc: 149399.54777678402, scale: 79111.08454921929)",
-                        " - [nakagami](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.nakagami.html)",
-                        "   - p-value: 0.965",
-                        "   - Parameters: (nu: 0.8441222819414649, loc: 28236.444673671464, scale: 192280.03015904326)",
-                        " - [skewnorm](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.skewnorm.html)",
-                        "   - p-value: 0.963",
-                        "   - Parameters: (a: 3.581779718590373, loc: 78497.27515496105, scale: 150470.02357042202)",
-                        " - [genlogistic](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.genlogistic.html)",
-                        "   - p-value: 0.962",
-                        "   - Parameters: (c: 129.5237086428741, loc: -233264.19892983814, scale: 78753.92432672696)",
-                    ]
-                )
-            ),
-            call(
-                "### Target variable correlations\n - ⚠️ no fields with absolute correlation greater than `0.5` found for target variable `fnlwgt`."
-            ),
-        ]
-    )
+    assert call_md_render.call_count == 3
+    calls = [re.sub(r"[.][0-9]{4,}", ".xx", c[0][0]) for c in call_md_render.call_args_list]
+    assert calls == [
+        "## Target variable analysis",
+        "\n".join(
+            [
+                "### Distribution fits for target variable",
+                " - [kstwobign](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.kstwobign.html)",
+                "   - p-value: 0.976",
+                "   - Parameters: (loc: -134163.xx, scale: 377621.xx)",
+                " - [gumbel_r](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.gumbel_r.html)",
+                "   - p-value: 0.966",
+                "   - Parameters: (loc: 149399.xx, scale: 79111.xx)",
+                " - [nakagami](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.nakagami.html)",
+                "   - p-value: 0.965",
+                "   - Parameters: (nu: 0.xx, loc: 28236.xx, scale: 192280.xx)",
+                " - [skewnorm](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.skewnorm.html)",
+                "   - p-value: 0.963",
+                "   - Parameters: (a: 3.xx, loc: 78497.xx, scale: 150470.xx)",
+                " - [genlogistic](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.genlogistic.html)",
+                "   - p-value: 0.962",
+                "   - Parameters: (c: 129.xx, loc: -233264.xx, scale: 78753.xx)",
+            ]
+        ),
+        "### Target variable correlations\n - ⚠️ no fields with absolute correlation greater than `0.5` found for target variable `fnlwgt`.",
+    ]
+
     call_ds_render.assert_called_once()
     call_cv_render.assert_called_once()
     call_fiv_render.assert_called_once()

--- a/eda/tests/unittests/visualization/test_interaction.py
+++ b/eda/tests/unittests/visualization/test_interaction.py
@@ -140,15 +140,15 @@ def __test_internal(monkeypatch, render_key, state, heatmap_args, facet_cls, tex
         auto.analyze(state=state, viz_facets=[analysis])
 
     call_yticks.assert_called_with(rotation=0)
-    call_subplots.assert_called_with(some_arg=123)
+    call_subplots.assert_called_with(some_arg=123, figsize=(4, 4))
     call_show.assert_called_with("fig")
 
     call_heatmap.assert_called_with(
         state[render_key].train_data,
         annot=True,
         ax="ax",
-        linewidths=0.9,
-        linecolor="white",
+        linewidths=0.5,
+        linecolor="lightgrey",
         fmt=".2f",
         square=True,
         cbar_kws={"shrink": 0.5},
@@ -186,7 +186,7 @@ def test_FeatureInteractionVisualization__happy_path(monkeypatch):
         dict(x="a", y="b", some_chart_arg=123),
     )
     call_show.assert_called_with("fig")
-    call_subplots.assert_called_with(key="value")
+    call_subplots.assert_called_with(key="value", figsize=(12, 6))
 
 
 @pytest.mark.parametrize("is_single, header", [(True, True), (False, True), (True, False), (False, False)])
@@ -531,11 +531,11 @@ def test_FeatureDistanceAnalysisVisualization__happy_path(monkeypatch, has_near_
         auto.analyze(state=state, viz_facets=[viz])
 
     call_dendrogram.assert_called_with(
-        ax=ax, Z=ANY, labels=state.feature_distance.columns, orientation="left", some_chart_arg=123
+        ax=ax, Z=ANY, labels=state.feature_distance.columns, leaf_font_size=10, orientation="left", some_chart_arg=123
     )
     np.testing.assert_array_equal(call_dendrogram.call_args[1]["Z"], state.feature_distance.linkage)
     call_show.assert_called_with("fig")
-    call_subplots.assert_called_with(key="value")
+    call_subplots.assert_called_with(key="value", figsize=(12, 3.5))
     if has_near_duplicates:
         call_render_markdown.assert_called_with(
             "**The following feature groups are considered as near-duplicates**:\n\nDistance threshold: <= `0.85`. "

--- a/eda/tests/unittests/visualization/test_model.py
+++ b/eda/tests/unittests/visualization/test_model.py
@@ -45,10 +45,18 @@ def test_ConfusionMatrix(monkeypatch, confusion_matrix_normalized, expected_fmt)
         viz = ConfusionMatrix(fig_args=dict(a=1, b=2), headers=True, some_kwarg=123)
         viz.render_text = call_render_text
         viz.render(state)
-    call_plt_subplots.assert_called_with(a=1, b=2)
+    call_plt_subplots.assert_called_with(a=1, b=2, figsize=(2, 2))
     call_plt_show.assert_called_with("fig")
     call_sns_heatmap.assert_called_with(
-        ANY, ax="ax", cmap="Blues", annot=True, fmt=expected_fmt, cbar=False, some_kwarg=123
+        ANY,
+        ax="ax",
+        cmap="Blues",
+        annot=True,
+        linewidths=0.5,
+        linecolor="lightgrey",
+        fmt=expected_fmt,
+        cbar=False,
+        some_kwarg=123,
     )
     call_render_text.assert_called_with("Confusion Matrix", text_type="h3")
 
@@ -183,7 +191,7 @@ def test_FeatureImportance(monkeypatch, show_barplots):
     call_display_obj.assert_called_once()
     call_render_text.assert_called_with("Feature Importance", text_type="h3")
     if show_barplots:
-        call_plt_subplots.assert_called_with(a=1, b=2)
+        call_plt_subplots.assert_called_with(a=1, b=2, figsize=(12, 0.75))
         call_plt_show.assert_called_with("fig")
         call_sns_barplot.assert_called_with(ax="ax", data=ANY, y="index", x="importance", some_kwarg=123)
     else:


### PR DESCRIPTION
*Issue #, if available:*

[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1LfgSKSTVWfF_IgTYEcaK6GjdfRqffgl0?usp=sharing)

*Description of changes:*
- Added `target_analysis` - target variable composite analysis
- Added feature distance for `dataset_overview`
- Added `distribution_fit` for `analyze_interaction` shortcut
- Added distribution plots for `covariate_shift_detection` when shift is detected
- Dynamic `figargs` setting for various components; adjusted fontsize and colors
- Added parameters names for distribution fit analysis

## `analyze_interaction()` now supports `fit_distributions` argument

```python
import autogluon.eda.auto as auto

 # fit all available distributions
auto.analyze_interaction(train_data=df_train, x='Age', fit_distributions=True) 

# fit only lognorm and gamma distributions
auto.analyze_interaction(train_data=df_train, x='Age', fit_distributions=['lognorm', 'gamma'])
```

![image](https://user-images.githubusercontent.com/10080307/211692100-74e6cfa6-a9fd-4004-bf1b-8cb0fd950883.png)

```

## `target_analysis()` - target variable composite analysis

Target variable composite analysis. Performs the following analysis components of the label field:
 - basic summary stats
 - feature values distribution charts; adds fitted distributions for numeric targets
 - target correlations analysis; with interaction charts of target vs high-correlated features

```
Parameters
----------
train_data: Optional[DataFrame]
    training dataset
label: : Optional[str]
    target variable
state: Union[None, dict, AnalysisState], default = None
    pass prior state if necessary; the object will be updated during `anlz_facets` `fit` call.
sample: Union[None, int, float], default = None
    sample size; if `int`, then row number is used;
    `float` must be between 0.0 and 1.0 and represents fraction of dataset to sample;
    `None` means no sampling
    See also :func:`autogluon.eda.analysis.dataset.Sampler`
return_state: bool, default = False
    return state if `True`
```

**Examples**
```python
import autogluon.eda.auto as auto

auto.target_analysis(train_data=..., label=...)
```

![image](https://user-images.githubusercontent.com/10080307/211688799-678a4639-bb6f-4a47-a6c4-8cce312e6fe4.png)
... more charts below

## `covariate_shift_detection()` changes
When distribution shift is detected between `train_data` and `test_data`, the analysis automatically charts distribution chart with both datasets in different colors.
```python
auto.covariate_shift_detection(train_data=df_train, test_data=df_test, label=target_col)
```

![image](https://user-images.githubusercontent.com/10080307/211689082-d95bde69-6848-4328-b4b1-b3951c8cdee3.png)

## `dataset_overview()` changes

Added feature distance for `dataset_overview`

```python
auto.dataset_overview(
    train_data=df_train, test_data=df_test, label=target_col, 
    chart_args={'feature_distance': dict(orientation='left')},
)
```

![image](https://user-images.githubusercontent.com/10080307/211689352-d0c48225-8773-4296-87a9-e491d238536c.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
