### PR TITLE
[Performance]Set persistent_worker in prediction dataloader to False + Remove seed in inference

### DIFF
--- a/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
@@ -7,7 +7,7 @@ env:
   per_gpu_batch_size_evaluation:  # This is deprecated. Use eval_batch_size_ratio instead.
   precision: 16  # training precision. Refer to https://pytorch-lightning.readthedocs.io/en/latest/advanced/mixed_precision.html
   num_workers: 2  # pytorch training dataloader workers.
-  num_workers_evaluation: 0  # pytorch prediction/test dataloader workers. Set to 0. See https://github.com/autogluon/autogluon/pull/2891
+  num_workers_evaluation: 2  # pytorch prediction/test dataloader workers.
   fast_dev_run: False
   deterministic: False
   auto_select_gpus: True

--- a/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
@@ -7,7 +7,7 @@ env:
   per_gpu_batch_size_evaluation:  # This is deprecated. Use eval_batch_size_ratio instead.
   precision: 16  # training precision. Refer to https://pytorch-lightning.readthedocs.io/en/latest/advanced/mixed_precision.html
   num_workers: 2  # pytorch training dataloader workers.
-  num_workers_evaluation: 0  # pytorch prediction/test dataloader workers. Need to set it to be 0
+  num_workers_evaluation: 0  # pytorch prediction/test dataloader workers. Set to 0. See https://github.com/autogluon/autogluon/pull/2891
   fast_dev_run: False
   deterministic: False
   auto_select_gpus: True

--- a/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
@@ -7,7 +7,7 @@ env:
   per_gpu_batch_size_evaluation:  # This is deprecated. Use eval_batch_size_ratio instead.
   precision: 16  # training precision. Refer to https://pytorch-lightning.readthedocs.io/en/latest/advanced/mixed_precision.html
   num_workers: 2  # pytorch training dataloader workers.
-  num_workers_evaluation: 2  # pytorch prediction/test dataloader workers.
+  num_workers_evaluation: 0 # pytorch prediction/test dataloader workers. Set to 0. See https://github.com/autogluon/autogluon/pull/2891
   fast_dev_run: False
   deterministic: False
   auto_select_gpus: True

--- a/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
@@ -7,7 +7,7 @@ env:
   per_gpu_batch_size_evaluation:  # This is deprecated. Use eval_batch_size_ratio instead.
   precision: 16  # training precision. Refer to https://pytorch-lightning.readthedocs.io/en/latest/advanced/mixed_precision.html
   num_workers: 2  # pytorch training dataloader workers.
-  num_workers_evaluation: 0 # pytorch prediction/test dataloader workers. Set to 0. See https://github.com/autogluon/autogluon/pull/2891
+  num_workers_evaluation: 2  # pytorch prediction/test dataloader workers.
   fast_dev_run: False
   deterministic: False
   auto_select_gpus: True

--- a/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
@@ -7,7 +7,7 @@ env:
   per_gpu_batch_size_evaluation:  # This is deprecated. Use eval_batch_size_ratio instead.
   precision: 16  # training precision. Refer to https://pytorch-lightning.readthedocs.io/en/latest/advanced/mixed_precision.html
   num_workers: 2  # pytorch training dataloader workers.
-  num_workers_evaluation: 2  # pytorch prediction/test dataloader workers
+  num_workers_evaluation: 0  # pytorch prediction/test dataloader workers. Need to set it to be 0
   fast_dev_run: False
   deterministic: False
   auto_select_gpus: True

--- a/multimodal/src/autogluon/multimodal/data/datamodule.py
+++ b/multimodal/src/autogluon/multimodal/data/datamodule.py
@@ -218,6 +218,6 @@ class BaseDataModule(LightningDataModule):
                 data_processors=self.data_processors,
                 per_gpu_batch_size=self.per_gpu_batch_size,
             ),
-            persistent_workers=self.num_workers > 0,
+            persistent_workers=False,
         )
         return loader

