### PR TITLE
[timeseries] Implement missing value imputation for TimeSeriesDataFrame

### DIFF
--- a/docs/api/autogluon.predictor.rst
+++ b/docs/api/autogluon.predictor.rst
@@ -205,5 +205,5 @@ Additional Time Series APIs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: TimeSeriesDataFrame
-    :members: freq, from_iterable_dataset, from_data_frame, from_pickle,
-              split_by_time, slice_by_timestep, slice_by_time
+    :members: freq, fill_missing_values, from_iterable_dataset, from_data_frame, from_pickle,
+              split_by_time, slice_by_timestep, slice_by_time, to_regular_index

--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -758,7 +758,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
         else:
             raise ValueError(f"Invalid fill method. Expecting one of {'ffill', 'interpolate'}. Got {method}")
 
-        filled_df = pd.DataFrame(self).groupby(level=ITEMID, sort=False).apply(fill_method)
+        filled_df = pd.DataFrame(self).groupby(level=ITEMID, sort=False, group_keys=False).apply(fill_method)
         # Drop leading NaNs (at the start of time series)
         filled_df.dropna(inplace=True)
         return TimeSeriesDataFrame(filled_df, static_features=self.static_features)

--- a/timeseries/tests/unittests/common.py
+++ b/timeseries/tests/unittests/common.py
@@ -59,10 +59,11 @@ def get_data_frame_with_variable_lengths(
     item_id_to_length: Dict[str, int],
     static_features: Optional[pd.DataFrame] = None,
     covariates_names: Optional[List[str]] = None,
+    freq: str = "D",
 ):
     tuples = []
     for item_id, length in item_id_to_length.items():
