### PR TITLE
Expand numpy,scipy,scikit-learn version ranges

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -309,7 +309,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup Env Vars
         uses: ./.github/actions/setup-env-vars
-      - name: Build Timeseries Tutorial on AWS Batch
+      - name: Build EDA Tutorial on AWS Batch
         uses: ./.github/actions/submit-job
         with:
           job-type: CI-GPU

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -20,15 +20,15 @@ PYTHON_REQUIRES = '>=3.8, <3.11'
 DEPENDENT_PACKAGES = {
     # note: if python 3.7 is used, the open CVEs are present: CVE-2021-41496 | CVE-2021-34141; fixes are available in 1.22.x, but python 3.8 only
     'boto3': '>=1.10,<2',  # <2 because unlikely to introduce breaking changes in minor releases. >=1.10 because 1.10 is 3 years old, no need to support older
-    'numpy': '>=1.21,<1.24',
-    'pandas': '>1.4.0,<1.6',
-    'scikit-learn': '>=1.0.0,<1.2',
-    'scipy': '>=1.5.4,<1.10.0',
-    'psutil': '>=5.7.3,<6',
-    'networkx': '>=2.3,<3.0',
-    'tqdm': '>=4.38.0',
-    'Pillow': '>=9.3.0,<9.6.0',
-    'timm': '>=0.5.4,<0.7.0',
+    'numpy': '>=1.21,<1.27',  # "<{N+3}" upper cap, where N is the latest released minor version, assuming no warnings using N
+    'pandas': '>=1.4.1,<1.6',  # "<{N+1}" upper cap
+    'scikit-learn': '>=1.0,<1.3',  # "<{N+1}" upper cap
+    'scipy': '>=1.5.4,<1.12',  # "<{N+2}" upper cap
+    'psutil': '>=5.7.3,<6',  # Major version cap
+    'networkx': '>=2.3,<3.0',  # TODO: v0.8, upgrade to 3.x
+    'tqdm': '>=4.38,<5',  # Major version cap
+    'Pillow': '>=9.3,<9.6',  # "<{N+2}" upper cap
+    'timm': '>=0.5.4,<0.7',  # "<{N+1}" upper cap
 }
 if LITE_MODE:
     DEPENDENT_PACKAGES = {

--- a/eda/tests/unittests/auto/test_simple.py
+++ b/eda/tests/unittests/auto/test_simple.py
@@ -388,9 +388,9 @@ def test_target_analysis__regression(monkeypatch):
                 " - [skewnorm](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.skewnorm.html)",
                 "   - p-value: 0.963",
                 "   - Parameters: (a: 3.xx, loc: 78497.xx, scale: 150470.xx)",
-                " - [genlogistic](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.genlogistic.html)",
-                "   - p-value: 0.962",
-                "   - Parameters: (c: 129.xx, loc: -233264.xx, scale: 78753.xx)",
+                " - [weibull_min](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.weibull_min.html)",
+                "   - p-value: 0.963",
+                "   - Parameters: (c: 1.xx, loc: 16324.xx, scale: 200669.xx)",
             ]
         ),
         "### Target variable correlations\n - ⚠️ no fields with absolute correlation greater than `0.5` found for target variable `fnlwgt`.",
@@ -425,5 +425,5 @@ def test_target_analysis__regression(monkeypatch):
         "gumbel_r",
         "nakagami",
         "skewnorm",
-        "genlogistic",
+        "weibull_min",
     ]


### PR DESCRIPTION
*Issue #, if available:*
#2813

*Description of changes:*

- Expand numpy, scipy, and scikit-learn version ranges to include latest release.
- Version cap tqdm to `<5` (Current latest is `4.x`)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
