### PR TITLE
[multimodal] undo changes to num_workers

### DIFF
--- a/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
@@ -11,6 +11,6 @@ env:
   fast_dev_run: False
   deterministic: False
   auto_select_gpus: True
-  strategy: "ddp_spawn"
+  strategy: "ddp"
   deepspeed_allgather_size: 1e9 # DeepSpeed allgather size (number of elements gathered at a time). Limits memory required for allgather on large models.
   deepspeed_allreduce_size: 1e9 # DeepSpeed allreduce size (number of elements reduced at a time). Limits memory required for allreduce on large models.

--- a/multimodal/src/autogluon/multimodal/presets.py
+++ b/multimodal/src/autogluon/multimodal/presets.py
@@ -19,7 +19,6 @@ def high_quality_fast_inference():
         ],
         "model.hf_text.checkpoint_name": "google/electra-base-discriminator",
         "model.timm_image.checkpoint_name": "swin_base_patch4_window7_224",
-        "env.num_workers": 2,
     }
 
 
@@ -41,7 +40,6 @@ def medium_quality_faster_train():
         "model.hf_text.checkpoint_name": "google/electra-small-discriminator",
         "model.timm_image.checkpoint_name": "swin_small_patch4_window7_224",
         "optimization.learning_rate": 4e-4,
-        "env.num_workers": 2,
     }
 
 
@@ -51,7 +49,6 @@ def medium_quality_faster_inference_image_classification():
         "model.names": ["timm_image"],
         "model.timm_image.checkpoint_name": "mobilenetv3_large_100",
         "optimization.learning_rate": 1e-3,
-        "env.num_workers": 2,
     }
 
 
@@ -61,7 +58,6 @@ def high_quality_fast_inference_image_classification():
         "model.names": ["timm_image"],
         "model.timm_image.checkpoint_name": "resnet50",
         "optimization.learning_rate": 1e-3,
-        "env.num_workers": 2,
     }
 
 
@@ -71,7 +67,6 @@ def high_quality():
         "model.names": ["categorical_mlp", "numerical_mlp", "timm_image", "hf_text", "fusion_mlp"],
         "model.hf_text.checkpoint_name": "google/electra-base-discriminator",
         "model.timm_image.checkpoint_name": "swin_base_patch4_window7_224",
-        "env.num_workers": 2,
     }
 
 
@@ -82,7 +77,6 @@ def best_quality():
         "model.hf_text.checkpoint_name": "microsoft/deberta-v3-base",
         "model.timm_image.checkpoint_name": "swin_large_patch4_window7_224",
         "env.per_gpu_batch_size": 1,
-        "env.num_workers": 2,
     }
 
 
@@ -91,7 +85,6 @@ def high_quality_image_classification():
     return {
         "model.names": ["timm_image"],
         "model.timm_image.checkpoint_name": "swin_base_patch4_window7_224",
-        "env.num_workers": 2,
     }
 
 
@@ -175,7 +168,6 @@ def zero_shot_image_classification():
         "model.clip.checkpoint_name": "openai/clip-vit-large-patch14-336",
         "model.clip.max_text_len": 0,
         "env.eval_batch_size_ratio": 1,
-        "env.num_workers": 2,
     }
 
 
@@ -198,7 +190,6 @@ def medium_quality_faster_inference_object_detection():
         "optimization.patience": 10,
         "optimization.max_epochs": 10,
         "optimization.val_metric": "direct_loss",
-        "env.num_workers": 2,
     }
 
 
@@ -211,7 +202,6 @@ def high_quality_fast_inference_object_detection():
         "env.precision": 32,
         "env.strategy": "ddp",
         "env.auto_select_gpus": False,  # Have to turn off for detection!
-        "env.num_workers": 2,
         "optimization.learning_rate": 1e-5,
         "optimization.lr_decay": 0.95,
         "optimization.lr_mult": 100,
@@ -234,7 +224,6 @@ def higher_quality_object_detection():
         "env.precision": 32,
         "env.strategy": "ddp",
         "env.auto_select_gpus": False,  # Have to turn off for detection!
-        "env.num_workers": 2,
         "optimization.learning_rate": 5e-6,
         "optimization.lr_decay": 0.95,
         "optimization.lr_mult": 100,
@@ -257,7 +246,6 @@ def best_quality_object_detection():
         "env.precision": 32,
         "env.strategy": "ddp",
         "env.auto_select_gpus": False,  # Have to turn off for detection!
-        "env.num_workers": 2,
         "optimization.learning_rate": 1e-5,
         "optimization.lr_decay": 0.95,
         "optimization.lr_mult": 100,
@@ -280,7 +268,6 @@ def object_detection():
         "env.precision": 32,
         "env.strategy": "ddp",  # TODO: support ddp_spawn for detection
         "env.auto_select_gpus": False,  # Have to turn off for detection!
