### PR TITLE
Remove usage of autogluon.vision in autogluon.tabular

### DIFF
--- a/core/src/autogluon/core/utils/try_import.py
+++ b/core/src/autogluon/core/utils/try_import.py
@@ -16,7 +16,6 @@ __all__ = [
     'try_import_torch',
     'try_import_d8',
     'try_import_autogluon_multimodal',
-    'try_import_autogluon_vision',
     'try_import_rapids_cuml',
     'try_import_imodels',
 ]
@@ -223,14 +222,6 @@ def try_import_autogluon_multimodal():
     except ImportError:
         raise ImportError("`import autogluon.multimodal` failed.\n"
                           f"A quick tip is to install via `pip install autogluon.multimodal=={__version__}`.\n")
-
-
-def try_import_autogluon_vision():
-    try:
-        import autogluon.vision
-    except ImportError:
-        raise ImportError("`import autogluon.vision` failed.\n"
-                          f"A quick tip is to install via `pip install autogluon.vision=={__version__}`.\n")
 
 
 def try_import_rapids_cuml():

--- a/tabular/src/autogluon/tabular/models/image_prediction/image_predictor.py
+++ b/tabular/src/autogluon/tabular/models/image_prediction/image_predictor.py
@@ -1,17 +1,12 @@
-
-from typing import Dict, Optional
 import logging
-import os
-import pickle
 
 import numpy as np
 import pandas as pd
 
 from autogluon.common.features.types import R_OBJECT, S_IMAGE_PATH
-from autogluon.common.utils.resource_utils import ResourceManager
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION, QUANTILE, SOFTCLASS
-from autogluon.core.models import AbstractModel
-from autogluon.core.utils import try_import_autogluon_vision
+
+from ..automm.automm_model import MultiModalPredictorModel
 
 logger = logging.getLogger(__name__)
 
@@ -19,19 +14,17 @@ logger = logging.getLogger(__name__)
 # FIXME: Avoid hard-coding 'image' column name
 # TODO: Handle multiple image columns?
 # TODO: Handle multiple images in a single image column?
-# TODO: Add regression support
-# TODO: refit_full does not work as expected: It won't use all data, will just split train data internally.
-class ImagePredictorModel(AbstractModel):
-    """Wrapper of autogluon.vision.ImagePredictor"""
-    nn_model_name = 'image_predictor'
-
+# TODO: Consider fully replacing with MultiModalPredictorModel
+#  first check if the null handling in this class provides value
+class ImagePredictorModel(MultiModalPredictorModel):
+    """
+    MultimodalPredictor that only uses image features.
+    Currently only supports 1 image column, with 1 image per sample.
+    Additionally has special null image handling to improve performance in the presence of null images (aka image path of '')
+        Note: null handling has not been compared to the built-in null handling of MultimodalPredictor yet.
+    """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._label_column_name = 'label'
-
-        # Whether to load inner model when loading. Set to None on init as it is only used during save/load
-        self._load_model = None
-
         self._internal_feature_map = None
         self._dummy_pred_proba = None  # Dummy value to predict if image is NaN
 
@@ -56,51 +49,13 @@ class ImagePredictorModel(AbstractModel):
         default_ag_args.update(extra_ag_args)
         return default_ag_args
 
