### PR TITLE
[AutoMM] Fix some comments and docstrings

### DIFF
--- a/multimodal/src/autogluon/multimodal/configs/data/default.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/data/default.yaml
@@ -1,6 +1,6 @@
 data:
   image:
-    missing_value_strategy: "zero"  # How to deal with missing images. By default, we skip a sample with missing images. We also support choice "zero", i.e., using a zero image to replace a missing image.
+    missing_value_strategy: "zero"  # How to deal with missing images. By default, we use a zero image to replace a missing image. We also support "skip", i.e., skipping a sample with missing images.
   text:
     normalize_text: False  # Whether to normalize text
   categorical:

--- a/multimodal/src/autogluon/multimodal/data/process_categorical.py
+++ b/multimodal/src/autogluon/multimodal/data/process_categorical.py
@@ -22,8 +22,8 @@ class CategoricalProcessor:
         """
         Parameters
         ----------
-        prefix
-            The prefix connecting a processor to its corresponding model.
+        model
+            The model for which this processor would be created.
         requires_column_info
             Whether to require feature column information in dataloader.
         """

--- a/multimodal/src/autogluon/multimodal/data/process_image.py
+++ b/multimodal/src/autogluon/multimodal/data/process_image.py
@@ -66,8 +66,8 @@ class ImageProcessor:
         """
         Parameters
         ----------
-        prefix
-            The prefix connecting a processor to its corresponding model.
+        model
+            The model for which this processor would be created.
         train_transform_types
             A list of image transforms used in training. Note that the transform order matters.
         val_transform_types

--- a/multimodal/src/autogluon/multimodal/data/process_label.py
+++ b/multimodal/src/autogluon/multimodal/data/process_label.py
@@ -20,8 +20,8 @@ class LabelProcessor:
         """
         Parameters
         ----------
-        prefix
-            The prefix connecting a processor to its corresponding model.
+        model
+            The model for which this processor would be created.
         """
         self.prefix = model.prefix
 

--- a/multimodal/src/autogluon/multimodal/data/process_mmlab/process_mmdet.py
+++ b/multimodal/src/autogluon/multimodal/data/process_mmlab/process_mmdet.py
@@ -38,8 +38,6 @@ class MMDetProcessor(MMLabProcessor):
         ----------
         model
             The model using this data processor.
-        collate_func
-            The collate function to use for this processor
         max_img_num_per_col
             The maximum number of images one sample can have.
         missing_value_strategy

--- a/multimodal/src/autogluon/multimodal/data/process_mmlab/process_mmocr.py
+++ b/multimodal/src/autogluon/multimodal/data/process_mmlab/process_mmocr.py
@@ -38,8 +38,6 @@ class MMOcrProcessor(MMLabProcessor):
         ----------
         model
             The model using this data processor.
-        collate_func
-            The collate function to use for this processor
         max_img_num_per_col
             The maximum number of images one sample can have.
         missing_value_strategy

--- a/multimodal/src/autogluon/multimodal/data/process_ner.py
+++ b/multimodal/src/autogluon/multimodal/data/process_ner.py
@@ -1,9 +1,6 @@
-import ast
 import logging
 import os
 import warnings
-from copy import deepcopy
-from lib2to3.pgen2.token import OP
 from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
@@ -12,21 +9,7 @@ from omegaconf import DictConfig
 from torch import nn
 from transformers import AutoConfig, AutoTokenizer, BertTokenizer, CLIPTokenizer, ElectraTokenizer
 
-from ..constants import (
-    AUTOMM,
-    CHOICES_IDS,
-    LABEL,
-    NER,
-    NER_ANNOTATION,
-    NER_TEXT,
-    TEXT,
-    TEXT_NER,
-    TEXT_SEGMENT_IDS,
-    TEXT_TOKEN_IDS,
-    TEXT_VALID_LENGTH,
-    TOKEN_WORD_MAPPING,
-    WORD_OFFSETS,
-)
+from ..constants import AUTOMM, NER_ANNOTATION, NER_TEXT, TEXT, TEXT_NER
 from .collator import PadCollator, StackCollator
 from .utils import process_ner_annotations, tokenize_ner_text
 
@@ -57,8 +40,14 @@ class NerProcessor:
         config
             Config dictionary.
         """
