### PR TITLE
[eda] Line plots support for date-numeric feature interaction

### DIFF
--- a/eda/src/autogluon/eda/analysis/interaction.py
+++ b/eda/src/autogluon/eda/analysis/interaction.py
@@ -514,7 +514,9 @@ class FeatureDistanceAnalysis(AbstractAnalysis):
         return self.all_keys_must_be_present(args, "train_data", "label", "feature_generator")
 
     def _fit(self, state: AnalysisState, args: AnalysisState, **fit_kwargs) -> None:
-        x = args.train_data.drop(labels=[args.label], axis=1)
+        x = args.train_data
+        if args.label is not None:
+            x = x.drop(labels=[args.label], axis=1)
         corr = np.round(spearmanr(x).correlation, 4)
         np.fill_diagonal(corr, 1)
         corr_condensed = hc.distance.squareform(1 - np.nan_to_num(corr))

--- a/eda/src/autogluon/eda/analysis/transform.py
+++ b/eda/src/autogluon/eda/analysis/transform.py
@@ -77,7 +77,9 @@ class ApplyFeatureGenerator(AbstractAnalysis, StateCheckMixin):
         return self.all_keys_must_be_present(args, "train_data", "label")
 
     def _fit(self, state: AnalysisState, args: AnalysisState, **fit_kwargs) -> None:
-        x = args.train_data.drop(columns=args.label)
+        x = args.train_data
+        if args.label is not None:
+            x = x.drop(columns=args.label)
         self.feature_generator.fit(x)
         self.args["feature_generator"] = True
         for (ds, df) in self.available_datasets(args):

--- a/eda/src/autogluon/eda/visualization/interaction.py
+++ b/eda/src/autogluon/eda/visualization/interaction.py
@@ -8,7 +8,7 @@ import seaborn as sns
 from scipy import stats
 from scipy.cluster import hierarchy as hc
 
-from autogluon.common.features.types import R_BOOL, R_CATEGORY, R_FLOAT, R_INT, R_OBJECT
+from autogluon.common.features.types import R_BOOL, R_CATEGORY, R_DATETIME, R_FLOAT, R_INT, R_OBJECT
 
 from ..state import AnalysisState
 from .base import AbstractVisualization
@@ -356,6 +356,7 @@ class FeatureInteractionVisualization(AbstractVisualization, JupyterMixin):
             ("numeric", "category", "category"): self._KdePlotRenderer,
             ("numeric", "numeric", None): self._RegPlotRenderer,
             ("numeric", "numeric", "category"): self._ScatterPlotRenderer,
+            ("datetime", "numeric", None): self._LinePlotRenderer,
         }
         return types.get((x_type, y_type, hue_type), None)
 
@@ -368,6 +369,8 @@ class FeatureInteractionVisualization(AbstractVisualization, JupyterMixin):
             return "category"
         elif raw_type in [R_INT, R_FLOAT]:
             return "numeric"
+        elif raw_type in [R_DATETIME]:
+            return "datetime"
         elif raw_type in [R_OBJECT, R_CATEGORY, R_BOOL]:
             return "category"
         else:
@@ -432,3 +435,7 @@ class FeatureInteractionVisualization(AbstractVisualization, JupyterMixin):
     class _RegPlotRenderer(_AbstractFeatureInteractionPlotRenderer):
         def _render(self, state, ds, params, param_types, ax, data, chart_args):
             sns.regplot(ax=ax, data=data, **chart_args)
+
+    class _LinePlotRenderer(_AbstractFeatureInteractionPlotRenderer):
+        def _render(self, state, ds, params, param_types, ax, data, chart_args):
+            sns.lineplot(ax=ax, data=data, **chart_args)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Added line plots support for date-numeric feature interaction
- Fixed feature interaction issue when label is not provided (label is not used in the plot)

#### Example
```python
import autogluon.eda.auto as auto

auto.analyze_interaction(train_data=df_train, x='date', y='members_who_viewed')
```

![image](https://user-images.githubusercontent.com/10080307/212205650-8f2fec75-ffab-42e2-8434-b9f57a2cef25.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
