### PR TITLE
[timeseries] Create an abstract class for time series ensembles

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/ensemble/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/ensemble/__init__.py
@@ -1,0 +1,2 @@
+from .abstract_timeseries_ensemble import AbstractTimeSeriesEnsembleModel
+from .greedy_ensemble import TimeSeriesGreedyEnsemble

--- a/timeseries/src/autogluon/timeseries/models/ensemble/abstract_timeseries_ensemble.py
+++ b/timeseries/src/autogluon/timeseries/models/ensemble/abstract_timeseries_ensemble.py
@@ -1,0 +1,58 @@
+import logging
+from typing import Dict, Optional
+
+from autogluon.core.utils.exceptions import TimeLimitExceeded
+from autogluon.timeseries.dataset import TimeSeriesDataFrame
+from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
+
+logger = logging.getLogger(__name__)
+
+
+class AbstractTimeSeriesEnsembleModel(AbstractTimeSeriesModel):
+    """Abstract class for time series ensemble models."""
+
+    def fit_ensemble(
+        self,
+        predictions: Dict[str, TimeSeriesDataFrame],
+        data: TimeSeriesDataFrame,
+        time_limit: Optional[int] = None,
+        **kwargs,
+    ):
+        """Fit ensemble model given predictions of candidate base models and the true data.
+
+        Parameters
+        ----------
+        predictions : Dict[str, TimeSeriesDataFrame]
+            Dictionary that maps the names of component models to their respective predictions as TimeSeriesDataFrames.
+        data : TimeSeriesDataFrame
+            Observed ground truth data used to train the ensemble. This includes both the forecast horizon (for which
+            the predictions are given in ``predictions``), as well as the "history".
+        time_limit : Optional[int]
+            Maximum allowed time for training in seconds.
+        """
+        if time_limit is not None and time_limit <= 0:
+            logger.warning(
+                f"\tWarning: Model has no time left to train, skipping model... (Time Left = {round(time_limit, 1)}s)"
+            )
+            raise TimeLimitExceeded
+        self._fit_ensemble(
+            predictions=predictions,
+            data=data,
+            time_limit=time_limit,
+        )
+        return self
+
+    def _fit_ensemble(
+        self,
+        predictions: Dict[str, TimeSeriesDataFrame],
+        data: TimeSeriesDataFrame,
+        time_limit: Optional[int] = None,
+        **kwargs,
+    ):
+        """Private method for `fit_ensemble`. See `fit_ensemble` for documentation of arguments. Apart from the model
+        training logic, `fit_ensemble` additionally implements other logic such as keeping track of the time limit.
+        """
+        raise NotImplementedError
+
+    def predict(self, data: Dict[str, TimeSeriesDataFrame], **kwargs) -> TimeSeriesDataFrame:
+        raise NotImplementedError

--- a/timeseries/src/autogluon/timeseries/models/ensemble/abstract_timeseries_ensemble.py
+++ b/timeseries/src/autogluon/timeseries/models/ensemble/abstract_timeseries_ensemble.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from autogluon.core.utils.exceptions import TimeLimitExceeded
 from autogluon.timeseries.dataset import TimeSeriesDataFrame
@@ -10,6 +10,11 @@ logger = logging.getLogger(__name__)
 
 class AbstractTimeSeriesEnsembleModel(AbstractTimeSeriesModel):
     """Abstract class for time series ensemble models."""
