### PR TITLE
Add predictor.predict_multi and predictor.predict_proba_multi

### DIFF
--- a/common/src/autogluon/common/savers/save_pkl.py
+++ b/common/src/autogluon/common/savers/save_pkl.py
@@ -38,7 +38,7 @@ def save_with_fn(path, object, pickle_fn, format=None, verbose=True, compression
     else:
         path_parent = os.path.dirname(path)
         if path_parent == '':
-            path_parent = '.'
+            path_parent = '.'  # Allows saving to working directory root without crashing
         os.makedirs(path_parent, exist_ok=True)
 
         if compression_fn_kwargs is None:

--- a/common/src/autogluon/common/savers/save_pkl.py
+++ b/common/src/autogluon/common/savers/save_pkl.py
@@ -36,7 +36,10 @@ def save_with_fn(path, object, pickle_fn, format=None, verbose=True, compression
     if format == 's3':
         save_s3(path, object, pickle_fn, verbose=verbose)
     else:
-        os.makedirs(os.path.dirname(path), exist_ok=True)
+        path_parent = os.path.dirname(path)
+        if path_parent == '':
+            path_parent = '.'
+        os.makedirs(path_parent, exist_ok=True)
 
         if compression_fn_kwargs is None:
             compression_fn_kwargs = {}

--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -260,7 +260,10 @@ def get_pred_from_proba_df(y_pred_proba, problem_type=BINARY):
 
 def get_pred_from_proba(y_pred_proba, problem_type=BINARY):
     if problem_type == BINARY:
-        y_pred = [1 if pred >= 0.5 else 0 for pred in y_pred_proba]
+        # Using > instead of >= to align with Pandas `.idxmax` logic which picks the left-most column during ties.
+        # If this is not done, then predictions can be inconsistent when converting in binary classification from multiclass-form pred_proba and
+        # binary-form pred_proba when the pred_proba is 0.5 for positive and negative classes.
+        y_pred = [1 if pred > 0.5 else 0 for pred in y_pred_proba]
     elif problem_type == REGRESSION:
         y_pred = y_pred_proba
     elif problem_type == QUANTILE:

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -195,31 +195,52 @@ class AbstractTabularLearner(AbstractLearner):
                 y_pred_proba = pd.Series(data=y_pred_proba, name=self.label, index=index)
         return y_pred_proba
 
-    # FIXME: bagged_mode isn't quite right, instead check if val data used
     def predict_proba_dict(self,
                            X: DataFrame = None,
                            models: List[str] = None,
-                           transform_features=True,
                            as_pandas=True,
                            as_multiclass=True,
+                           transform_features=True,
                            inverse_transform=True,
                            ) -> dict:
         """
         Returns a dictionary of prediction probabilities where the key is
         the model name and the value is the model's prediction probabilities on the data.
 
+        Note that this will generally be much faster than calling `self.predict_proba` separately for each model
+        because this method leverages the model dependency graph to avoid redundant computation.
+
         Parameters
         ----------
         X : DataFrame, default = None
             The data to predict on.
             If None:
-                If bagged mode is disabled, the validation data is used.
-                If bagged mode is enabled, the out-of-fold prediction probabilities are used.
+                If self.trainer.has_val, the validation data is used.
+                Else, the out-of-fold prediction probabilities are used.
         models : List[str], default = None
             The list of models to get predictions for.
             If None, all models that can infer are used.
-        # TODO: Finish docs
+        as_pandas : bool, default = True
+            Whether to return the output of each model as a pandas object (True) or numpy array (False).
+            Pandas object is a DataFrame if this is a multiclass problem or `as_multiclass=True`, otherwise it is a Series.
+            If the output is a DataFrame, the column order will be equivalent to `predictor.class_labels`.
+        as_multiclass : bool, default = True
+            Whether to return binary classification probabilities as if they were for multiclass classification.
+                Output will contain two columns, and if `as_pandas=True`, the column names will correspond to the binary class labels.
+                The columns will be the same order as `predictor.class_labels`.
+            If False, output will contain only 1 column for the positive class (get positive_class name via `predictor.positive_class`).
+            Only impacts output for binary classification problems.
+        transform_features : bool, default = True
+            If True, preprocesses data before predicting with models.
+            If False, skips global feature preprocessing.
+                This is useful to save on inference time if you have already called `data = predictor.transform_features(data)`.
+        inverse_transform : bool, default = True
+            If True, will return prediction probabilities in the original format.
+            If False (advanced), will return prediction probabilities in AutoGluon's internal format.
 
+        Returns
+        -------
+        Dictionary with model names as keys and model prediction probabilities as values.
         """
         trainer = self.load_trainer()
 
@@ -228,26 +249,49 @@ class AbstractTabularLearner(AbstractLearner):
         if X is not None and transform_features:
             X = self.transform_features(X)
         if X is None:
-            if trainer.bagged_mode:
+            if not trainer.has_val:
                 X = trainer.load_X()
-                model_pred_proba_dict = dict()
+                predict_proba_dict = dict()
                 for m in models:
-                    model_pred_proba_dict[m] = trainer.get_model_oof(m)
+                    predict_proba_dict[m] = trainer.get_model_oof(m)
             else:
                 X = trainer.load_X_val()
-                model_pred_proba_dict = trainer.get_model_pred_proba_dict(X=X, models=models, use_val_cache=True)
+                predict_proba_dict = trainer.get_model_pred_proba_dict(X=X, models=models, use_val_cache=True)
         else:
-            model_pred_proba_dict = trainer.get_model_pred_proba_dict(X=X, models=models)
+            predict_proba_dict = trainer.get_model_pred_proba_dict(X=X, models=models)
 
         if inverse_transform:
             # Inverse Transform labels
-            for m, pred_proba in model_pred_proba_dict.items():
-                model_pred_proba_dict[m] = self._inverse_transform_proba(y_pred_proba=pred_proba,
-                                                                         as_pandas=as_pandas,
-                                                                         as_multiclass=as_multiclass,
-                                                                         index=X.index,
-                                                                         inverse_transform=True)
-        return model_pred_proba_dict
+            for m, pred_proba in predict_proba_dict.items():
+                predict_proba_dict[m] = self._inverse_transform_proba(y_pred_proba=pred_proba,
+                                                                      as_pandas=as_pandas,
+                                                                      as_multiclass=as_multiclass,
+                                                                      index=X.index,
+                                                                      inverse_transform=True)
+        return predict_proba_dict
+
+    def predict_dict(self,
+                     X: DataFrame = None,
+                     models: List[str] = None,
+                     as_pandas=True,
+                     transform_features=True,
+                     inverse_transform=True) -> dict:
+        """
+        Identical to predict_proba_dict, except returns predictions instead of probabilities.
+        """
+        predict_proba_dict = self.predict_proba_dict(X=X,
+                                                     models=models,
+                                                     as_pandas=as_pandas,
+                                                     transform_features=transform_features,
+                                                     inverse_transform=inverse_transform)
+        predict_dict = {}
+        if as_pandas:
+            for m in predict_proba_dict:
+                predict_dict[m] = get_pred_from_proba_df(predict_proba_dict[m], problem_type=self.problem_type)
+        else:
+            for m in predict_proba_dict:
+                predict_dict[m] = get_pred_from_proba(predict_proba_dict[m], problem_type=self.problem_type)
+        return predict_dict
 
 
     def _validate_fit_input(self, X: DataFrame, **kwargs):

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -195,14 +195,14 @@ class AbstractTabularLearner(AbstractLearner):
                 y_pred_proba = pd.Series(data=y_pred_proba, name=self.label, index=index)
         return y_pred_proba
 
-    def predict_proba_dict(self,
-                           X: DataFrame = None,
-                           models: List[str] = None,
-                           as_pandas=True,
-                           as_multiclass=True,
-                           transform_features=True,
-                           inverse_transform=True,
-                           ) -> dict:
+    def predict_proba_multi(self,
+                            X: DataFrame = None,
+                            models: List[str] = None,
+                            as_pandas: bool = True,
+                            as_multiclass: bool = True,
+                            transform_features: bool = True,
+                            inverse_transform: bool = True,
+                            ) -> dict:
         """
         Returns a dictionary of prediction probabilities where the key is
         the model name and the value is the model's prediction probabilities on the data.
@@ -270,20 +270,20 @@ class AbstractTabularLearner(AbstractLearner):
                                                                       inverse_transform=True)
         return predict_proba_dict
 
-    def predict_dict(self,
-                     X: DataFrame = None,
-                     models: List[str] = None,
-                     as_pandas=True,
-                     transform_features=True,
-                     inverse_transform=True) -> dict:
+    def predict_multi(self,
+                      X: DataFrame = None,
+                      models: List[str] = None,
+                      as_pandas: bool = True,
+                      transform_features: bool = True,
+                      inverse_transform: bool = True) -> dict:
         """
-        Identical to predict_proba_dict, except returns predictions instead of probabilities.
+        Identical to predict_proba_multi, except returns predictions instead of probabilities.
         """
-        predict_proba_dict = self.predict_proba_dict(X=X,
-                                                     models=models,
-                                                     as_pandas=as_pandas,
-                                                     transform_features=transform_features,
-                                                     inverse_transform=inverse_transform)
+        predict_proba_dict = self.predict_proba_multi(X=X,
+                                                      models=models,
+                                                      as_pandas=as_pandas,
+                                                      transform_features=transform_features,
+                                                      inverse_transform=inverse_transform)
         predict_dict = {}
         if as_pandas:
             for m in predict_proba_dict:

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1619,6 +1619,16 @@ class TabularPredictor:
         return self._learner.leaderboard(X=data, extra_info=extra_info, extra_metrics=extra_metrics,
                                          only_pareto_frontier=only_pareto_frontier, skip_score=skip_score, silent=silent)
 
+    def get_model_pred_proba_dict(self, data=None, models=None, as_pandas=True, as_multiclass=True, inverse_transform=True):
+        # TODO: Add docs
+        model_pred_proba_dict = self._learner.predict_proba_dict(X=data,
+                                                                 models=models,
+                                                                 as_pandas=as_pandas,
+                                                                 as_multiclass=as_multiclass,
+                                                                 inverse_transform=inverse_transform,
+                                                                 )
+        return model_pred_proba_dict
+
     def fit_summary(self, verbosity=3, show_plot=False):
         """
         Output summary of information about models produced during `fit()`.

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1491,7 +1491,13 @@ class TabularPredictor:
         return self._learner.evaluate_predictions(y_true=y_true, y_pred=y_pred, sample_weight=sample_weight, silent=silent,
                                                   auxiliary_metrics=auxiliary_metrics, detailed_report=detailed_report)
 
-    def leaderboard(self, data=None, extra_info=False, extra_metrics=None, only_pareto_frontier=False, skip_score=False, silent=False) -> pd.DataFrame:
+    def leaderboard(self,
+                    data=None,
+                    extra_info: bool = False,
+                    extra_metrics: list = None,
+                    only_pareto_frontier: bool = False,
+                    skip_score: bool = False,
+                    silent: bool = False) -> pd.DataFrame:
         """
         Output summary of information about models produced during `fit()` as a :class:`pd.DataFrame`.
         Includes information on test and validation scores for all models, model training times, inference times, and stack levels.
@@ -1615,11 +1621,17 @@ class TabularPredictor:
         :class:`pd.DataFrame` of model performance summary information.
         """
         self._assert_is_fit('leaderboard')
-        data = self.__get_dataset(data) if data is not None else data
+        data = self.__get_dataset(data, allow_nan=True)
         return self._learner.leaderboard(X=data, extra_info=extra_info, extra_metrics=extra_metrics,
                                          only_pareto_frontier=only_pareto_frontier, skip_score=skip_score, silent=silent)
 
-    def predict_proba_dict(self, data=None, models=None, as_pandas=True, as_multiclass=True, transform_features=True, inverse_transform=True) -> dict:
+    def predict_proba_multi(self,
+                            data=None,
+                            models: List[str] = None,
+                            as_pandas: bool = True,
+                            as_multiclass: bool = True,
+                            transform_features: bool = True,
+                            inverse_transform: bool = True) -> dict:
         """
         Returns a dictionary of prediction probabilities where the key is
         the model name and the value is the model's prediction probabilities on the data.
@@ -1636,7 +1648,7 @@ class TabularPredictor:
 
         Parameters
         ----------
-        data : DataFrame, default = None
+        data : str or DataFrame, default = None
             The data to predict on.
             If None:
                 If self.trainer.has_val, the validation data is used.
@@ -1666,14 +1678,21 @@ class TabularPredictor:
         -------
         Dictionary with model names as keys and model prediction probabilities as values.
         """
-        return self._learner.predict_proba_dict(X=data,
-                                                models=models,
-                                                as_pandas=as_pandas,
-                                                as_multiclass=as_multiclass,
-                                                transform_features=transform_features,
-                                                inverse_transform=inverse_transform)
+        self._assert_is_fit('predict_proba_multi')
+        data = self.__get_dataset(data, allow_nan=True)
+        return self._learner.predict_proba_multi(X=data,
+                                                 models=models,
+                                                 as_pandas=as_pandas,
+                                                 as_multiclass=as_multiclass,
+                                                 transform_features=transform_features,
+                                                 inverse_transform=inverse_transform)
 
-    def predict_dict(self, data=None, models=None, as_pandas=True, transform_features=True, inverse_transform=True) -> dict:
+    def predict_multi(self,
+                      data=None,
+                      models: List[str] = None,
+                      as_pandas: bool = True,
+                      transform_features: bool = True,
+                      inverse_transform: bool = True) -> dict:
         """
         Returns a dictionary of predictions where the key is
         the model name and the value is the model's prediction probabilities on the data.
@@ -1714,11 +1733,13 @@ class TabularPredictor:
         -------
         Dictionary with model names as keys and model predictions as values.
         """
-        return self._learner.predict_dict(X=data,
-                                          models=models,
-                                          as_pandas=as_pandas,
-                                          transform_features=transform_features,
-                                          inverse_transform=inverse_transform)
+        self._assert_is_fit('predict_multi')
+        data = self.__get_dataset(data, allow_nan=True)
+        return self._learner.predict_multi(X=data,
+                                           models=models,
+                                           as_pandas=as_pandas,
+                                           transform_features=transform_features,
+                                           inverse_transform=inverse_transform)
 
     def fit_summary(self, verbosity=3, show_plot=False):
         """
@@ -1917,7 +1938,7 @@ class TabularPredictor:
 
         """
         self._assert_is_fit('transform_features')
-        data = self.__get_dataset(data) if data is not None else data
+        data = self.__get_dataset(data, allow_nan=True)
         return self._learner.get_inputs_to_stacker(dataset=data, model=model, base_models=base_models,
                                                    use_orig_features=return_original_features)
 
@@ -2057,7 +2078,7 @@ class TabularPredictor:
             'pXX_low': Lower end of XX% confidence interval for true feature importance score.
         """
         self._assert_is_fit('feature_importance')
-        data = self.__get_dataset(data) if data is not None else data
+        data = self.__get_dataset(data, allow_nan=True)
         if (data is None) and (not self._trainer.is_data_saved):
             raise AssertionError(
                 'No data was provided and there is no cached data to load for feature importance calculation. `cache_data=True` must be set in the `TabularPredictor` init `learner_kwargs` argument call to enable this functionality when data is not specified.')
@@ -2937,8 +2958,13 @@ class TabularPredictor:
             print(msg + ": " + str(results[key]))
 
     @staticmethod
-    def __get_dataset(data):
-        if isinstance(data, TabularDataset):
+    def __get_dataset(data, allow_nan: bool = False):
+        if data is None:
+            if allow_nan:
+                return data
+            else:
+                raise TypeError("data=None is invalid. data must be a TabularDataset or pandas.DataFrame or str file path to data")
+        elif isinstance(data, TabularDataset):
             return data
         elif isinstance(data, pd.DataFrame):
             return TabularDataset(data)

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -70,8 +70,8 @@ def test_tabular():
 
 def _assert_predict_dict_identical_to_predict(predictor, data):
     """Assert that predict_proba_dict and predict_dict are identical to looping calls to predict and predict_proba"""
-    predict_proba_dict = predictor.predict_proba_dict(data=data)
-    predict_dict = predictor.predict_dict(data=data)
+    predict_proba_dict = predictor.predict_proba_multi(data=data)
+    predict_dict = predictor.predict_multi(data=data)
     assert set(predictor.get_model_names()) == set(predict_proba_dict.keys())
     assert set(predictor.get_model_names()) == set(predict_dict.keys())
     for m in predictor.get_model_names():
@@ -258,7 +258,7 @@ def test_advanced_functionality_bagging():
     oof_pred_proba = predictor.get_oof_pred_proba()
     assert(len(oof_pred_proba) == len(train_data))
 
-    predict_proba_dict_oof = predictor.predict_proba_dict()
+    predict_proba_dict_oof = predictor.predict_proba_multi()
     for m in predictor.get_model_names():
         predict_proba_oof = predictor.get_oof_pred_proba(model=m)
         assert predict_proba_oof.equals(predict_proba_dict_oof[m])

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -68,6 +68,19 @@ def test_tabular():
     run_tabular_benchmark_toy(fit_args=fit_args)
 
 
+def _assert_predict_dict_identical_to_predict(predictor, data):
+    """Assert that predict_proba_dict and predict_dict are identical to looping calls to predict and predict_proba"""
+    predict_proba_dict = predictor.predict_proba_dict(data=data)
+    predict_dict = predictor.predict_dict(data=data)
+    assert set(predictor.get_model_names()) == set(predict_proba_dict.keys())
+    assert set(predictor.get_model_names()) == set(predict_dict.keys())
+    for m in predictor.get_model_names():
+        model_pred = predictor.predict(data, model=m)
+        model_pred_proba = predictor.predict_proba(data, model=m)
+        assert model_pred.equals(predict_dict[m])
+        assert model_pred_proba.equals(predict_proba_dict[m])
+
+
 def test_advanced_functionality():
     """
     Tests a bunch of advanced functionality, including when used in combination.
@@ -96,15 +109,7 @@ def test_advanced_functionality():
     leaderboard = predictor.leaderboard(data=test_data)
     extra_metrics = ['accuracy', 'roc_auc', 'log_loss']
     leaderboard_extra = predictor.leaderboard(data=test_data, extra_info=True, extra_metrics=extra_metrics)
-    predict_proba_dict = predictor.predict_proba_dict(data=test_data)
-    predict_dict = predictor.predict_dict(data=test_data)
-    assert set(predictor.get_model_names()) == set(predict_proba_dict.keys())
-    assert set(predictor.get_model_names()) == set(predict_dict.keys())
-    for m in predictor.get_model_names():  # Assert that predict_proba_dict and predict_dict are identical to looping calls to predict and predict_proba
-        model_pred = predictor.predict(test_data, model=m)
-        model_pred_proba = predictor.predict_proba(test_data, model=m)
-        assert model_pred.equals(predict_dict[m])
-        assert model_pred_proba.equals(predict_proba_dict[m])
+    _assert_predict_dict_identical_to_predict(predictor=predictor, data=test_data)
     assert set(predictor.get_model_names()) == set(leaderboard['model'])
     assert set(predictor.get_model_names()) == set(leaderboard_extra['model'])
     assert set(leaderboard_extra.columns).issuperset(set(leaderboard.columns))
@@ -248,15 +253,7 @@ def test_advanced_functionality_bagging():
     expected_num_models = 2
     assert(len(predictor.get_model_names()) == expected_num_models)
 
-    predict_proba_dict = predictor.predict_proba_dict(data=test_data)
-    predict_dict = predictor.predict_dict(data=test_data)
-    assert set(predictor.get_model_names()) == set(predict_proba_dict.keys())
-    assert set(predictor.get_model_names()) == set(predict_dict.keys())
-    for m in predictor.get_model_names():  # Assert that predict_proba_dict and predict_dict are identical to looping calls to predict and predict_proba
-        model_pred = predictor.predict(test_data, model=m)
-        model_pred_proba = predictor.predict_proba(test_data, model=m)
-        assert model_pred.equals(predict_dict[m])
-        assert model_pred_proba.equals(predict_proba_dict[m])
+    _assert_predict_dict_identical_to_predict(predictor=predictor, data=test_data)
 
     oof_pred_proba = predictor.get_oof_pred_proba()
     assert(len(oof_pred_proba) == len(train_data))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add predictor.predict_dict and predictor.predict_proba_dict
- This is an optimized way to get predictions for a list of models, faster than looping through predictor.predict or predictor.predict_proba
- Also serves as a clean way to vend per-model out-of-fold predictions, validation predictions, and test predictions for the purposes of more advanced logic (Meta-learning / Zero-shot HPO)
- Fixed inconsistency with predictions, now will round pred_proba ties to 0 instead of 1 always when converting proba to pred, previously if object was pandas DF we would round to 0 and if it was a pandas Series we would round to 1.
- Fixed bug in save_pkl where it would crash if saving file to working directory root.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
