### PR TITLE
Lower-bound Pillow

### DIFF
--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -24,7 +24,7 @@ install_requires = [
     "scipy",
     "pandas",
     "scikit-learn",
-    "Pillow",
+    "Pillow>=9.1.0",
     "tqdm",
     "boto3",
     "requests",


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/autogluon/autogluon/issues/2707

*Description of changes:*
The PIL.Image.Resampling was added in Pillow 9.1.0. So added the lower-bound. Reference: https://stackoverflow.com/questions/71738218/module-pil-has-not-attribute-resampling


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
