### PR TITLE
[WIP] Add document classification pipeline

### DIFF
--- a/multimodal/src/autogluon/multimodal/configs/model/fusion_mlp_image_text_tabular.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/model/fusion_mlp_image_text_tabular.yaml
@@ -88,6 +88,28 @@ model:
     special_tags: 
       - X # CLS, SEP, and non-first tokens of a word will be labelled as X
       - O # Outside of a named entity
+  document_transformer:
+    checkpoint_name: "microsoft/layoutlmv3-base" # document foundation models
+    gradient_checkpointing: False
+    pooling_mode: 'mean'  # The pooling mode, can be 'cls' or 'mean'
+    data_types:
+      - "document"
+    train_transform_types:
+      - "resize_shorter_side"
+      - "center_crop"
+    val_transform_types:
+      - "resize_shorter_side"
+      - "center_crop"
+    image_norm: "imagenet"
+    image_size: 224
+    tokenizer_name: "hf_auto"
+    max_text_len: 512  # If None or <=0, then use the max length of pretrained models.
+    insert_sep: True
+    low_cpu_mem_usage: False
+    text_segment_num: 2
+    stochastic_chunk: False
+    text_aug_detect_length: 10                # We perform text augmentation only if a text has more than text_detection_length words. It is used to differentiate text columns versus tabular columns that are treated as text.
+    text_trivial_aug_maxscale: 0.0            # augmentation magnitude randomly drawn from [0, text_trivial_aug_maxscale]
   t_few:
     checkpoint_name: "t5-small" #"bigscience/T0_3B"
     gradient_checkpointing: False

--- a/multimodal/src/autogluon/multimodal/configs/model/fusion_mlp_image_text_tabular.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/model/fusion_mlp_image_text_tabular.yaml
@@ -91,7 +91,7 @@ model:
   document_transformer:
     checkpoint_name: "microsoft/layoutlmv3-base" # document foundation models
     gradient_checkpointing: False
-    pooling_mode: 'mean'  # The pooling mode, can be 'cls' or 'mean'
+    pooling_mode: 'cls'  # The pooling mode, can be 'cls' or 'mean'
     data_types:
       - "document"
     train_transform_types:

--- a/multimodal/src/autogluon/multimodal/constants.py
+++ b/multimodal/src/autogluon/multimodal/constants.py
@@ -126,7 +126,7 @@ MMDET = "mmdet"
 MMOCR = "mmocr"
 
 # Modality keys. may need to update here if new modality keys are added in above.
-ALL_MODALITIES = [IMAGE, TEXT, CATEGORICAL, NUMERICAL, TEXT_NER]
+ALL_MODALITIES = [IMAGE, TEXT, CATEGORICAL, NUMERICAL, TEXT_NER, DOCUMENT]
 
 # Keys to compute metrics
 Y_PRED = "y_pred"

--- a/multimodal/src/autogluon/multimodal/constants.py
+++ b/multimodal/src/autogluon/multimodal/constants.py
@@ -9,6 +9,7 @@ NUMERICAL = "numerical"
 IMAGE_PATH = "image_path"
 IMAGE_BYTEARRAY = "image_bytearray"
 IDENTIFIER = "identifier"
+DOCUMENT = "document"
 
 # Problem types
 CLASSIFICATION = "classification"
@@ -40,6 +41,10 @@ CHOICES_IDS = "choices_ids"
 TEXT_VALID_LENGTH = "text_valid_length"
 TEXT_SEGMENT_IDS = "text_segment_ids"
 COLUMN = "column"
+ATTENTION_MASK = "attention_mask"
+TOKEN_TYPE_IDS = "token_type_ids"
+PIXEL_VALUES = "pixel_values"
+INPUT_IDS = "input_ids"
 
 # Output keys
 LOGITS = "logits"
@@ -204,7 +209,8 @@ MMDET_IMAGE = "mmdet_image"
 MMOCR_TEXT_DET = "mmocr_text_detection"
 MMOCR_TEXT_RECOG = "mmocr_text_recognition"
 NER_TEXT = "ner_text"
-HF_MODELS = (HF_TEXT, T_FEW, CLIP, NER_TEXT)
+DOCUMENT_TRANSFORMER = "document_transformer"
+HF_MODELS = (HF_TEXT, T_FEW, CLIP, NER_TEXT, DOCUMENT_TRANSFORMER)
 MMLAB_MODELS = (MMDET_IMAGE, MMOCR_TEXT_DET, MMOCR_TEXT_RECOG)
 
 # matcher loss type