-        "env.num_workers": 2,
         "optimization.learning_rate": 5e-5,
         "optimization.lr_decay": 0.95,
         "optimization.lr_mult": 100,
@@ -336,7 +323,6 @@ def best_quality_image_similarity():
     return {
         "model.names": ["timm_image"],
         "model.timm_image.checkpoint_name": "swin_large_patch4_window7_224",
-        "env.num_workers": 2,
     }
 
 
@@ -346,7 +332,6 @@ def high_quality_fast_inference_image_similarity():
     return {
         "model.names": ["timm_image"],
         "model.timm_image.checkpoint_name": "swin_base_patch4_window7_224",
-        "env.num_workers": 2,
     }
 
 
@@ -356,7 +341,6 @@ def medium_quality_faster_inference_image_similarity():
     return {
         "model.names": ["timm_image"],
         "model.timm_image.checkpoint_name": "swin_small_patch4_window7_224",
-        "env.num_workers": 2,
     }
 
 
@@ -417,7 +401,6 @@ def best_quality_image_text_similarity():
         "matcher.loss.type": "multi_negatives_softmax_loss",
         "env.per_gpu_batch_size": 8,
         "optimization.learning_rate": 1e-5,
-        "env.num_workers": 2,
     }
 
 
@@ -430,7 +413,6 @@ def high_quality_fast_inference_image_text_similarity():
         "matcher.loss.type": "multi_negatives_softmax_loss",
         "env.per_gpu_batch_size": 16,
         "optimization.learning_rate": 1e-5,
-        "env.num_workers": 2,
     }
 
 
@@ -449,7 +431,6 @@ def medium_quality_faster_inference_image_text_similarity():
         "matcher.loss.type": "multi_negatives_softmax_loss",
         "env.per_gpu_batch_size": 128,
         "optimization.learning_rate": 1e-5,
-        "env.num_workers": 2,
     }
 
 

--- a/multimodal/src/autogluon/multimodal/presets.py
+++ b/multimodal/src/autogluon/multimodal/presets.py
@@ -19,6 +19,7 @@ def high_quality_fast_inference():
         ],
         "model.hf_text.checkpoint_name": "google/electra-base-discriminator",
         "model.timm_image.checkpoint_name": "swin_base_patch4_window7_224",
+        "env.num_workers": 2,
     }
 
 
@@ -40,6 +41,7 @@ def medium_quality_faster_train():
         "model.hf_text.checkpoint_name": "google/electra-small-discriminator",
         "model.timm_image.checkpoint_name": "swin_small_patch4_window7_224",
         "optimization.learning_rate": 4e-4,
+        "env.num_workers": 2,
     }
 
 
@@ -49,6 +51,7 @@ def medium_quality_faster_inference_image_classification():
         "model.names": ["timm_image"],
         "model.timm_image.checkpoint_name": "mobilenetv3_large_100",
         "optimization.learning_rate": 1e-3,
+        "env.num_workers": 2,
     }
 
 
@@ -58,6 +61,7 @@ def high_quality_fast_inference_image_classification():
         "model.names": ["timm_image"],
         "model.timm_image.checkpoint_name": "resnet50",
         "optimization.learning_rate": 1e-3,
+        "env.num_workers": 2,
     }
 
 
@@ -67,6 +71,7 @@ def high_quality():
         "model.names": ["categorical_mlp", "numerical_mlp", "timm_image", "hf_text", "fusion_mlp"],
         "model.hf_text.checkpoint_name": "google/electra-base-discriminator",
         "model.timm_image.checkpoint_name": "swin_base_patch4_window7_224",
+        "env.num_workers": 2,
     }
 
 
@@ -77,6 +82,7 @@ def best_quality():
         "model.hf_text.checkpoint_name": "microsoft/deberta-v3-base",
         "model.timm_image.checkpoint_name": "swin_large_patch4_window7_224",
         "env.per_gpu_batch_size": 1,
+        "env.num_workers": 2,
     }
 
 
@@ -85,6 +91,7 @@ def high_quality_image_classification():
     return {
         "model.names": ["timm_image"],
         "model.timm_image.checkpoint_name": "swin_base_patch4_window7_224",
+        "env.num_workers": 2,
     }
 
 
@@ -168,6 +175,7 @@ def zero_shot_image_classification():
         "model.clip.checkpoint_name": "openai/clip-vit-large-patch14-336",
         "model.clip.max_text_len": 0,
         "env.eval_batch_size_ratio": 1,
+        "env.num_workers": 2,
     }
 
 
@@ -190,6 +198,7 @@ def medium_quality_faster_inference_object_detection():
         "optimization.patience": 10,
         "optimization.max_epochs": 10,
         "optimization.val_metric": "direct_loss",
+        "env.num_workers": 2,
     }
 
 
