### PR TITLE
[timeseries] Add support for past_covariates to Predictor & models

### DIFF
--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -95,7 +95,6 @@ class TimeSeriesLearner(AbstractLearner):
                 "\tThis metric's sign has been flipped to adhere to being 'higher is better'. "
                 "The reported score can be multiplied by -1 to get the metric value.",
             )
-
         train_data = self.feature_generator.fit_transform(train_data, data_frame_name="train_data")
         if val_data is not None:
             val_data = self.feature_generator.transform(val_data, data_frame_name="tuning_data")

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -292,8 +292,9 @@ class AbstractTimeSeriesModel(AbstractModel):
             of input items.
         """
         past_data = data.slice_by_timestep(None, -self.prediction_length)
-        if len(data.columns) > 1:
-            known_covariates = data.slice_by_timestep(-self.prediction_length, None).drop(self.target, axis=1)
+        if len(self.metadata.known_covariates_real) > 0:
+            future_data = data.slice_by_timestep(-self.prediction_length, None)
+            known_covariates = future_data[self.metadata.known_covariates_real]
         else:
             known_covariates = None
         return self.predict(past_data, known_covariates=known_covariates, **kwargs)

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
@@ -26,6 +26,7 @@ class AutoGluonTabularModel(AbstractTimeSeriesModel):
 
     - lag features (observed time series values) based on ``freq`` of the data
     - time features (e.g., day of the week) based on the timestamp of the measurement
+    - lagged known and past covariates (if available)
     - static features of each item (if available)
 
     Quantiles are obtained by assuming that the residuals follow zero-mean normal distribution, scale of which is
@@ -51,10 +52,10 @@ class AutoGluonTabularModel(AbstractTimeSeriesModel):
     PREDICTION_BATCH_SIZE = 100_000
 
     TIMESERIES_METRIC_TO_TABULAR_METRIC = {
-        "MASE": "root_mean_squared_error",
+        "MASE": "mean_absolute_error",
         "MAPE": "mean_absolute_percentage_error",
         "sMAPE": "mean_absolute_percentage_error",
-        "mean_wQuantileLoss": "root_mean_squared_error",
+        "mean_wQuantileLoss": "mean_absolute_error",
         "MSE": "mean_squared_error",
         "RMSE": "root_mean_squared_error",
     }
@@ -79,7 +80,9 @@ class AutoGluonTabularModel(AbstractTimeSeriesModel):
             hyperparameters=hyperparameters,
             **kwargs,
         )
-        self._lag_indices: np.array = None
+        self._target_lag_indices: np.array = None
+        self._known_covariates_lag_indices = np.arange(0, 10)
+        self._past_covariates_lag_indices = np.arange(1, 10)
         self._time_features: List[Callable] = None
         self._available_features: pd.Index = None
         self.residuals_std = 0.0
@@ -106,25 +109,62 @@ class AutoGluonTabularModel(AbstractTimeSeriesModel):
             If provided, features will be generated only for the last `last_k_values` timesteps of each time series.
         """
 
-        def get_lag_features_and_target(group):
-            timestamp = group.index.get_level_values(TIMESTAMP)
-            lag_columns = {f"lag_{idx}": group.shift(idx).values.ravel() for idx in self._lag_indices}
-            features = pd.DataFrame(lag_columns, index=timestamp)
+        def get_lags(df: pd.DataFrame, lag_indices: List[int]) -> pd.DataFrame:
+            shifted = [df.shift(idx).add_suffix(f"_lag_{idx}") for idx in lag_indices]
+            return pd.concat(shifted, axis=1)
+
+        def apply_mask(
+            df: pd.DataFrame, num_hidden: np.ndarray, lag_indices: np.ndarray, num_columns: int = 1
+        ) -> pd.DataFrame:
+            if num_columns > 1:
+                lag_indices = np.repeat(lag_indices, num_columns)
+            mask = num_hidden[:, None] >= lag_indices[None]  # shape [len(num_hidden), len(lag_indices) * num_columns]
+            df[mask] = np.nan
+            return df
+
+        def get_lag_features_and_target(time_series):
             # Starting from the end of the time series, mask the values as if the last `prediction_length` steps weren't observed
             # This mimics what will happen at test time, when we simultaneously predict the next `prediction_length` values
-            num_windows = (len(group) - 1) // self.prediction_length
+            num_windows = (len(time_series) - 1) // self.prediction_length
             # We don't hide any past values for the first `remainder` values, otherwise the features will be all empty
-            remainder = len(group) - num_windows * self.prediction_length
+            remainder = len(time_series) - num_windows * self.prediction_length
             num_hidden = np.concatenate([np.zeros(remainder), np.tile(np.arange(self.prediction_length), num_windows)])