--- a/multimodal/src/autogluon/multimodal/data/__init__.py
+++ b/multimodal/src/autogluon/multimodal/data/__init__.py
@@ -5,6 +5,7 @@ from .labelencoder_ner import NerLabelEncoder
 from .mixup import MixupModule
 from .preprocess_dataframe import MultiModalFeaturePreprocessor
 from .process_categorical import CategoricalProcessor
+from .process_document import DocumentProcessor
 from .process_image import ImageProcessor
 from .process_label import LabelProcessor
 from .process_mmlab import MMDetProcessor, MMOcrProcessor

--- a/multimodal/src/autogluon/multimodal/data/process_document.py
+++ b/multimodal/src/autogluon/multimodal/data/process_document.py
@@ -119,7 +119,6 @@ class DocumentProcessor:
                 self.model.text_token_ids_key: PadCollator(pad_val=self.tokenizer.pad_token_id),
                 self.model.text_attention_mask_key: PadCollator(pad_val=0),
                 self.model.text_bbox_key: PadCollator(pad_val=0),
-                self.model.label_key: StackCollator(),
                 self.model.text_segment_ids_key: PadCollator(pad_val=0),
             }
         )
@@ -286,7 +285,7 @@ class DocumentProcessor:
                 input_ids = self.tokenizer(sent, boxes=normalized_word_boxes, truncation=True)["input_ids"]
 
             # Padding of token_boxes up the bounding boxes to the sequence length.
