### PR TITLE
Fix RF HPO n_estimators

### DIFF
--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -122,7 +122,10 @@ class RFModel(AbstractModel):
     def _estimate_memory_usage(self, X, **kwargs):
         params = self._get_model_params()
         n_estimators_final = params['n_estimators']
-        n_estimators_minimum = min(40, n_estimators_final)
+        if isinstance(n_estimators_final, int):
+            n_estimators_minimum = min(40, n_estimators_final)
+        else:  # if search space
+            n_estimators_minimum = 40
         num_trees_per_estimator = self._get_num_trees_per_estimator()
         bytes_per_estimator = num_trees_per_estimator * len(X) / 60000 * 1e6  # Underestimates by 3x on ExtraTrees
         expected_min_memory_usage = bytes_per_estimator * n_estimators_minimum


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Previously, if n_estimators was searched, it would error during HPO initialization due to a memory check causing a type error. Fixed by first checking the type during the type check.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
