### PR TITLE
[eda] LabelInsightsAnalysis/LabelInsightsVisualization - label column insights for classification and regression

### DIFF
--- a/eda/src/autogluon/eda/analysis/__init__.py
+++ b/eda/src/autogluon/eda/analysis/__init__.py
@@ -1,5 +1,13 @@
 from .base import Namespace
-from .dataset import Sampler, TrainValidationSplit
+from .dataset import (
+    LabelInsightsAnalysis,
+    ProblemTypeControl,
+    RawTypesAnalysis,
+    Sampler,
+    SpecialTypesAnalysis,
+    TrainValidationSplit,
+    VariableTypeAnalysis,
+)
 from .interaction import Correlation, CorrelationSignificance, DistributionFit, FeatureInteraction
 from .missing import MissingValuesAnalysis
 from .model import AutoGluonModelEvaluator, AutoGluonModelQuickFit

--- a/eda/src/autogluon/eda/analysis/dataset.py
+++ b/eda/src/autogluon/eda/analysis/dataset.py
@@ -399,9 +399,52 @@ class SpecialTypesAnalysis(AbstractAnalysis):
 
 
 class LabelInsightsAnalysis(AbstractAnalysis):
+    """
+     Analyze label for insights:
+
+     - classification: low cardinality classes detection
+     - classification: classes present in test data, but not in the train data
+     - regression: out-of-domain labels detection
+
+     Note: this Analysis requires `problem_type` present in state.
+     It can be detected/set via :py:class:`~autogluon.eda.analysis.dataset.ProblemTypeControl` component
+
+    Parameters
+     ----------
+     low_cardinality_classes_threshold: int, default = 50
+         Minimum class instances present in the dataset to consider marking a class as low-cardinality
+     regression_ood_threshold: float, default = 0.01
+         mark results as out-of-domain when test label range in regression task is beyond train data range + regression_ood_threshold margin,
+         This is performed because some algorithms can't extrapolate beyond training data.
+     parent: Optional[AbstractAnalysis], default = None
+         parent Analysis
+     children: Optional[List[AbstractAnalysis]], default None
+         wrapped analyses; these will receive sampled `args` during `fit` call
+     state: AnalysisState
+         state object to perform check on
+
+     Examples
+     --------
+     >>> import autogluon.eda.analysis as eda
+     >>> import autogluon.eda.visualization as viz
+     >>> import autogluon.eda.auto as auto
+     >>> auto.analyze(
+     >>> auto.analyze(train_data=..., test_data=..., label=..., anlz_facets=[
+     >>>     eda.dataset.ProblemTypeControl(),
+     >>>     eda.dataset.LabelInsightsAnalysis(low_cardinality_classes_threshold=50, regression_ood_threshold=0.01),
+     >>> ], viz_facets=[
+     >>>     viz.dataset.LabelInsightsVisualization()
+     >>> ])
+
+     See Also
+     --------
+     :py:class:`~autogluon.eda.analysis.dataset.ProblemTypeControl`
+     :py:class:`~autogluon.eda.visualization.dataset.LabelInsightsVisualization`
+
+    """
+
     def __init__(
         self,
-        problem_type: str = "auto",
         low_cardinality_classes_threshold: int = 50,
         regression_ood_threshold: float = 0.01,
         parent: Optional[AbstractAnalysis] = None,
@@ -412,10 +455,6 @@ class LabelInsightsAnalysis(AbstractAnalysis):
         super().__init__(parent, children, state, **kwargs)
         assert low_cardinality_classes_threshold > 0
         self.low_cardinality_classes_threshold = low_cardinality_classes_threshold
-
-        valid_problem_types = ["auto"] + PROBLEM_TYPES_REGRESSION + PROBLEM_TYPES_CLASSIFICATION
-        assert problem_type in valid_problem_types, f"Valid problem_type values include {valid_problem_types}"
-        self.problem_type = problem_type
 
         assert regression_ood_threshold >= 0, "regression_ood_threshold must be non-negative"
         self.regression_ood_threshold = regression_ood_threshold

--- a/eda/src/autogluon/eda/analysis/dataset.py
+++ b/eda/src/autogluon/eda/analysis/dataset.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
+import numpy as np
 import pandas as pd
 
 from autogluon.common.features.infer_types import get_type_group_map_special, get_type_map_raw
@@ -17,9 +18,17 @@ __all__ = [
     "SpecialTypesAnalysis",
     "VariableTypeAnalysis",
     "TrainValidationSplit",
+    "ProblemTypeControl",
+    "LabelInsightsAnalysis",
 ]
 
-from autogluon.core.constants import PROBLEM_TYPES_CLASSIFICATION, PROBLEM_TYPES_REGRESSION
+from autogluon.core.constants import (
+    BINARY,
+    MULTICLASS,
+    PROBLEM_TYPES_CLASSIFICATION,
+    PROBLEM_TYPES_REGRESSION,
+    REGRESSION,
+)
 from autogluon.core.utils import generate_train_test_split_combined, infer_problem_type
 
 
@@ -80,17 +89,53 @@ class Sampler(AbstractAnalysis):
                 self.args[ds] = df.sample(**{arg: self.sample}, random_state=0)
 
 
-class TrainValidationSplit(AbstractAnalysis):
+class ProblemTypeControl(AbstractAnalysis):
     """
-    This wrapper splits `train_data` into training and validation sets stored in `train_data` and `val_data` for the wrapped analyses.
-    The split is performed for datasets in `args` and passed to all `children` during `fit` call shadowing outer parameters.
-
+    Helper component to control problem type. Autodetect if `problem_type = 'auto'`.
 
     Parameters
     ----------
     problem_type: str, default = 'auto'
         problem type to use. Valid problem_type values include ['auto', 'binary', 'multiclass', 'regression', 'quantile', 'softclass']
         auto means it will be Auto-detected using AutoGluon methods.
+    parent: Optional[AbstractAnalysis], default = None
+        parent Analysis
+    children: Optional[List[AbstractAnalysis]], default None
+        wrapped analyses; these will receive sampled `args` during `fit` call
+    kwargs
+    """
+
+    def __init__(
+        self,
+        problem_type: str = "auto",
+        parent: Optional[AbstractAnalysis] = None,
+        children: Optional[List[AbstractAnalysis]] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(parent, children, **kwargs)
+        valid_problem_types = ["auto"] + PROBLEM_TYPES_REGRESSION + PROBLEM_TYPES_CLASSIFICATION
+        assert problem_type in valid_problem_types, f"Valid problem_type values include {valid_problem_types}"
+        self.problem_type = problem_type
+
+    def can_handle(self, state: AnalysisState, args: AnalysisState) -> bool:
+        return self.all_keys_must_be_present(args, "train_data", "label")
+
+    def _fit(self, state: AnalysisState, args: AnalysisState, **fit_kwargs) -> None:
+        if self.problem_type == "auto":
+            state.problem_type = infer_problem_type(args.train_data[args.label], silent=True)
+        else:
+            state.problem_type = self.problem_type
+
+
+class TrainValidationSplit(AbstractAnalysis):
+    """
+    This wrapper splits `train_data` into training and validation sets stored in `train_data` and `val_data` for the wrapped analyses.
+    The split is performed for datasets in `args` and passed to all `children` during `fit` call shadowing outer parameters.
+
+    This component requires :py:class:`~autogluon.eda.visualization.dataset.ProblemTypeControl` present in the analysis call to set `problem_type`.
+
+    Parameters
+    ----------
     val_size: float, default = 0.3
         fraction of training set to be assigned as validation set during the split.
     parent: Optional[AbstractAnalysis], default = None
@@ -109,12 +154,14 @@ class TrainValidationSplit(AbstractAnalysis):
     >>> df_train = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)), columns=list("ABCD"))
     >>> analysis = BaseAnalysis(train_data=df_train, label="D", children=[
     >>>         Namespace(namespace="ns_val_split_specified", children=[
+    >>>             ProblemTypeControl(),
     >>>             TrainValidationSplit(val_pct=0.4, children=[
     >>>                 # This analysis sees 60/40 split of df_train between train_data and val_data
     >>>                 SomeAnalysis()
     >>>             ])
     >>>         ]),
     >>>         Namespace(namespace="ns_val_split_default", children=[
+    >>>             ProblemTypeControl(),
     >>>             TrainValidationSplit(children=[
     >>>                 # This analysis sees 70/30 split (default) of df_train between train_data and val_data
     >>>                 SomeAnalysis()
@@ -129,12 +176,16 @@ class TrainValidationSplit(AbstractAnalysis):
     >>>
     >>> state = analysis.fit()
     >>>
+
+    See Also
+    --------
+    :py:class:`~autogluon.eda.visualization.dataset.ProblemTypeControl`
+
     """
 
     def __init__(
         self,
         val_size: float = 0.3,
-        problem_type: str = "auto",
         parent: Optional[AbstractAnalysis] = None,
         children: Optional[List[AbstractAnalysis]] = None,
         **kwargs,
@@ -144,23 +195,15 @@ class TrainValidationSplit(AbstractAnalysis):
         assert 0 < val_size < 1.0, "val_size must be between 0 and 1"
         self.val_size = val_size
 
-        valid_problem_types = ["auto"] + PROBLEM_TYPES_REGRESSION + PROBLEM_TYPES_CLASSIFICATION
-        assert problem_type in valid_problem_types, f"Valid problem_type values include {valid_problem_types}"
-        self.problem_type = problem_type
-
     def can_handle(self, state: AnalysisState, args: AnalysisState) -> bool:
-        return self.all_keys_must_be_present(args, "train_data", "label")
+        return self.all_keys_must_be_present(state, "problem_type")
 
     def _fit(self, state: AnalysisState, args: AnalysisState, **fit_kwargs) -> None:
-        problem_type = self.problem_type
-        if problem_type == "auto":
-            problem_type = infer_problem_type(args.train_data[args.label], silent=True)
         train_data, val_data = generate_train_test_split_combined(
-            args.train_data, args.label, problem_type, test_size=self.val_size, **self.args
+            args.train_data, args.label, state.problem_type, test_size=self.val_size, **self.args
         )
         self.args["train_data"] = train_data
         self.args["val_data"] = val_data
-        state["problem_type"] = problem_type
 
 
 class DatasetSummary(AbstractAnalysis):
@@ -353,3 +396,79 @@ class SpecialTypesAnalysis(AbstractAnalysis):
         for col, types in special_types.items():
             result[col] = ", ".join(sorted(types))
         return result
+
+
+class LabelInsightsAnalysis(AbstractAnalysis):
+    def __init__(
+        self,
+        problem_type: str = "auto",
+        low_cardinality_classes_threshold: int = 50,
+        regression_ood_threshold: float = 0.01,
+        parent: Optional[AbstractAnalysis] = None,
+        children: Optional[List[AbstractAnalysis]] = None,
+        state: Optional[AnalysisState] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(parent, children, state, **kwargs)
+        assert low_cardinality_classes_threshold > 0
+        self.low_cardinality_classes_threshold = low_cardinality_classes_threshold
+
+        valid_problem_types = ["auto"] + PROBLEM_TYPES_REGRESSION + PROBLEM_TYPES_CLASSIFICATION
+        assert problem_type in valid_problem_types, f"Valid problem_type values include {valid_problem_types}"
+        self.problem_type = problem_type
+
+        assert regression_ood_threshold >= 0, "regression_ood_threshold must be non-negative"
+        self.regression_ood_threshold = regression_ood_threshold
+
+    def can_handle(self, state: AnalysisState, args: AnalysisState) -> bool:
+        return self.all_keys_must_be_present(args, "train_data", "label") and self.all_keys_must_be_present(
+            state, "problem_type"
+        )
+
+    def _fit(self, state: AnalysisState, args: AnalysisState, **fit_kwargs) -> None:
+        label = args.label
+        train_data = args.train_data
+
+        s: Dict[str, Any] = {}
+
+        if state.problem_type in [BINARY, MULTICLASS]:
+            # Low-cardinality class
+            label_counts = train_data[label].value_counts()
+            label_counts = label_counts[label_counts < self.low_cardinality_classes_threshold].to_dict()
+            if len(label_counts) > 0:
+                s["low_cardinality_classes"] = {
+                    "instances": label_counts,
+                    "threshold": self.low_cardinality_classes_threshold,
+                }
+
+            # TODO: class imbalance
+
+            #  Classes not found in test_data
+            if self._test_data_with_label_present(args, label):
+                train_labels = set(train_data[label].unique())
+                test_labels = set(args.test_data[label].unique())
+                if sorted(train_labels) != sorted(test_labels):
+                    missing_classes = test_labels.difference(train_labels)
+                    s["not_present_in_train"] = missing_classes
+        elif (state.problem_type in [REGRESSION]) and self._test_data_with_label_present(args, label):
+            # Out-of-domain range detection
+            test_data = args.test_data
+            label_min, label_max = np.min(train_data[label]), np.max(train_data[label])
+            padding = np.abs(label_max - label_min) * self.regression_ood_threshold
+            df_ood = args.test_data[
+                (test_data[label] < label_min - padding) | (test_data[label] > label_max + padding)
+            ]
+            # from pdb import set_trace; set_trace()
+
+            if len(df_ood) > 0:
+                s["ood"] = {
+                    "count": len(df_ood),
+                    "train_range": [label_min, label_max],
+                    "test_range": [np.min(test_data[label]), np.max(test_data[label])],
+                    "threshold": self.regression_ood_threshold,
+                }
+        if len(s) > 0:
+            state.label_insights = s
+
+    def _test_data_with_label_present(self, args, label):
+        return (args.test_data is not None) and (label in args.test_data.columns)

--- a/eda/src/autogluon/eda/auto/simple.py
+++ b/eda/src/autogluon/eda/auto/simple.py
@@ -512,7 +512,7 @@ def dataset_overview(
                 anlz_facets=[FeatureInteraction(key=f"{nodes[0]}:{n}", x=nodes[0], y=n) for n in nodes[1:]],
                 viz_facets=[
                     MarkdownSectionComponent(
-                        f'### Near duplicate group analysis: `{"`, `".join(nodes)}` - distance `{group["distance"]}`'
+                        f'### Near duplicate group analysis: `{"`, `".join(nodes)}` - distance `{group["distance"]:.4f}`'
                     ),
                     *[FeatureInteractionVisualization(headers=True, key=f"{nodes[0]}:{n}") for n in nodes[1:]],
                 ],

--- a/eda/src/autogluon/eda/visualization/__init__.py
+++ b/eda/src/autogluon/eda/visualization/__init__.py
@@ -1,4 +1,4 @@
-from .dataset import DatasetStatistics, DatasetTypeMismatch
+from .dataset import DatasetStatistics, DatasetTypeMismatch, LabelInsightsVisualization
 from .interaction import (
     CorrelationSignificanceVisualization,
     CorrelationVisualization,

--- a/eda/src/autogluon/eda/visualization/dataset.py
+++ b/eda/src/autogluon/eda/visualization/dataset.py
@@ -182,6 +182,41 @@ class DatasetTypeMismatch(AbstractVisualization, JupyterMixin):
 
 
 class LabelInsightsVisualization(AbstractVisualization, JupyterMixin):
+    """
+    Render label insights performed by :py:class:`~autogluon.eda.analysis.dataset.LabelInsightsAnalysis`.
+
+    The following insights can be rendered:
+
+    - classification: low cardinality classes detection
+    - classification: classes present in test data, but not in the train data
+    - regression: out-of-domain labels detection
+
+    Examples
+    --------
+    >>> import autogluon.eda.analysis as eda
+    >>> import autogluon.eda.visualization as viz
+    >>> import autogluon.eda.auto as auto
+    >>> auto.analyze(
+    >>> auto.analyze(train_data=..., test_data=..., label=..., anlz_facets=[
+    >>>     eda.dataset.ProblemTypeControl(),
+    >>>     eda.dataset.LabelInsightsAnalysis(low_cardinality_classes_threshold=50, regression_ood_threshold=0.01),
+    >>> ], viz_facets=[
+    >>>     viz.dataset.LabelInsightsVisualization()
+    >>> ])
+
+    Parameters
+    ----------
+    headers: bool, default = False
+        if `True` then render headers
+    namespace: str, default = None
+        namespace to use; can be nested like `ns_a.ns_b.ns_c`
+
+    See Also
+    --------
+    :py:class:`~autogluon.eda.analysis.dataset.ProblemTypeControl`
+    :py:class:`~autogluon.eda.analysis.dataset.LabelInsightsAnalysis`
+    """
+
     def __init__(self, headers: bool = False, namespace: Optional[str] = None, **kwargs) -> None:
         super().__init__(namespace, **kwargs)
         self.headers = headers

--- a/eda/tests/unittests/analysis/test_model.py
+++ b/eda/tests/unittests/analysis/test_model.py
@@ -81,6 +81,7 @@ def test_AutoGluonModelQuickFit(save_model_to_state):
             label=target_col,
             return_state=True,
             anlz_facets=[
+                eda.dataset.ProblemTypeControl(),
                 eda.dataset.TrainValidationSplit(
                     children=[
                         eda.model.AutoGluonModelQuickFit(
@@ -97,7 +98,7 @@ def test_AutoGluonModelQuickFit(save_model_to_state):
                             children=[eda.model.AutoGluonModelEvaluator()],
                         )
                     ]
-                )
+                ),
             ],
         )
 

--- a/eda/tests/unittests/auto/test_simple.py
+++ b/eda/tests/unittests/auto/test_simple.py
@@ -30,6 +30,7 @@ from autogluon.eda.visualization import (
     DatasetTypeMismatch,
     FeatureImportance,
     FeatureInteractionVisualization,
+    LabelInsightsVisualization,
     MarkdownSectionComponent,
     ModelLeaderboard,
     PropertyRendererComponent,
@@ -295,17 +296,20 @@ def test_target_analysis__classification(monkeypatch):
     call_ds_render = MagicMock()
     call_cv_render = MagicMock()
     call_fiv_render = MagicMock()
+    call_liv_render = MagicMock()
     with monkeypatch.context() as m:
         m.setattr(MarkdownSectionComponent, "render_markdown", call_md_render)
         m.setattr(DatasetStatistics, "render", call_ds_render)
         m.setattr(CorrelationVisualization, "render", call_cv_render)
         m.setattr(FeatureInteractionVisualization, "render", call_fiv_render)
+        m.setattr(LabelInsightsVisualization, "render", call_liv_render)
 
         state = target_analysis(train_data=df_train, label="class", return_state=True)
 
     call_md_render.assert_has_calls(
         [
             call("## Target variable analysis"),
+            call("### Label Insights"),
             call(
                 "### Target variable correlations\n"
                 " - absolute correlation greater than `0.5` found for target variable `class`"
@@ -314,6 +318,7 @@ def test_target_analysis__classification(monkeypatch):
     )
     call_ds_render.assert_called_once()
     call_cv_render.assert_called_once()
+    call_liv_render.assert_called_once()
     assert call_fiv_render.call_count == 2
     assert sorted(set(state.keys())) == [
         "correlations",
@@ -323,7 +328,9 @@ def test_target_analysis__classification(monkeypatch):
         "correlations_method",
         "dataset_stats",
         "interactions",
+        "label_insights",
         "missing_statistics",
+        "problem_type",
         "raw_type",
         "special_types",
         "variable_type",
@@ -341,11 +348,13 @@ def test_target_analysis__regression(monkeypatch):
     call_ds_render = MagicMock()
     call_cv_render = MagicMock()
     call_fiv_render = MagicMock()
+    call_liv_render = MagicMock()
     with monkeypatch.context() as m:
         m.setattr(MarkdownSectionComponent, "render_markdown", call_md_render)
         m.setattr(DatasetStatistics, "render", call_ds_render)
         m.setattr(CorrelationVisualization, "render", call_cv_render)
         m.setattr(FeatureInteractionVisualization, "render", call_fiv_render)
+        m.setattr(LabelInsightsVisualization, "render", call_liv_render)
 
         state = target_analysis(train_data=df_train, label="fnlwgt", return_state=True)
 
@@ -379,6 +388,7 @@ def test_target_analysis__regression(monkeypatch):
     call_ds_render.assert_called_once()
     call_cv_render.assert_called_once()
     call_fiv_render.assert_called_once()
+    call_liv_render.assert_called_once()
     assert sorted(set(state.keys())) == [
         "correlations",
         "correlations_focus_field",
@@ -390,6 +400,7 @@ def test_target_analysis__regression(monkeypatch):
         "distributions_fit_pvalue_min",
         "interactions",
         "missing_statistics",
+        "problem_type",
         "raw_type",
         "special_types",
         "variable_type",

--- a/eda/tests/unittests/auto/test_simple.py
+++ b/eda/tests/unittests/auto/test_simple.py
@@ -170,7 +170,7 @@ def test_dataset_overview(monkeypatch):
     call_md_render.assert_has_calls(
         [
             call("### Feature Distance"),
-            call("### Near duplicate group analysis: `education-num`, `near_duplicate` - distance `0.0`"),
+            call("### Near duplicate group analysis: `education-num`, `near_duplicate` - distance `0.0000`"),
         ]
     )
     call_ds_render.assert_called_once()

--- a/eda/tests/unittests/visualization/test_dataset.py
+++ b/eda/tests/unittests/visualization/test_dataset.py
@@ -1,9 +1,51 @@
+import os
+from unittest.mock import ANY, MagicMock
+
 import numpy as np
 import pandas as pd
 import pytest
+from numpy import dtype
 
 from autogluon.eda import AnalysisState
-from autogluon.eda.visualization import DatasetStatistics
+from autogluon.eda.analysis import MissingValuesAnalysis, RawTypesAnalysis, SpecialTypesAnalysis, VariableTypeAnalysis
+from autogluon.eda.analysis.dataset import DatasetSummary
+from autogluon.eda.auto import analyze
+from autogluon.eda.visualization import DatasetStatistics, DatasetTypeMismatch, LabelInsightsVisualization
+
+RESOURCE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "resources"))
+
+
+def test_DatasetStatistics():
+    train_data = pd.read_csv(os.path.join(RESOURCE_PATH, "adult", "train_data.csv"))[["education", "class"]]
+
+    viz = DatasetStatistics()
+    viz.display_obj = MagicMock()
+
+    analyze(
+        train_data=train_data,
+        label="class",
+        anlz_facets=[
+            DatasetSummary(),
+            RawTypesAnalysis(),
+            VariableTypeAnalysis(),
+            SpecialTypesAnalysis(),
+            MissingValuesAnalysis(),
+        ],
+        viz_facets=[viz],
+    )
+
+    assert viz.display_obj.call_args.args[0].to_dict() == {
+        "count": {"class": 200, "education": 200},
+        "dtypes": {"class": dtype("O"), "education": dtype("O")},
+        "freq": {"class": 154, "education": 59},
+        "missing_count": {"class": "", "education": ""},
+        "missing_ratio": {"class": "", "education": ""},
+        "raw_type": {"class": "object", "education": "object"},
+        "special_types": {"class": "", "education": ""},
+        "top": {"class": " <=50K", "education": " HS-grad"},
+        "unique": {"class": 2, "education": 14},
+        "variable_type": {"class": "category", "education": "category"},
+    }
 
 
 @pytest.mark.parametrize(
@@ -16,7 +58,7 @@ from autogluon.eda.visualization import DatasetStatistics
         ("unknown_type", False),
     ],
 )
-def test_DatasetStatistics(state_present, expected):
+def test_DatasetStatistics__can_handle(state_present, expected):
     assert DatasetStatistics().can_handle(AnalysisState({state_present: ""})) is expected
 
 
@@ -71,3 +113,89 @@ def test__fix_counts():
     )
     expected_out = {"a": {0: 1, 1: ""}, "b": {0: 1.0, 1: "--NA--"}, "c": {0: 1, 1: ""}, "d": {0: 1, 1: 2}}
     assert DatasetStatistics._fix_counts(df, cols=["a", "c", "d"]).fillna("--NA--").to_dict() == expected_out
+
+
+def test_DatasetTypeMismatch():
+    df_train = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+    df_test = pd.DataFrame({"x": ["1", "2", "3"], "y": [4, 5, 6]})
+
+    viz = DatasetTypeMismatch()
+    viz.render_header_if_needed = MagicMock()
+    viz.display_obj = MagicMock()
+
+    analyze(train_data=df_train, test_data=df_test, anlz_facets=[RawTypesAnalysis()], viz_facets=[viz])
+
+    viz.render_header_if_needed.assert_called_with(ANY, "Types warnings summary")
+    assert viz.display_obj.call_args.args[0].to_dict() == {
+        "test_data": {"x": "object"},
+        "train_data": {"x": "int"},
+        "warnings": {"x": "warning"},
+    }
+
+
+def test_DatasetTypeMismatch__no_warnings():
+    df_train = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+
+    viz = DatasetTypeMismatch()
+    viz.render_header_if_needed = MagicMock()
+    viz.display_obj = MagicMock()
+    analyze(train_data=df_train, test_data=df_train, anlz_facets=[RawTypesAnalysis()], viz_facets=[viz])
+
+    viz.render_header_if_needed.assert_not_called()
+    viz.display_obj.assert_not_called()
+
+
+def test_LabelInsightsVisualization():
+    state = AnalysisState(
+        {
+            "label_insights": {
+                "low_cardinality_classes": {
+                    "instances": {"A": 10, "B": 20},
+                    "threshold": 50,
+                },
+                "not_present_in_train": [1, "2", True],
+                "ood": {
+                    "count": 100,
+                    "train_range": [10, 100],
+                    "test_range": [10, 50],
+                },
+            }
+        }
+    )
+    viz = LabelInsightsVisualization()
+    viz.render_header_if_needed = MagicMock()
+    viz.render_markdown = MagicMock()
+
+    viz.render(state)
+
+    viz.render_header_if_needed.assert_called_with(state, "Label insights")
+    viz.render_markdown.assert_called_with(
+        " - Low-cardinality classes are detected. It is recommended to have at least "
+        "`50` instances per class. Consider adding more data to cover the classes or "
+        "remove such rows.\n"
+        "   - class `A`: `10` instances\n"
+        "   - class `B`: `20` instances\n"
+        " - the following classes are found in `test_data`, but not present in "
+        "`train_data`: `1`, `2`, `True`. Consider either removing the rows with "
+        "classes not covered or adding more training data covering the classes.\n"
+        " - Rows with out-of-domain labels were found. Consider removing rows with "
+        "labels outside of this range or expand training data since some algorithms "
+        "(i.e. trees) are unable to extrapolate beyond data present in the training "
+        "data.\n"
+        "   - `100` rows\n"
+        "   - `train_data` values range `[10, 100]`\n"
+        "   - `test_data` values range `[10, 50]`"
+    )
+
+
+def test_LabelInsightsVisualization__no_state():
+    state = AnalysisState()
+
+    viz = LabelInsightsVisualization()
+    viz.render_header_if_needed = MagicMock()
+    viz.render_markdown = MagicMock()
+
+    viz.render(state)
+
+    viz.render_header_if_needed.assert_not_called()
+    viz.render_markdown.assert_not_called()


### PR DESCRIPTION
*Description of changes:*

### `LabelInsightsAnalysis`
Analyze label for insights:
 - classification: low cardinality classes detection
 - classification: classes present in test data, but not in the train data
 - regression: out-of-domain labels detection

**Example**
```python
import autogluon.eda.analysis as eda
import autogluon.eda.visualization as viz
import autogluon.eda.auto as auto
auto.analyze(
auto.analyze(train_data=..., test_data=..., label=..., anlz_facets=[
    eda.dataset.ProblemTypeControl(),
    eda.dataset.LabelInsightsAnalysis(low_cardinality_classes_threshold=50, regression_ood_threshold=0.01),
], viz_facets=[
    viz.dataset.LabelInsightsVisualization()
])
```

**Classification outputs:**
![image](https://user-images.githubusercontent.com/10080307/213598567-c9086b23-05c7-4bd1-8846-2e9b8cf18965.png)
![image](https://user-images.githubusercontent.com/10080307/213820067-29044ae6-43ed-4978-9db1-c43ab4aacac7.png)

**Regression outputs:**
![image](https://user-images.githubusercontent.com/10080307/213598612-27e85c93-8a58-4d09-9d9c-ad40596e2053.png)

### `ProblemTypeControl`
Helper component to control problem type. Autodetect if `problem_type = 'auto'`. See example of use above.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
