### PR TITLE
[multimodal] avoid deepcopy of data_processors

### DIFF
--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -1768,7 +1768,7 @@ class MultiModalPredictor:
         else:  # called .fit() or .load()
             df_preprocessor = self._df_preprocessor
 
-        data_processors = copy.deepcopy(self._data_processors)
+        data_processors = copy.copy(self._data_processors)
         # For prediction data with no labels provided.
         if not requires_label:
             data_processors.pop(LABEL, None)


### PR DESCRIPTION
*Issue #, if available:*

Performing prediction on an image classification task wasted most of the time on preprocessing. See a complete breakdown below :

```
elapsed (preprocess): 42.2 ms
> elapsed (data_to_df): 0.3 ms
> elapsed (infer_column_types): 1.2 ms
> elapsed (deepcopy): 40.5 ms
elapsed (compute_xxx): 0.3 ms
elapsed (realtime_predict): 36.1 ms
```

, while total prediction time is 78.8 ms

*Description of changes:*

* avoid deepcopy of data_preprocessors in predict() function
* preprocess time reduced from 42.2 ms to 1.9 ms
* overall prediction time (image classification task) reduced from 78.8 ms to 39.7 ms

To reproduce
```python
import time
from autogluon.multimodal.utils.misc import shopee_dataset
from autogluon.multimodal import MultiModalPredictor

def main():
    download_dir = './ag_automm_tutorial_imgcls'
    train_data_byte, test_data_byte = shopee_dataset(download_dir, is_bytearray=True)
    model_path = f"./tmp/automm_shopee"
    predictor = MultiModalPredictor(label="label", path=model_path)
    # predictor.fit(
    #     train_data=train_data_byte, # you can use train_data_byte as well
    #     time_limit=30, # seconds
    # ) # you can trust the default config, e.g., we use a `swin_base_patch4_window7_224` model
    predictor = MultiModalPredictor.load(path=model_path)

    image_byte = test_data_byte.iloc[0]['image']
    avg = 0
    n = 100
    for _ in range(n):
        tic = time.time()
        y_pred = predictor.predict({'image': [image_byte]})
        t_ms = (time.time() - tic) * 1000
        print(f'elapsed: {t_ms:.1f} ms')
        avg += t_ms
    avg = avg/n
    print(f'Average: {avg:.1f} ms')

if __name__=="__main__":
    main()
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