-            mask = num_hidden[:, None] >= self._lag_indices[None]  # shape [num_timesteps, num_lags]
-            features[mask] = np.nan
+
+            target_lags = get_lags(time_series[[self.target]], self._target_lag_indices)
+            target_lags = apply_mask(target_lags, num_hidden=num_hidden, lag_indices=self._target_lag_indices)
+            feature_dfs = [target_lags]
+
+            if self.metadata.past_covariates_real:
+                past_covariates_lags = get_lags(
+                    time_series[self.metadata.past_covariates_real], self._past_covariates_lag_indices
+                )
+                past_covariates_lags = apply_mask(
+                    past_covariates_lags,
+                    num_hidden=num_hidden,
+                    lag_indices=self._past_covariates_lag_indices,
+                    num_columns=len(self.metadata.past_covariates_real),
+                )
+                feature_dfs.append(past_covariates_lags)
+
+            if self.metadata.known_covariates_real:
+                known_covariates_lags = get_lags(
+                    time_series[self.metadata.known_covariates_real], self._known_covariates_lag_indices
+                )
+                feature_dfs.append(known_covariates_lags)
+
+            if len(feature_dfs) > 1:
+                features = pd.concat(feature_dfs, axis=1)
+            else:
+                features = target_lags
 
             # Prediction target
-            features[self.target] = group.values.ravel()
+            features[self.target] = time_series[self.target]
             return features
 
-        features = data[self.target].groupby(level=ITEMID, sort=False).apply(get_lag_features_and_target)
-        timestamps = features.index.get_level_values(TIMESTAMP)
+        df = pd.DataFrame(data).reset_index(level=TIMESTAMP)
+        timestamps = pd.DatetimeIndex(df.pop(TIMESTAMP))
+        features = df.groupby(level=ITEMID, sort=False).apply(get_lag_features_and_target)
+
         for time_feat in self._time_features:
             features[time_feat.__name__] = time_feat(timestamps)
 
@@ -149,7 +189,7 @@ class AutoGluonTabularModel(AbstractTimeSeriesModel):
         if self.tabular_predictor._learner.is_fit:
             raise AssertionError(f"{self.name} predictor has already been fit!")
         verbosity = kwargs.get("verbosity", 2)
-        self._lag_indices = np.array(get_lags_for_frequency(train_data.freq), dtype=np.int64)
+        self._target_lag_indices = np.array(get_lags_for_frequency(train_data.freq), dtype=np.int64)
         self._time_features = time_features_from_frequency_str(train_data.freq)
 
         train_data, _ = self._normalize_targets(train_data)

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
@@ -50,7 +50,6 @@ class AutoGluonTabularModel(AbstractTimeSeriesModel):
     }
 
     PREDICTION_BATCH_SIZE = 100_000
