### PR TITLE
Fix TIMM integration to support adaptive image size

### DIFF
--- a/multimodal/src/autogluon/multimodal/configs/model/fusion_mlp_image_text_tabular.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/model/fusion_mlp_image_text_tabular.yaml
@@ -117,7 +117,7 @@ model:
       - "resize_shorter_side"
       - "center_crop"
     image_norm: "imagenet"
-    image_size: 224
+    image_size: null
     max_img_num_per_col: 2
 
   mmdet_image:

--- a/multimodal/src/autogluon/multimodal/data/process_image.py
+++ b/multimodal/src/autogluon/multimodal/data/process_image.py
@@ -38,6 +38,7 @@ from ..constants import (
     IMAGE_VALID_NUM,
     TIMM_IMAGE,
 )
+from ..models.timm_image import TimmAutoModelForImagePrediction
 from .collator import PadCollator, StackCollator
 from .trivial_augmenter import TrivialAugment
 from .utils import extract_value_from_config, is_rois_input
@@ -82,7 +83,7 @@ class ImageProcessor:
                 Normalize image by mean (0.48145466, 0.4578275, 0.40821073) and
                 std (0.26862954, 0.26130258, 0.27577711), used for CLIP.
         size
-            The width / height of a square image.
+            The provided width / height of a square image.
         max_img_num_per_col
             The maximum number of images one sample can have.
         missing_value_strategy
@@ -93,12 +94,6 @@ class ImageProcessor:
                 Use an image with zero pixels.
         requires_column_info
             Whether to require feature column information in dataloader.
-        trivial_augment_maxscale
-            Used in trivial augment as the maximum scale that can be random generated
-            A value of 0 means turn off trivial augment
-            https://arxiv.org/pdf/2103.10158.pdf
-        model
-            The model using this data processor.
         """
         self.train_transform_types = train_transform_types
         self.val_transform_types = val_transform_types
@@ -114,6 +109,24 @@ class ImageProcessor:
 
         if model is not None:
             self.size, self.mean, self.std = self.extract_default(model.config)
+            if isinstance(model, TimmAutoModelForImagePrediction):
+                if model.support_variable_input_size() and size is not None:
+                    # We have detected that the model supports using an image size that is
+                    # different from the pretrained model, e.g., ConvNets with global pooling
+                    if size < self.size:
+                        logger.warn(
+                            f"The provided image size={size} is smaller than the default size "
+                            f"of the pretrained backbone, which is {self.size}. "
+                            f"Detailed configuration of the backbone is in {model.config}. "
+                            f"You may like to double check your configuration."
+                        )
+                    self.size = size
+            elif size is not None and size != self.size:
+                logger.warn(
+                    f"The model does not support using an image size that is different from the default size. "
+                    f"Provided image size={size}. Default size={self.size}. "
+                    f"Detailed model configuration={model.config}. We have ignored the provided image size."
+                )
         if self.size is None:
             if size is not None:
                 self.size = size
@@ -370,7 +383,6 @@ class ImageProcessor:
                             is_zero_img = True
                         else:
                             raise e
-
                 if is_training:
                     img = self.train_processor(img)
                 else:

--- a/multimodal/src/autogluon/multimodal/models/timm_image.py
+++ b/multimodal/src/autogluon/multimodal/models/timm_image.py
@@ -13,6 +13,10 @@ from .utils import assign_layer_ids, get_column_features, get_model_head
 logger = logging.getLogger(AUTOMM)
 
 
+# Stores the
+SUPPORT_VARIABLE_INPUT_SIZE_TIMM_CLASSES = {"convnext", "efficientnet", "mobilenetv3", "regnet", "resnet"}
+
+
 class TimmAutoModelForImagePrediction(nn.Module):
     """
     Support TIMM image backbones.
@@ -113,6 +117,16 @@ class TimmAutoModelForImagePrediction(nn.Module):
     @property
     def image_feature_dim(self):
         return self.model.num_features
+
+    def support_variable_input_size(self):
+        """Whether the TIMM image support images sizes that are different from the default used in the backbones"""
+        if "test_input_size" in self.config and self.config["test_input_size"] != self.config["input_size"]:
+            return True
+        cls_name = type(self.model).__name__.lower()
+        for k in SUPPORT_VARIABLE_INPUT_SIZE_TIMM_CLASSES:
+            if cls_name in k:
+                return True
+        return False
 
     def forward(
         self,

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -2629,6 +2629,16 @@ class MultiModalPredictor:
         ):
             data_processors = None
 
+        # backward compatibility for variable image size.
+        if version.parse(assets["version"]) <= version.parse("0.6.2"):
+            print("hasattr model.timm_image", hasattr(config, "model.timm_image"))
+            if OmegaConf.select(config, "model.timm_image") is not None:
+                logger.warn(
+                    "Loading a model that has been trained via AutoGluon Multimodal<=0.6.2. "
+                    "Try to update the timm image size."
+                )
+                config.model.timm_image.image_size = None
+
         predictor._label_column = assets["label_column"]
         predictor._problem_type = assets["problem_type"]
         if "pipeline" in assets:  # backward compatibility

