### PR TITLE
Fix Tabular multimodal preset

### DIFF
--- a/tabular/src/autogluon/tabular/configs/hyperparameter_configs.py
+++ b/tabular/src/autogluon/tabular/configs/hyperparameter_configs.py
@@ -82,7 +82,8 @@ hyperparameter_config_dict = dict(
         'CAT': {},
         'XGB': {},
         # 'FASTAI': {},  # FastAI gets killed if the dataset is large (400K rows).
-        'AG_AUTOMM': {},
+        'AG_TEXT_NN': {},
+        'AG_IMAGE_NN': {},
         'VW': {},
     },
     # Hyperparameters intended to find an interpretable model which doesn't sacrifice predictive accuracy

--- a/tabular/src/autogluon/tabular/configs/hyperparameter_configs.py
+++ b/tabular/src/autogluon/tabular/configs/hyperparameter_configs.py
@@ -82,8 +82,7 @@ hyperparameter_config_dict = dict(
         'CAT': {},
         'XGB': {},
         # 'FASTAI': {},  # FastAI gets killed if the dataset is large (400K rows).
-        'AG_TEXT_NN': {'presets': 'medium_quality_faster_train'},
-        'AG_IMAGE_NN': {},  # TODO, Support changing the config w.r.t the preset option.
+        'AG_AUTOMM': {},
         'VW': {},
     },
     # Hyperparameters intended to find an interpretable model which doesn't sacrifice predictive accuracy


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix Tabular multimodal preset, previously text model crashed due to 'medium_quality_faster_train' being an invalid preset.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
