### PR TITLE
Cleanup lite flag

### DIFF
--- a/common/src/autogluon/common/utils/lite.py
+++ b/common/src/autogluon/common/utils/lite.py
@@ -1,4 +1,4 @@
-from .utils import get_autogluon_metadata
+from .utils import LITE_MODE
 
 
 def disable_if_lite_mode(ret=None):
@@ -7,8 +7,7 @@ def disable_if_lite_mode(ret=None):
             if callable(ret):
                 return ret(*args, **kwargs)
             return ret
-        metadata = get_autogluon_metadata()
-        if 'lite' in metadata and metadata['lite']:
+        if LITE_MODE:
             return do_nothing
         return func
     return inner

--- a/common/src/autogluon/common/utils/utils.py
+++ b/common/src/autogluon/common/utils/utils.py
@@ -7,7 +7,15 @@ import platform
 import sys
 from typing import Dict, Any
 
+from ..version import __version__
+try:
+    from ..version import __lite__
+except ImportError:
+    __lite__ = False
+
 logger = logging.getLogger(__name__)
+
+LITE_MODE: bool = __lite__ is not None and __lite__
 
 
 def setup_outputdir(path, warn_if_exist=True, create_dir=True, path_suffix=None):
@@ -72,8 +80,6 @@ def get_package_versions() -> Dict[str, str]:
 
 
 def get_autogluon_metadata() -> Dict[str, Any]:
-    from ..version import __version__, __lite__
-
     metadata = dict(
         system=platform.system(),
         version=f"{__version__}",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Clean up lite flag code
- Now we don't repeatedly call `get_autogluon_metadata` during autogluon import just to get the lite status
- Now developers don't need to re-run setup when pulling the lite commit to avoid crashing. We now wrap the `__lite__` import in a try/except.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
