### PR TITLE
[timeseries] Remove deprecations scheduled for v0.7

### DIFF
--- a/timeseries/src/autogluon/timeseries/configs/presets_configs.py
+++ b/timeseries/src/autogluon/timeseries/configs/presets_configs.py
@@ -22,7 +22,4 @@ TIMESERIES_PRESETS_CONFIGS = dict(
     },
     medium_quality={"hyperparameters": "medium_quality"},
     fast_training={"hyperparameters": "local_only"},
-    # TODO: Remove deprecated presets below
-    good_quality={"hyperparameters": "medium_quality"},
-    low_quality={"hyperparameters": "local_only"},
 )

--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -545,8 +545,10 @@ class TimeSeriesDataFrame(pd.DataFrame):
                 2019-01-05       8
 
         """
-        if not isinstance(start_index, (int, None)) or not isinstance(end_index, (int, None)):
-            raise ValueError("start_index and end_index must be of type int or None")
+        if start_index is not None and not isinstance(start_index, int):
+            raise ValueError(f"start_index must be of type int or None (got {type(start_index)})")
+        if end_index is not None and not isinstance(end_index, int):
+            raise ValueError(f"end_index must be of type int or None (got {type(end_index)})")
 
         time_step_slice = slice(start_index, end_index)
         result = self.groupby(level=ITEMID, sort=False, as_index=False).nth(time_step_slice)

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -22,11 +22,6 @@ from autogluon.timeseries.utils.random import set_random_seed
 
 logger = logging.getLogger(__name__)
 
-DEPRECATED_PRESETS_TO_FALLBACK = {
-    "low_quality": "fast_training",
-    "good_quality": "high_quality",
-}
-
 SUPPORTED_FREQUENCIES = {"D", "W", "M", "Q", "A", "Y", "H", "T", "min", "S"}
 
 
@@ -459,14 +454,6 @@ class TimeSeriesPredictor:
         logger.info("================ TimeSeriesPredictor ================")
         logger.info("TimeSeriesPredictor.fit() called")
         if presets is not None:
-            if presets in DEPRECATED_PRESETS_TO_FALLBACK:
-                new_presets = DEPRECATED_PRESETS_TO_FALLBACK[presets]
-                warnings.warn(
-                    f"Presets {presets} are deprecated as of version 0.6.0. Please see the documentation for "
-                    f"TimeSeriesPredictor.fit for the list of available presets. "
-                    f"Falling back to presets='{new_presets}'."
-                )
-                presets = new_presets
             logger.info(f"Setting presets to: {presets}")
         logger.info("Fitting with arguments:")
         logger.info(f"{pprint.pformat(fit_args)}")
@@ -572,16 +559,15 @@ class TimeSeriesPredictor:
         """
         if "quantile_levels" in kwargs:
             warnings.warn(
-                "Passing `quantile_levels` as a keyword argument to `TimeSeriesPredictor.predict` is deprecated and "
-                "will be removed in v0.7. This might also lead to some models not working properly. "
-                "Please specify the desired quantile levels when creating the predictor as "
-                "`TimeSeriesPredictor(..., quantile_levels=quantile_levels)`.",
+                "Passing `quantile_levels` as a keyword argument to `TimeSeriesPredictor.predict` is deprecated as of "
+                "v0.7. This argument is ignored. Please specify the desired quantile levels when creating the "
+                "predictor as `TimeSeriesPredictor(..., quantile_levels=quantile_levels)`.",
                 category=DeprecationWarning,
             )
         if random_seed is not None:
             set_random_seed(random_seed)
         data = self._check_and_prepare_data_frame(data)
-        return self._learner.predict(data, known_covariates=known_covariates, model=model, **kwargs)
+        return self._learner.predict(data, known_covariates=known_covariates, model=model)
 
     def evaluate(self, data: Union[TimeSeriesDataFrame, pd.DataFrame], **kwargs):
         """Evaluate the performance for given dataset, computing the score determined by ``self.eval_metric``

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -564,10 +564,11 @@ class TimeSeriesPredictor:
                 "predictor as `TimeSeriesPredictor(..., quantile_levels=quantile_levels)`.",
                 category=DeprecationWarning,
             )
+            kwargs.pop("quantile_levels")
         if random_seed is not None:
             set_random_seed(random_seed)
         data = self._check_and_prepare_data_frame(data)
-        return self._learner.predict(data, known_covariates=known_covariates, model=model)
+        return self._learner.predict(data, known_covariates=known_covariates, model=model, **kwargs)
 
     def evaluate(self, data: Union[TimeSeriesDataFrame, pd.DataFrame], **kwargs):
         """Evaluate the performance for given dataset, computing the score determined by ``self.eval_metric``

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -614,7 +614,7 @@ def test_when_static_features_index_has_wrong_name_then_its_renamed_to_item_id()
 
 def test_when_dataset_sliced_by_time_then_static_features_are_correct():
     df = SAMPLE_TS_DATAFRAME_STATIC
-    dfv = df.subsequence(START_TIMESTAMP, START_TIMESTAMP + datetime.timedelta(days=1))
+    dfv = df.slice_by_time(START_TIMESTAMP, START_TIMESTAMP + datetime.timedelta(days=1))
 
     assert isinstance(dfv, TimeSeriesDataFrame)
     assert len(dfv) == 1 * len(dfv.item_ids)


### PR DESCRIPTION
*Description of changes:*
- Remove deprecated methods & presets from `autogluon.timeseries`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
