### PR TITLE
[timeseries] Fix PerformanceWarning in AutoGluonTabularModel

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
@@ -201,7 +201,7 @@ class AutoGluonTabularModel(AbstractTimeSeriesModel):
             remainder = len(time_series) - num_windows * self.prediction_length
             num_hidden = np.concatenate([np.zeros(remainder), np.tile(np.arange(self.prediction_length), num_windows)])
             target_lags = apply_mask(target_lags, num_hidden=num_hidden, lag_indices=self._target_lag_indices)
-            feature_dfs = [target_lags]
+            feature_dfs = [target_lags, time_series[[self.target]]]
 
             if self.metadata.past_covariates_real:
                 past_covariates_lags = get_lags(
@@ -221,13 +221,7 @@ class AutoGluonTabularModel(AbstractTimeSeriesModel):
                 )
                 feature_dfs.append(known_covariates_lags)
 
-            if len(feature_dfs) > 1:
-                features = pd.concat(feature_dfs, axis=1)
-            else:
-                features = target_lags
-
-            # Prediction target
-            features[self.target] = time_series[self.target]
+            features = pd.concat(feature_dfs, axis=1)
             return features
 
         df = pd.DataFrame(data).reset_index(level=TIMESTAMP)


### PR DESCRIPTION
*Description of changes:*
- When training `AutoGluonTabular` model with both past & known covariates, the following warning is raised by pandas

> /local/home/shchuro/workspace/autogluon/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py:230: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`

This happens at line
```
  features[self.target] = time_series[self.target]
```

This PR replaces column insertion with a concatenation, which fixes this warning.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