-    MAX_STEPS = 10
 
     TIMESERIES_METRIC_TO_TABULAR_METRIC = {
         "MASE": "mean_absolute_error",
@@ -260,8 +259,8 @@ class AutoGluonTabularModel(AbstractTimeSeriesModel):
             raise AssertionError(f"{self.name} predictor has already been fit!")
         verbosity = kwargs.get("verbosity", 2)
         self._target_lag_indices = np.array(get_lags_for_frequency(train_data.freq), dtype=np.int64)
-        self._past_covariates_lag_indices = self._target_lag_indices[: self.MAX_STEPS]
-        self._known_covariates_lag_indices = np.concatenate([[0], self._target_lag_indices])[: self.MAX_STEPS]
+        self._past_covariates_lag_indices = self._target_lag_indices
+        self._known_covariates_lag_indices = np.concatenate([[0], self._target_lag_indices])
         self._time_features = time_features_from_frequency_str(train_data.freq)
 
         train_data, _ = self._normalize_targets(train_data)

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
@@ -275,7 +275,7 @@ class AutoGluonTabularModel(AbstractTimeSeriesModel):
 
         if len(train_df) > max_train_size:
             train_df = train_df.sample(max_train_size)
-        logger.debug(f"Generated training dataframe with shape {val_df.shape}")
+        logger.debug(f"Generated training dataframe with shape {train_df.shape}")
 
         if val_data is not None:
             if val_data.freq != train_data.freq:

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -136,6 +136,8 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
     int_dtype: Type = np.int64
     # default number of samples for prediction
     default_num_samples: int = 1000
+    supports_known_covariates: bool = False
+    supports_past_covariates: bool = False
 
     def __init__(
         self,
@@ -212,10 +214,10 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
                     feat_static_cat = ds.static_features[self.metadata.static_features_cat]
                     self.feat_static_cat_cardinality = feat_static_cat.nunique().tolist()
             disable_known_covariates = model_params.get("disable_known_covariates", False)
-            if not disable_known_covariates:
+            if not disable_known_covariates and self.supports_known_covariates:
                 self.num_feat_dynamic_real = len(self.metadata.known_covariates_real)
             disable_past_covariates = model_params.get("disable_past_covariates", False)
-            if not disable_past_covariates:
+            if not disable_past_covariates and self.supports_past_covariates:
                 self.num_past_feat_dynamic_real = len(self.metadata.past_covariates_real)
 
         if "callbacks" in kwargs:

--- a/timeseries/src/autogluon/timeseries/models/gluonts/mx/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/mx/models.py
@@ -195,6 +195,8 @@ class MQCNNMXNetModel(AbstractGluonTSSeq2SeqModel):
     """
 
     gluonts_estimator_class: Type[GluonTSEstimator] = MQCNNEstimator
+    supports_known_covariates = True
+    supports_past_covariates = True
 
     def _get_estimator_init_args(self) -> dict:
         init_kwargs = super()._get_estimator_init_args()
@@ -202,6 +204,7 @@ class MQCNNMXNetModel(AbstractGluonTSSeq2SeqModel):
         init_kwargs["use_feat_static_real"] = self.num_feat_static_real > 0
         init_kwargs["cardinality"] = self.feat_static_cat_cardinality
         init_kwargs["use_feat_dynamic_real"] = self.num_feat_dynamic_real > 0
+        init_kwargs["use_past_feat_dynamic_real"] = self.num_past_feat_dynamic_real > 0
         return init_kwargs
 
 

--- a/timeseries/src/autogluon/timeseries/models/gluonts/mx/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/mx/models.py
@@ -97,6 +97,7 @@ class DeepARMXNetModel(AbstractGluonTSMXNetModel):
 
     gluonts_estimator_class: Type[GluonTSEstimator] = DeepAREstimator
     default_num_samples: int = 250
+    supports_known_covariates = True
 
     def _get_estimator_init_args(self) -> dict:
         init_kwargs = super()._get_estimator_init_args()
@@ -251,6 +252,7 @@ class MQRNNMXNetModel(AbstractGluonTSSeq2SeqModel):
     """
 
     gluonts_estimator_class: Type[GluonTSEstimator] = MQRNNEstimator
+    supports_known_covariates = True
 
 
 class SimpleFeedForwardMXNetModel(AbstractGluonTSMXNetModel):
@@ -349,6 +351,8 @@ class TemporalFusionTransformerMXNetModel(AbstractGluonTSMXNetModel):
 
     gluonts_estimator_class: Type[GluonTSEstimator] = TemporalFusionTransformerEstimator
     supported_quantiles: set = set([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
+    supports_known_covariates = True
+    supports_past_covariates = True
 
     def _get_estimator_init_args(self) -> dict:
         init_kwargs = super()._get_estimator_init_args()

--- a/timeseries/src/autogluon/timeseries/models/gluonts/mx/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/mx/models.py
@@ -354,8 +354,13 @@ class TemporalFusionTransformerMXNetModel(AbstractGluonTSMXNetModel):
         init_kwargs = super()._get_estimator_init_args()
         if self.num_feat_static_real > 0:
             init_kwargs["static_feature_dims"] = {FieldName.FEAT_STATIC_REAL: self.num_feat_static_real}
-        if self.num_feat_dynamic_real > 0:
-            init_kwargs["dynamic_feature_dims"] = {FieldName.FEAT_DYNAMIC_REAL: self.num_feat_dynamic_real}
+        if self.num_feat_dynamic_real > 0 or self.num_past_feat_dynamic_real > 0:
+            init_kwargs["dynamic_feature_dims"] = {}
+            if self.num_feat_dynamic_real > 0:
+                init_kwargs["dynamic_feature_dims"][FieldName.FEAT_DYNAMIC_REAL] = self.num_feat_dynamic_real
+            if self.num_past_feat_dynamic_real > 0:
+                init_kwargs["dynamic_feature_dims"][FieldName.PAST_FEAT_DYNAMIC_REAL] = self.num_past_feat_dynamic_real
+                init_kwargs["past_dynamic_features"] = [FieldName.PAST_FEAT_DYNAMIC_REAL]
 
         # Turning off hybridization prevents MXNet errors when training on GPU
         init_kwargs["hybridize"] = False

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -206,6 +206,7 @@ class DeepARModel(AbstractGluonTSPyTorchModel):
 
     gluonts_estimator_class: Type[GluonTSPyTorchLightningEstimator] = DeepAREstimator
     default_num_samples: int = 250
+    supports_known_covariates = True
 
     def _get_estimator_init_args(self) -> Dict[str, Any]:
         init_kwargs = super()._get_estimator_init_args()

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -274,8 +274,10 @@ class TimeSeriesPredictor:
 
             If ``known_covariates_names`` were specified when creating the predictor, ``train_data`` must include the
             columns listed in ``known_covariates_names`` with the covariates values aligned with the target time series.
-            The known covariates must have a numeric (float or integer) dtype. Columns of ``train_data`` except
-            ``target`` and those listed in ``known_covariates_names`` will be ignored.
+            The known covariates must have a numeric (float or integer) dtype.
+
+            Columns of ``train_data`` except ``target`` and those listed in ``known_covariates_names`` will be
+            interpreted as ``past_covariates`` - covariates that are known only in the past.
 
             If ``train_data`` has static features (i.e., ``train_data.static_features`` is a pandas DataFrame), the
             predictor will interpret columns with ``int`` and ``float`` dtypes as continuous (real-valued) features,
@@ -306,8 +308,8 @@ class TimeSeriesPredictor:
             the columns listed in ``known_covariates_names`` with the covariates values aligned with the target time
             series.
 
-            If ``train_data`` has static features, ``tuning_data`` must have also have static features with the same
-            column names and dtypes.
+            If ``train_data`` has past covariates or static features, ``tuning_data`` must have also include them (with
+            same columns names and dtypes).
 
             If provided data is an instance of pandas DataFrame, AutoGluon will attempt to automatically convert it
             to a ``TimeSeriesDataFrame``.
@@ -508,8 +510,8 @@ class TimeSeriesPredictor:
             If ``known_covariates_names`` were specified when creating the predictor, ``data`` must include the columns
             listed in ``known_covariates_names`` with the covariates values aligned with the target time series.
 
-            If ``train_data`` used to train the predictor contained static features, then ``data`` must also contain
-            static features that have the same columns and dtypes.
+            If ``train_data`` used to train the predictor contained past covariates or static features, then ``data``
+            must also include them (with same column names and dtypes).
 
             If provided data is an instance of pandas DataFrame, AutoGluon will attempt to automatically convert it
             to a ``TimeSeriesDataFrame``.
@@ -583,8 +585,8 @@ class TimeSeriesPredictor:
             If ``known_covariates_names`` were specified when creating the predictor, ``data`` must include the columns
             listed in ``known_covariates_names`` with the covariates values aligned with the target time series.
 
-            If ``train_data`` used to train the predictor contained static features, then ``data`` must also contain
-            static features that have the same columns and dtypes.
+            If ``train_data`` used to train the predictor contained past covariates or static features, then ``data``
+            must also include them (with same column names and dtypes).
 
             If provided data is an instance of pandas DataFrame, AutoGluon will attempt to automatically convert it
             to a ``TimeSeriesDataFrame``.
@@ -681,8 +683,8 @@ class TimeSeriesPredictor:
             If ``known_covariates_names`` were specified when creating the predictor, ``data`` must include the columns
             listed in ``known_covariates_names`` with the covariates values aligned with the target time series.
 
-            If ``train_data`` used to train the predictor contained static features, then ``data`` must also contain
-            static features that have the same columns and dtypes.
+            If ``train_data`` used to train the predictor contained past covariates or static features, then ``data``
+            must also include them (with same column names and dtypes).
 
             If provided data is an instance of pandas DataFrame, AutoGluon will attempt to automatically convert it
             to a ``TimeSeriesDataFrame``.

--- a/timeseries/src/autogluon/timeseries/utils/features.py
+++ b/timeseries/src/autogluon/timeseries/utils/features.py
@@ -86,11 +86,11 @@ class TimeSeriesFeatureGenerator:
                 self.past_covariates_names.append(column)
 
         logger.info("\nProvided dataset contains following columns:")
-        logger.info(f"\ttarget: {self.target}")
+        logger.info(f"\ttarget:           '{self.target}'")
         if len(self.known_covariates_names) > 0:
             logger.info(f"\tknown covariates: {self.known_covariates_names}")
         if len(self.known_covariates_names) > 0:
-            logger.info(f"\tpast covariates: {self.past_covariates_names}")
+            logger.info(f"\tpast covariates:  {self.past_covariates_names}")
 
         static_features_cat = []
         static_features_real = []
@@ -108,7 +108,7 @@ class TimeSeriesFeatureGenerator:
                     unused.append(col_name)
 
             logger.info("Following types of static features have been inferred:")
-            logger.info(f"\tcategorical: {static_features_cat}")
+            logger.info(f"\tcategorical:        {static_features_cat}")
             logger.info(f"\tcontinuous (float): {static_features_real}")
             if len(unused) > 0:
                 logger.info(f"\tremoved (neither categorical nor continuous): {unused}")

--- a/timeseries/src/autogluon/timeseries/utils/features.py
+++ b/timeseries/src/autogluon/timeseries/utils/features.py
@@ -77,9 +77,6 @@ class TimeSeriesFeatureGenerator:
     def fit(self, data: TimeSeriesDataFrame) -> None:
         assert not self._is_fit, f"{self.__class__.__name__} has already been fit"
 
-        for column in self.known_covariates_names:
-            assert column in data.columns, f"known_covariates column {column} is missing from the provided data"
-
         self.past_covariates_names = []
         for column in data.columns:
             if column != self.target and column not in self.known_covariates_names:

--- a/timeseries/src/autogluon/timeseries/utils/features.py
+++ b/timeseries/src/autogluon/timeseries/utils/features.py
@@ -86,7 +86,7 @@ class TimeSeriesFeatureGenerator:
         logger.info(f"\ttarget:           '{self.target}'")
         if len(self.known_covariates_names) > 0:
             logger.info(f"\tknown covariates: {self.known_covariates_names}")
-        if len(self.known_covariates_names) > 0:
+        if len(self.past_covariates_names) > 0:
             logger.info(f"\tpast covariates:  {self.past_covariates_names}")
 
         static_features_cat = []

--- a/timeseries/src/autogluon/timeseries/utils/features.py
+++ b/timeseries/src/autogluon/timeseries/utils/features.py
@@ -77,10 +77,20 @@ class TimeSeriesFeatureGenerator:
     def fit(self, data: TimeSeriesDataFrame) -> None:
         assert not self._is_fit, f"{self.__class__.__name__} has already been fit"
 
-        past_covariates_names = []
+        for column in self.known_covariates_names:
+            assert column in data.columns, f"known_covariates column {column} is missing from the provided data"
+
+        self.past_covariates_names = []
         for column in data.columns:
             if column != self.target and column not in self.known_covariates_names:
-                past_covariates_names.append(column)
+                self.past_covariates_names.append(column)
+
+        logger.info("\nProvided dataset contains following columns:")
+        logger.info(f"\ttarget: {self.target}")
+        if len(self.known_covariates_names) > 0:
+            logger.info(f"\tknown covariates: {self.known_covariates_names}")
+        if len(self.known_covariates_names) > 0:
+            logger.info(f"\tpast covariates: {self.past_covariates_names}")
 
         static_features_cat = []
         static_features_real = []
@@ -110,7 +120,7 @@ class TimeSeriesFeatureGenerator:
             static_features_cat=static_features_cat,
             static_features_real=static_features_real,
             known_covariates_real=self.known_covariates_names,
-            past_covariates_real=past_covariates_names,
+            past_covariates_real=self.past_covariates_names,
             # TODO: Categorical time-varying covariates are not yet supported
             known_covariates_cat=[],
             past_covariates_cat=[],

--- a/timeseries/tests/unittests/common.py
+++ b/timeseries/tests/unittests/common.py
@@ -58,7 +58,7 @@ DUMMY_TS_DATAFRAME = get_data_frame_with_item_index(["10", "A", "2", "1"])
 def get_data_frame_with_variable_lengths(
     item_id_to_length: Dict[str, int],
     static_features: Optional[pd.DataFrame] = None,
-    known_covariates_names: Optional[List[str]] = None,
+    covariates_names: Optional[List[str]] = None,
 ):
     tuples = []
     for item_id, length in item_id_to_length.items():
@@ -74,8 +74,8 @@ def get_data_frame_with_variable_lengths(
     )
     df.freq  # compute _cached_freq
     df.static_features = static_features
-    if known_covariates_names is not None:
-        for name in known_covariates_names:
+    if covariates_names is not None:
+        for name in covariates_names:
             df[name] = np.random.normal(size=len(df))
     return df
 
@@ -102,7 +102,7 @@ DATAFRAME_WITH_STATIC = get_data_frame_with_variable_lengths(
 )
 
 DATAFRAME_WITH_COVARIATES = get_data_frame_with_variable_lengths(
-    ITEM_ID_TO_LENGTH, known_covariates_names=["cov1", "cov2", "cov3"]
+    ITEM_ID_TO_LENGTH, covariates_names=["cov1", "cov2", "cov3"]
 )
 
 

--- a/timeseries/tests/unittests/models/test_autogluon_tabular.py
+++ b/timeseries/tests/unittests/models/test_autogluon_tabular.py
@@ -24,7 +24,7 @@ def test_when_feature_df_is_constructed_then_shape_is_correct(data, last_k_value
     # Initialize model._lag_indices and model._time_features from freq
     model.fit(train_data=data, time_limit=2)
     df = model._get_features_dataframe(data, last_k_values=last_k_values)
-    expected_num_features = len(model._lag_indices) + len(model._time_features) + 1
+    expected_num_features = len(model._target_lag_indices) + len(model._time_features) + 1
     assert df.shape == (expected_length, expected_num_features)
 
 
@@ -49,10 +49,12 @@ def test_when_predict_is_called_then_get_features_dataframe_receives_correct_inp
 def test_when_static_features_present_then_shape_is_correct(temp_model_path):
     data = DATAFRAME_WITH_STATIC.copy()
     model = AutoGluonTabularModel(path=temp_model_path)
-    # Initialize model._lag_indices and model._time_features from freq
+    # Initialize model._target_lag_indices and model._time_features from freq
     model.fit(train_data=data, time_limit=2)
     df = model._get_features_dataframe(data)
-    expected_num_features = len(model._lag_indices) + len(model._time_features) + 1 + len(data.static_features.columns)
+    expected_num_features = (
+        len(model._target_lag_indices) + len(model._time_features) + 1 + len(data.static_features.columns)
+    )
     assert len(df.columns) == expected_num_features
     assert all(col in df.columns for col in data.static_features.columns)
 

--- a/timeseries/tests/unittests/models/test_autogluon_tabular.py
+++ b/timeseries/tests/unittests/models/test_autogluon_tabular.py
@@ -1,10 +1,13 @@
 from unittest import mock
 
+import numpy as np
+import pandas as pd
 import pytest
 
 from autogluon.timeseries.models.autogluon_tabular import AutoGluonTabularModel
+from autogluon.timeseries.utils.features import TimeSeriesFeatureGenerator
 
-from ..common import DATAFRAME_WITH_STATIC, DUMMY_VARIABLE_LENGTH_TS_DATAFRAME
+from ..common import DATAFRAME_WITH_STATIC, DUMMY_VARIABLE_LENGTH_TS_DATAFRAME, get_data_frame_with_variable_lengths
 
 TESTABLE_MODELS = [
     AutoGluonTabularModel,
@@ -46,17 +49,36 @@ def test_when_predict_is_called_then_get_features_dataframe_receives_correct_inp
                     assert len(new_timestamps.difference(original_timestamps)) == prediction_length
 
 
-def test_when_static_features_present_then_shape_is_correct(temp_model_path):
-    data = DATAFRAME_WITH_STATIC.copy()
-    model = AutoGluonTabularModel(path=temp_model_path)
+@pytest.mark.parametrize("known_covariates_names", [["known_1", "known_2"], []])
+@pytest.mark.parametrize("past_covariates_names", [["past_1", "past_2", "past_3"], []])
+@pytest.mark.parametrize("static_features_names", [["cat_1"], []])
+def test_when_covariates_and_features_present_then_shape_is_correct(
+    temp_model_path, known_covariates_names, past_covariates_names, static_features_names
+):
+    item_id_to_length = {1: 10, 5: 20, 2: 30}
+    data = get_data_frame_with_variable_lengths(
+        item_id_to_length, covariates_names=known_covariates_names + past_covariates_names
+    )
+    if static_features_names:
+        columns = {k: np.random.normal(size=len(item_id_to_length)) for k in static_features_names}
+        data.static_features = pd.DataFrame(columns, index=data.item_ids)
+
+    feat_gen = TimeSeriesFeatureGenerator(target="target", known_covariates_names=known_covariates_names)
+    data = feat_gen.fit_transform(data)
     # Initialize model._target_lag_indices and model._time_features from freq
+    model = AutoGluonTabularModel(path=temp_model_path, metadata=feat_gen.covariate_metadata)
     model.fit(train_data=data, time_limit=2)
     df = model._get_features_dataframe(data)
     expected_num_features = (
-        len(model._target_lag_indices) + len(model._time_features) + 1 + len(data.static_features.columns)
+        len(model._time_features)
+        + 1
+        + len(model._target_lag_indices)
+        + len(known_covariates_names) * len(model._known_covariates_lag_indices)
+        + len(past_covariates_names) * len(model._past_covariates_lag_indices)
+        + len(static_features_names)
     )
     assert len(df.columns) == expected_num_features
-    assert all(col in df.columns for col in data.static_features.columns)
+    assert all(col in df.columns for col in static_features_names)
 
 
 def test_when_static_features_present_then_prediction_works(temp_model_path):

--- a/timeseries/tests/unittests/models/test_autogluon_tabular.py
+++ b/timeseries/tests/unittests/models/test_autogluon_tabular.py
@@ -52,7 +52,7 @@ def test_when_predict_is_called_then_get_features_dataframe_receives_correct_inp
 @pytest.mark.parametrize("known_covariates_names", [["known_1", "known_2"], []])
 @pytest.mark.parametrize("past_covariates_names", [["past_1", "past_2", "past_3"], []])
 @pytest.mark.parametrize("static_features_names", [["cat_1"], []])
-def test_when_covariates_and_features_present_then_shape_is_correct(
+def test_when_covariates_and_features_present_then_feature_df_shape_is_correct(
     temp_model_path, known_covariates_names, past_covariates_names, static_features_names
 ):
     item_id_to_length = {1: 10, 5: 20, 2: 30}

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -108,6 +108,8 @@ def test_given_hyperparameter_spaces_when_tune_called_then_tuning_output_correct
         quantile_levels=[0.1, 0.9],
         hyperparameters={
             "epochs": ag.Int(1, 3),
+            "num_epochs_per_batch": 1,
+            "maxiter": 1,
         },
     )
     if model.name == "AutoGluonTabular":

--- a/timeseries/tests/unittests/test_features.py
+++ b/timeseries/tests/unittests/test_features.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+
 from autogluon.timeseries.utils.features import TimeSeriesFeatureGenerator
 
 from .common import get_data_frame_with_variable_lengths

--- a/timeseries/tests/unittests/test_features.py
+++ b/timeseries/tests/unittests/test_features.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pandas as pd
+import pytest
+from autogluon.timeseries.utils.features import TimeSeriesFeatureGenerator
+
+from .common import get_data_frame_with_variable_lengths
+
+
+@pytest.mark.parametrize("known_covariates_names", [["known_1", "known_2"], []])
+@pytest.mark.parametrize("past_covariates_names", [["past_1", "past_2", "past_3"], []])
+@pytest.mark.parametrize("static_features_cat", [["cat_1"], []])
+@pytest.mark.parametrize("static_features_real", [["real_1", "real_3"], []])
+def test_when_covariates_present_in_data_then_they_are_included_in_metadata(
+    known_covariates_names, past_covariates_names, static_features_cat, static_features_real
+):
+    feat_generator = TimeSeriesFeatureGenerator(target="target", known_covariates_names=known_covariates_names)
+    item_id_to_length = {1: 10, 5: 20, 2: 30}
+    data = get_data_frame_with_variable_lengths(
+        item_id_to_length, covariates_names=known_covariates_names + past_covariates_names
+    )
+    if static_features_cat or static_features_real:
+        cat_dict = {k: np.random.choice(["foo", "bar"], size=len(item_id_to_length)) for k in static_features_cat}
+        real_dict = {k: np.random.normal(size=len(item_id_to_length)) for k in static_features_real}
+        data.static_features = pd.DataFrame({**cat_dict, **real_dict}, index=data.item_ids)
+    feat_generator.fit(data)
+    metadata = feat_generator.covariate_metadata
+
+    assert metadata.known_covariates_real == known_covariates_names
+    assert metadata.past_covariates_real == past_covariates_names
+    assert metadata.static_features_cat == static_features_cat
+    assert metadata.static_features_real == static_features_real

--- a/timeseries/tests/unittests/test_learner.py
+++ b/timeseries/tests/unittests/test_learner.py
@@ -381,7 +381,7 @@ def test_when_ignore_index_is_true_and_known_covariates_available_then_learner_c
         prediction_length=prediction_length,
         ignore_time_index=True,
     )
-    train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["Y", "X"])
+    train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, covariates_names=["Y", "X"])
     learner.fit(train_data=train_data, hyperparameters={"DeepAR": {"epochs": 1, "num_batches_per_epoch": 1}})
     known_covariates = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, covariates_names=["X", "Y"])
     preds = learner.predict(train_data, known_covariates=known_covariates)

--- a/timeseries/tests/unittests/test_learner.py
+++ b/timeseries/tests/unittests/test_learner.py
@@ -271,23 +271,14 @@ def test_given_expected_known_covariates_missing_from_train_data_when_learner_fi
     temp_model_path,
 ):
     learner = TimeSeriesLearner(path_context=temp_model_path, known_covariates_names=["Y", "Z", "X"])
-    train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["X", "Z"])
+    train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, covariates_names=["X", "Z"])
     with pytest.raises(ValueError, match="columns are missing from train_data: \\['Y'\\]"):
         learner.fit(train_data=train_data, hyperparameters=HYPERPARAMETERS_DUMMY)
 
 
