### PR TITLE
Tabular: Switch to use multimodal fusion

### DIFF
--- a/tabular/src/autogluon/tabular/configs/hyperparameter_configs.py
+++ b/tabular/src/autogluon/tabular/configs/hyperparameter_configs.py
@@ -82,8 +82,7 @@ hyperparameter_config_dict = dict(
         'CAT': {},
         'XGB': {},
         # 'FASTAI': {},  # FastAI gets killed if the dataset is large (400K rows).
-        'AG_TEXT_NN': {},
-        'AG_IMAGE_NN': {},
+        'AG_AUTOMM': {},
         'VW': {},
     },
     # Hyperparameters intended to find an interpretable model which doesn't sacrifice predictive accuracy

--- a/tabular/tests/unittests/models/test_automm.py
+++ b/tabular/tests/unittests/models/test_automm.py
@@ -3,7 +3,6 @@ import pytest
 
 @pytest.mark.gpu
 def test_automm_sts(fit_helper):
-    pytest.skip("Temporary skip the unittest")
     fit_args = dict(
         hyperparameters={'AG_AUTOMM': {}},
     )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Switch Tabular's `'multimodal'` hyperparameter preset to use 1 AutoMM model rather than 2 models (one for text+tabular and one for vision).
- This leverages the benefits of AutoMM's multimodal fusion accuracy enhancements when text, tabular, and images are present in a single dataset.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
