### PR TITLE
[BugFix] Fix usage of BART in HF_Text

### DIFF
--- a/multimodal/tests/hf_model_list.yaml
+++ b/multimodal/tests/hf_model_list.yaml
@@ -2,6 +2,7 @@
 - bert-base-chinese
 - bert-base-german-cased
 - bert-base-uncased
+- facebook/bart-base
 - distilbert-base-uncased
 - distilroberta-base
 - google/bert_uncased_L-6_H-768_A-12

--- a/multimodal/tests/unittests/others_2/test_predictor_with_bart.py
+++ b/multimodal/tests/unittests/others_2/test_predictor_with_bart.py
@@ -4,29 +4,29 @@ import warnings
 
 import numpy.testing as npt
 import pytest
+from datasets import load_dataset
 from torch import Tensor
 
 from autogluon.multimodal import MultiModalPredictor
 from autogluon.multimodal.constants import IA3_LORA
 
-from datasets import load_dataset
-
 
 @pytest.mark.parametrize("checkpoint_name", ["facebook/bart-base"])
 @pytest.mark.parametrize("efficient_finetune", [None, IA3_LORA])
 def test_predictor_with_bart(checkpoint_name, efficient_finetune):
-    train_data = load_dataset("glue", 'mrpc')['train'].to_pandas().drop('idx', axis=1).sample(500)
-    test_data = load_dataset("glue", 'mrpc')['validation'].to_pandas().drop('idx', axis=1).sample(20)
-    predictor = MultiModalPredictor(label='label')
-    predictor.fit(train_data,
-                  hyperparameters={
-                      "model.hf_text.checkpoint_name": "yuchenlin/BART0",
-                      "optimization.max_epochs": 1,
-                      "optimization.efficient_finetune": efficient_finetune,
-                      "optimization.top_k": 1,
-                      "optimization.top_k_average_method": "best",
-                      "env.batch_size": 2,
-                  },
-                  time_limit=20
+    train_data = load_dataset("glue", "mrpc")["train"].to_pandas().drop("idx", axis=1).sample(500)
+    test_data = load_dataset("glue", "mrpc")["validation"].to_pandas().drop("idx", axis=1).sample(20)
+    predictor = MultiModalPredictor(label="label")
+    predictor.fit(
+        train_data,
+        hyperparameters={
+            "model.hf_text.checkpoint_name": "yuchenlin/BART0",
+            "optimization.max_epochs": 1,
+            "optimization.efficient_finetune": efficient_finetune,
+            "optimization.top_k": 1,
+            "optimization.top_k_average_method": "best",
+            "env.batch_size": 2,
+        },
+        time_limit=20,
     )
     predictor.predict(test_data)

--- a/multimodal/tests/unittests/others_2/test_predictor_with_bart.py
+++ b/multimodal/tests/unittests/others_2/test_predictor_with_bart.py
@@ -23,7 +23,10 @@ def test_predictor_with_bart(checkpoint_name, efficient_finetune):
                       "model.hf_text.checkpoint_name": "yuchenlin/BART0",
                       "optimization.max_epochs": 1,
                       "optimization.efficient_finetune": efficient_finetune,
+                      "optimization.top_k": 1,
+                      "optimization.top_k_average_method": "best",
+                      "env.batch_size": 2,
                   },
-                  time_limit=180
+                  time_limit=60
     )
     predictor.predict(test_data)

--- a/multimodal/tests/unittests/others_2/test_predictor_with_bart.py
+++ b/multimodal/tests/unittests/others_2/test_predictor_with_bart.py
@@ -15,8 +15,8 @@ from datasets import load_dataset
 @pytest.mark.parametrize("checkpoint_name", ["facebook/bart-base"])
 @pytest.mark.parametrize("efficient_finetune", [None, IA3_LORA])
 def test_predictor_with_bart(checkpoint_name, efficient_finetune):
