### PR TITLE
Fix image type fallback

### DIFF
--- a/docs/tutorials/multimodal/advanced_topics/customization.md
+++ b/docs/tutorials/multimodal/advanced_topics/customization.md
@@ -536,9 +536,9 @@ How to deal with missing images, opening which fails.
 
 ```
 # default used by AutoMM
-predictor.fit(hyperparameters={"data.image.missing_value_strategy": "skip"})
-# use zero image
 predictor.fit(hyperparameters={"data.image.missing_value_strategy": "zero"})
+# skip the image
+predictor.fit(hyperparameters={"data.image.missing_value_strategy": "skip"})
 ```
 
 ### data.text.normalize_text

--- a/multimodal/src/autogluon/multimodal/configs/data/default.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/data/default.yaml
@@ -1,6 +1,6 @@
 data:
   image:
-    missing_value_strategy: "skip"  # How to deal with missing images. By default, we skip a sample with missing images. We also support choice "zero", i.e., using a zero image to replace a missing image.
+    missing_value_strategy: "zero"  # How to deal with missing images. By default, we skip a sample with missing images. We also support choice "zero", i.e., using a zero image to replace a missing image.
   text:
     normalize_text: False  # Whether to normalize text
   categorical:

--- a/multimodal/src/autogluon/multimodal/data/process_image.py
+++ b/multimodal/src/autogluon/multimodal/data/process_image.py
@@ -60,7 +60,7 @@ class ImageProcessor:
         norm_type: Optional[str] = None,
         size: Optional[int] = None,
         max_img_num_per_col: Optional[int] = 1,
-        missing_value_strategy: Optional[str] = "skip",
+        missing_value_strategy: Optional[str] = "zero",
         requires_column_info: bool = False,
     ):
         """

--- a/multimodal/src/autogluon/multimodal/data/process_mmlab/process_mmdet.py
+++ b/multimodal/src/autogluon/multimodal/data/process_mmlab/process_mmdet.py
@@ -30,7 +30,7 @@ class MMDetProcessor(MMLabProcessor):
         self,
         model: nn.Module,
         max_img_num_per_col: Optional[int] = 1,
-        missing_value_strategy: Optional[str] = "skip",
+        missing_value_strategy: Optional[str] = "zero",
         requires_column_info: bool = False,
     ):
         """

--- a/multimodal/src/autogluon/multimodal/data/process_mmlab/process_mmlab_base.py
+++ b/multimodal/src/autogluon/multimodal/data/process_mmlab/process_mmlab_base.py
@@ -53,7 +53,7 @@ class MMLabProcessor:
         model: nn.Module,
         collate_func: Callable,
         max_img_num_per_col: Optional[int] = 1,
-        missing_value_strategy: Optional[str] = "skip",
+        missing_value_strategy: Optional[str] = "zero",
         requires_column_info: bool = False,
     ):
         """

--- a/multimodal/src/autogluon/multimodal/data/process_mmlab/process_mmocr.py
+++ b/multimodal/src/autogluon/multimodal/data/process_mmlab/process_mmocr.py
@@ -30,7 +30,7 @@ class MMOcrProcessor(MMLabProcessor):
         self,
         model: nn.Module,
         max_img_num_per_col: Optional[int] = 1,
-        missing_value_strategy: Optional[str] = "skip",
+        missing_value_strategy: Optional[str] = "zero",
         requires_column_info: bool = False,
     ):
         """

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -1752,7 +1752,7 @@ class MultiModalPredictor:
                     elif is_image_column(data=data[col_name], col_name=col_name, image_type=IMAGE_BYTEARRAY):
                         image_type = IMAGE_BYTEARRAY
                     else:
-                        raise ValueError(f"Image type in column {col_name} is not supported!")
+                        image_type = col_type
                     if col_type != image_type:
                         column_types_copy[col_name] = image_type
             self._df_preprocessor._column_types = column_types_copy


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Fallback to original column type when `infer_type` on image was not successful during inference;
2. Update default `missing_value_strategy` to `zero`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
