### PR TITLE
[timeseries] Fix dependency version ranges

### DIFF
--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -23,26 +23,33 @@ version = ag.update_version(version)
 submodule = "timeseries"
 install_requires = [
     # version ranges added in ag.get_dependency_version_ranges()
-    "joblib~=1.1",
+    "joblib>=1.1,<2",
     "numpy",  # version range defined in `core/_setup_utils.py`
     "scipy",  # version range defined in `core/_setup_utils.py`
     "pandas",  # version range defined in `core/_setup_utils.py`
-    "statsmodels~=0.13.0",
-    "gluonts~=0.12.0",
+    "statsmodels>=0.13.0,<0.14",
+    "gluonts>=0.12.0,<0.13",
     "torch>=1.9,<1.14",
-    "pytorch-lightning>=1.7.4,<1.9.0",
+    "pytorch-lightning>=1.7.4,<1.10.0",
     "networkx",  # version range defined in `core/_setup_utils.py`
-    "statsforecast==1.4.0",
+    "statsforecast>=1.4.0,<1.5",
     "tqdm",  # version range defined in `core/_setup_utils.py`
-    "ujson",  # needed to silence GluonTS warning
+    "ujson>=5,<6",  # needed to silence GluonTS warning
     f"autogluon.core[raytune]=={version}",
     f"autogluon.common=={version}",
     f"autogluon.tabular[catboost,lightgbm,xgboost]=={version}",
 ]
 
 extras_require = {
-    "tests": ["pytest", "flake8~=4.0", "flaky~=3.7", "pytest-timeout~=2.1", "isort>=5.10", "black>=22.3,<23.0"],
-    "sktime": ["sktime>=0.13.1,<0.14", "pmdarima~=1.8.2", "tbats~=1.1"],
+    "tests": [
+        "pytest",
+        "flake8>=4.0,<5",
+        "flaky>=3.7,<4",
+        "pytest-timeout>=2.1,<3",
+        "isort>=5.10",
+        "black>=22.3,<23.0",
+    ],
+    "sktime": ["sktime>=0.13.1,<0.14", "pmdarima>=1.8.2,<1.9", "tbats>=1.1,<2"],
 }
 
 all_requires = []


### PR DESCRIPTION
*Issue #, if available:*

#2831 

*Description of changes:*

Fixing dependency version ranges in line with #2831, getting rid of the `~=` notation. Note that we install `ujson` just to silence GluonTS warnings, but we cap the version to <6 nevertheless. Changes were tested with regression tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
