### PR TITLE
[NER] Allow noisy annotations

### DIFF
--- a/multimodal/src/autogluon/multimodal/data/utils.py
+++ b/multimodal/src/autogluon/multimodal/data/utils.py
@@ -262,7 +262,7 @@ def process_ner_annotations(ner_annotations, ner_text, entity_map, tokenizer, is
         for idx, word_offset in enumerate(word_offsets[:num_words, :]):
             # support multiple words in an annotated offset range.
             # Allow partial overlapping between custom annotations and pretokenized words.
-            if (word_offset[0] < custom_offset[1]) and (custom_offset[0]< word_offset[1]):
+            if (word_offset[0] < custom_offset[1]) and (custom_offset[0] < word_offset[1]):
                 if not (
                     re.match(b_prefix, custom_label, re.IGNORECASE) or re.match(i_prefix, custom_label, re.IGNORECASE)
                 ):

--- a/multimodal/src/autogluon/multimodal/data/utils.py
+++ b/multimodal/src/autogluon/multimodal/data/utils.py
@@ -261,7 +261,8 @@ def process_ner_annotations(ner_annotations, ner_text, entity_map, tokenizer, is
         is_start_word = True
         for idx, word_offset in enumerate(word_offsets[:num_words, :]):
             # support multiple words in an annotated offset range.
-            if word_offset[0] >= custom_offset[0] and word_offset[1] <= custom_offset[1]:
+            # Allow partial overlapping between custom annotations and pretokenized words.
+            if (word_offset[0] < custom_offset[1]) and (custom_offset[0]< word_offset[1]):
                 if not (
                     re.match(b_prefix, custom_label, re.IGNORECASE) or re.match(i_prefix, custom_label, re.IGNORECASE)
                 ):


### PR DESCRIPTION
*Description of changes:*

Allow partial overlapping between custom annotations and the words from pre-tokenization. Previous version only labels words that are within the custom annotations offset and skips all other words.

Add unit test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