-def test_given_extra_covariates_are_present_in_dataframe_when_learner_fits_then_they_are_ignored(temp_model_path):
-    learner = TimeSeriesLearner(path_context=temp_model_path, known_covariates_names=["Y", "X"])
-    train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["X", "Y", "Z"])
-    with mock.patch("autogluon.timeseries.trainer.auto_trainer.AutoTimeSeriesTrainer.fit") as mock_fit:
-        learner.fit(train_data=train_data, hyperparameters=HYPERPARAMETERS_DUMMY)
-        passed_train = mock_fit.call_args[1]["train_data"]
-        assert len(passed_train.columns.symmetric_difference(["Y", "X", "target"])) == 0
-
-
 def test_given_known_covariates_have_non_numeric_dtypes_when_learner_fits_then_exception_is_raised(temp_model_path):
     learner = TimeSeriesLearner(path_context=temp_model_path, known_covariates_names=["Y", "Z", "X"])
-    train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["X", "Z", "Y"])
+    train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, covariates_names=["X", "Z", "Y"])
     train_data["Y"] = np.random.choice(["foo", "bar", "baz"], size=len(train_data)).astype("O")
     with pytest.raises(ValueError, match="must all have numeric \(float or int\) dtypes"):
         learner.fit(train_data=train_data, hyperparameters=HYPERPARAMETERS_DUMMY)
