### PR TITLE
[eda] Updates for quick-fit to include samples display

### DIFF
--- a/eda/src/autogluon/eda/analysis/interaction.py
+++ b/eda/src/autogluon/eda/analysis/interaction.py
@@ -104,7 +104,7 @@ class Correlation(AbstractAnalysis):
             if self.method == "phik":
                 state.correlations[ds] = df.phik_matrix(**self.args, verbose=False)
             else:
-                state.correlations[ds] = df.corr(method=self.method, **self.args)
+                state.correlations[ds] = df.corr(method=self.method, numeric_only=True, **self.args)
 
             if self.focus_field is not None and self.focus_field in state.correlations[ds].columns:
                 state.correlations_focus_field = self.focus_field

--- a/eda/src/autogluon/eda/state.py
+++ b/eda/src/autogluon/eda/state.py
@@ -85,3 +85,12 @@ class StateCheckMixin:
                 f'The following keys are missing: [{", ".join(keys_not_present)}]'
             )
         return can_handle
+
+
+def is_key_present_in_state(state, key):
+    path = state
+    for p in key.split("."):
+        if p not in path:
+            return False
+        path = path[p]
+    return True

--- a/eda/src/autogluon/eda/visualization/__init__.py
+++ b/eda/src/autogluon/eda/visualization/__init__.py
@@ -4,7 +4,13 @@ from .interaction import (
     CorrelationVisualization,
     FeatureInteractionVisualization,
 )
-from .layouts import MarkdownSectionComponent, SimpleHorizontalLayout, SimpleVerticalLinearLayout, TabLayout
+from .layouts import (
+    MarkdownSectionComponent,
+    PropertyRendererComponent,
+    SimpleHorizontalLayout,
+    SimpleVerticalLinearLayout,
+    TabLayout,
+)
 from .missing import MissingValues
 from .model import ConfusionMatrix, FeatureImportance, ModelLeaderboard, RegressionEvaluation
 from .shift import XShiftSummary

--- a/eda/src/autogluon/eda/visualization/layouts.py
+++ b/eda/src/autogluon/eda/visualization/layouts.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Union
 
 from IPython.display import display
 from ipywidgets import HBox, Layout, Output, Tab
@@ -7,7 +7,15 @@ from .. import AnalysisState
 from .base import AbstractVisualization
 from .jupyter import JupyterMixin
 
-__all__ = ["MarkdownSectionComponent", "SimpleVerticalLinearLayout", "SimpleHorizontalLayout", "TabLayout"]
+__all__ = [
+    "MarkdownSectionComponent",
+    "SimpleVerticalLinearLayout",
+    "SimpleHorizontalLayout",
+    "TabLayout",
+    "PropertyRendererComponent",
+]
+
+from ..state import is_key_present_in_state
 
 
 class SimpleVerticalLinearLayout(AbstractVisualization):
@@ -78,14 +86,70 @@ class MarkdownSectionComponent(AbstractVisualization, JupyterMixin):
     Render provided string as a Markdown cell.
     See `Jupyter Markdown cell <https://jupyter-notebook.readthedocs.io/en/stable/examples/Notebook/Working%20With%20Markdown%20Cells.html>`_
     documentation for details.
