### PR TITLE
Update version cap of lightning in timeseries

### DIFF
--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     "statsmodels~=0.13.0",
     "gluonts~=0.12.0",
     "torch>=1.9,<1.14",
-    "pytorch-lightning>=1.7.4,<1.9.0",
+    "pytorch-lightning>=1.7.4,<1.10.0",
     "networkx",  # version range defined in `core/_setup_utils.py`
     "statsforecast==1.4.0",
     "tqdm",  # version range defined in `core/_setup_utils.py`


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/autogluon/autogluon/issues/2830

*Description of changes:*

- [x] Update version cap of lightning in timeseries to be the same as multimodal

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
