### PR TITLE
Update vowpalwabbit version

### DIFF
--- a/core/src/autogluon/core/utils/try_import.py
+++ b/core/src/autogluon/core/utils/try_import.py
@@ -249,8 +249,8 @@ def try_import_vowpalwabbit():
         import vowpalwabbit
         from pkg_resources import parse_version  # pylint: disable=import-outside-toplevel
         vowpalwabbit_version = parse_version(vowpalwabbit.__version__)
-        assert vowpalwabbit_version >= parse_version('8.10.1') and vowpalwabbit_version < parse_version('8.11.0'), \
-            f'Currently, we only support VW version >=8.10.1 and <8.11.0. Found vowpalwabbit version: {vowpalwabbit_version}'
+        assert vowpalwabbit_version >= parse_version('9.0.0') and vowpalwabbit_version < parse_version('9.5.0'), \
+            f'Currently, we only support vowpalwabbit version >=9.0 and <9.5. Found vowpalwabbit version: {vowpalwabbit_version}'
     except ImportError:
         raise ImportError("`import vowpalwabbit` failed.\n"
-                          "A quick tip is to install via `pip install vowpalwabbit==8.10.1")
+                          "A quick tip is to install via `pip install vowpalwabbit>=9,<9.5")

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -56,7 +56,8 @@ extras_require = {
         'imodels>=1.3.10,<1.4.0',  # 1.3.8/1.3.9 either remove/renamed attribute `complexity_` causing failures. https://github.com/csinva/imodels/issues/147
     ],
     'vowpalwabbit': [
-        'vowpalwabbit>=8.10,<8.11'
+        # FIXME: 9.5+ causes VW to save an empty model which always predicts 0. Confirmed on MacOS (Intel CPU). Unknown how to fix.
+        'vowpalwabbit>=9,<9.5',
     ],
     'skl2onnx': [
         'skl2onnx>=1.13.0,<1.14.0',

--- a/tabular/src/autogluon/tabular/models/vowpalwabbit/vowpalwabbit_model.py
+++ b/tabular/src/autogluon/tabular/models/vowpalwabbit/vowpalwabbit_model.py
@@ -52,7 +52,7 @@ class VowpalWabbitModel(AbstractModel):
              **kwargs):  # kwargs includes many other potential inputs, refer to AbstractModel documentation for details
         time_start = time.time()
         try_import_vowpalwabbit()
-        from vowpalwabbit import pyvw
+        import vowpalwabbit
         seed = 0  # Random seed
 
         # Valid self.problem_type values include ['binary', 'multiclass', 'regression', 'quantile', 'softclass']
@@ -96,7 +96,7 @@ class VowpalWabbitModel(AbstractModel):
             # Ref: https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Predicting-probabilities#multi-class---oaa
             extra_params['oaa'] = self.num_classes
             extra_params['probabilities'] = True
-        self.model = pyvw.vw(**params, **extra_params)
+        self.model = vowpalwabbit.Workspace(**params, **extra_params)
 
         time_start_fit = time.time()
         if time_limit is not None:
@@ -182,7 +182,7 @@ class VowpalWabbitModel(AbstractModel):
         For VW, based on different problem_type/hyperparams, loading arguments will be different
         """
         try_import_vowpalwabbit()
-        from vowpalwabbit import pyvw
+        import vowpalwabbit
         # Load Abstract Model. This is without the internal model
         model = super().load(path, reset_paths=reset_paths, verbose=verbose)
         params = model._get_model_params()
@@ -196,7 +196,7 @@ class VowpalWabbitModel(AbstractModel):
             if params['sparse_weights']:
                 model_load_params += " --sparse_weights"
 
-            model.model = pyvw.vw(model_load_params)
+            model.model = vowpalwabbit.Workspace(model_load_params)
         model._load_model = None
         return model
 
@@ -216,7 +216,7 @@ class VowpalWabbitModel(AbstractModel):
     # User-specified parameters will override these values on a key-by-key basis.
     def _set_default_params(self):
         default_params = {
-            'passes': 10,
+            'passes': 10,  # TODO: Much better if 500+, revisit this if wanting to use VW to get strong results
             'bit_precision': 32,
             'ngram': 2,
             'skips': 1,


### PR DESCRIPTION
*Issue #, if available:*
#2686 

*Description of changes:*
- Update vowpalwabbit version
- This should hopefully fix Py310 MacOS install
- Note: Bug in vowpalwabbit>=9.5 : Model is not saved correctly, so avoiding that version for now.

This PR is low risk: vowpalwabbit is an optional dependency not installed by default, and it is not imported unless the user specifies vowpalwabbit to be trained.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
