### PR TITLE
[AutoMM] Speed up training

### DIFF
--- a/multimodal/src/autogluon/multimodal/data/datamodule.py
+++ b/multimodal/src/autogluon/multimodal/data/datamodule.py
@@ -146,6 +146,7 @@ class BaseDataModule(LightningDataModule):
                 data_processors=self.data_processors,
                 per_gpu_batch_size=self.per_gpu_batch_size,
             ),
+            persistent_workers=True,
         )
         return loader
 
@@ -169,6 +170,7 @@ class BaseDataModule(LightningDataModule):
                 data_processors=self.data_processors,
                 per_gpu_batch_size=self.per_gpu_batch_size,
             ),
+            persistent_workers=True,
         )
         return loader
 
@@ -192,6 +194,7 @@ class BaseDataModule(LightningDataModule):
                 data_processors=self.data_processors,
                 per_gpu_batch_size=self.per_gpu_batch_size,
             ),
+            persistent_workers=True,
         )
         return loader
 
@@ -215,5 +218,6 @@ class BaseDataModule(LightningDataModule):
                 data_processors=self.data_processors,
                 per_gpu_batch_size=self.per_gpu_batch_size,
             ),
+            persistent_workers=True,
         )
         return loader

--- a/multimodal/src/autogluon/multimodal/data/datamodule.py
+++ b/multimodal/src/autogluon/multimodal/data/datamodule.py
@@ -146,7 +146,7 @@ class BaseDataModule(LightningDataModule):
                 data_processors=self.data_processors,
                 per_gpu_batch_size=self.per_gpu_batch_size,
             ),
-            persistent_workers=True,
+            persistent_workers=self.num_workers > 0,
         )
         return loader
 
@@ -170,7 +170,7 @@ class BaseDataModule(LightningDataModule):
                 data_processors=self.data_processors,
                 per_gpu_batch_size=self.per_gpu_batch_size,
             ),
-            persistent_workers=True,
+            persistent_workers=self.num_workers > 0,
         )
         return loader
 
@@ -194,7 +194,7 @@ class BaseDataModule(LightningDataModule):
                 data_processors=self.data_processors,
                 per_gpu_batch_size=self.per_gpu_batch_size,
             ),
-            persistent_workers=True,
+            persistent_workers=self.num_workers > 0,
         )
         return loader
 
@@ -218,6 +218,6 @@ class BaseDataModule(LightningDataModule):
                 data_processors=self.data_processors,
                 per_gpu_batch_size=self.per_gpu_batch_size,
             ),
-            persistent_workers=True,
+            persistent_workers=self.num_workers > 0,
         )
         return loader

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -1375,7 +1375,6 @@ class MultiModalPredictor:
                 check_val_every_n_epoch=config.optimization.check_val_every_n_epoch
                 if hasattr(config.optimization, "check_val_every_n_epoch")
                 else 1,
-                reload_dataloaders_every_n_epochs=1,
                 plugins=[custom_checkpoint_plugin],
             )
 
@@ -1410,6 +1409,7 @@ class MultiModalPredictor:
                     standalone=standalone,
                     clean_ckpts=clean_ckpts,
                 )
+            self._best_score = trainer.callback_metrics[f"val_{self._validation_metric_name}"]
         else:
             sys.exit(f"Training finished, exit the process with global_rank={trainer.global_rank}...")
 
@@ -1525,9 +1525,6 @@ class MultiModalPredictor:
             prefix=prefix,
             strict=strict_loading,
         )
-
-        if self._problem_type != OBJECT_DETECTION:  # TODO: update detection's evaluation to support this
-            self._best_score = self.evaluate(val_df, metrics=[validation_metric_name])[validation_metric_name]
 
         if is_distill:
             avg_state_dict = self._replace_model_name_prefix(

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -1409,7 +1409,7 @@ class MultiModalPredictor:
                     standalone=standalone,
                     clean_ckpts=clean_ckpts,
                 )
-            self._best_score = trainer.callback_metrics[f"val_{self._validation_metric_name}"]
+            self._best_score = trainer.callback_metrics[f"val_{self._validation_metric_name}"].item()
         else:
             sys.exit(f"Training finished, exit the process with global_rank={trainer.global_rank}...")
 

--- a/multimodal/tests/unittests/others/test_save_path.py
+++ b/multimodal/tests/unittests/others/test_save_path.py
@@ -27,6 +27,8 @@ def test_existing_save_path_but_empty_folder(save_path):
     }
 
     abs_path = os.path.abspath(os.path.expanduser(save_path))
+    if os.path.exists(abs_path):
+        shutil.rmtree(abs_path)
     os.makedirs(abs_path, exist_ok=True)
     predictor = MultiModalPredictor(
         label=dataset.label_columns[0],
@@ -77,6 +79,8 @@ def test_existing_save_path_with_content_inside(save_path):
     }
 
     abs_path = os.path.abspath(os.path.expanduser(save_path))
+    if os.path.exists(abs_path):
+        shutil.rmtree(abs_path)
     os.makedirs(abs_path, exist_ok=True)
     dummy_file_path = os.path.join(abs_path, "dummy.txt")
     with open(dummy_file_path, "w") as f:


### PR DESCRIPTION
*Issue #, if available:*
#2756 

*Description of changes:*

1. persistent_workers=True if num_workers > 0.
2. reload_dataloaders_every_n_epochs=0.
3. Remove the additional evaluation in top_k_average. Use the best validation score from training instead to reduce overhead.

This PR can substantially reduce the time overhead of multi-gpu training introduced by 0.6.2. Specifically, for 60s time limit, it even uses less training time compared to 0.5.2.

**Environment**
g4dn.12xlarge, pytorch-lightning 1.8.6

**time_limit=30**

* best
    * PR's time: 76.5s
    * 0.5.2 time: 75.6s
* greedy soup
    * PR's time: 87.3s
    * 0.5.2 time: 82.2s
* uniform soup
    * PR's time: 77.1s
    * 0.5.2 time: 75.9s

**time_limit=60**

* best
    * PR's time: 104.7s
    * 0.5.2 time: 110.8s
* greedy soup
    * PR's time: 116.7s
    * 0.5.2 time: 120.0s
* uniform soup
    * PR's time: 105.9s
    * 0.5.2 time: 111.7s

Here is the code to reproduce results:
```
train_dataset, _, test_dataset = ImageDataset.from_folders(
        "https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip")

    version = core.version.__version__
    predictor = MultiModalPredictor(label="label", path=f"./automm_imgcls/{version}/{time.time()}")
    print("starting fit\n")
    start = time.time()
    predictor.fit(
        train_data=train_dataset,
        hyperparameters={
            "optimization.top_k_average_method": "best",  # "uniform_soup" or "greedy_soup"
        },
        time_limit=30,  # or 60
    )  # you can trust the default config, e.g., we use a `swin_base_patch4_window7_224` model
    end = time.time()
    print(f"version {version} takes {end - start} seconds")
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
