### PR TITLE
Add `_add_stream_handler()` call to common init

### DIFF
--- a/common/src/autogluon/common/__init__.py
+++ b/common/src/autogluon/common/__init__.py
@@ -1,5 +1,8 @@
 from .version import __version__
 
+from .utils.log_utils import _add_stream_handler, fix_logging_if_kaggle as __fix_logging_if_kaggle
+
 # Fixes logger in Kaggle to show logs in notebook.
-from .utils.log_utils import fix_logging_if_kaggle as __fix_logging_if_kaggle
 __fix_logging_if_kaggle()
+
+_add_stream_handler()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Currently, all AutoGluon modules except common will call `_add_stream_handler()` during init.
- This meant that AutoGluon logging would not log correctly if only `autogluon.common` was imported. For example, changing log level would be ignored.
- Note that `_add_stream_handler()` only performs operations the first time it is called in a session, so multiple calls will not change behavior, and are safe to do.


Example:

```python3

from autogluon.common.utils.log_utils import set_logger_verbosity
from autogluon.common.loaders.load_pd import logger

logger.warning('before verbosity 4')
logger.debug("should not see debug")

set_logger_verbosity(verbosity=4, logger=logger)

logger.warning('after verbosity 4')
logger.debug("should see debug")
```

Mainline Out (incorrect):

```
before verbosity 4
after verbosity 4
```

This PR Out (correct):

```
before verbosity 4
after verbosity 4
should see debug
```

This aligns with what output we get with instead using a logger from tabular (or multimodal / timeseries):

```python3
from autogluon.common.utils.log_utils import set_logger_verbosity
from autogluon.tabular.predictor.predictor import logger

logger.warning('before verbosity 4')
logger.debug("should not see debug")

set_logger_verbosity(verbosity=4, logger=logger)

logger.warning('after verbosity 4')
logger.debug("should see debug")

```

Out (both mainline and this PR) (correct):

```
before verbosity 4
after verbosity 4
should see debug
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