-            padding_length = 512 - len(input_ids)
+            padding_length = self.text_max_len - len(input_ids)
             token_boxes += [pad_token_box] * padding_length
 
             ret.update(

--- a/multimodal/src/autogluon/multimodal/data/process_document.py
+++ b/multimodal/src/autogluon/multimodal/data/process_document.py
@@ -1,0 +1,328 @@
+import logging
+import os
+import warnings
+from io import BytesIO
+from typing import Any, Dict, List, Optional, Union
+
+import numpy as np
+import PIL
+import pytesseract
+import torch
+from nptyping import NDArray
+from PIL import ImageFile
+from torch import nn
+from torchvision import transforms
+from transformers import AutoTokenizer
+
+from ..constants import AUTOMM, BBOX
+from .collator import PadCollator, StackCollator
+from .utils import construct_processor, mean_std
+
+logger = logging.getLogger(AUTOMM)
+
+# Disable tokenizer parallelism
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+
+class DocumentProcessor:
+    """
+    Prepare document data for Document Classification.
+    OCR (Optical character recognition) is applied to get the document texts and bounding boxes.
+    Both texts and images will be processed.
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        train_transform_types: List[str],
+        val_transform_types: List[str],
+        norm_type: Optional[str] = None,
+        size: Optional[int] = None,
+        text_max_len: Optional[int] = 512,
+    ):
+        """
+        Parameters
+        ----------
+        model
+            The model using this data processor.
+        train_transform_types
+            A list of image transforms used in training. Note that the transform order matters.
+        val_transform_types
+            A list of image transforms used in validation/test/prediction. Note that the transform order matters.
+        norm_type
+            How to normalize an image. We now support:
+            - inception
+                Normalize image by IMAGENET_INCEPTION_MEAN and IMAGENET_INCEPTION_STD from timm
+            - imagenet
+                Normalize image by IMAGENET_DEFAULT_MEAN and IMAGENET_DEFAULT_STD from timm
+            - clip
+                Normalize image by mean (0.48145466, 0.4578275, 0.40821073) and
+                std (0.26862954, 0.26130258, 0.27577711), used for CLIP.
+        size
+            The width / height of a square image.
+        text_max_len
+            The max text length of tokenizer. Default: 512.
+        """
+        self.prefix = model.prefix
+        self.model = model
+
+        # For document image processing.
+        self.size = size
+        self.train_transform_types = train_transform_types
+        self.val_transform_types = val_transform_types
+        self.mean, self.std = mean_std(norm_type)
+        self.normalization = transforms.Normalize(self.mean, self.std)
+        self.train_processor = construct_processor(self.size, self.normalization, self.train_transform_types)
+        self.val_processor = construct_processor(self.size, self.normalization, self.val_transform_types)
+
+        # Store OCR results
+        self.documents = {}
+
+        # Whether only text is used (automatically detected).
+        # If True, normal text foundation models (e.g., bert-base) can be used.
+        self.is_text_only_flag = model.is_text_only_flag
+
+        # For document text processing.
+        self.tokenizer = model.tokenizer
+        if text_max_len is None or text_max_len <= 0:
+            self.text_max_len = self.tokenizer.model_max_length
+        else:
+            if text_max_len < self.tokenizer.model_max_length:
+                warnings.warn(
+                    f"provided max length: {text_max_len} "
+                    f"is smaller than {model.checkpoint_name}'s default: {self.tokenizer.model_max_length}"
+                )
+            self.text_max_len = min(text_max_len, self.tokenizer.model_max_length)
+
+        self.tokenizer.model_max_length = self.text_max_len
+
+    @staticmethod
+    def get_pretrained_tokenizer(
+        tokenizer_name: str,
+        checkpoint_name: str,
+    ):
+        return AutoTokenizer.from_pretrained(checkpoint_name)
+
+    def collate_fn(self, text_column_names: Optional[List] = None) -> Dict:
+        """
+        Collate multimodal features into a batch.
+        This function will be used when creating Pytorch DataLoader.
+
+        Returns
+        -------
+        A dictionary containing one model's collator function for multimodal data.
+        """
+        fn = {}
+
+        fn.update(
+            {
+                self.model.text_token_ids_key: PadCollator(pad_val=self.tokenizer.pad_token_id),
+                self.model.text_attention_mask_key: PadCollator(pad_val=0),
+                self.model.text_bbox_key: PadCollator(pad_val=0),
+                self.model.label_key: StackCollator(),
+                self.model.text_segment_ids_key: PadCollator(pad_val=0),
+            }
+        )
+        # If not text only, document images will be used.
+        if not self.is_text_only_flag:
+            fn.update(
+                {
+                    self.model.document_pixel_value_key: PadCollator(pad_val=0),
+                }
+            )
+        return fn
+
+    @staticmethod
+    def normalize_box(box, width, height):
+        """
+        Normalize the bounding boxes.
+
+        Parameters
+        ----------
+        box
+            The bounding box to be processed.
+        width
+            Width of the document image.
+        height
+            Height of the document image.
+
+        Returns
+        -------
+        A normalized bounding box.
+        """
+        return [
+            int(1000 * (box[0] / width)),
+            int(1000 * (box[1] / height)),
+            int(1000 * (box[2] / width)),
+            int(1000 * (box[3] / height)),
+        ]
+
+    def apply_ocr(self, doc_image):
+        """
+        Apply OCR on document images to ecognize and “read” the text embedded in document images.
+        Specifically, Python-tesseract, a wrapper for Google's Tesseract-OCR Engine, will be used.
+
+        Parameters
+        ----------
+        doc_image
+            The document image.
+
+        Returns
+        -------
+        A dictionary with recognized text and corresponding bounding boxes.
+        """
+        results = {}
+        width, height = doc_image.size
+
+        # apply ocr to the document image.
+        ocr_df = pytesseract.image_to_data(doc_image, output_type="data.frame")
+        float_cols = ocr_df.select_dtypes("float").columns
+        ocr_df = ocr_df.dropna().reset_index(drop=True)
+        ocr_df[float_cols] = ocr_df[float_cols].round(0).astype(int)
+        ocr_df = ocr_df.replace(r"^\s*$", np.nan, regex=True)
+        ocr_df = ocr_df.dropna().reset_index(drop=True)
+
+        # get the words and actual (unnormalized) bounding boxes.
+        words = list(ocr_df.text)
+        words = [str(w) for w in words]
+        coordinates = ocr_df[["left", "top", "width", "height"]]
+        actual_boxes = []
+        for idx, row in coordinates.iterrows():
+            # the row comes in (left, top, width, height) format.
+            x, y, w, h = tuple(row)
+            # we turn it into (left, top, left+width, top+height) to get the actual box.
+            actual_box = [x, y, x + w, y + h]
+            actual_boxes.append(actual_box)
+
+        # normalize the bounding boxes.
+        boxes = []
+        for box in actual_boxes:
+            boxes.append(self.normalize_box(box, width, height))
+
+        assert len(words) == len(boxes)
+
+        results["words"] = words
+        results[BBOX] = boxes
+        return results
+
+    def process_one_sample(
+        self,
+        document_features: Dict[str, Union[NDArray[(Any,), Any], list]],
+        feature_modalities: Dict[str, Union[NDArray[(Any,), Any], list]],
+        is_training: bool,
+        image_mode: Optional[str] = "RGB",
+    ):
+        """
+        Read documents, process them, and stack them. One sample has one document image.
+
+        Parameters
+        ----------
+        document_features
+            One sample has one document image column in a pd.DataFrame.
+        feature_modalities
+            What modality each column belongs to.
+        is_training
+            Whether to process document images in the training mode.
+        image_mode
+            A string which defines the type and depth of a pixel in the image.
+            For example, RGB, RGBA, CMYK, and etc.
+
+        Returns
+        -------
+        A dictionary containing one sample's document and its features.
+        """
+        ret = {}
+        for per_col_name, per_col_image_features in document_features.items():
+            # Open the document image.
+            try:
+                doc_image = PIL.Image.open(per_col_image_features[0])
+            except Exception as e:
+                raise e
+
+            # The OCR process is time-consuming, so apply OCR on each image only once.
+            if per_col_image_features[0] not in self.documents:
+                ocr_res = self.apply_ocr(doc_image)
+                # store the ocr results.
+                self.documents.update({per_col_image_features[0]: ocr_res})
+            else:
+                # reuse the ocr results.
+                ocr_res = self.documents[per_col_image_features[0]]
+
+            words = ocr_res["words"]
+            doc_image = doc_image.convert(image_mode)
+
+            if is_training:
+                doc_image = self.train_processor(doc_image)
+            else:
+                doc_image = self.val_processor(doc_image)
+
+            normalized_word_boxes = ocr_res[BBOX]
+
+            # Truncation of token_boxes
+            token_boxes = []
+            for word, box in zip(words, normalized_word_boxes):
+                word_tokens = self.tokenizer.tokenize(word)
+                token_boxes.extend([box] * len(word_tokens))
+            pad_token_box = [0, 0, 0, 0]
+            special_tokens_count = 2
+            if len(token_boxes) > self.text_max_len - special_tokens_count:
+                token_boxes = token_boxes[: (self.text_max_len - special_tokens_count)]
+            # add bounding boxes of cls + sep tokens
+            token_boxes = [[0, 0, 0, 0]] + token_boxes + [[1000, 1000, 1000, 1000]]
+
+            if self.is_text_only_flag:
+                sent = " ".join(words)
+                encoding = self.tokenizer(sent, padding="max_length", truncation=True, return_token_type_ids=True)
+                input_ids = self.tokenizer(sent, truncation=True)["input_ids"]
+            else:
+                sent = words
+                encoding = self.tokenizer(
+                    sent,
+                    boxes=normalized_word_boxes,
+                    padding="max_length",
+                    truncation=True,
+                    return_token_type_ids=True,
+                )
+                input_ids = self.tokenizer(sent, boxes=normalized_word_boxes, truncation=True)["input_ids"]
+
+            # Padding of token_boxes up the bounding boxes to the sequence length.
+            padding_length = 512 - len(input_ids)
+            token_boxes += [pad_token_box] * padding_length
+
+            ret.update(
+                {
+                    self.model.text_token_ids_key: np.array(encoding.input_ids, dtype=np.int32),
+                    self.model.text_attention_mask_key: encoding.attention_mask,
+                    self.model.text_bbox_key: np.array(token_boxes, dtype=np.int32),
+                    self.model.text_segment_ids_key: np.array(encoding.token_type_ids, dtype=np.int32),
+                }
+            )
+            if not self.is_text_only_flag:
+                ret.update({self.model.document_pixel_value_key: doc_image})
+
+        return ret
+
+    def __call__(
+        self,
+        all_features: Dict[str, Union[NDArray[(Any,), Any], list]],
+        feature_modalities: Dict[str, Union[NDArray[(Any,), Any], list]],
+        is_training: bool,
+    ) -> Dict:
+        """
+        Extract one sample's multimodal data.
+
+        Parameters
+        ----------
+        all
+            All the raw input data.
+        is_training
+            Whether to do processing in the training mode.
+
+        Returns
+        -------
+        A dictionary containing one sample's features and/or labels.
+        """
+
+        ret = self.process_one_sample(all_features, feature_modalities, is_training)
+
+        return ret

--- a/multimodal/src/autogluon/multimodal/models/__init__.py
+++ b/multimodal/src/autogluon/multimodal/models/__init__.py
@@ -2,6 +2,7 @@ from . import utils
 from .categorical_mlp import CategoricalMLP
 from .categorical_transformer import CategoricalTransformer
 from .clip import CLIPForImageText
+from .document_transformer import DocumentTransformer
 from .fusion import MultimodalFusionMLP, MultimodalFusionNER, MultimodalFusionTransformer
 from .huggingface_text import HFAutoModelForTextPrediction
 from .mmdet_image import MMDetAutoModelForObjectDetection

--- a/multimodal/src/autogluon/multimodal/models/document_transformer.py
+++ b/multimodal/src/autogluon/multimodal/models/document_transformer.py
@@ -190,10 +190,8 @@ class DocumentTransformer(HFAutoModelForTextPrediction):
         if self.pooling_mode == "cls":
             pooled_features = outputs.last_hidden_state[:, 0, :]
         elif self.pooling_mode == "mean":
-            pooled_features = (outputs.last_hidden_state * text_masks.unsqueeze(-1)).sum(1)
-            sum_mask = text_masks.unsqueeze(-1).sum(1)
-            sum_mask = torch.clamp(sum_mask, min=1e-9)
-            pooled_features = pooled_features / sum_mask
+            # In some models, last_hidden_state is the concatenation of document image features and text features.
+            pooled_features = outputs.last_hidden_state.mean(1)
         else:
             raise NotImplementedError(f"Pooling mode={self.pooling_mode} is not supported.")
 

--- a/multimodal/src/autogluon/multimodal/models/document_transformer.py
+++ b/multimodal/src/autogluon/multimodal/models/document_transformer.py
@@ -1,0 +1,220 @@
+import inspect
+import logging
+from typing import Callable, Dict, List, Optional, Tuple, Union, cast
+
+import torch
+from torch import nn
+from transformers import AutoTokenizer, LayoutLMTokenizer, LayoutLMTokenizerFast, RobertaTokenizerFast
+from transformers import logging as hf_logging
+
+from ..constants import (
+    ATTENTION_MASK,
+    AUTOMM,
+    BBOX,
+    COLUMN,
+    COLUMN_FEATURES,
+    FEATURES,
+    IMAGE,
+    INPUT_IDS,
+    LABEL,
+    LOGITS,
+    MASKS,
+    PIXEL_VALUES,
+    TEXT_SEGMENT_IDS,
+    TEXT_TOKEN_IDS,
+    TEXT_VALID_LENGTH,
+    TOKEN_TYPE_IDS,
+)
+from .huggingface_text import HFAutoModelForTextPrediction
+from .utils import DummyLayer, assign_layer_ids, get_column_features, get_hf_config_and_model, init_weights
+
+hf_logging.set_verbosity_error()
+
+logger = logging.getLogger(AUTOMM)
+
+
+class DocumentTransformer(HFAutoModelForTextPrediction):
+    """
+    Document Classification with Huggingface backbones. Inherit from HFAutoModelForTextPrediction.
+    """
+
+    def __init__(
+        self,
+        prefix: str,
+        checkpoint_name: str = "microsoft/layoutlmv3-base",
+        num_classes: Optional[int] = 0,
+        pooling_mode: Optional[str] = "cls",
+        gradient_checkpointing: Optional[bool] = False,
+        low_cpu_mem_usage: Optional[bool] = False,
+        pretrained: Optional[bool] = True,
+    ):
+        """
+        Load a pretrained huggingface layout-aware document transformer backbone.
+
+        Parameters
+        ----------
+        prefix
+            The model prefix.
+        checkpoint_name
+            Name of the checkpoint. We support loading checkpoint from
+            Huggingface Models list: https://huggingface.co/models
+            For example, you can use layout-aware models:
+                - microsoft/layoutlmv3-base
+                - microsoft/layoutlm-base-uncased
+                - microsoft/xdoc-base
+                - microsoft/layoutxlm-base
+                - microsoft/layoutlmv2-base-uncased
+            you may also use text focused transformers:
+                - 'microsoft/deberta-v3-base'
+                - 'bert-base-uncased'
+        num_classes
+            The number of classes. 1 for a regression task.
+        pooling_mode
+            The pooling mode for the Transformer. Can be "cls", or "mean"
+        gradient_checkpointing
+            Whether to enable gradient checkpointing
+        low_cpu_mem_usage
+            Whether to turn on the optimization of reducing the peak CPU memory usage when loading the pretrained model.
+        pretrained
+            Whether using the pretrained weights. If pretrained=True, download the pretrained model.
+        """
+        super().__init__(
+            prefix=prefix,
+            checkpoint_name=checkpoint_name,
+            num_classes=num_classes,
+            pooling_mode=pooling_mode,
+            gradient_checkpointing=gradient_checkpointing,
+            low_cpu_mem_usage=low_cpu_mem_usage,
+            pretrained=pretrained,
+        )
+        logger.debug(f"initializing {checkpoint_name}")
+
+        self.tokenizer = AutoTokenizer.from_pretrained(checkpoint_name)
+        self.is_text_only_flag = self.is_text_only(self.tokenizer)
+
+        if self.is_text_only_flag:
+            logger.debug(f"Checkpoint: {checkpoint_name} uses the text data only for classification.")
+
+    def is_text_only(self, tokenizer):
+        """
+        Check the tokenizer to see if it is a text only tokenizer.
+
+        Parameters
+        ----------
+        tokenizer
+            The tokenizer to be used.
+
+        Returns
+        -------
+        True if the tokenizer only accept text, otherwise, False.
+        """
+        model_args = list(inspect.signature(tokenizer.__call__).parameters.keys())
+        # Tokenizers of document foundation models usually have a "boxes" argument.
+        if "boxes" not in model_args:
+            return True
+        else:
+            return False
+
+    @property
+    def text_attention_mask_key(self):
+        return f"{self.prefix}_{ATTENTION_MASK}"
+
+    @property
+    def text_bbox_key(self):
+        return f"{self.prefix}_{BBOX}"
+
+    @property
+    def document_pixel_value_key(self):
+        return f"{self.prefix}_{PIXEL_VALUES}"
+
+    def update_input_data(
+        self,
+        input_data: dict,
+        batch: dict,
+        keys: dict,
+    ):
+        """
+        Update the model input data based on the model argument.
+        For example, microsoft/layoutlm-base-uncased has a "bbox" argument;
+        microsoft/layoutlmv3-base has arguments: "bbox" and "image".
+        Text only bert does not have these two arguments.
+
+        Parameters
+        ----------
+        input_data
+            A dictionary containing the model input data.
+        batch:
+            A dictionary containing the input mini-batch data.
+            We need to use the keys with the model prefix to index required data.
+        keys:
+            A dictionary containing the model arguments and corresponding batch keys.
+        """
+        model_args = list(inspect.signature(self.model.forward).parameters.keys())
+        for key, value in keys.items():
+            if key in model_args:
+                input_data.update({key: batch[value]})
+
+    def forward(
+        self,
+        batch: dict,
+    ):
+        """
+        Parameters
+        ----------
+        batch
+            A dictionary containing the input mini-batch data.
+            We need to use the keys with the model prefix to index required data.
+
+        Returns
+        -------
+            A dictionary with logits and features.
+        """
+        input_data = {}
+        self.update_input_data(
+            input_data,
+            batch,
+            keys={
+                INPUT_IDS: self.text_token_ids_key,
+                TOKEN_TYPE_IDS: self.text_segment_ids_key,
+                ATTENTION_MASK: self.text_attention_mask_key,
+                BBOX: self.text_bbox_key,
+                PIXEL_VALUES: self.document_pixel_value_key,
+                IMAGE: self.document_pixel_value_key,
+            },
+        )
+
+        text_masks = batch[self.text_attention_mask_key]
+
+        outputs = self.model(**input_data)
+
+        if self.pooling_mode == "cls":
+            pooled_features = outputs.last_hidden_state[:, 0, :]
+        elif self.pooling_mode == "mean":
+            pooled_features = (outputs.last_hidden_state * text_masks.unsqueeze(-1)).sum(1)
+            sum_mask = text_masks.unsqueeze(-1).sum(1)
+            sum_mask = torch.clamp(sum_mask, min=1e-9)
+            pooled_features = pooled_features / sum_mask
+        else:
+            raise NotImplementedError(f"Pooling mode={self.pooling_mode} is not supported.")
+
+        logits = self.head(pooled_features)
+
+        ret = {COLUMN_FEATURES: {FEATURES: {}, MASKS: {}}}
+        column_features, column_feature_masks = get_column_features(
+            batch=batch,
+            column_name_prefix=self.text_column_prefix,
+            features=outputs.last_hidden_state,
+            valid_lengths=sum(text_masks),
+            cls_feature=pooled_features,
+        )
+        ret[COLUMN_FEATURES][FEATURES].update(column_features)
+        ret[COLUMN_FEATURES][MASKS].update(column_feature_masks)
+
+        ret.update(
+            {
+                LOGITS: logits,
+                FEATURES: pooled_features,
+            }
+        )
+
+        return {self.prefix: ret}

--- a/multimodal/src/autogluon/multimodal/presets.py
+++ b/multimodal/src/autogluon/multimodal/presets.py
@@ -16,9 +16,11 @@ def high_quality_fast_inference():
             "timm_image",
             "hf_text",
             "fusion_mlp",
+            "document_transformer",
         ],
         "model.hf_text.checkpoint_name": "google/electra-base-discriminator",
         "model.timm_image.checkpoint_name": "swin_base_patch4_window7_224",
+        "model.document_transformer.checkpoint_name": "microsoft/layoutlmv3-base",
         "env.num_workers": 2,
     }
 
@@ -321,6 +323,48 @@ def feature_extraction():
         "model.hf_text.checkpoint_name": "sentence-transformers/msmarco-MiniLM-L-12-v3",
         "model.hf_text.pooling_mode": "mean",
         "env.eval_batch_size_ratio": 1,
+    }
+
+
+@automm_presets.register()
+def high_quality_fast_inference_document_classification():
+    return {
+        "model.names": [
+            "categorical_mlp",
+            "numerical_mlp",
+            "timm_image",
+            "hf_text",
+            "document_transformer",
+        ],
+        "model.document_transformer.checkpoint_name": "microsoft/layoutlmv3-base",
+    }
+
+
+@automm_presets.register()
+def best_quality_document_classification():
+    return {
+        "model.names": [
+            "categorical_mlp",
+            "numerical_mlp",
+            "timm_image",
+            "hf_text",
+            "document_transformer",
+        ],
+        "model.document_transformer.checkpoint_name": "microsoft/layoutlmv3-large",
+    }
+
+
+@automm_presets.register()
+def medium_quality_faster_inference_document_classification():
+    return {
+        "model.names": [
+            "categorical_mlp",
+            "numerical_mlp",
+            "timm_image",
+            "hf_text",
+            "document_transformer",
+        ],
+        "model.document_transformer.checkpoint_name": "microsoft/layoutlm-base-uncased",
     }
 
 

--- a/multimodal/src/autogluon/multimodal/utils/data.py
+++ b/multimodal/src/autogluon/multimodal/utils/data.py
@@ -20,6 +20,7 @@ from ..constants import (
     BINARY,
     CATEGORICAL,
     DEFAULT_SHOT,
+    DOCUMENT,
     FEW_SHOT,
     IMAGE,
     LABEL,
@@ -34,6 +35,7 @@ from ..constants import (
 )
 from ..data import (
     CategoricalProcessor,
+    DocumentProcessor,
     ImageProcessor,
     LabelProcessor,
     MixupModule,
@@ -169,6 +171,15 @@ def create_data_processor(
             max_img_num_per_col=model_config.max_img_num_per_col,
             missing_value_strategy=config.data.image.missing_value_strategy,
         )
+    elif data_type == DOCUMENT:
+        data_processor = DocumentProcessor(
+            model=model,
+            train_transform_types=model_config.train_transform_types,
+            val_transform_types=model_config.val_transform_types,
+            norm_type=model_config.image_norm,
+            size=model_config.image_size,
+            text_max_len=model_config.max_text_len,
+        )
     else:
         raise ValueError(f"unknown data type: {data_type}")
 
@@ -210,6 +221,7 @@ def create_fusion_data_processors(
         LABEL: [],
         ROIS: [],
         TEXT_NER: [],
+        DOCUMENT: [],
     }
 
     model_dict = {model.prefix: model}

--- a/multimodal/src/autogluon/multimodal/utils/model.py
+++ b/multimodal/src/autogluon/multimodal/utils/model.py
@@ -14,6 +14,8 @@ from ..constants import (
     CATEGORICAL_MLP,
     CATEGORICAL_TRANSFORMER,
     CLIP,
+    DOCUMENT,
+    DOCUMENT_TRANSFORMER,
     FUSION_MLP,
     FUSION_NER,
     FUSION_TRANSFORMER,
@@ -37,6 +39,7 @@ from ..models import (
     CategoricalMLP,
     CategoricalTransformer,
     CLIPForImageText,
+    DocumentTransformer,
     HFAutoModelForNER,
     HFAutoModelForTextPrediction,
     MMDetAutoModelForObjectDetection,
@@ -97,6 +100,8 @@ def select_model(
         data_status[NUMERICAL] = True
     if len(df_preprocessor.ner_feature_names) > 0:
         data_status[TEXT_NER] = True
+    if len(df_preprocessor.document_feature_names) > 0:
+        data_status[DOCUMENT] = True
 
     names = config.model.names
     if isinstance(names, str):
@@ -281,6 +286,13 @@ def create_model(
             cls_token=False,
             additive_attention=OmegaConf.select(model_config, "additive_attention", default=False),
             share_qv_weights=OmegaConf.select(model_config, "share_qv_weights", default=False),
+        )
+    elif model_name.lower().startswith(DOCUMENT_TRANSFORMER):
+        model = DocumentTransformer(
+            prefix=model_name,
+            checkpoint_name=model_config.checkpoint_name,
+            num_classes=num_classes,
+            pretrained=pretrained,
         )
     elif model_name.lower().startswith(MMDET_IMAGE):
         model = MMDetAutoModelForObjectDetection(

--- a/multimodal/src/autogluon/multimodal/utils/model.py
+++ b/multimodal/src/autogluon/multimodal/utils/model.py
@@ -292,6 +292,9 @@ def create_model(
             prefix=model_name,
             checkpoint_name=model_config.checkpoint_name,
             num_classes=num_classes,
+            pooling_mode=OmegaConf.select(model_config, "pooling_mode", default="cls"),
+            gradient_checkpointing=OmegaConf.select(model_config, "gradient_checkpointing"),
+            low_cpu_mem_usage=OmegaConf.select(model_config, "low_cpu_mem_usage", default=False),
             pretrained=pretrained,
         )
     elif model_name.lower().startswith(MMDET_IMAGE):

--- a/multimodal/tests/unittests/others/test_doc_classification.py
+++ b/multimodal/tests/unittests/others/test_doc_classification.py
@@ -1,0 +1,59 @@
+import os
+
+import pandas as pd
+import pytest
+
+from autogluon.core.utils.loaders import load_zip
+from autogluon.multimodal import MultiModalPredictor
+
+DOC_PATH_COL = "image_path"
+
+
+def path_expander(path, base_folder):
+    path_l = path.split(";")
+    return ";".join([os.path.abspath(os.path.join(base_folder, path)) for path in path_l])
+
+
+def get_rvl_cdip_sample_data():
+    zip_file = "https://automl-mm-bench.s3.amazonaws.com/doc_classification/rvl_cdip_sample.zip"
+
+    download_dir = "./ag_automm_rvl_cdip"
+    load_zip.unzip(zip_file, unzip_dir=download_dir)
+
+    dataset_path = os.path.join(download_dir, "rvl_cdip_sample")
+    rvl_cdip_data = pd.read_csv(f"{dataset_path}/rvl_cdip_train_data.csv")
+    train_data = rvl_cdip_data.sample(frac=0.8, random_state=200)
+    test_data = rvl_cdip_data.drop(train_data.index)
+
+    train_data[DOC_PATH_COL] = train_data[DOC_PATH_COL].apply(lambda ele: path_expander(ele, base_folder=dataset_path))
+    test_data[DOC_PATH_COL] = test_data[DOC_PATH_COL].apply(lambda ele: path_expander(ele, base_folder=dataset_path))
+
+    return train_data, test_data
+
+
+# Both text only backbones and document foundation models are supported.
+@pytest.mark.parametrize(
+    "checkpoint_name",
+    [("google/electra-small-discriminator"), ("microsoft/layoutlmv2-base-uncased")],
+)
+def test_doc_classification(checkpoint_name):
+    predictor = MultiModalPredictor(label="label")
+    train_data, test_data = get_rvl_cdip_sample_data()
+    predictor.fit(
+        train_data=train_data,
+        hyperparameters={
+            "model.document_transformer.checkpoint_name": checkpoint_name,
+            "env.num_workers": 0,
+        },
+        time_limit=30,
+    )
+
+    predictor.evaluate(test_data)
+
+    doc_path = test_data.iloc[0][DOC_PATH_COL]
+    # make predictions
+    predictions = predictor.predict({DOC_PATH_COL: [doc_path]})
+    # output probability
+    proba = predictor.predict_proba({DOC_PATH_COL: [doc_path]})
+    # extract embeddings
+    feature = predictor.extract_embedding({DOC_PATH_COL: [doc_path]})


### PR DESCRIPTION
*Description of changes:*
This pull request adds a document classification pipeline which can classify scanned document images into appropriate categories. Specifically,
(1) documents are represented as images; 
(3) an OCR pipeline is used to obtain their texts and layout information; 
(3) document foundation models (or document transformer) such as LayoutLM, LayoutLmv*, are used as the backbone which can be fine-tuned with document classification datasets.

We added
- DocumentProcessor: for document processing, e.g., OCR, text, layout, and image feature generation. 
- DocumentTransformer: a classification wrapper for document foundation models. Text-focused models are also supported.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