-    def _preprocess(self, X, fit=False, **kwargs):
-        X = super()._preprocess(X, **kwargs)
-        if fit:
-            X_features = list(X.columns)
-            if len(X_features) != 1:
-                raise AssertionError(f'ImagePredictorModel only supports one image feature, but {len(X_features)} were given: {X_features}')
-            if X_features[0] != 'image':
-                self._internal_feature_map = {X_features[0]: 'image'}
-        if self._internal_feature_map:
-            X = X.rename(columns=self._internal_feature_map)
-        from autogluon.vision import ImageDataset
-        if isinstance(X, ImageDataset):
-            # Use normal DataFrame, otherwise can crash due to `class` attribute conflicts
-            X = pd.DataFrame(X)
-        return X
-
-    def _fit(self,
-             X: pd.DataFrame,
-             y: pd.Series,
-             X_val: Optional[pd.DataFrame] = None,
-             y_val: Optional[pd.Series] = None,
-             time_limit: Optional[int] = None,
-             sample_weight=None,
-             verbosity=2,
-             **kwargs):
-        try_import_autogluon_vision()
-        from autogluon.vision import ImagePredictor
-        params = self._get_model_params()
-
-        X = self.preprocess(X, fit=True)
-        if X_val is not None:
-            X_val = self.preprocess(X_val)
-
-        if sample_weight is not None:  # TODO: support
-            logger.log(15, "\tsample_weight not yet supported for ImagePredictorModel, this model will ignore them in training.")
-
-        X = X.reset_index(drop=True)
-        y = y.reset_index(drop=True)
-        if X_val is not None:
-            X_val = X_val.reset_index(drop=True)
-            y_val = y_val.reset_index(drop=True)
-        X[self._label_column_name] = y
-        if X_val is not None:
-            X_val[self._label_column_name] = y_val
-
+    def preprocess_fit(self, X, y, X_val=None, y_val=None, **kwargs):
+        X_features = list(X.columns)
+        if len(X_features) != 1:
+            raise AssertionError(f'ImagePredictorModel only supports one image feature, but {len(X_features)} were given: {X_features}')
+        if X_features[0] != 'image':
+            self._internal_feature_map = {X_features[0]: 'image'}
+        X, y, X_val, y_val = super().preprocess_fit(X=X, y=y, X_val=X_val, y_val=y_val, **kwargs)
         null_indices = X['image'] == ''
 
         # TODO: Consider some kind of weighting of the two options so there isn't a harsh cutoff at 50
@@ -113,36 +68,21 @@ class ImagePredictorModel(AbstractModel):
 
         if null_indices.sum() > 0:
             X = X[~null_indices]
+            y = y[~null_indices]
+
         if X_val is not None:
             null_indices_val = X_val['image'] == ''
             if null_indices_val.sum() > 0:
                 X_val = X_val[~null_indices_val]
+                y_val = y_val[~null_indices_val]
 
-        verbosity_image = max(0, verbosity - 1)
-        root_logger = logging.getLogger('autogluon')
-        root_log_level = root_logger.level
-        # TODO: ImagePredictor doesn't use problem_type in any way at present.
-        #  It also doesn't error or warn if problem_type is not one it expects.
-        self.model = ImagePredictor(
-            problem_type=self.problem_type,
-            path=self.path,
-            # eval_metric=self.eval_metric,  # TODO: multiclass/binary vision problem works only with accuracy, regression with rmse
-            verbosity=verbosity_image
-        )
+        return X, y, X_val, y_val
 
-        logger.log(15, f'\tHyperparameters: {params}')
-
-        # FIXME: ImagePredictor crashes if given float time_limit
-        if time_limit is not None:
-            time_limit = int(time_limit)
-
-        self.model.fit(train_data=X,
-                       tuning_data=X_val,
-                       time_limit=time_limit,
-                       hyperparameters=params,
-                       random_state=0)
-        # self.model.set_verbosity(verbosity)  # TODO: How to set verbosity of fit predictor?
-        root_logger.setLevel(root_log_level)  # Reset log level
+    def _preprocess(self, X, **kwargs):
+        X = super()._preprocess(X, **kwargs)
+        if self._internal_feature_map:
+            X = X.rename(columns=self._internal_feature_map)
+        return X
 
     def _predict_proba(self, X, **kwargs):
         X = self.preprocess(X, **kwargs)
@@ -183,61 +123,3 @@ class ImagePredictorModel(AbstractModel):
         else:
             raise NotImplementedError(f'Computing dummy pred_proba is not implemented for {self.problem_type}.')
         return pred_proba_mean