--- a/multimodal/src/autogluon/multimodal/matcher.py
+++ b/multimodal/src/autogluon/multimodal/matcher.py
@@ -99,6 +99,7 @@ from .utils import (
     split_train_tuning_data,
     try_to_infer_pos_label,
     update_hyperparameters,
+    upgrade_config,
 )
 
 logger = logging.getLogger(AUTOMM)

--- a/multimodal/src/autogluon/multimodal/matcher.py
+++ b/multimodal/src/autogluon/multimodal/matcher.py
@@ -1855,6 +1855,9 @@ class MultiModalMatcher:
         with open(os.path.join(path, "assets.json"), "r") as fp:
             assets = json.load(fp)
 
+        query_config = upgrade_config(query_config, assets["version"])
+        response_config = upgrade_config(response_config, assets["version"])
+
         with open(os.path.join(path, "df_preprocessor.pkl"), "rb") as fp:
             df_preprocessor = CustomUnpickler(fp).load()
 

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -152,6 +152,7 @@ from .utils import (
     update_config_by_rules,
     update_hyperparameters,
     update_tabular_config_by_resources,
+    upgrade_config,
 )
 
 logger = logging.getLogger(AUTOMM)

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -1789,6 +1789,7 @@ class MultiModalPredictor(ExportMixin):
         label: Optional[str] = None,
         return_pred: Optional[bool] = False,
         realtime: Optional[bool] = None,
+        seed: Optional[int] = 123,
         eval_tool: Optional[str] = None,
     ):
         """
@@ -1824,6 +1825,8 @@ class MultiModalPredictor(ExportMixin):
             Whether to do realtime inference, which is efficient for small data (default None).
             If not specified, we would infer it on based on the data modalities
             and sample number.
+        seed
+            The random seed to use for this evaluation run.
         eval_tool
             The eval_tool for object detection. Could be "pycocotools" or "torchmetrics".
 
@@ -1858,6 +1861,7 @@ class MultiModalPredictor(ExportMixin):
                     anno_file_or_df=data,
                     metrics=metrics,
                     return_pred=return_pred,
+                    seed=seed,
                     eval_tool=eval_tool,
                 )
             else:
@@ -1867,6 +1871,7 @@ class MultiModalPredictor(ExportMixin):
                     anno_file_or_df=data,
                     metrics=metrics,
                     return_pred=return_pred,
+                    seed=seed,
                     eval_tool="torchmetrics",
                 )
 
@@ -1880,6 +1885,7 @@ class MultiModalPredictor(ExportMixin):
             data=data,
             requires_label=True,
             realtime=realtime,
+            seed=seed,
         )
         logits = extract_from_output(ret_type=ret_type, outputs=outputs)
 
@@ -1998,6 +2004,7 @@ class MultiModalPredictor(ExportMixin):
         id_mappings: Optional[Union[Dict[str, Dict], Dict[str, pd.Series]]] = None,
         as_pandas: Optional[bool] = None,
         realtime: Optional[bool] = None,
+        seed: Optional[int] = 123,
         save_results: Optional[bool] = None,
     ):
         """
@@ -2019,9 +2026,10 @@ class MultiModalPredictor(ExportMixin):
             Whether to do realtime inference, which is efficient for small data (default None).
             If not specified, we would infer it on based on the data modalities
             and sample number.
+        seed
+            The random seed to use for this prediction run.
         save_results
             Whether to save the prediction results (only works for detection now)
-
         Returns
         -------
         Array of predictions, one corresponding to each row in given dataset.
@@ -2062,6 +2070,7 @@ class MultiModalPredictor(ExportMixin):
                 data=data,
                 requires_label=False,
                 realtime=realtime,
+                seed=seed,
             )
 
             if self._problem_type == OCR_TEXT_RECOGNITION:
@@ -2127,6 +2136,7 @@ class MultiModalPredictor(ExportMixin):
         as_pandas: Optional[bool] = None,
         as_multiclass: Optional[bool] = True,
         realtime: Optional[bool] = None,
