### PR TITLE
[MERGE AFTER HF CACHE ENABLED] Enforce model list check

### DIFF
--- a/.github/workflows/check_hf_model_list.yml
+++ b/.github/workflows/check_hf_model_list.yml
@@ -2,7 +2,7 @@ name: Check HF Model List
 
 on:
   pull_request:
-    types: [synchronize, opened]
+    types: [labeled, synchronize, opened]
     paths:
       - 'multimodal/tests/**'
       - 'docs/tutorials/multimodal/**'
@@ -11,8 +11,8 @@ jobs:
   model_list_check:
     runs-on: ubuntu-latest
     steps:
-      - name: Check PR Safe to Run
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'model list checked') == 'false' }}
+      - name: Check model list
+        if: contains(github.event.pull_request.labels.*.name, 'model list checked') == false
         run: |
-        echo It appears that you have modified multimodal unit tests/docs. Please make sure to update `multimodal/tests/hf_model_list.yaml` to include any model changes and tag this PR with `model list checked`.
-        exit 1
+          echo It appears that you have modified multimodal unit tests/docs. Please make sure to update \"multimodal/tests/hf_model_list.yaml\" to include any model changes and label this PR with \"model list checked\".
+          exit 1

--- a/.github/workflows/check_hf_model_list.yml
+++ b/.github/workflows/check_hf_model_list.yml
@@ -1,0 +1,18 @@
+name: Check HF Model List
+
+on:
+  pull_request:
+    types: [synchronize, opened]
+    paths:
+      - 'multimodal/tests/**'
+      - 'docs/tutorials/multimodal/**'
+
+jobs:
+  model_list_check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR Safe to Run
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'model list checked') == 'false' }}
+        run: |
+        echo It appears that you have modified multimodal unit tests/docs. Please make sure to update `multimodal/tests/hf_model_list.yaml` to include any model changes and tag this PR with `model list checked`.
+        exit 1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* This workflow will fail whenever the commit modified multimodal unit tests/doc to ensure people remember updating the model list file if necessary. Can be passed by adding the label `model list checked`
* Have tested on my fork: https://github.com/yinweisu/autogluon/pull/20


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
