### PR TITLE
Remove gluoncv

### DIFF
--- a/CI/docker/full_install_image.sh
+++ b/CI/docker/full_install_image.sh
@@ -7,6 +7,5 @@ python3 -m pip install features/
 python3 -m pip install tabular/[all,tests]
 python3 -m pip install multimodal/[tests]
 python3 -m pip install text/[tests]
-python3 -m pip install vision/
 python3 -m pip install timeseries/[all,tests]
 python3 -m pip install autogluon/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,8 +67,6 @@ cd ../extra/
 pytest
 cd ../text/
 pytest
-cd ../vision/
-pytest
 cd ../features/
 pytest
 ```

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -32,7 +32,7 @@ DEPENDENT_PACKAGES = {
 if LITE_MODE:
     DEPENDENT_PACKAGES = {
         package: version for package, version in DEPENDENT_PACKAGES.items()
-        if package not in ['psutil', 'gluoncv', 'Pillow', 'timm']
+        if package not in ['psutil', 'Pillow', 'timm']
     }
 
 DEPENDENT_PACKAGES = {package: package + version for package, version in DEPENDENT_PACKAGES.items()}


### PR DESCRIPTION
*Issue #, if available:*
#2694 

*Description of changes:*
Remove remaining existence of `autogluon.vision`, `ImagePredictor`, `ObjectDetector` and `gluoncv`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