@@ -298,9 +289,11 @@ def test_given_expected_known_covariates_missing_from_data_when_learner_predicts
 ):
     prediction_length = 5
     learner = TimeSeriesLearner(
-        path_context=temp_model_path, known_covariates_names=["X", "Y"], prediction_length=prediction_length
+        path_context=temp_model_path,
+        known_covariates_names=["X", "Y"],
+        prediction_length=prediction_length,
     )
-    train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["Y", "X"])
+    train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, covariates_names=["Y", "X"])
     learner.fit(train_data=train_data, hyperparameters=HYPERPARAMETERS_DUMMY)
 
     pred_data = train_data.slice_by_timestep(None, -prediction_length)
@@ -315,10 +308,10 @@ def test_given_extra_covariates_are_present_in_dataframe_when_learner_predicts_t
     learner = TimeSeriesLearner(
         path_context=temp_model_path, known_covariates_names=["Y", "X"], prediction_length=prediction_length
     )
-    train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["Y", "X"])
+    train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, covariates_names=["Y", "X"])
     learner.fit(train_data=train_data, hyperparameters=HYPERPARAMETERS_DUMMY)
 
-    data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["Z", "Y", "X"])
+    data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, covariates_names=["Z", "Y", "X"])
     pred_data = data.slice_by_timestep(None, -prediction_length)
     known_covariates = data.slice_by_timestep(-prediction_length, None).drop("target", axis=1)
     with mock.patch("autogluon.timeseries.trainer.auto_trainer.AutoTimeSeriesTrainer.predict") as mock_predict:
