### PR TITLE
[timeseries] update sktime dependency range

### DIFF
--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -49,7 +49,7 @@ extras_require = {
         "isort>=5.10",
         "black>=22.3,<23.0",
     ],
-    "sktime": ["sktime>=0.13.1,<0.14", "pmdarima>=1.8.2,<1.9", "tbats>=1.1,<2"],
+    "sktime": ["sktime>=0.14,<0.16", "pmdarima>=1.8.2,<1.9", "tbats>=1.1,<2"],
 }
 
 all_requires = []

--- a/timeseries/src/autogluon/timeseries/__init__.py
+++ b/timeseries/src/autogluon/timeseries/__init__.py
@@ -30,7 +30,7 @@ try:
     import sktime
     import tbats
 
-    if parse("0.14") > parse(sktime.__version__) >= parse("0.13.1"):
+    if parse("0.16") > parse(sktime.__version__) >= parse("0.14"):
         SKTIME_INSTALLED = True
     else:
         warnings.warn(


### PR DESCRIPTION
*Issue #, if available:*

#2841 

*Description of changes:*

As of v0.7, we are deprecating sktime in AG-TS, due to instability and efficiency issues. Nevertheless, we update the version ranges for conda compatibility. There are no regressions or additional faults in regression tests with v0.14 or v0.15, we cap at 0.16 as we will deprecate in the next release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
