### PR TITLE
[CI] Enable HF model caching

### DIFF
--- a/.github/workflow_scripts/build_multimodal_tutorial.sh
+++ b/.github/workflow_scripts/build_multimodal_tutorial.sh
@@ -12,4 +12,6 @@ PR_NUMBER=$5  # For push events, PR_NUMBER will be empty
 source $(dirname "$0")/env_setup.sh
 source $(dirname "$0")/build_doc.sh
 
+setup_hf_model_mirror docs
+
 build_doc multimodal $BRANCH $GIT_REPO $COMMIT_SHA ${PR_NUMBER:-""} $SUB_DOC

--- a/.github/workflow_scripts/build_text_prediction_tutorial.sh
+++ b/.github/workflow_scripts/build_text_prediction_tutorial.sh
@@ -14,6 +14,5 @@ source $(dirname "$0")/build_doc.sh
 
 setup_torch_cpu
 export CUDA_VISIBLE_DEVICES=0
-setup_hf_model_mirror docs
 
 build_doc text_prediction $BRANCH $GIT_REPO $COMMIT_SHA $PR_NUMBER

--- a/.github/workflow_scripts/build_text_prediction_tutorial.sh
+++ b/.github/workflow_scripts/build_text_prediction_tutorial.sh
@@ -14,5 +14,6 @@ source $(dirname "$0")/build_doc.sh
 
 setup_torch_cpu
 export CUDA_VISIBLE_DEVICES=0
+setup_hf_model_mirror docs
 
 build_doc text_prediction $BRANCH $GIT_REPO $COMMIT_SHA $PR_NUMBER

--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -38,6 +38,11 @@ function setup_torch_cpu_non_linux {
     pip3 install torch==1.13.1 torchvision==0.14.1
 }
 