+        seed: Optional[int] = 123,
     ):
         """
         Predict probabilities class probabilities rather than class labels.
@@ -2151,6 +2161,8 @@ class MultiModalPredictor(ExportMixin):
             Whether to do realtime inference, which is efficient for small data (default None).
             If not specified, we would infer it on based on the data modalities
             and sample number.
+        seed
+            The random seed to use for this prediction run.
 
         Returns
         -------
@@ -2184,6 +2196,7 @@ class MultiModalPredictor(ExportMixin):
                 data=data,
                 requires_label=False,
                 realtime=realtime,
+                seed=seed,
             )
 
             if self._problem_type == NER:

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -2438,6 +2438,7 @@ class MultiModalPredictor(ExportMixin):
 
         with open(os.path.join(path, "assets.json"), "r") as fp:
             assets = json.load(fp)
+        config = upgrade_config(config, assets["version"])
 
         with open(os.path.join(path, "df_preprocessor.pkl"), "rb") as fp:
             df_preprocessor = CustomUnpickler(fp).load()
@@ -2482,16 +2483,6 @@ class MultiModalPredictor(ExportMixin):
             "pipeline" in assets and assets["pipeline"] == OBJECT_DETECTION
         ):
             data_processors = None
-
-        # backward compatibility for variable image size.
-        if version.parse(assets["version"]) <= version.parse("0.6.2"):
-            print("hasattr model.timm_image", hasattr(config, "model.timm_image"))
-            if OmegaConf.select(config, "model.timm_image") is not None:
-                logger.warn(
-                    "Loading a model that has been trained via AutoGluon Multimodal<=0.6.2. "
-                    "Try to update the timm image size."
-                )
-                config.model.timm_image.image_size = None
 
         predictor._label_column = assets["label_column"]
         predictor._problem_type = assets["problem_type"]

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -1789,7 +1789,6 @@ class MultiModalPredictor(ExportMixin):
         label: Optional[str] = None,
         return_pred: Optional[bool] = False,
         realtime: Optional[bool] = None,
-        seed: Optional[int] = 123,
         eval_tool: Optional[str] = None,
     ):
         """
@@ -1825,8 +1824,6 @@ class MultiModalPredictor(ExportMixin):
             Whether to do realtime inference, which is efficient for small data (default None).
             If not specified, we would infer it on based on the data modalities
             and sample number.
-        seed
-            The random seed to use for this evaluation run.
         eval_tool
             The eval_tool for object detection. Could be "pycocotools" or "torchmetrics".
 
@@ -1861,7 +1858,6 @@ class MultiModalPredictor(ExportMixin):
                     anno_file_or_df=data,
                     metrics=metrics,
                     return_pred=return_pred,
-                    seed=seed,
                     eval_tool=eval_tool,
                 )
             else:
@@ -1871,7 +1867,6 @@ class MultiModalPredictor(ExportMixin):
                     anno_file_or_df=data,
                     metrics=metrics,
                     return_pred=return_pred,
-                    seed=seed,
                     eval_tool="torchmetrics",
                 )
 
@@ -1885,7 +1880,6 @@ class MultiModalPredictor(ExportMixin):
             data=data,
             requires_label=True,
             realtime=realtime,
-            seed=seed,
         )
         logits = extract_from_output(ret_type=ret_type, outputs=outputs)
 
@@ -2004,7 +1998,6 @@ class MultiModalPredictor(ExportMixin):
         id_mappings: Optional[Union[Dict[str, Dict], Dict[str, pd.Series]]] = None,
         as_pandas: Optional[bool] = None,
         realtime: Optional[bool] = None,