+
+    @property
+    def model_names(self) -> List[str]:
+        """Names of base models included in the ensemble."""
+        raise NotImplementedError
 
     def fit_ensemble(
         self,

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -18,7 +18,7 @@ from autogluon.core.utils.loaders import load_pkl
 from autogluon.core.utils.savers import save_json, save_pkl
 from autogluon.timeseries import TimeSeriesDataFrame, TimeSeriesEvaluator
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
-from autogluon.timeseries.models.ensemble.greedy_ensemble import TimeSeriesEnsembleSelection, TimeSeriesEnsembleWrapper
+from autogluon.timeseries.models.ensemble import AbstractTimeSeriesEnsembleModel, TimeSeriesGreedyEnsemble
 from autogluon.timeseries.models.gluonts.abstract_gluonts import AbstractGluonTSModel
 from autogluon.timeseries.models.presets import contains_searchspace
 from autogluon.timeseries.utils.features import CovariateMetadata
@@ -171,9 +171,6 @@ class SimpleAbstractTrainer:
             path = self.get_model_attribute(model=model_name, attribute="path")
         if model_type is None:
             model_type = self.get_model_attribute(model=model_name, attribute="type")
-        if model_type == TimeSeriesEnsembleWrapper:
-            # FIXME: Hack to avoid having to save/load
-            return self.get_model_attribute(model=model_name, attribute="model")
         return model_type.load(path=path, reset_paths=self.reset_paths)
 
     def construct_model_templates(self, hyperparameters: Union[str, Dict[str, Any]], **kwargs):
@@ -292,6 +289,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         self.metadata = kwargs.get("metadata", CovariateMetadata())
         self.is_data_saved = False
         self.enable_ensemble = enable_ensemble
+        self.ensemble_model_type = TimeSeriesGreedyEnsemble
 
         self.verbosity = verbosity
         set_logger_verbosity(self.verbosity, logger=logger)
@@ -350,12 +348,12 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
             The model to be added to the model graph.
         base_models : List[str], optional, default None
             If the model is an ensemble, the list of base model names that are included in the ensemble.
-            Expected only when ``model`` is a ``TimeSeriesEnsembleWrapper``.
+            Expected only when ``model`` is a ``AbstractTimeSeriesEnsembleModel``.
 
         Raises
         ------
         AssertionError
-            If ``base_models`` are provided and ``model`` is not a ``TimeSeriesEnsembleWrapper``.
+            If ``base_models`` are provided and ``model`` is not a ``AbstractTimeSeriesEnsembleModel``.
         """
         node_attrs = dict(
             path=model.path,
@@ -364,12 +362,10 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
             predict_time=model.predict_time,
             val_score=model.val_score,
         )
-        if isinstance(model, TimeSeriesEnsembleWrapper):
-            node_attrs.update({"model": model})
         self.model_graph.add_node(model.name, **node_attrs)
 
         if base_models:
-            assert isinstance(model, TimeSeriesEnsembleWrapper)
+            assert isinstance(model, AbstractTimeSeriesEnsembleModel)
             for base_model in base_models:
                 self.model_graph.add_edge(base_model, model.name)
 
@@ -683,12 +679,6 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
     def fit_ensemble(
         self, val_data: TimeSeriesDataFrame, model_names: List[str], time_limit: Optional[float] = None
     ) -> str:
-        evaluator = TimeSeriesEvaluator(
-            eval_metric=self.eval_metric,
-            prediction_length=self.prediction_length,
-            target_column=self.target,
-        )
-
         logger.info("Fitting simple weighted ensemble.")
 
         model_preds = {}
@@ -700,52 +690,42 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
             model_preds[model_name] = model.predict_for_scoring(data=val_data, quantile_levels=self.quantile_levels)
 
         time_start = time.time()
-
-        ensemble = TimeSeriesEnsembleSelection(
-            ensemble_size=100,
-            metric=evaluator,
-        )
-        predictions = [model_preds[p] for p in model_names]
-
-        ensemble.fit(
-            predictions=predictions,
-            labels=val_data,
-            time_limit=time_limit,
-        )
-
-        # FIXME: This is currently **extremely** hacky to simply get it working.
-        #  Align on design / API of ensembles after v0.5.
-        simple_ensemble = TimeSeriesEnsembleWrapper(
-            weights={model_names[i]: w for i, w in enumerate(ensemble.weights_) if w != 0},
+        ensemble = self.ensemble_model_type(
             name=self._get_ensemble_model_name(),
-            freq=val_data.freq,
-            prediction_length=self.prediction_length,
             eval_metric=self.eval_metric,
-            path=self.path,
             target=self.target,
-            quantiles=self.quantile_levels,
+            prediction_length=self.prediction_length,
+            path=self.path,
+            freq=val_data.freq,
+            quantile_levels=self.quantile_levels,
+            metadata=self.metadata,
         )
+        ensemble.fit_ensemble(predictions=model_preds, data=val_data, time_limit=time_limit)
         time_end = time.time()
-        simple_ensemble.fit_time = time_end - time_start
+        ensemble.fit_time = time_end - time_start
 
-        forecasts = simple_ensemble.predict({n: model_preds[n] for n in simple_ensemble.model_names})
-        simple_ensemble.val_score = evaluator(val_data, forecasts) * evaluator.coefficient
+        evaluator = TimeSeriesEvaluator(
+            eval_metric=self.eval_metric,
+            prediction_length=self.prediction_length,
+            target_column=self.target,
+        )
+        forecasts = ensemble.predict({n: model_preds[n] for n in ensemble.model_names})
+        ensemble.val_score = evaluator(val_data, forecasts) * evaluator.coefficient
 
         predict_time = 0
-        # FIXME: This is a hack, should instead leverage `predict_time_marginal` as in Tabular.
-        for m in simple_ensemble.model_names:
+        for m in ensemble.model_names:
             predict_time += self.get_model_attribute(model=m, attribute="predict_time")
-        simple_ensemble.predict_time = predict_time
+        ensemble.predict_time = predict_time
 
         self._log_scores_and_times(
-            val_score=simple_ensemble.val_score,
-            fit_time=simple_ensemble.fit_time,
-            predict_time=simple_ensemble.predict_time,
+            val_score=ensemble.val_score,
+            fit_time=ensemble.fit_time,
+            predict_time=ensemble.predict_time,
         )
 
-        self._add_model(model=simple_ensemble, base_models=simple_ensemble.model_names)
-        self.save_model(model=simple_ensemble)
-        return simple_ensemble.name
+        self._add_model(model=ensemble, base_models=ensemble.model_names)
+        self.save_model(model=ensemble)
+        return ensemble.name
 
     def leaderboard(self, data: Optional[TimeSeriesDataFrame] = None) -> pd.DataFrame:
         logger.debug("Generating leaderboard for all models trained")
@@ -848,7 +828,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         model = self._get_model_for_prediction(model)
         eval_metric = self.eval_metric if metric is None else metric
 
-        if isinstance(model, TimeSeriesEnsembleWrapper):
+        if isinstance(model, AbstractTimeSeriesEnsembleModel):
             evaluator = TimeSeriesEvaluator(
                 eval_metric=eval_metric,
                 prediction_length=self.prediction_length,

--- a/timeseries/tests/unittests/models/test_ensemble.py
+++ b/timeseries/tests/unittests/models/test_ensemble.py
@@ -1,7 +1,7 @@
 import pytest
 
 from autogluon.timeseries.models import ETSModel
-from autogluon.timeseries.models.ensemble.greedy_ensemble import TimeSeriesEnsembleWrapper
+from autogluon.timeseries.models.ensemble.greedy_ensemble import TimeSeriesGreedyEnsemble
 
 from ..common import DUMMY_TS_DATAFRAME
 
@@ -9,13 +9,15 @@ from ..common import DUMMY_TS_DATAFRAME
 def test_when_some_base_models_fail_during_prediction_then_ensemble_can_still_predict():
     ets = ETSModel(prediction_length=1, freq=DUMMY_TS_DATAFRAME.freq)
     ets.fit(train_data=DUMMY_TS_DATAFRAME, hyperparameters={"maxiter": 1, "seasonal": None})
-    ensemble = TimeSeriesEnsembleWrapper(weights={"ARIMA": 0.5, "ETS": 0.5}, name="WeightedEnsemble")
+    ensemble = TimeSeriesGreedyEnsemble(name="WeightedEnsemble")
+    ensemble.model_to_weight = {"ARIMA": 0.5, "ETS": 0.5}
     ets_preds = ets.predict(DUMMY_TS_DATAFRAME)
     ensemble_preds = ensemble.predict(data={"ARIMA": None, "ETS": ets_preds})
     assert (ets_preds.values == ensemble_preds.values).all()
 
 
 def test_when_all_base_models_fail_during_prediction_then_ensemble_raises_runtime_error():
-    ensemble = TimeSeriesEnsembleWrapper(weights={"ARIMA": 0.5, "ETS": 0.5}, name="WeightedEnsemble")
+    ensemble = TimeSeriesGreedyEnsemble(name="WeightedEnsemble")
+    ensemble.model_to_weight = {"ARIMA": 0.5, "ETS": 0.5}
     with pytest.raises(RuntimeError):
         ensemble.predict(data={"ARIMA": None, "ETS": None})


### PR DESCRIPTION
This PR lays the groundwork for the implementation of more sophisticated ensembling strategies for time series.

*Description of changes:*
- Introduce `AbstractTimeSeriesEnsembleModel` - base class implementing different ensembling strategies for time series models.
- Refactor and simplify the logic for fitting the simple greedy ensemble for time series.
  - Combine `SimpleTimeSeriesWeightedEnsemble` and `TimeSeriesEnsembleWrapper` into a single class -> `TimeSeriesGreedyEnsemble`
  - Simplify the logic in `AbstractTimeSeriesTrainer.fit_ensemble`.
  - Save ensemble to disk as a usual model instead of storing it inside the `model_graph`.
- Minor change: 10x speedup for `mean_wQuantileLoss` calculation using vectorization.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