+function setup_hf_model_mirror {
+    SUB_FOLDER="$1"
+    python3 setup_hf_model_mirror.py --model_list_file $(dirname "$0")/../../multimodal/tests/hf_model_list.yaml --sub_folder $SUB_FOLDER
+}
+
 function install_local_packages {
     while(($#)) ; do
         python3 -m pip install --upgrade -e $1

--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -40,7 +40,7 @@ function setup_torch_cpu_non_linux {
 
 function setup_hf_model_mirror {
     SUB_FOLDER="$1"
-    python3 setup_hf_model_mirror.py --model_list_file $(dirname "$0")/../../multimodal/tests/hf_model_list.yaml --sub_folder $SUB_FOLDER
+    python3 $(dirname "$0")/setup_hf_model_mirror.py --model_list_file $(dirname "$0")/../../multimodal/tests/hf_model_list.yaml --sub_folder $SUB_FOLDER
 }
 
 function install_local_packages {

--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -39,6 +39,7 @@ function setup_torch_cpu_non_linux {
 }
 
 function setup_hf_model_mirror {
+    pip3 install PyYAML
     SUB_FOLDER="$1"
     python3 $(dirname "$0")/setup_hf_model_mirror.py --model_list_file $(dirname "$0")/../../multimodal/tests/hf_model_list.yaml --sub_folder $SUB_FOLDER
 }

--- a/.github/workflow_scripts/setup_hf_model_mirror.py
+++ b/.github/workflow_scripts/setup_hf_model_mirror.py
@@ -6,8 +6,8 @@ import yaml
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-parser.add_argument("--model_list_file", help="file containing list of models to download.", type=str)
-parser.add_argument("--sub_folder", help="which subfolder to download models for")
+parser.add_argument("--model_list_file", help="file containing list of models to download.", type=str, required=True)
+parser.add_argument("--sub_folder", help="which subfolder to download models for", required=True)
 parser.add_argument("--cache_dir", help="place to cache the downloaded models", default="~/.cache/huggingface/hub")
 
 args = parser.parse_args()

--- a/.github/workflow_scripts/setup_hf_model_mirror.py
+++ b/.github/workflow_scripts/setup_hf_model_mirror.py
@@ -1,0 +1,34 @@
+import argparse
+import os
+import subprocess
+import yaml
+
+
+parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+parser.add_argument("--model_list_file", help="file containing list of models to download.", type=str)
+parser.add_argument("--sub_folder", help="which subfolder to download models for")
+parser.add_argument("--cache_dir", help="place to cache the downloaded models", default="~/.cache/hugging_face/hub")
+
+args = parser.parse_args()
+
+model_list_file = args.model_list_file
+sub_folder = args.sub_folder
+cache_dir = args.cache_dir
+cache_dir = os.path.expanduser(cache_dir)
+
+with open(model_list_file, "r") as fp:
+    models = yaml.safe_load(fp)
+    sub_folder_models = models[sub_folder]
+
+os.makedirs(cache_dir)
+
+bucket = "s3://autogluon-hf-model-mirror"
+model_prefix = "models"
+for model in sub_folder_models:
+    model_name = "--".join(model.split('/'))
+    model_name = "--".join([model_prefix, model_name])
+    model_path = os.path.join(cache_dir, model_name)
+    os.makedirs(model_path)
+    s3_path = bucket + "/" + model_name
+    subprocess.run(["aws", "s3", "cp", s3_path, model_path, '--recursive'])

--- a/.github/workflow_scripts/setup_hf_model_mirror.py
+++ b/.github/workflow_scripts/setup_hf_model_mirror.py
@@ -8,7 +8,7 @@ parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFo
 
 parser.add_argument("--model_list_file", help="file containing list of models to download.", type=str)
 parser.add_argument("--sub_folder", help="which subfolder to download models for")
-parser.add_argument("--cache_dir", help="place to cache the downloaded models", default="~/.cache/hugging_face/hub")
+parser.add_argument("--cache_dir", help="place to cache the downloaded models", default="~/.cache/huggingface/hub")
 
 args = parser.parse_args()
 
@@ -21,7 +21,7 @@ with open(model_list_file, "r") as fp:
     models = yaml.safe_load(fp)
     sub_folder_models = models[sub_folder]
 
-os.makedirs(cache_dir)
+os.makedirs(cache_dir, exist_ok=True)
 
 bucket = "s3://autogluon-hf-model-mirror"
 model_prefix = "models"
@@ -29,6 +29,6 @@ for model in sub_folder_models:
     model_name = "--".join(model.split('/'))
     model_name = "--".join([model_prefix, model_name])
     model_path = os.path.join(cache_dir, model_name)
-    os.makedirs(model_path)
+    os.makedirs(model_path, exist_ok=True)
     s3_path = bucket + "/" + model_name
     subprocess.run(["aws", "s3", "cp", s3_path, model_path, '--recursive'])

--- a/.github/workflow_scripts/test_multimodal.sh
+++ b/.github/workflow_scripts/test_multimodal.sh
@@ -6,6 +6,7 @@ function test_multimodal {
 
     setup_build_env
     setup_torch_gpu
+    setup_hf_model_mirror "$SUB_FOLDER"
     export CUDA_VISIBLE_DEVICES=0
     install_local_packages "common/[tests]" "core/[all,tests]" "features/"
     install_multimodal "[tests]"

--- a/CI/hf_mirror/Dockerfile
+++ b/CI/hf_mirror/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.8
+
+RUN python3 -m pip --no-cache-dir install --upgrade wheel setuptools \
+    && python3 -m pip --no-cache-dir install --upgrade huggingface-hub awscli
+
+COPY download_hf_models.py ./
+COPY download_hf_models.sh ./
+RUN chmod +x download_hf_models.sh
+
+CMD ["/bin/bash"]

--- a/CI/hf_mirror/deploy.sh
+++ b/CI/hf_mirror/deploy.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 369469875935.dkr.ecr.us-east-1.amazonaws.com
+docker build -t autogluon-hf-mirror .
+docker tag autogluon-hf-mirror:latest 369469875935.dkr.ecr.us-east-1.amazonaws.com/autogluon-hf-mirror:latest
+docker push 369469875935.dkr.ecr.us-east-1.amazonaws.com/autogluon-hf-mirror:latest

--- a/CI/hf_mirror/deploy.sh
+++ b/CI/hf_mirror/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-
-aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 369469875935.dkr.ecr.us-east-1.amazonaws.com
+ECR_REPO=369469875935.dkr.ecr.us-east-1.amazonaws.com
+aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $ECR_REPO
 docker build -t autogluon-hf-mirror .
-docker tag autogluon-hf-mirror:latest 369469875935.dkr.ecr.us-east-1.amazonaws.com/autogluon-hf-mirror:latest
-docker push 369469875935.dkr.ecr.us-east-1.amazonaws.com/autogluon-hf-mirror:latest
+docker tag autogluon-hf-mirror:latest $ECR_REPO/autogluon-hf-mirror:latest
+docker push $ECR_REPO/autogluon-hf-mirror:latest

--- a/CI/hf_mirror/download_hf_models.py
+++ b/CI/hf_mirror/download_hf_models.py
@@ -1,0 +1,27 @@
+import argparse
+import yaml
+
+from huggingface_hub import snapshot_download
+from huggingface_hub.utils import RepositoryNotFoundError
+
+
+parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+parser.add_argument('--model_list_file', help='file containing list of models to download.', type=str)
+
+args = parser.parse_args()
+
+model_list_file = args.model_list_file
+
+with open(model_list_file, 'r') as fp:
+    model_list = yaml.safe_load(fp)  # a dict containing models for different sub_folders
+    model_list = list(model_list.values())
+    model_list = set(sum(model_list, []))  # concatenate inner model lists
+
+for model in model_list:
+    print(f"Downloading {model}")
+    try:
+        snapshot_download(repo_id=model, cache_dir="/mnt/efs/")
+        print(f"Finished downloading {model}")
+    except RepositoryNotFoundError:
+        print(f"Invalid repo_id: {model}. Failed to download")

--- a/CI/hf_mirror/download_hf_models.py
+++ b/CI/hf_mirror/download_hf_models.py
@@ -7,7 +7,7 @@ from huggingface_hub.utils import RepositoryNotFoundError
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-parser.add_argument('--model_list_file', help='file containing list of models to download.', type=str)
+parser.add_argument('--model_list_file', help='file containing list of models to download.', type=str, required=True)
 
 args = parser.parse_args()
 

--- a/CI/hf_mirror/download_hf_models.sh
+++ b/CI/hf_mirror/download_hf_models.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+df -h  # debug purpose to make sure efs is attached correclty
+git clone https://github.com/autogluon/autogluon.git
+python3 download_hf_models.py --model_list_file autogluon/multimodal/tests/hf_model_list.yaml
+aws s3 sync --delete /mnt/efs s3://autogluon-hf-model-mirror

--- a/CI/hf_mirror/download_hf_models.sh
+++ b/CI/hf_mirror/download_hf_models.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-df -h  # debug purpose to make sure efs is attached correclty
+if grep -qs '/mnt/efs ' /proc/mounts; 
+then 
+    echo EFS attached
+else
+    echo EFS failed to attach
+    exit 1
+fi
 git clone https://github.com/autogluon/autogluon.git
 python3 download_hf_models.py --model_list_file autogluon/multimodal/tests/hf_model_list.yaml
 aws s3 sync --delete /mnt/efs s3://autogluon-hf-model-mirror

--- a/multimodal/tests/hf_model_list.yaml
+++ b/multimodal/tests/hf_model_list.yaml
@@ -1,30 +1,42 @@
-- WinKawaks/vit-tiny-patch16-224
-- bert-base-chinese
+docs:
 - bert-base-german-cased
+- google/electra-small-discriminator
+- hfl/chinese-lert-small
+- sentence-transformers/all-MiniLM-L6-v2
+- google/bert_uncased_L-6_H-768_A-12
+others:
+- bert-base-chinese
 - bert-base-uncased
 - facebook/bart-base
 - distilbert-base-uncased
 - distilroberta-base
-- google/bert_uncased_L-6_H-768_A-12
+- facebook/bart-base
 - google/electra-base-discriminator
 - google/electra-small-discriminator
-- google/flan-t5-small
-- google/flan-t5-xl
 - gpt2
-- hfl/chinese-lert-small
 - huawei-noah/TinyBERT_General_4L_312D
 - microsoft/deberta-base
 - microsoft/deberta-v3-base
-- microsoft/deberta-v3-small
-- microsoft/resnet-18
-- microsoft/swin-base-patch4-window7-224
-- microsoft/swin-tiny-patch4-window7-224
-- monsoon-nlp/hindi-bert
 - nlpaueb/legal-bert-small-uncased
 - openai/clip-vit-base-patch32
 - roberta-base
 - sentence-transformers/all-MiniLM-L6-v2
 - sentence-transformers/all-mpnet-base-v2
 - sentence-transformers/msmarco-MiniLM-L-12-v3
-- t5-small
 - xlm-roberta-base
+others_2:
+- google/electra-small-discriminator
+- google/flan-t5-small
+- hfl/chinese-lert-small
+- microsoft/deberta-v3-small
+- nlpaueb/legal-bert-small-uncased
+- sentence-transformers/all-MiniLM-L6-v2
+- t5-small
+predictor:
+- CLTL/MedRoBERTa.nl
+- google/electra-small-discriminator
+- monsoon-nlp/hindi-bert
+- nlpaueb/legal-bert-small-uncased
+- openai/clip-vit-base-patch32
+- sentence-transformers/all-MiniLM-L6-v2
+- t5-small

--- a/multimodal/tests/hf_model_list.yaml
+++ b/multimodal/tests/hf_model_list.yaml
@@ -10,7 +10,6 @@ others:
 - facebook/bart-base
 - distilbert-base-uncased
 - distilroberta-base
-- facebook/bart-base
 - google/electra-base-discriminator
 - google/electra-small-discriminator
 - gpt2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Have setup an AWS Batch job running chronically to sync up our models stored in S3 with HF. An EFS was used as a cache so we don't re-download the model each time.
  * List of models will be fetched dynamically from our repo with `hf_model_list.yaml`
  * All models in the list will be downloaded and synced to our S3, no matter which subfolder it belongs to
* CI job will use `setup_hf_model_mirror.py` to download the corresponding models to `~/.cache/huggingface/hub` for the specific subfolder to test.
* Updated the structure of the model list.
* A follow-up PR to enforce model list updating will be sent


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