@@ -337,17 +330,17 @@ def test_given_extra_items_and_timestamps_are_present_in_dataframe_when_learner_
     learner = TimeSeriesLearner(
         path_context=temp_model_path, known_covariates_names=["Y", "X"], prediction_length=prediction_length
     )
-    train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["Y", "X"])
+    train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, covariates_names=["Y", "X"])
     learner.fit(train_data=train_data, hyperparameters=HYPERPARAMETERS_DUMMY)
 
-    data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["Y", "X"])
+    data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, covariates_names=["Y", "X"])
     pred_data = data.slice_by_timestep(None, -prediction_length)
 
     # known_covariates includes additional item_ids and additional timestamps
     extended_item_id_to_length = {"D": 25, "E": 37, "F": 14}
     for item_id, length in ITEM_ID_TO_LENGTH.items():
         extended_item_id_to_length[item_id] = length + 7
-    extended_data = get_data_frame_with_variable_lengths(extended_item_id_to_length, known_covariates_names=["Y", "X"])
+    extended_data = get_data_frame_with_variable_lengths(extended_item_id_to_length, covariates_names=["Y", "X"])
     known_covariates = extended_data.drop("target", axis=1)
 
     with mock.patch("autogluon.timeseries.trainer.auto_trainer.AutoTimeSeriesTrainer.predict") as mock_predict:
