### PR TITLE
[AutoMM] Filter out unused model configs

### DIFF
--- a/multimodal/src/autogluon/multimodal/utils/model.py
+++ b/multimodal/src/autogluon/multimodal/utils/model.py
@@ -142,9 +142,7 @@ def select_model(
     # clean up unused model configs
     model_keys = list(config.model.keys())
     for model_name in model_keys:
-        if model_name == "names":
-            pass
-        if model_name not in selected_model_names:
+        if model_name not in selected_model_names + ["names"]:
             delattr(config.model, model_name)
 
     return config

--- a/multimodal/src/autogluon/multimodal/utils/model.py
+++ b/multimodal/src/autogluon/multimodal/utils/model.py
@@ -141,8 +141,9 @@ def select_model(
 
     # clean up unused model configs
     model_keys = list(config.model.keys())
-    model_keys.remove("names")
     for model_name in model_keys:
+        if model_name == "names":
+            pass
         if model_name not in selected_model_names:
             delattr(config.model, model_name)
 

--- a/multimodal/src/autogluon/multimodal/utils/model.py
+++ b/multimodal/src/autogluon/multimodal/utils/model.py
@@ -139,6 +139,13 @@ def select_model(
     for model_name in selected_model_names:
         logger.debug(f"model dtypes: {getattr(config.model, model_name).data_types}")
 
+    # clean up unused model configs
+    model_keys = list(config.model.keys())
+    model_keys.remove("names")
+    for model_name in model_keys:
+        if model_name not in selected_model_names:
+            delattr(config.model, model_name)
+
     return config
 
 

--- a/multimodal/tests/unittests/predictor/test_predictor.py
+++ b/multimodal/tests/unittests/predictor/test_predictor.py
@@ -89,6 +89,12 @@ def verify_realtime_inference(predictor, df, verify_embedding=True):
             npt.assert_equal(embeddings_default, embeddings_realtime)
 
 
+def verify_no_redundant_model_configs(predictor):
+    model_names = list(predictor._config.model.keys())
+    model_names.remove("names")
+    assert sorted(predictor._config.model.names) == sorted(model_names)
+
+
 @pytest.mark.parametrize(
     "dataset_name,model_names,text_backbone,image_backbone,top_k_average_method,efficient_finetune,loss_function",
     [
@@ -253,7 +259,7 @@ def test_predictor(
         time_limit=20,
         save_path=save_path,
     )
-
+    verify_no_redundant_model_configs(predictor)
     score = predictor.evaluate(dataset.test_df)
     verify_predictor_save_load(predictor, dataset.test_df)
     verify_realtime_inference(predictor, dataset.test_df)
@@ -264,6 +270,7 @@ def test_predictor(
         hyperparameters=hyperparameters,
         time_limit=20,
     )
+    verify_no_redundant_model_configs(predictor)
     verify_predictor_save_load(predictor, dataset.test_df)
 
     # Saving to folder, loading the saved model and call fit again (continuous fit)


### PR DESCRIPTION
*Issue #, if available:*
Some unused model configs still exist in the saved config, which can confuse users.

*Description of changes:*
Filter out the unused model configs and only keep the used ones.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
