### PR TITLE
[multimodal] Log warning for multi-gpu realtime prediction

### DIFF
--- a/multimodal/src/autogluon/multimodal/utils/inference.py
+++ b/multimodal/src/autogluon/multimodal/utils/inference.py
@@ -153,7 +153,7 @@ def infer_batch(
     device = torch.device(device_type)
     batch_size = len(batch[next(iter(batch))])
     if 1 < num_gpus <= batch_size:
-        model = nn.DataParallel(model)
+        logger.warning("Not able to benefit from multi-gpu in realtime prediction.")
     model.to(device).eval()
     batch = move_to_device(batch, device=device)
     precision_context = get_precision_context(precision=precision, device_type=device_type)
@@ -162,10 +162,6 @@ def infer_batch(
         if model_postprocess_fn:
             output = model_postprocess_fn(output)
 
-    if isinstance(model, nn.DataParallel):
-        model = model.module
-    else:
-        model = model
     output = move_to_device(output, device=torch.device("cpu"))
     return output[model.prefix]
 


### PR DESCRIPTION
*Issue #, if available:*

I think we don't have a DictCollator in case of realtime prediction, therefore DataParallel here isn't actually functional.

*Description of changes:*

Log warning for multi-gpu realtime prediction

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