@@ -371,10 +364,10 @@ def test_given_ignore_index_is_true_and_covariates_too_short_when_learner_predic
         prediction_length=prediction_length,
         ignore_time_index=True,
     )
-    train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["Y", "X"])
+    train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, covariates_names=["Y", "X"])
     learner.fit(train_data=train_data, hyperparameters=HYPERPARAMETERS_DUMMY)
     short_known_covariates = get_data_frame_with_variable_lengths(
-        {k: 4 for k in ITEM_ID_TO_LENGTH.keys()}, known_covariates_names=["X", "Y"]
+        {k: 4 for k in ITEM_ID_TO_LENGTH.keys()}, covariates_names=["X", "Y"]
     )
     with pytest.raises(ValueError, match=f"should include the values for prediction_length={prediction_length}"):
         learner.predict(train_data, known_covariates=short_known_covariates)
@@ -390,7 +383,7 @@ def test_when_ignore_index_is_true_and_known_covariates_available_then_learner_c
     )
     train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["Y", "X"])
     learner.fit(train_data=train_data, hyperparameters={"DeepAR": {"epochs": 1, "num_batches_per_epoch": 1}})
-    known_covariates = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["X", "Y"])
+    known_covariates = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, covariates_names=["X", "Y"])
     preds = learner.predict(train_data, known_covariates=known_covariates)
     assert preds.item_ids.equals(train_data.item_ids)
 