-        seed: Optional[int] = 123,
         save_results: Optional[bool] = None,
     ):
         """
@@ -2026,10 +2019,9 @@ class MultiModalPredictor(ExportMixin):
             Whether to do realtime inference, which is efficient for small data (default None).
             If not specified, we would infer it on based on the data modalities
             and sample number.
-        seed
-            The random seed to use for this prediction run.
         save_results
             Whether to save the prediction results (only works for detection now)
+
         Returns
         -------
         Array of predictions, one corresponding to each row in given dataset.
@@ -2070,7 +2062,6 @@ class MultiModalPredictor(ExportMixin):
                 data=data,
                 requires_label=False,
                 realtime=realtime,
-                seed=seed,
             )
 
             if self._problem_type == OCR_TEXT_RECOGNITION:
@@ -2136,7 +2127,6 @@ class MultiModalPredictor(ExportMixin):
         as_pandas: Optional[bool] = None,
         as_multiclass: Optional[bool] = True,
         realtime: Optional[bool] = None,
-        seed: Optional[int] = 123,
     ):
         """
         Predict probabilities class probabilities rather than class labels.
@@ -2161,8 +2151,6 @@ class MultiModalPredictor(ExportMixin):
             Whether to do realtime inference, which is efficient for small data (default None).
             If not specified, we would infer it on based on the data modalities
             and sample number.
-        seed
-            The random seed to use for this prediction run.
 
         Returns
         -------
@@ -2196,7 +2184,6 @@ class MultiModalPredictor(ExportMixin):
                 data=data,
                 requires_label=False,
                 realtime=realtime,
-                seed=seed,
             )
 
             if self._problem_type == NER:

--- a/multimodal/src/autogluon/multimodal/utils/__init__.py
+++ b/multimodal/src/autogluon/multimodal/utils/__init__.py
@@ -15,6 +15,7 @@ from .config import (
     update_config_by_rules,
     update_hyperparameters,
     update_tabular_config_by_resources,
+    upgrade_config,
 )
 from .data import (
     assign_feature_column_names,

--- a/multimodal/src/autogluon/multimodal/utils/config.py
+++ b/multimodal/src/autogluon/multimodal/utils/config.py
@@ -390,7 +390,7 @@ def get_local_pretrained_config_paths(config: DictConfig, path: str) -> DictConf
 
 
 def upgrade_config(config, loaded_version):
-    """
+    """Upgrade outdated configurations
 
     Parameters
     ----------

--- a/multimodal/src/autogluon/multimodal/utils/config.py
+++ b/multimodal/src/autogluon/multimodal/utils/config.py
@@ -412,11 +412,6 @@ def upgrade_config(config, loaded_version):
                 "Try to update the timm image size."
             )
             config.model.timm_image.image_size = None
-    if version.parse(loaded_version) < version.parse("0.7.0"):
-        logger.info(f"Start to upgrade the previous configuration trained by AutoMM version={loaded_version}.")
-        if OmegaConf.select(config, "env.num_workers_evaluation") > 0:
-            logger.warn("Set the number of workers in evaluation to be 0")
-            config.env.num_workers_evaluation = 0
     return config
 
 

--- a/multimodal/src/autogluon/multimodal/utils/config.py
+++ b/multimodal/src/autogluon/multimodal/utils/config.py
@@ -413,8 +413,13 @@ def upgrade_config(config, loaded_version):
                 "Try to update the timm image size."
             )
             config.model.timm_image.image_size = None
-    return config
 