--- a/multimodal/tests/unittests/others/test_process_image.py
+++ b/multimodal/tests/unittests/others/test_process_image.py
@@ -1,0 +1,44 @@
+import pytest
+import torch as th
+
+from autogluon.multimodal.data.process_image import ImageProcessor
+from autogluon.multimodal.models.timm_image import TimmAutoModelForImagePrediction
+from autogluon.multimodal.utils.misc import shopee_dataset
+
+
+@pytest.mark.parametrize(
+    "checkpoint_name,provided_size,expected_size",
+    [
+        ("swinv2_tiny_window8_256", 300, 256),  # SwinTransformer
+        ("convnext_nano", 300, 300),  # ConvNext
+        ("resnet50", 300, 300),  # ResNet
+        ("regnety_004", 300, 300),  # RegNet
+        ("fbnetv3_b", 300, 300),  # MobileNetV3
+        ("tf_efficientnet_b2", 300, 300),
+    ],
+)  # EfficientNet
+def test_variable_input_size_backbone(checkpoint_name, provided_size, expected_size):
+    download_dir = "./ag_automm_tutorial_imgcls"
+    train_df, test_df = shopee_dataset(download_dir)
+
+    train_transform_types = ["resize_shorter_side", "center_crop", "trivial_augment"]
+    val_transform_types = ["resize_shorter_side", "center_crop"]
+
+    timm_model = TimmAutoModelForImagePrediction(
+        prefix="timm_image", checkpoint_name=checkpoint_name, pretrained=False
+    )
+
+    image_processor = ImageProcessor(
+        model=timm_model,
+        train_transform_types=train_transform_types,
+        val_transform_types=val_transform_types,
+        size=provided_size,
+    )
+    ret = image_processor.process_one_sample(
+        {"image": train_df["image"].tolist()}, feature_modalities={"image": "image"}, is_training=True
+    )
+    assert ret["timm_image_image"].shape[-1] == expected_size
+    out = timm_model(
+        th.unsqueeze(ret[timm_model.image_key], dim=0),
+        th.unsqueeze(th.Tensor(ret[timm_model.image_valid_num_key]), dim=0),
+    )

--- a/multimodal/tests/unittests/others_2/test_backward_compatibility.py
+++ b/multimodal/tests/unittests/others_2/test_backward_compatibility.py
@@ -7,6 +7,7 @@ import pytest
 
 from autogluon.multimodal import MultiModalPredictor
 from autogluon.multimodal.utils import download
+from autogluon.multimodal.utils.misc import shopee_dataset
 
 from ..predictor.test_predictor import verify_predictor_save_load
 from ..utils.unittest_datasets import AmazonReviewSentimentCrossLingualDataset
@@ -14,9 +15,9 @@ from ..utils.utils import get_home_dir, protected_zip_extraction
 
 
 @pytest.mark.parametrize("cls", [MultiModalPredictor])
-def test_load_old_checkpoint(cls):
+def test_load_old_checkpoint_text_only(cls):
     dataset = AmazonReviewSentimentCrossLingualDataset()
-    sha1sum_id = "4ba096cdf6bd76c06386f2c27140db055e59c91b"
+    sha1_hash = "4ba096cdf6bd76c06386f2c27140db055e59c91b"
     checkpoint_name = "mdeberta-v3-base-checkpoint"
     save_path = os.path.join(get_home_dir(), "checkpoints")
     file_path = os.path.join(save_path, f"{checkpoint_name}.zip")
@@ -26,11 +27,11 @@ def test_load_old_checkpoint(cls):
     download(
         url=f"s3://automl-mm-bench/unit-tests-0.4/checkpoints/{checkpoint_name}.zip",
         path=file_path,
-        sha1_hash=sha1sum_id,
+        sha1_hash=sha1_hash,
     )
     protected_zip_extraction(
         file_path,
-        sha1_hash=sha1sum_id,
+        sha1_hash=sha1_hash,
         folder=save_path,
     )
     predictor = cls.load(checkpoint_path)
@@ -43,3 +44,32 @@ def test_load_old_checkpoint(cls):
         time_limit=10,
         hyperparameters={"optimization.top_k_average_method": "uniform_soup", "env.num_gpus": 1},
     )
+
+
+def test_v0_6_2_checkpoint_timm_image():
+    train_df, test_df = shopee_dataset("./ag_automm_tutorial_imgcls")
+
+    file_path = "convnext_nano_shopee_0.6.2_backward_compatible_test.zip"
+    save_path = os.path.join(get_home_dir(), "checkpoints_0.6.2_backward_compatible")
+    checkpoint_path = os.path.join(save_path, "convnext_nano_shopee")
+    sha1_hash = "b0b36fd076b3e0ab599f917c9b2924aef84a02b6"
+    download(
+        url="https://automl-mm-bench.s3.amazonaws.com/unit-tests/convnext_nano_shopee_0.6.2_backward_compatible_test.zip",
+        path=file_path,
+        sha1_hash=sha1_hash,
+    )
+    protected_zip_extraction(
+        file_path,
+        sha1_hash=sha1_hash,
+        folder=save_path,
+    )
+    predictor = MultiModalPredictor.load(checkpoint_path)
+    print(predictor._config)
+    assert predictor._config.model.timm_image.image_size is None
+
+    predictor.fit(
+        train_df,
+        hyperparameters={"model.timm_image.image_size": 288},
+        time_limit=10,
+    )
+    assert predictor._config.model.timm_image.image_size == 288

--- a/multimodal/tests/unittests/others_2/test_predictor_with_bart.py
+++ b/multimodal/tests/unittests/others_2/test_predictor_with_bart.py
@@ -20,7 +20,7 @@ def test_predictor_with_bart(checkpoint_name, efficient_finetune):
     predictor.fit(
         train_data,
         hyperparameters={
-            "model.hf_text.checkpoint_name": "yuchenlin/BART0",
+            "model.hf_text.checkpoint_name": checkpoint_name,
             "optimization.max_epochs": 1,
             "optimization.efficient_finetune": efficient_finetune,
             "optimization.top_k": 1,


### PR DESCRIPTION
*Issue #, if available:*

Solve https://github.com/autogluon/autogluon/issues/2585

*Description of changes:*

- [x] Support specifying different image_size for specific TIMM backbones like ResNet / RegNet / MobileNetV3 / EfficientNet, while disable the behavior for backbones like SwinTransformer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