-
-    def _get_default_searchspace(self):
-        try_import_autogluon_vision()
-        from autogluon.vision.configs import presets_configs
-        searchspace = presets_configs.preset_image_predictor['good_quality_fast_inference']['hyperparameters']
-        return searchspace
-
-    def save(self, path: str = None, verbose=True) -> str:
-        self._load_model = self.model is not None
-        __model = self.model
-        self.model = None
-        # save this AbstractModel object without NN weights
-        path = super().save(path=path, verbose=verbose)
-        self.model = __model
-
-        if self._load_model:
-            image_nn_path = os.path.join(path, self.nn_model_name)
-            self.model.save(image_nn_path)
-            logger.log(15, f"\tSaved Image NN weights and model hyperparameters to '{image_nn_path}'.")
-        self._load_model = None
-        return path
-
-    @classmethod
-    def load(cls, path: str, reset_paths=True, verbose=True):
-        model = super().load(path=path, reset_paths=reset_paths, verbose=verbose)
-        if model._load_model:
-            try_import_autogluon_vision()
-            from autogluon.vision import ImagePredictor
-            model.model = ImagePredictor.load(os.path.join(path, cls.nn_model_name))
-        model._load_model = None
-        return model
-
-    def get_memory_size(self) -> int:
-        """Return the memory size by calculating the total number of parameters.
-
-        Returns
-        -------
-        memory_size
-            The total memory size in bytes.
-        """
-        return len(pickle.dumps(self.model._classifier, pickle.HIGHEST_PROTOCOL))
-
-    def _get_default_resources(self):
-        num_cpus = ResourceManager.get_cpu_count()
-        try_import_autogluon_vision()
-        from autogluon.vision import ImagePredictor
-        num_gpus = ImagePredictor._get_num_gpus_available()
-        return num_cpus, num_gpus
-
-    def get_minimum_resources(self, is_gpu_available=False) -> Dict[str, int]:
-        return {
-            'num_cpus': 1,
-            'num_gpus': 1,
-        }
-
-    def _more_tags(self):
-        # `can_refit_full=False` because ImagePredictor does not communicate how to train until the best epoch in refit_full.
-        return {'can_refit_full': False}

--- a/tabular/tests/unittests/models/test_image_predictor.py
+++ b/tabular/tests/unittests/models/test_image_predictor.py
@@ -5,13 +5,15 @@ from autogluon.tabular import TabularPredictor
 
 @pytest.mark.gpu
 def test_image_predictor_multiclass(fit_helper):
-    # Test ImagePredictor with Torch
-    from autogluon.vision import ImageDataset
-    train_data, _, test_data = ImageDataset.from_folders('https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
+    from autogluon.multimodal.utils.misc import shopee_dataset
+
+    download_dir = './automm_shopee_data_multiclass'
+    train_data, test_data = shopee_dataset(download_dir)
+    train_data = train_data.sample(100, random_state=0)  # Subsample for faster test
     feature_metadata = FeatureMetadata.from_df(train_data).add_special_types({'image': ['image_path']})
     predictor = TabularPredictor(label='label').fit(
         train_data=train_data,
-        hyperparameters={'AG_IMAGE_NN': {'epochs': 2, 'model': 'resnet18'}},
+        hyperparameters={'AG_IMAGE_NN': {"optimization.max_epochs": 1}},
         feature_metadata=feature_metadata
     )
     leaderboard = predictor.leaderboard(test_data)
@@ -20,13 +22,15 @@ def test_image_predictor_multiclass(fit_helper):
 
 @pytest.mark.gpu
 def test_image_predictor_regression(fit_helper):
-    # Test ImagePredictor with Torch
-    from autogluon.vision import ImageDataset
-    train_data, _, test_data = ImageDataset.from_folders('https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
+    from autogluon.multimodal.utils.misc import shopee_dataset
+
+    download_dir = './automm_shopee_data_regression'
+    train_data, test_data = shopee_dataset(download_dir)
+    train_data = train_data.sample(100, random_state=0)  # Subsample for faster test
     feature_metadata = FeatureMetadata.from_df(train_data).add_special_types({'image': ['image_path']})
     predictor = TabularPredictor(label='label', problem_type='regression').fit(
         train_data=train_data,
-        hyperparameters={'AG_IMAGE_NN': {'epochs': 2, 'model': 'resnet18'}},
+        hyperparameters={'AG_IMAGE_NN': {"optimization.max_epochs": 1}},
         feature_metadata=feature_metadata
     )
     leaderboard = predictor.leaderboard(test_data)


### PR DESCRIPTION
*Issue #, if available:*
#2694 

*Description of changes:*
- Remove usage of autogluon.vision in autogluon.tabular, switch to using autogluon.multimodal
- Not identical from prior functionality since previously Tabular was using the gluoncv backend of autogluon.vision.
- Note that the special null image handling logic has been preserved, can be revisited if it makes sense to remove.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
