### PR TITLE
[timeseries] Add ujson dependency to silence the GluonTS warning

### DIFF
--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -34,6 +34,7 @@ install_requires = [
     "networkx",
     "statsforecast==1.4.0",
     "tqdm",
+    "ujson",  # needed to silence GluonTS warning
     f"autogluon.core[raytune]=={version}",
     f"autogluon.common=={version}",
     f"autogluon.tabular[catboost,lightgbm,xgboost]=={version}",

--- a/timeseries/src/autogluon/timeseries/models/gluonts/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/__init__.py
@@ -1,12 +1,3 @@
-import warnings
-
-gluonts_json_warning = (
-    "Using `json`-module for json-handling. "
-    "Consider installing one of `orjson`, `ujson` "
-    "to speed up serialization and deserialization."
-)
-warnings.filterwarnings("ignore", message=gluonts_json_warning)
-
 from .torch import DeepARModel, SimpleFeedForwardModel, TemporalFusionTransformerModel
 
 __all__ = ["DeepARModel", "SimpleFeedForwardModel", "TemporalFusionTransformerModel"]


### PR DESCRIPTION
*Description of changes:*
- The new GluonTS version seems to overcome our method for silencing the JSON warning, so it's probably easier to just add `ujson` as a dependency. The library is actively developed and actually isn't use in our code, so it should be safe.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