+    if version.parse(loaded_version) < version.parse("0.7.0"):
+        logger.info(f"Start to upgrade the previous configuration trained by AutoMM version={loaded_version}.")
+        if OmegaConf.select(config, "env.num_workers_evaluation") > 0:
+            logger.warn("Set the number of workers in evaluation to be 0")
+            config.env.num_workers_evaluation = 0
+    return config
 
 def parse_dotlist_conf(conf):
     """

--- a/multimodal/src/autogluon/multimodal/utils/config.py
+++ b/multimodal/src/autogluon/multimodal/utils/config.py
@@ -388,6 +388,38 @@ def get_local_pretrained_config_paths(config: DictConfig, path: str) -> DictConf
     return config
 
 
+def upgrade_config(config, loaded_version):
+    """
+
+    Parameters
+    ----------
+    config
+        The configuration
+    loaded_version
+        The version of the config that has been loaded
+
+    Returns
+    -------
+    config
+        The upgraded configuration
+    """
+    # backward compatibility for variable image size.
+    if version.parse(loaded_version) <= version.parse("0.6.2"):
+        logger.info(f"Start to upgrade the previous configuration trained by AutoMM version={loaded_version}.")
+        if OmegaConf.select(config, "model.timm_image") is not None:
+            logger.warn(
+                "Loading a model that has been trained via AutoGluon Multimodal<=0.6.2. "
+                "Try to update the timm image size."
+            )
+            config.model.timm_image.image_size = None
+    if version.parse(loaded_version) < version.parse("0.7.0"):
+        logger.info(f"Start to upgrade the previous configuration trained by AutoMM version={loaded_version}.")
+        if OmegaConf.select(config, "env.num_workers_evaluation") > 0:
+            logger.warn("Set the number of workers in evaluation to be 0")
+            config.env.num_workers_evaluation = 0
+    return config
+
+
 def parse_dotlist_conf(conf):
     """
     Parse the config files that is potentially in the dotlist format to a dictionary.

--- a/multimodal/src/autogluon/multimodal/utils/config.py
+++ b/multimodal/src/autogluon/multimodal/utils/config.py
@@ -413,13 +413,8 @@ def upgrade_config(config, loaded_version):
                 "Try to update the timm image size."
             )
             config.model.timm_image.image_size = None
-
-    if version.parse(loaded_version) < version.parse("0.7.0"):
-        logger.info(f"Start to upgrade the previous configuration trained by AutoMM version={loaded_version}.")
-        if OmegaConf.select(config, "env.num_workers_evaluation") > 0:
-            logger.warn("Set the number of workers in evaluation to be 0")
-            config.env.num_workers_evaluation = 0
     return config
+
 
 def parse_dotlist_conf(conf):
     """

--- a/multimodal/src/autogluon/multimodal/utils/config.py
+++ b/multimodal/src/autogluon/multimodal/utils/config.py
@@ -6,6 +6,7 @@ import warnings
 from typing import Dict, List, Optional, Tuple, Union
 
 from omegaconf import DictConfig, OmegaConf
+from packaging import version
 from torch import nn
 
 from ..constants import (

--- a/multimodal/src/autogluon/multimodal/utils/inference.py
+++ b/multimodal/src/autogluon/multimodal/utils/inference.py
@@ -434,6 +434,7 @@ def predict(
     signature: Optional[str] = None,
     realtime: Optional[bool] = None,
     is_matching: Optional[bool] = False,
+    seed: Optional[int] = 123,
 ) -> List[Dict]:
     """
     Perform inference for predictor or matcher.
