### PR TITLE
Add model failed to train check

### DIFF
--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -293,6 +293,7 @@ def run_tabular_benchmark_toy(fit_args):
     savedir = directory + 'AutogluonOutput/'
     shutil.rmtree(savedir, ignore_errors=True)  # Delete AutoGluon output directory to ensure previous runs' information has been removed.
     predictor = TabularPredictor(label=dataset['label'], path=savedir).fit(train_data, **fit_args)
+    assert len(predictor._trainer._models_failed_to_train) == 0
     print(predictor.feature_metadata)
     print(predictor.feature_metadata.type_map_raw)
     print(predictor.feature_metadata.type_group_map_special)
@@ -379,6 +380,7 @@ def run_tabular_benchmarks(fast_benchmark, subsample_size, perf_threshold, seed_
                     # .sample instead of .head to increase diversity and test cases where data index is not monotonically increasing.
                     train_data = train_data.sample(n=subsample_size, random_state=seed_val)  # subsample for fast_benchmark
             predictor = TabularPredictor(label=label, path=savedir).fit(train_data, **fit_args)
+            assert len(predictor._trainer._models_failed_to_train) == 0
             results = predictor.fit_summary(verbosity=4)
             original_features = list(train_data)
             original_features.remove(label)


### PR DESCRIPTION
*Issue #, if available:*
Currently unit test will not fail as long as there's at least one model being trained. We would like to capture any failures in our unit test instead

*Description of changes:*
* Added a variable recording failed models and check it during unit tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
