### PR TITLE
[timeseries] Add deprecation warning for Sktime models

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/sktime/abstract_sktime.py
+++ b/timeseries/src/autogluon/timeseries/models/sktime/abstract_sktime.py
@@ -68,6 +68,11 @@ class AbstractSktimeModel(AbstractTimeSeriesModel):
             hyperparameters=hyperparameters,
             **kwargs,
         )
+        logger.warning(
+            f"Warning: Model {self.__class__.__name__} has been deprecated in v0.7.\n"
+            "\tStarting from v0.8, using this model will raise an exception.\n"
+            "\tConsider instead using other local models such as 'AutoETS', 'AutoARIMA' and 'ARIMA'.",
+        )
         self.sktime_forecaster: Optional[BaseForecaster] = None
         self._fit_hash: Optional[pd.Series] = None
 


### PR DESCRIPTION
*Description of changes:*
- We switched to the `StatsForecast` implementation of `AutoETS` and `AutoARIMA` (instead of `sktime` and `pmdarima`), so these dependencies will be removed in a future release.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