@@ -462,6 +463,9 @@ def predict(
     -------
     A list of output dicts.
     """
+    with apply_log_filter(LogFilter("Global seed set to")):  # Ignore the log "Global seed set to"
+        pl.seed_everything(seed, workers=True)
+
     if is_matching:
         data, df_preprocessor, data_processors, match_label = predictor._on_predict_start(
             data=data,

--- a/multimodal/src/autogluon/multimodal/utils/inference.py
+++ b/multimodal/src/autogluon/multimodal/utils/inference.py
@@ -434,7 +434,6 @@ def predict(
     signature: Optional[str] = None,
     realtime: Optional[bool] = None,
     is_matching: Optional[bool] = False,
-    seed: Optional[int] = 123,
 ) -> List[Dict]:
     """
     Perform inference for predictor or matcher.
@@ -463,9 +462,6 @@ def predict(
     -------
     A list of output dicts.
     """
-    with apply_log_filter(LogFilter("Global seed set to")):  # Ignore the log "Global seed set to"
-        pl.seed_everything(seed, workers=True)
-
     if is_matching:
         data, df_preprocessor, data_processors, match_label = predictor._on_predict_start(
             data=data,

--- a/multimodal/src/autogluon/multimodal/utils/object_detection.py
+++ b/multimodal/src/autogluon/multimodal/utils/object_detection.py
@@ -1368,7 +1368,6 @@ def evaluate_coco(
     anno_file_or_df: str,
     metrics: str,
     return_pred: Optional[bool] = False,
-    seed: Optional[int] = 123,
     eval_tool: Optional[str] = None,
 ):
     """
@@ -1403,7 +1402,6 @@ def evaluate_coco(
         predictor=predictor,
         data=data,
         requires_label=True,
-        seed=seed,
     )  # outputs shape: num_batch, 1(["bbox"]), batch_size, 2(if using mask_rcnn)/na, 80, n, 5
 
     # Cache prediction results as COCO format # TODO: refactor this

--- a/multimodal/src/autogluon/multimodal/utils/object_detection.py
+++ b/multimodal/src/autogluon/multimodal/utils/object_detection.py
@@ -1368,6 +1368,7 @@ def evaluate_coco(
     anno_file_or_df: str,
     metrics: str,
     return_pred: Optional[bool] = False,
+    seed: Optional[int] = 123,
     eval_tool: Optional[str] = None,
 ):
     """
@@ -1402,6 +1403,7 @@ def evaluate_coco(
         predictor=predictor,
         data=data,
         requires_label=True,
+        seed=seed,
     )  # outputs shape: num_batch, 1(["bbox"]), batch_size, 2(if using mask_rcnn)/na, 80, n, 5
 
     # Cache prediction results as COCO format # TODO: refactor this

--- a/multimodal/tests/unittests/predictor/test_predictor.py
+++ b/multimodal/tests/unittests/predictor/test_predictor.py
@@ -667,8 +667,6 @@ def test_image_bytearray():
         "optimization.max_epochs": 2,
         "model.names": model_names,
         "model.timm_image.checkpoint_name": "swin_tiny_patch4_window7_224",
-        "env.num_workers": 0,
-        "env.num_workers_evaluation": 0,
     }
     predictor_1.fit(
         train_data=train_data_1,


### PR DESCRIPTION
*Issue #, if available:*

- https://github.com/autogluon/autogluon/issues/2898

*Description of changes:*

- [x] Disable persistent_worker for evaluation dataloader.
- [x] Remove seed in `.predict()`. 

*Update, @zhiqiangdon noticed that we can simply set persistent_worker to False in the evaluation dataloader.

After setting `persistent_worker`, there seems to be an additional overhead in creating the prediction / evaluation dataloader. I thus compared the speed of `num_worders_evaluation` set to 0 and 2, and noticed that `num_workers_evaluation=0` will be 10x faster:

```python
import time
from autogluon.multimodal import MultiModalPredictor
from autogluon.multimodal.utils.misc import shopee_dataset

def test_num_workers_evaluation(num_workers=0, nrepeat=20):
    download_dir = "./"
    train_data_1, test_data_1 = shopee_dataset(download_dir=download_dir)
    train_data_2, test_data_2 = shopee_dataset(download_dir=download_dir, is_bytearray=True)
    predictor_1 = MultiModalPredictor(
        label="label",
    )
    predictor_2 = MultiModalPredictor(
        label="label",
    )
    model_names = ["timm_image"]
    hyperparameters = {
        "optimization.max_epochs": 2,
        "model.names": model_names,
        "model.timm_image.checkpoint_name": "swin_tiny_patch4_window7_224",
        "env.num_workers": 2,
        "env.num_workers_evaluation": num_workers,
    }
    predictor_1.fit(
        train_data=train_data_1,
        hyperparameters=hyperparameters,
        seed=42,
    )
    start = time.time()
    for i in range(nrepeat):
        prediction_1 = predictor_1.predict(test_data_1, as_pandas=False)
    end = time.time()
    return end - start


print("Total time for num_workers=0", test_num_workers_evaluation(0, 20))
print("Total time for num_workers=2", test_num_workers_evaluation(2, 20))
```

Output:

```
Total time for num_workers=0 14.960921049118042
Total time for num_workers=2 166.43815088272095
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
