### PR TITLE
Refactor AbstractTrainer.get_inputs_to_stacker

### DIFF
--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -3,7 +3,7 @@ import logging
 import os
 import time
 from collections import defaultdict
-from typing import Dict, List, Union, Tuple
+from typing import Dict, List, Union, Tuple, Optional
 
 import networkx as nx
 import numpy as np
@@ -878,10 +878,7 @@ class AbstractTrainer:
         """
         Returns a dictionary of out-of-fold prediction probabilities, keyed by model name
         """
-        model_oof_dict = {}
-        for model in models:
-            model_oof_dict[model] = self.get_model_oof(model=model)
-        return model_oof_dict
+        return {model: self.get_model_oof(model) for model in models}
 
     def get_model_pred_dict(self,
                             X: pd.DataFrame,
@@ -960,7 +957,7 @@ class AbstractTrainer:
     def get_inputs_to_stacker(self,
                               X: pd.DataFrame,
                               base_models: List[str],
-                              model_pred_proba_dict: dict = None,
+                              model_pred_proba_dict: Optional[dict] = None,
                               fit: bool = False,
                               use_orig_features: bool = True,
                               use_val_cache: bool = False) -> pd.DataFrame:
@@ -994,7 +991,6 @@ class AbstractTrainer:
         """
         if not base_models:
             return X
-        pred_proba_list = []
         if fit:
             model_pred_proba_dict = self.get_model_oof_dict(models=base_models)
         else:
@@ -1002,8 +998,7 @@ class AbstractTrainer:
                                                                    models=base_models,
                                                                    model_pred_proba_dict=model_pred_proba_dict,
                                                                    use_val_cache=use_val_cache)
-        for model in base_models:
-            pred_proba_list.append(model_pred_proba_dict[model])
+        pred_proba_list = [model_pred_proba_dict[model] for model in base_models]
         stack_column_names, _ = self._get_stack_column_names(models=base_models)
         X_stacker = convert_pred_probas_to_df(pred_proba_list=pred_proba_list, problem_type=self.problem_type, columns=stack_column_names, index=X.index)
         if use_orig_features:

--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -275,6 +275,36 @@ def get_pred_from_proba(y_pred_proba, problem_type=BINARY):
     return y_pred
 
 
+def convert_pred_probas_to_df(pred_proba_list: list, columns: List[str], problem_type: str, index: pd.Index = None) -> DataFrame:
+    """
+    Converts a list of pred_proba model outputs to a DataFrame
+
+    Parameters
+    ----------
+    pred_proba_list : list
+        A list of prediction probabilities.
+        Each element is a numpy array or ndarray of prediction probabilities for a given model.
+    columns : List[str]
+        The column names for the output DataFrame
+    problem_type : str
+        The problem type. This informs the way in which the DataFrame is constructed.
+    index : pd.Index, default = None
+        If specified, sets the output DataFrame's index.
+
+    Returns
+    -------
+    DataFrame
+    """
+    if problem_type in [MULTICLASS, SOFTCLASS, QUANTILE]:
+        pred_proba_list = np.concatenate(pred_proba_list, axis=1)
+        pred_proba_df = pd.DataFrame(data=pred_proba_list, columns=columns)
+    else:
+        pred_proba_df = pd.DataFrame(data=np.asarray(pred_proba_list).T, columns=columns)
+    if index is not None:
+        pred_proba_df.set_index(index, inplace=True)
+    return pred_proba_df
+
+
 def extract_label(data: DataFrame, label: str) -> (DataFrame, Series):
     """
     Extract the label column from a dataset and return X, y.

--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -275,13 +275,16 @@ def get_pred_from_proba(y_pred_proba, problem_type=BINARY):
     return y_pred
 
 
-def convert_pred_probas_to_df(pred_proba_list: list, columns: List[str], problem_type: str, index: pd.Index = None) -> DataFrame:
+def convert_pred_probas_to_df(pred_proba_list: List[np.typing.ArrayLike],
+                              columns: List[str],
+                              problem_type: str,
+                              index: pd.Index = None) -> DataFrame:
     """
     Converts a list of pred_proba model outputs to a DataFrame
 
     Parameters
     ----------
-    pred_proba_list : list
+    pred_proba_list : List[np.typing.ArrayLike]
         A list of prediction probabilities.
         Each element is a numpy array or ndarray of prediction probabilities for a given model.
     columns : List[str]

--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -9,6 +9,7 @@ from typing import Callable, List, Tuple
 import numpy as np
 import pandas as pd
 import scipy.stats
+from numpy.typing import ArrayLike
 from pandas import DataFrame, Series
 from sklearn.model_selection import RepeatedKFold, RepeatedStratifiedKFold, LeaveOneGroupOut
 from sklearn.model_selection import train_test_split
@@ -275,7 +276,7 @@ def get_pred_from_proba(y_pred_proba, problem_type=BINARY):
     return y_pred
 
 
-def convert_pred_probas_to_df(pred_proba_list: List[np.typing.ArrayLike],
+def convert_pred_probas_to_df(pred_proba_list: List[ArrayLike],
                               columns: List[str],
                               problem_type: str,
                               index: pd.Index = None) -> DataFrame:
@@ -284,7 +285,7 @@ def convert_pred_probas_to_df(pred_proba_list: List[np.typing.ArrayLike],
 
     Parameters
     ----------
-    pred_proba_list : List[np.typing.ArrayLike]
+    pred_proba_list : List[ArrayLike]
         A list of prediction probabilities.
         Each element is a numpy array or ndarray of prediction probabilities for a given model.
     columns : List[str]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Refactor AbstractTrainer.get_inputs_to_stacker
- This resolves a long-standing code hack that depended on creating a dummy stack ensemble model to preprocess stack features. With this refactor, we no longer create a dummy stack ensemble and Trainer no longer depends on StackerEnsembleModel, greatly simplifying the code.
- Tested for equivalence by first having the tests run and succeed end-to-end with both old and new variant running with assert equals of their values. (Refer to [this version of the code](https://github.com/autogluon/autogluon/pull/2744/commits/bf6e2edce022b4538a2509c1960a5df0f974d3d9) for the successful CI run with both variants active and checked for equivalence)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