-    train_data = load_dataset("glue", 'mrpc')['train'].to_pandas().drop('idx', axis=1)
-    test_data = load_dataset("glue", 'mrpc')['validation'].to_pandas().drop('idx', axis=1)
+    train_data = load_dataset("glue", 'mrpc')['train'].to_pandas().drop('idx', axis=1).sample(100)
+    test_data = load_dataset("glue", 'mrpc')['validation'].to_pandas().drop('idx', axis=1).sample(20)
     predictor = MultiModalPredictor(label='label')
     predictor.fit(train_data,
                   hyperparameters={

--- a/multimodal/tests/unittests/others_2/test_predictor_with_bart.py
+++ b/multimodal/tests/unittests/others_2/test_predictor_with_bart.py
@@ -7,20 +7,22 @@ import pytest
 from torch import Tensor
 
 from autogluon.multimodal import MultiModalPredictor
-from autogluon.multimodal.constants import BIT_FIT, IA3, IA3_BIAS, IA3_LORA, LORA_BIAS, LORA_NORM, NORM_FIT
+from autogluon.multimodal.constants import IA3_LORA
 
 from datasets import load_dataset
 
 
 @pytest.mark.parametrize("checkpoint_name", ["facebook/bart-base"])
-def test_predictor_with_bart(checkpoint_name):
+@pytest.mark.parametrize("efficient_finetune", [None, IA3_LORA])
+def test_predictor_with_bart(checkpoint_name, efficient_finetune):
     train_data = load_dataset("glue", 'mrpc')['train'].to_pandas().drop('idx', axis=1)
     test_data = load_dataset("glue", 'mrpc')['validation'].to_pandas().drop('idx', axis=1)
     predictor = MultiModalPredictor(label='label')
     predictor.fit(train_data,
                   hyperparameters={
                       "model.hf_text.checkpoint_name": "yuchenlin/BART0",
-                      "optimization.max_epochs": 1
+                      "optimization.max_epochs": 1,
+                      "optimization.efficient_finetune": efficient_finetune,
                   },
                   time_limit=180
     )

--- a/multimodal/tests/unittests/others_2/test_predictor_with_bart.py
+++ b/multimodal/tests/unittests/others_2/test_predictor_with_bart.py
@@ -1,0 +1,27 @@
+import os
+import shutil
+import warnings
+
+import numpy.testing as npt
+import pytest
+from torch import Tensor
+
+from autogluon.multimodal import MultiModalPredictor
+from autogluon.multimodal.constants import BIT_FIT, IA3, IA3_BIAS, IA3_LORA, LORA_BIAS, LORA_NORM, NORM_FIT
+
+from datasets import load_dataset
+
+
+@pytest.mark.parametrize("checkpoint_name", ["facebook/bart-base"])
+def test_predictor_with_bart(checkpoint_name):
+    train_data = load_dataset("glue", 'mrpc')['train'].to_pandas().drop('idx', axis=1)
+    test_data = load_dataset("glue", 'mrpc')['validation'].to_pandas().drop('idx', axis=1)
+    predictor = MultiModalPredictor(label='label')
+    predictor.fit(train_data,
+                  hyperparameters={
+                      "model.hf_text.checkpoint_name": "yuchenlin/BART0",
+                      "optimization.max_epochs": 1
+                  },
+                  time_limit=180
+    )
+    predictor.predict(test_data)

--- a/multimodal/tests/unittests/others_2/test_predictor_with_bart.py
+++ b/multimodal/tests/unittests/others_2/test_predictor_with_bart.py
@@ -15,7 +15,7 @@ from datasets import load_dataset
 @pytest.mark.parametrize("checkpoint_name", ["facebook/bart-base"])
 @pytest.mark.parametrize("efficient_finetune", [None, IA3_LORA])
 def test_predictor_with_bart(checkpoint_name, efficient_finetune):
-    train_data = load_dataset("glue", 'mrpc')['train'].to_pandas().drop('idx', axis=1).sample(100)
+    train_data = load_dataset("glue", 'mrpc')['train'].to_pandas().drop('idx', axis=1).sample(500)
     test_data = load_dataset("glue", 'mrpc')['validation'].to_pandas().drop('idx', axis=1).sample(20)
     predictor = MultiModalPredictor(label='label')
     predictor.fit(train_data,

--- a/multimodal/tests/unittests/others_2/test_predictor_with_bart.py
+++ b/multimodal/tests/unittests/others_2/test_predictor_with_bart.py
@@ -27,6 +27,6 @@ def test_predictor_with_bart(checkpoint_name, efficient_finetune):
                       "optimization.top_k_average_method": "best",
                       "env.batch_size": 2,
                   },
-                  time_limit=60
+                  time_limit=20
     )
     predictor.predict(test_data)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

BART models won't support `token_type_ids`. This is identified via:

```python3

from transformers import AutoTokenizer

tokenizer_bart = AutoTokenizer.from_pretrained("facebook/bart-base")
print("BART: ", tokenizer_bart.model_input_names)

tokenizer_electra = AutoTokenizer.from_pretrained("google/electra-base-discriminator")
print("ELECTRA:", tokenizer_electra.model_input_names)
```

Output:
```
BART:  ['input_ids', 'attention_mask']
ELECTRA: ['input_ids', 'token_type_ids', 'attention_mask']
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
