### PR TITLE
Skip validation

### DIFF
--- a/docs/tutorials/multimodal/advanced_topics/customization.md
+++ b/docs/tutorials/multimodal/advanced_topics/customization.md
@@ -264,7 +264,7 @@ Whether to skip the final validation after training is signaled to stop.
 # default used by AutoMM
 predictor.fit(hyperparameters={"optimization.skip_final_val": False})
 # skip the final validation
-predictor.fit(hyperparameters={"optimization.top_k_average_method": True})
+predictor.fit(hyperparameters={"optimization.skip_final_val": True})
 ```
 
 ## Environment

--- a/docs/tutorials/multimodal/advanced_topics/customization.md
+++ b/docs/tutorials/multimodal/advanced_topics/customization.md
@@ -256,6 +256,17 @@ predictor.fit(hyperparameters={"optimization.efficient_finetune": "bit_fit"})
 predictor.fit(hyperparameters={"optimization.efficient_finetune": "ia3_bias"})
 ```
 
+### optimization.skip_final_val
+
+Whether to skip the final validation after training is signaled to stop.
+
+```
+# default used by AutoMM
+predictor.fit(hyperparameters={"optimization.skip_final_val": False})
+# skip the final validation
+predictor.fit(hyperparameters={"optimization.top_k_average_method": True})
+```
+
 ## Environment
 
 ### env.num_gpus

--- a/multimodal/src/autogluon/multimodal/configs/optimization/adamw.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/optimization/adamw.yaml
@@ -13,6 +13,7 @@ optimization:
   patience: 10
   val_check_interval: 0.5 # Check validation score a fraction of epoch if float and every n steps if integer with n < total step in epoch.
   check_val_every_n_epoch: 1 # Check validation score every n epochs.
+  skip_final_val: False # Flag to skip the last validation
   gradient_clip_val: 1
   gradient_clip_algorithm: "norm"
   track_grad_norm: -1 # Whether to check gradient norm. We can set it to 2 to check for gradient norm.

--- a/multimodal/src/autogluon/multimodal/optimization/lit_module.py
+++ b/multimodal/src/autogluon/multimodal/optimization/lit_module.py
@@ -46,6 +46,7 @@ class LitModule(pl.LightningModule):
         mixup_fn: Optional[MixupModule] = None,
         mixup_off_epoch: Optional[int] = 0,
         model_postprocess_fn: Callable = None,
+        skip_final_val: Optional[bool] = False,
     ):
         """
         Parameters
@@ -127,6 +128,7 @@ class LitModule(pl.LightningModule):
         self.custom_metric_func = custom_metric_func
         self.model_postprocess_fn = model_postprocess_fn
         self.trainable_param_names = trainable_param_names if trainable_param_names else []
+        self.skip_final_val = skip_final_val
 
     def _compute_template_loss(
         self,
@@ -232,6 +234,17 @@ class LitModule(pl.LightningModule):
         output, loss = self._shared_step(batch)
         self.log("train_loss", loss)
         return loss
+
+    def on_validation_start(self) -> None:
+        if self.skip_final_val and self.trainer.should_stop:
+            self.trainer.val_dataloaders = []  # skip the final validation by setting val_dataloaders empty
+            self.log(
+                self.validation_metric_name,
+                self.validation_metric,
+                on_step=False,
+                on_epoch=True,
+            )
+        return super().on_validation_start()
 
     def validation_step(self, batch, batch_idx):
         """

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -1226,6 +1226,7 @@ class MultiModalPredictor(ExportMixin):
                 mixup_off_epoch=OmegaConf.select(config, "data.mixup.turn_off_epoch"),
                 model_postprocess_fn=model_postprocess_fn,
                 trainable_param_names=trainable_param_names,
+                skip_final_val=OmegaConf.select(config, "optimization.skip_final_val", default=False),
                 **metrics_kwargs,
                 **optimization_kwargs,
             )
@@ -1631,6 +1632,7 @@ class MultiModalPredictor(ExportMixin):
                 model_postprocess_fn=self._model_postprocess_fn,
                 efficient_finetune=OmegaConf.select(self._config, "optimization.efficient_finetune"),
                 trainable_param_names=trainable_param_names,
+                skip_final_val=self._config.optimization.skip_final_val,
                 **optimization_kwargs,
             )
 

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -1632,7 +1632,6 @@ class MultiModalPredictor(ExportMixin):
                 model_postprocess_fn=self._model_postprocess_fn,
                 efficient_finetune=OmegaConf.select(self._config, "optimization.efficient_finetune"),
                 trainable_param_names=trainable_param_names,
-                skip_final_val=self._config.optimization.skip_final_val,
                 **optimization_kwargs,
             )
 

--- a/multimodal/tests/unittests/others_2/test_predictor_advanced.py
+++ b/multimodal/tests/unittests/others_2/test_predictor_advanced.py
@@ -95,6 +95,8 @@ def test_predictor_skip_final_val():
         "model.timm_image.checkpoint_name": "ghostnet_100",
         "model.hf_text.checkpoint_name": "nlpaueb/legal-bert-small-uncased",
         "optimization.skip_final_val": True,
+        "env.num_workers": 0,
+        "env.num_workers_evaluation": 0,
     }
     predictor.fit(
         train_data=dataset.train_df,


### PR DESCRIPTION
*Issue #, if available:*
By default, a final validation is run after the training is signaled to stop, and as a result, AutoPilot team's 10min quick build on large dataset overshoots by quite a long time.

*Description of changes:*
By passing in a `skip_final_val` flag, we disable the final validation by setting the `trainer.val_dataloaders = []` to stop the validation.

By setting:
```
hyperparameters = {
    "optimization.top_k_average_method": "best",
    "optimization.val_check_interval": 1.0,
    "optimization.skip_final_val" = True,
}
```
we were able to reduce the `.fit()` time from 30-40min down to 10min.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
