### PR TITLE
[NER] add support for predict_proba 

### DIFF
--- a/docs/tutorials/multimodal/text_prediction/ner.md
+++ b/docs/tutorials/multimodal/text_prediction/ner.md
@@ -96,6 +96,12 @@ print('Predicted entities:', predictions[0])
 visualize_ner(sentence, predictions[0])
 ```
 
+## Prediction Probabilities 
+You can also output the probabilities for a deep dive into the predictions.
+```{.python .input}
+predictions = predictor.predict_proba({'text_snippet': [sentence]})
+print(predictions[0][0]['probability'])
+```
 ## Reloading and Continuous Training 
 The trained predictor is automatically saved and you can easily reload it using the path. If you are not saftisfied with the current model performance, you can continue training the loaded model with new data.
 

--- a/multimodal/src/autogluon/multimodal/data/labelencoder_ner.py
+++ b/multimodal/src/autogluon/multimodal/data/labelencoder_ner.py
@@ -9,7 +9,7 @@ import pandas as pd
 from nptyping import NDArray
 from omegaconf import DictConfig, OmegaConf
 
-from ..constants import AUTOMM, END_OFFSET, ENTITY_GROUP, NER_ANNOTATION, START_OFFSET
+from ..constants import AUTOMM, END_OFFSET, ENTITY_GROUP, NER_ANNOTATION, PROBABILITY, START_OFFSET
 from .utils import process_ner_annotations
 
 logger = logging.getLogger(AUTOMM)
@@ -168,13 +168,21 @@ class NerLabelEncoder:
         pred_with_offset
             Predictions with both labels and the position (character offset) of the corresponding words.
         """
-        pred_label_only, pred_with_offset = [], []
-        for token_preds, offsets in y:
-            temp_pred, temp_offset = [], []
-            for token_pred, offset in zip(token_preds, offsets):
+        pred_label_only, pred_with_offset, pred_with_proba = [], [], []
+        for token_preds, offsets, pred_proba in y:
+            temp_pred, temp_offset, temp_proba = [], [], []
+            for token_pred, offset, probability in zip(token_preds, offsets, pred_proba):
                 inverse_pred_label = self.inverse_entity_map[token_pred]
                 temp_pred.append(inverse_pred_label)
-                if inverse_pred_label != self.ner_special_tags[-1]:
+                temp_proba.append(
+                    {
+                        ENTITY_GROUP: inverse_pred_label,
+                        START_OFFSET: offset[0],
+                        END_OFFSET: offset[1],
+                        PROBABILITY: {e: p for e, p in zip(list(self.entity_map.keys())[1:], probability[1:])},
+                    }
+                )
+                if inverse_pred_label not in self.ner_special_tags:
                     temp_offset.append(
                         {
                             ENTITY_GROUP: inverse_pred_label,
@@ -184,4 +192,5 @@ class NerLabelEncoder:
                     )
             pred_label_only.append(temp_pred)
             pred_with_offset.append(temp_offset)
-        return pred_label_only, pred_with_offset
+            pred_with_proba.append(temp_proba)
+        return pred_label_only, pred_with_offset, pred_with_proba

--- a/multimodal/src/autogluon/multimodal/data/preprocess_dataframe.py
+++ b/multimodal/src/autogluon/multimodal/data/preprocess_dataframe.py
@@ -695,6 +695,7 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
         self,
         y_pred: Union[np.ndarray, dict],
         inverse_categorical: bool = True,
+        return_proba: bool = False,
     ) -> NDArray[(Any,), Any]:
         """
         Transform model's output logits/probability into class labels for classification
@@ -706,8 +707,8 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
             The model's output logits/probability.
         inverse_categorical
             Whether to transform categorical value back to the original space, e.g., string values.
-        loss_func
-            The loss function of the model.
+        return_proba
+            Whether return the probability or not.
 
         Returns
         -------
@@ -730,11 +731,16 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
             y_pred = np.nan_to_num(y_pred)
         elif self.label_type == NER_ANNOTATION:
             y_pred = self._label_generator.inverse_transform(y_pred)
-            if inverse_categorical:
-                # Return annotations and offsets
-                y_pred = y_pred[1]
+
+            if return_proba:
+                y_pred = y_pred[-1]
             else:
-                y_pred = y_pred[0]
+                if inverse_categorical:
+                    # Return annotations and offsets
+                    y_pred = y_pred[1]
+                else:
+                    y_pred = y_pred[0]
+
         else:
             raise NotImplementedError
 

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -2180,7 +2180,6 @@ class MultiModalPredictor:
 
         assert self._problem_type not in [
             REGRESSION,
-            NAMED_ENTITY_RECOGNITION,
         ], f"Problem {self._problem_type} has no probability output."
 
         if candidate_data:
@@ -2197,9 +2196,16 @@ class MultiModalPredictor:
                 realtime=realtime,
                 seed=seed,
             )
-            logits = extract_from_output(outputs=outputs, ret_type=LOGITS)
 
-            prob = logits_to_prob(logits)
+            if self._problem_type == NER:
+                ner_outputs = extract_from_output(outputs=outputs, ret_type=NER_RET)
+                prob = self._df_preprocessor.transform_prediction(
+                    y_pred=ner_outputs,
+                    return_proba=True,
+                )
+            else:
+                logits = extract_from_output(outputs=outputs, ret_type=LOGITS)
+                prob = logits_to_prob(logits)
 
         if not as_multiclass:
             if self._problem_type == BINARY:

--- a/multimodal/src/autogluon/multimodal/utils/inference.py
+++ b/multimodal/src/autogluon/multimodal/utils/inference.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytorch_lightning as pl
 import torch
 from omegaconf import OmegaConf
+from scipy.special import softmax
 from torch import nn
 
 from ..constants import (
@@ -92,19 +93,21 @@ def extract_from_output(outputs: List[Dict], ret_type: str, as_ndarray: Optional
         as_ndarray = False
         for ele in outputs:
             logits_label = ele[NER_ANNOTATION].detach().cpu().numpy()
+            logits = softmax(ele[LOGITS].detach().cpu().numpy(), axis=-1)
             token_word_mapping = ele[TOKEN_WORD_MAPPING].detach().cpu().numpy()
             word_offsets = ele[WORD_OFFSETS].detach().cpu().numpy()
-            for token_preds, mappings, offsets in zip(logits_label, token_word_mapping, word_offsets):
-                pred_one_sentence, word_offset = [], []
+            for token_preds, logit, mappings, offsets in zip(logits_label, logits, token_word_mapping, word_offsets):
+                pred_one_sentence, word_offset, pred_proba = [], [], []
                 counter = 0
                 temp = set()
-                for token_pred, mapping in zip(token_preds, mappings):
+                for token_pred, mapping, lt in zip(token_preds, mappings, logit):
                     if mapping != -1 and mapping not in temp:
                         temp.add(mapping)
                         word_offset.append(list(offsets[counter]))
                         pred_one_sentence.append(token_pred)
+                        pred_proba.append(lt)
                         counter += 1
-                ner_pred.append((pred_one_sentence, word_offset))
+                ner_pred.append((pred_one_sentence, word_offset, pred_proba))
         return ner_pred
     else:
         raise ValueError(f"Unknown return type: {ret_type}")

--- a/multimodal/tests/unittests/others/test_ner.py
+++ b/multimodal/tests/unittests/others/test_ner.py
@@ -75,4 +75,5 @@ def test_multi_ner(checkpoint_name):
     test_predict = train_data.drop(label_col, axis=1)
     test_predict = test_predict.head(2)
     predictions = predictor.predict(test_predict)
+    proba = predictor.predict_proba(test_predict)
     embeddings = predictor.extract_embedding(test_predict)


### PR DESCRIPTION

*Description of changes:*
Now, we can get the detailed probabilities for NER output, using

predictions = `predictor.predict_proba(data)`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