@@ -398,26 +391,32 @@ def test_when_ignore_index_is_true_and_known_covariates_available_then_learner_c
 @pytest.mark.parametrize("pred_data_present", [True, False])
 @pytest.mark.parametrize("static_features_present", [True, False])
 @pytest.mark.parametrize("known_covariates_present", [True, False])
+@pytest.mark.parametrize("past_covariates_present", [True, False])
 def test_when_train_data_has_static_or_dynamic_feat_then_leaderboard_works(
-    temp_model_path, pred_data_present, static_features_present, known_covariates_present
+    temp_model_path, pred_data_present, static_features_present, known_covariates_present, past_covariates_present
 ):
     if static_features_present:
         static_features = get_static_features(["B", "A"], feature_names=["f1", "f2"])
     else:
         static_features = None
 
+    covariates_names = []
     if known_covariates_present:
         known_covariates_names = ["X", "Y"]
+        covariates_names.extend(known_covariates_names)
     else:
         known_covariates_names = None
 
+    if past_covariates_present:
+        covariates_names.extend(["A", "B", "C"])
+
     train_data = get_data_frame_with_variable_lengths(
-        {"B": 20, "A": 15}, static_features=static_features, known_covariates_names=known_covariates_names
+        {"B": 20, "A": 15}, static_features=static_features, covariates_names=covariates_names
     )
 
     if pred_data_present:
         pred_data = get_data_frame_with_variable_lengths(
-            {"B": 20, "A": 15}, static_features=static_features, known_covariates_names=known_covariates_names
+            {"B": 20, "A": 15}, static_features=static_features, covariates_names=covariates_names
         )
     else:
         pred_data = None


### PR DESCRIPTION
*Description of changes:*
- Fix several bugs related to `past_covariates` handling
- Include documentation for `past_covariates`
- Add support for `past_covariates` and `known_covariates` to `AutoGluonTabular` model
- Add support for `past_covariates` to `TemporalFusionTransformerMXNet` model
- Add tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