-        self.model = model
         self.prefix = model.prefix
+        self.text_token_ids_key = model.text_token_ids_key
+        self.text_valid_length_key = model.text_valid_length_key
+        self.text_segment_ids_key = model.text_segment_ids_key
+        self.text_token_word_mapping_key = model.text_token_word_mapping_key
+        self.text_word_offsets_key = model.text_word_offsets_key
+        self.label_key = model.label_key
+
         self.tokenizer = None
         self.tokenizer_name = model.prefix
         self.max_len = max_len
@@ -99,12 +88,12 @@ class NerProcessor:
         if self.prefix == NER_TEXT:
             fn.update(
                 {
-                    self.model.text_token_ids_key: PadCollator(pad_val=self.tokenizer.pad_token_id),
-                    self.model.text_valid_length_key: StackCollator(),
-                    self.model.text_segment_ids_key: PadCollator(pad_val=0),
-                    self.model.text_token_word_mapping_key: PadCollator(pad_val=0),
-                    self.model.text_word_offsets_key: PadCollator(pad_val=0),
-                    self.model.label_key: StackCollator(),
+                    self.text_token_ids_key: PadCollator(pad_val=self.tokenizer.pad_token_id),
+                    self.text_valid_length_key: StackCollator(),
+                    self.text_segment_ids_key: PadCollator(pad_val=0),
+                    self.text_token_word_mapping_key: PadCollator(pad_val=0),
+                    self.text_word_offsets_key: PadCollator(pad_val=0),
+                    self.label_key: StackCollator(),
                 }
             )
         return fn
@@ -147,18 +136,18 @@ class NerProcessor:
             label, col_tokens, token_to_word_mappings, word_offsets = process_ner_annotations(
                 ner_annotation, ner_text, self.config.entity_map, self.tokenizer
             )
-            ret.update({self.model.label_key: label})
+            ret.update({self.label_key: label})
         else:
             col_tokens, token_to_word_mappings, word_offsets = tokenize_ner_text(ner_text, self.tokenizer)
-            ret.update({self.model.label_key: np.array([], dtype=np.int32)})
+            ret.update({self.label_key: np.array([], dtype=np.int32)})
 
         ret.update(
             {
-                self.model.text_token_ids_key: np.array(col_tokens.input_ids, dtype=np.int32),
-                self.model.text_valid_length_key: sum(col_tokens.attention_mask),
-                self.model.text_segment_ids_key: np.array(col_tokens.token_type_ids, dtype=np.int32),
-                self.model.text_token_word_mapping_key: token_to_word_mappings,
-                self.model.text_word_offsets_key: word_offsets,
+                self.text_token_ids_key: np.array(col_tokens.input_ids, dtype=np.int32),
+                self.text_valid_length_key: sum(col_tokens.attention_mask),
+                self.text_segment_ids_key: np.array(col_tokens.token_type_ids, dtype=np.int32),
+                self.text_token_word_mapping_key: token_to_word_mappings,
+                self.text_word_offsets_key: word_offsets,
             }
         )
 

--- a/multimodal/src/autogluon/multimodal/data/process_numerical.py
+++ b/multimodal/src/autogluon/multimodal/data/process_numerical.py
@@ -23,8 +23,8 @@ class NumericalProcessor:
         """
         Parameters
         ----------
-        prefix
-            The prefix connecting a processor to its corresponding model.
+        model
+            The model for which this processor would be created.
         merge
             How to merge numerical features from multiple columns in a multimodal pd.DataFrame.
             Currently, it only supports one choice:

--- a/multimodal/src/autogluon/multimodal/data/process_text.py
+++ b/multimodal/src/autogluon/multimodal/data/process_text.py
@@ -99,10 +99,8 @@ class TextProcessor:
         """
         Parameters
         ----------
-        prefix
-            The prefix connecting a processor to its corresponding model.
-        checkpoint_name
-            Name of the pretrained huggingface checkpoint, e.g., "microsoft/deberta-v3-small"
+        model
+            The model for which this processor would be created.
         tokenizer_name
             Name of the huggingface tokenizer type (default "hf_auto").
         max_len


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Align `missing_value_strategy `'s default with comments.
2. Fix/remove some docstrings in data processors.
3. Clean up some unused variables in ner processor.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