@@ -202,6 +211,7 @@ def high_quality_fast_inference_object_detection():
         "env.precision": 32,
         "env.strategy": "ddp",
         "env.auto_select_gpus": False,  # Have to turn off for detection!
+        "env.num_workers": 2,
         "optimization.learning_rate": 1e-5,
         "optimization.lr_decay": 0.95,
         "optimization.lr_mult": 100,
@@ -224,6 +234,7 @@ def higher_quality_object_detection():
         "env.precision": 32,
         "env.strategy": "ddp",
         "env.auto_select_gpus": False,  # Have to turn off for detection!
+        "env.num_workers": 2,
         "optimization.learning_rate": 5e-6,
         "optimization.lr_decay": 0.95,
         "optimization.lr_mult": 100,
@@ -246,6 +257,7 @@ def best_quality_object_detection():
         "env.precision": 32,
         "env.strategy": "ddp",
         "env.auto_select_gpus": False,  # Have to turn off for detection!
+        "env.num_workers": 2,
         "optimization.learning_rate": 1e-5,
         "optimization.lr_decay": 0.95,
         "optimization.lr_mult": 100,
@@ -268,6 +280,7 @@ def object_detection():
         "env.precision": 32,
         "env.strategy": "ddp",  # TODO: support ddp_spawn for detection
         "env.auto_select_gpus": False,  # Have to turn off for detection!
+        "env.num_workers": 2,
         "optimization.learning_rate": 5e-5,
         "optimization.lr_decay": 0.95,
         "optimization.lr_mult": 100,
@@ -323,6 +336,7 @@ def best_quality_image_similarity():
     return {
         "model.names": ["timm_image"],
         "model.timm_image.checkpoint_name": "swin_large_patch4_window7_224",
+        "env.num_workers": 2,
     }
 
 
@@ -332,6 +346,7 @@ def high_quality_fast_inference_image_similarity():
     return {
         "model.names": ["timm_image"],
         "model.timm_image.checkpoint_name": "swin_base_patch4_window7_224",
+        "env.num_workers": 2,
     }
 
 
@@ -341,6 +356,7 @@ def medium_quality_faster_inference_image_similarity():
     return {
         "model.names": ["timm_image"],
         "model.timm_image.checkpoint_name": "swin_small_patch4_window7_224",
+        "env.num_workers": 2,
     }
 
 
@@ -401,6 +417,7 @@ def best_quality_image_text_similarity():
         "matcher.loss.type": "multi_negatives_softmax_loss",
         "env.per_gpu_batch_size": 8,
         "optimization.learning_rate": 1e-5,
+        "env.num_workers": 2,
     }
 
 
@@ -413,6 +430,7 @@ def high_quality_fast_inference_image_text_similarity():
         "matcher.loss.type": "multi_negatives_softmax_loss",
         "env.per_gpu_batch_size": 16,
         "optimization.learning_rate": 1e-5,
+        "env.num_workers": 2,
     }
 
 
@@ -431,6 +449,7 @@ def medium_quality_faster_inference_image_text_similarity():
         "matcher.loss.type": "multi_negatives_softmax_loss",
         "env.per_gpu_batch_size": 128,
         "optimization.learning_rate": 1e-5,
+        "env.num_workers": 2,
     }
 
 


### PR DESCRIPTION
*Issue #, if available:*

#2756

*Description of changes:*

The root cause of the issue is that https://github.com/autogluon/autogluon/commit/93fcbb955eb628b6896b8d277386a4c9a9345384 changed num_workers=2

Here is a visualization before and after the change #2416 that could affect the overall evaluation time of beginner_image_cls.ipynb .

![image](https://user-images.githubusercontent.com/857821/214765473-8c0ae121-08e0-4b55-ad25-96f08144274a.png)

By removing ‘num_workers=2’, we can reduce predictor.fit from 206 seconds to 128 seconds. Training throughput increased from 3.92s/it to 0.68s/it (aka 1.46it/s).

Code to reproduce the results

```python
import pandas as pd
import time
import os
import shutil

from autogluon.multimodal.utils.misc import shopee_dataset
from autogluon.multimodal import MultiModalPredictor

def main():
    download_dir = './ag_automm_tutorial_imgcls'
    train_data_byte, test_data_byte = shopee_dataset(download_dir, is_bytearray=True)
    model_path = f"./tmp/automm_shopee"
    if os.path.exists(model_path):
        shutil.rmtree(model_path)
    predictor = MultiModalPredictor(label="label", path=model_path)
    tic = time.time()
    predictor.fit(
        train_data=train_data_byte, # you can use train_data_byte as well
        time_limit=30, # seconds
    ) # you can trust the default config, e.g., we use a `swin_base_patch4_window7_224` model
    print(f"elapsed (fit): {(time.time()-tic)*1000:.1f} ms")

if __name__=="__main__":
    main()
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
