### PR TITLE
[AutoMM] Set num_workers>0 by default

### DIFF
--- a/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
@@ -6,7 +6,7 @@ env:
   eval_batch_size_ratio: 4  # per_gpu_batch_size_evaluation = per_gpu_batch_size * eval_batch_size_ratio
   per_gpu_batch_size_evaluation:  # This is deprecated. Use eval_batch_size_ratio instead.
   precision: 16  # training precision. Refer to https://pytorch-lightning.readthedocs.io/en/latest/advanced/mixed_precision.html
-  num_workers: 0  # pytorch training dataloader workers. FIXME: setting it to 0 to avoid ProcessExitedException for deberta-v3, flan-t5-xl, etc.
+  num_workers: 2  # pytorch training dataloader workers.
   num_workers_evaluation: 2  # pytorch prediction/test dataloader workers
   fast_dev_run: False
   deterministic: False

--- a/multimodal/src/autogluon/multimodal/presets.py
+++ b/multimodal/src/autogluon/multimodal/presets.py
@@ -69,7 +69,6 @@ def default(presets: str = DEFAULT):
             "document_transformer",
             "fusion_mlp",
         ],
-        "env.num_workers": 2,
     }
     hyperparameter_tune_kwargs = {}
 
@@ -252,7 +251,6 @@ def zero_shot_image_classification(presets: str = DEFAULT):
     hyperparameters = {
         "model.names": ["clip"],
         "model.clip.max_text_len": 0,
-        "env.num_workers": 2,
     }
     hyperparameter_tune_kwargs = {}
 
@@ -312,7 +310,6 @@ def object_detection(presets: str = DEFAULT):
         "optimization.top_k_average_method": "best",
         "optimization.warmup_steps": 0.0,
         "optimization.patience": 10,
-        "env.num_workers": 2,
     }
     hyperparameter_tune_kwargs = {}
 
@@ -469,7 +466,6 @@ def image_similarity(presets: str = DEFAULT):
     """
     hyperparameters = {
         "model.names": ["timm_image"],
-        "env.num_workers": 2,
     }
     hyperparameter_tune_kwargs = {}
 
@@ -579,7 +575,6 @@ def image_text_similarity(presets: str = DEFAULT):
         "model.names": ["clip"],
         "matcher.loss.type": "multi_negatives_softmax_loss",
         "optimization.learning_rate": 1e-5,
-        "env.num_workers": 2,
     }
     hyperparameter_tune_kwargs = {}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The recent package updates make the previous cuda error disappear for deberta, num_workers>0, and muti-gpu. For fast training, we'd better use num_workers>0 by default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
