### PR TITLE
[AutoMM] Fix label type

### DIFF
--- a/multimodal/src/autogluon/multimodal/data/preprocess_dataframe.py
+++ b/multimodal/src/autogluon/multimodal/data/preprocess_dataframe.py
@@ -661,7 +661,7 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
         ), "You will need to first call preprocessor.fit_y() before calling preprocessor.transform_label."
         y_df = df[self._label_column]
         if self.label_type == CATEGORICAL:
-            y = self._label_generator.transform(y_df)
+            y = self._label_generator.transform(y_df).astype(np.int64)
         elif self.label_type == NUMERICAL:
             y = pd.to_numeric(y_df).to_numpy()
             y = self._label_scaler.transform(np.expand_dims(y, axis=-1))[:, 0].astype(np.float32)


### PR DESCRIPTION
*Issue #, if available:*
#2777 

*Description of changes:*
Force converting the encoded categorical label to be type int64 ( corresponding to torch.LongTensor), which may be required in some environments, e.g., #2777.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
