### PR TITLE
[timeseries] Bump pandas dependency to >=1.4.0

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -17,7 +17,7 @@ PYTHON_REQUIRES = '>=3.7, <3.11'
 DEPENDENT_PACKAGES = {
     # note: if python 3.7 is used, the open CVEs are present: CVE-2021-41496 | CVE-2021-34141; fixes are available in 1.22.x, but python 3.8 only
     'numpy': '>=1.21,<1.24',
-    'pandas': '>=1.2.5,!=1.4.0,<1.6',
+    'pandas': '>1.4.0,<1.6',
     'scikit-learn': '>=1.0.0,<1.2',
     'scipy': '>=1.5.4,<1.10.0',
     'psutil': '>=5.7.3,<6',

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -26,7 +26,7 @@ install_requires = [
     "joblib~=1.1",
     "numpy",
     "scipy",
-    "pandas",
+    "pandas>=1.4.0",
     "statsmodels~=0.13.0",
     "gluonts~=0.11.0",
     "torch>=1.9,<1.13",

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -26,7 +26,7 @@ install_requires = [
     "joblib~=1.1",
     "numpy",
     "scipy",
-    "pandas>=1.4.0",
+    "pandas",
     "statsmodels~=0.13.0",
     "gluonts~=0.11.0",
     "torch>=1.9,<1.13",


### PR DESCRIPTION
*Issue #, if available:* #2689, #2697

*Description of changes:*
- Ensure that the pandas version is >= 1.4.0 for [`GroupBy.nth`](https://pandas.pydata.org/docs/reference/api/pandas.core.groupby.GroupBy.nth.html) to work with `slice` objects. This is required for https://github.com/autogluon/autogluon/blob/master/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py#L572

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