+
+    Parameters
+    ----------
+    markdown: str
+        markdown text to render
+    condition_fn: Optional[Callable], default = None
+        if specified, call the provided function with `state` arg. The function expected to return bool value
+    namespace: Optional[str], default = None
+        namespace to use; can be nested like `ns_a.ns_b.ns_c`
+
     """
 
-    def __init__(self, markdown: str, namespace: Optional[str] = None, **kwargs) -> None:
+    def __init__(
+        self, markdown: str, condition_fn: Optional[Callable] = None, namespace: Optional[str] = None, **kwargs
+    ) -> None:
+        """
+
+        Parameters
+        ----------
+        markdown
+        condition_fn
+        namespace
+        kwargs
+        """
         super().__init__(namespace, **kwargs)
         self.markdown = markdown
+        self.condition_fn = condition_fn
 
     def can_handle(self, state: AnalysisState) -> bool:
-        return True
+        return True if self.condition_fn is None else self.condition_fn(state)
 
     def _render(self, state: AnalysisState) -> None:
         self.render_markdown(self.markdown)
+
+
+class PropertyRendererComponent(AbstractVisualization, JupyterMixin):
+    """
+    Render component stored in `state`'s dot-separated path to property (i.e. `a.b` results in `state.a.b`)
+
+    Parameters
+    ----------
+    property: str
+        dot-separated path to property (i.e. `a.b` results in `state.a.b`)
+    transform_fn: Optional[Callable], default = None
+        if specified, call the provided function with the object extracted from `state`'s `property`.
+        Returned transformation is then passed into render function
+    namespace: Optional[str], default = None
+        namespace to use; can be nested like `ns_a.ns_b.ns_c`
+    """
+
+    def __init__(
+        self, property: str, transform_fn: Optional[Callable] = None, namespace: Optional[str] = None, **kwargs
+    ) -> None:
+        super().__init__(namespace, **kwargs)
+        self.property = property
+        self.transform_fn = transform_fn
+
+    def can_handle(self, state: AnalysisState) -> bool:
+        return is_key_present_in_state(state, self.property)
+
+    def _render(self, state: AnalysisState) -> None:
+        obj = state
+        for p in self.property.split("."):
+            obj = obj[p]
+        if self.transform_fn is not None:
+            obj = self.transform_fn(obj)
+        self.display_obj(obj)

--- a/eda/src/autogluon/eda/visualization/layouts.py
+++ b/eda/src/autogluon/eda/visualization/layouts.py
@@ -11,8 +11,8 @@ __all__ = [
     "MarkdownSectionComponent",
     "SimpleVerticalLinearLayout",
     "SimpleHorizontalLayout",
-    "TabLayout",
     "PropertyRendererComponent",
+    "TabLayout",
 ]
 
 from ..state import is_key_present_in_state

--- a/eda/src/autogluon/eda/visualization/model.py
+++ b/eda/src/autogluon/eda/visualization/model.py
@@ -217,7 +217,8 @@ class FeatureImportance(AbstractVisualization, JupyterMixin):
     def _render(self, state: AnalysisState) -> None:
         self.render_header_if_needed(state, "Feature Importance")
         importance = state.model_evaluation.importance
-        self.display_obj(importance)
+        with pd.option_context("display.max_rows", 100 if len(importance) <= 100 else 20):
+            self.display_obj(importance)
         if self.show_barplots:
             fig_args = self.fig_args.copy()
             if "figsize" not in fig_args:
@@ -269,4 +270,6 @@ class ModelLeaderboard(AbstractVisualization, JupyterMixin):
 
     def _render(self, state: AnalysisState) -> None:
         self.render_header_if_needed(state, "Model Leaderboard")
-        self.display_obj(state.model_evaluation.leaderboard)
+        df = state.model_evaluation.leaderboard
+        with pd.option_context("display.max_rows", 100 if len(df) <= 100 else 20):
+            self.display_obj(df)

--- a/eda/tests/unittests/auto/test_simple.py
+++ b/eda/tests/unittests/auto/test_simple.py
@@ -32,6 +32,7 @@ from autogluon.eda.visualization import (
     FeatureInteractionVisualization,
     MarkdownSectionComponent,
     ModelLeaderboard,
+    PropertyRendererComponent,
     RegressionEvaluation,
     XShiftSummary,
 )
@@ -125,6 +126,7 @@ def test_quick_fit(monkeypatch):
     call_reg_render = MagicMock()
     call_ldr_render = MagicMock()
     call_fi_render = MagicMock()
+    call_prc_render = MagicMock()
 
     with monkeypatch.context() as m:
         m.setattr(MarkdownSectionComponent, "render", call_md_render)
@@ -132,11 +134,13 @@ def test_quick_fit(monkeypatch):
         m.setattr(RegressionEvaluation, "render", call_reg_render)
         m.setattr(ModelLeaderboard, "render", call_ldr_render)
         m.setattr(FeatureImportance, "render", call_fi_render)
+        m.setattr(PropertyRendererComponent, "render", call_prc_render)
 
         with tempfile.TemporaryDirectory() as path:
             quick_fit(path=path, train_data=df_train, label="class")
 
-    assert call_md_render.call_count == 3
+    assert call_md_render.call_count == 7
+    assert call_prc_render.call_count == 2
     call_cm_render.assert_called_once()
     call_reg_render.assert_called_once()
     call_ldr_render.assert_called_once()

--- a/eda/tests/unittests/visualization/test_layouts.py
+++ b/eda/tests/unittests/visualization/test_layouts.py
@@ -1,0 +1,21 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from autogluon.eda import AnalysisState
+from autogluon.eda.visualization import PropertyRendererComponent
+
+
+@pytest.mark.parametrize("with_transform_fn, expected", [(True, "VALUE"), (False, "value")])
+def test_PropertyRendererComponent(with_transform_fn, expected):
+    state = AnalysisState({"some": {"prop": "value"}})
+    call_display_obj = MagicMock()
+
+    transform_fn = (lambda v: v.upper()) if with_transform_fn else None
+
+    viz = PropertyRendererComponent("some.prop", transform_fn=transform_fn)
+    viz.display_obj = call_display_obj
+
+    viz.render(state)
+
+    call_display_obj.assert_called_with(expected)


### PR DESCRIPTION
*Description of changes:*

### Minor components changes
- Added `PropertyRendererComponent` to enable simplified properties rendering stored in `state`:
  - The following component apply `transform_fn` to an object stored in `state.model_evaluation.highest_error` then render it (if the object present):
```python
PropertyRendererComponent("model_evaluation.highest_error", transform_fn=(lambda df: df.head(10))),
```
- `MarkdownSectionComponent` now supports `condition_fn` argument to enable conditional rendering:
```python
MarkdownSectionComponent(
    condition_fn=(lambda state: is_key_present_in_state(state, "model_evaluation.undecided")),
    markdown="Text to render",
),
```

### Updates for `quick-fit()`
- samples with the highest prediction error - candidates for inspection
- smaples with the least distance from the other class - candidates for labeling

<img width="947" alt="image" src="https://user-images.githubusercontent.com/10080307/213053910-c1b4c515-c7c4-41d1-9172-39243bcfc04f.png">




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