-        for ts in pd.date_range(pd.Timestamp("2022-01-01"), periods=length, freq="D"):
+        for ts in pd.date_range(pd.Timestamp("2022-01-01"), periods=length, freq=freq):
             tuples.append((item_id, ts))
     index = pd.MultiIndex.from_tuples(tuples, names=[ITEMID, TIMESTAMP])
     df = TimeSeriesDataFrame(

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -753,7 +753,7 @@ def test_when_path_is_given_to_constructor_then_tsdf_is_constructed_correctly():
 
 @pytest.mark.parametrize("freq", ["D", "W", "M", "Q", "A", "Y", "H", "T", "min", "S"])
 def test_given_index_is_irregular_when_to_regular_index_called_then_result_has_regular_index(freq):
-    df_original = get_data_frame_with_variable_lengths({"B": 15, "A": 20}, freq=freq)
+    df_original = get_data_frame_with_variable_lengths({"B": 15, "A": 20}, freq=freq, covariates_names=["Y", "X"])
 
     # Select random rows & reset cached freq
     df_irregular = df_original.iloc[[2, 5, 7, 10, 14, 15, 16, 33]]

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -751,7 +751,7 @@ def test_when_path_is_given_to_constructor_then_tsdf_is_constructed_correctly():
         assert len(ts_df) == len(SAMPLE_TS_DATAFRAME)
 
 
-@pytest.mark.parametrize("freq", ["D", "W", "M", "Q", "A", "Y", "H", "T", "min", "S"])
+@pytest.mark.parametrize("freq", ["D", "W", "M", "Q", "A", "Y", "H", "T", "min", "S", "30T", "2H", "17S"])
 def test_given_index_is_irregular_when_to_regular_index_called_then_result_has_regular_index(freq):
     df_original = get_data_frame_with_variable_lengths({"B": 15, "A": 20}, freq=freq, covariates_names=["Y", "X"])
 
@@ -793,18 +793,17 @@ def test_given_irregular_index_isnt_compatible_with_given_freq_then_exception_is
         df.to_regular_index(freq=freq)
 
 
-@pytest.mark.parametrize("freq", ["D", "W", "M", "Q", "A", "Y", "H", "T", "min", "S"])
-def test_when_missing_values_filled_then_leading_missing_values_are_removed(freq):
-    df = get_data_frame_with_variable_lengths({"B": 15, "A": 20}, freq=freq)
-    missing_index = [0, 1, 2, 15, 16]
-    df.iloc[missing_index] = np.nan
-    df_filled = df.fill_missing_values()
-    assert all(idx not in df_filled.index for idx in df.index[missing_index])
-
-
-@pytest.mark.parametrize("freq", ["D", "W", "M", "Q", "A", "Y", "H", "T", "min", "S"])
-def test_given_no_leading_nans_when_missing_values_filled_then_index_doesnt_change(freq):
-    df = get_data_frame_with_variable_lengths({"B": 15, "A": 20}, freq=freq)
-    df.iloc[[1, 5, 10, 22]] = np.nan
-    df_filled = df.fill_missing_values()
+@pytest.mark.parametrize("method", ["auto", "ffill", "pad", "interpolate", "constant"])
+def test_when_fill_missing_values_called_then_missing_values_are_filled_and_index_is_unchanged(method):
+    df = get_data_frame_with_variable_lengths({"B": 15, "A": 20})
+    df.iloc[[1, 5, 10, 14, 22]] = np.nan
+    df_filled = df.fill_missing_values(method=method)
+    assert not df_filled.isna().any().any()
     assert df_filled.index.equals(df.index)
+
+
+def test_when_dropna_called_then_missing_values_are_dropped():
+    df = get_data_frame_with_variable_lengths({"B": 15, "A": 20})
+    df.iloc[[1, 5, 10, 14, 22]] = np.nan
+    df_dropped = df.dropna()
+    assert not df_dropped.isna().any().any()

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -18,6 +18,8 @@ from autogluon.timeseries.dataset.ts_dataframe import (
     TimeSeriesDataFrame,
 )
 
+from .common import get_data_frame_with_variable_lengths
+
 START_TIMESTAMP = pd.Timestamp("01-01-2019", freq="D")  # type: ignore
 END_TIMESTAMP = pd.Timestamp("01-02-2019", freq="D")  # type: ignore
 ITEM_IDS = (0, 1, 2)
@@ -747,3 +749,62 @@ def test_when_path_is_given_to_constructor_then_tsdf_is_constructed_correctly():
         assert isinstance(ts_df.index, pd.MultiIndex)
         assert ts_df.index.names == [ITEMID, TIMESTAMP]
         assert len(ts_df) == len(SAMPLE_TS_DATAFRAME)
+
+
+@pytest.mark.parametrize("freq", ["D", "W", "M", "Q", "A", "Y", "H", "T", "min", "S"])
+def test_given_index_is_irregular_when_to_regular_index_called_then_result_has_regular_index(freq):
+    df_original = get_data_frame_with_variable_lengths({"B": 15, "A": 20}, freq=freq)
+
+    # Select random rows & reset cached freq
+    df_irregular = df_original.iloc[[2, 5, 7, 10, 14, 15, 16, 33]]
+    df_irregular._cached_freq = None
+    df_regular = df_irregular.to_regular_index(freq=freq)
+    for idx, value in df_regular.iterrows():
+        if idx in df_irregular.index:
+            assert (value == df_original.loc[idx]).all()
+        else:
+            assert value.isna().all()
+
+
+def test_given_index_is_regular_when_to_regular_index_called_then_original_df_is_returned():
+    df = SAMPLE_TS_DATAFRAME.copy()
+    df_regular = df.to_regular_index(freq=df.freq)
+    assert df is df_regular
+
+
+def test_given_index_is_regular_and_freq_doesnt_match_when_to_regular_index_called_then_exception_is_raised():
+    df = SAMPLE_TS_DATAFRAME.copy()
+    with pytest.raises(ValueError, match="already has a regular index with freq"):
+        df.to_regular_index(freq="Q")
+
+
+@pytest.mark.parametrize("freq", ["D", "W", "M", "Q", "A", "H"])
+def test_given_irregular_index_isnt_compatible_with_given_freq_then_exception_is_raised(freq):
+    df = TimeSeriesDataFrame(
+        pd.DataFrame(
+            {
+                ITEMID: [0, 0, 0],
+                TIMESTAMP: ["1900-01-01 00:00", "1900-01-02 00:00", "1900-01-03 00:30"],
+                "target": [1, 2, 3],
+            }
+        )
+    )
+    with pytest.raises(ValueError, match="timestamps in this TimeSeriesDataFrame are not compatible"):
+        df.to_regular_index(freq=freq)
+
+
+@pytest.mark.parametrize("freq", ["D", "W", "M", "Q", "A", "Y", "H", "T", "min", "S"])
+def test_when_missing_values_filled_then_leading_missing_values_are_removed(freq):
+    df = get_data_frame_with_variable_lengths({"B": 15, "A": 20}, freq=freq)
+    missing_index = [0, 1, 2, 15, 16]
+    df.iloc[missing_index] = np.nan
+    df_filled = df.fill_missing_values()
+    assert all(idx not in df_filled.index for idx in df.index[missing_index])
+
+
+@pytest.mark.parametrize("freq", ["D", "W", "M", "Q", "A", "Y", "H", "T", "min", "S"])
+def test_given_no_leading_nans_when_missing_values_filled_then_index_doesnt_change(freq):
+    df = get_data_frame_with_variable_lengths({"B": 15, "A": 20}, freq=freq)
+    df.iloc[[1, 5, 10, 22]] = np.nan
+    df_filled = df.fill_missing_values()
+    assert df_filled.index.equals(df.index)


### PR DESCRIPTION
*Description of changes:*
- Two new methods for imputing the missing values. These should be called before passing the data to the `TimeSeriesPredictor`.
  - `to_regular_index(freq)` - fills gaps in an irregularly-sampled time series with NaNs
  - `fill_missing_values(method)`  - drop leading NaNs & replace other NaNs (middle/trailing) using the chosen method (forward fill or interpolation)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
