### PR TITLE
[AutoMM] Fix logger

### DIFF
--- a/multimodal/src/autogluon/multimodal/constants.py
+++ b/multimodal/src/autogluon/multimodal/constants.py
@@ -176,7 +176,7 @@ CLIP_IMAGE_MEAN = (0.48145466, 0.4578275, 0.40821073)
 CLIP_IMAGE_STD = (0.26862954, 0.26130258, 0.27577711)
 
 # Logger name
-AUTOMM = "automm"
+AUTOMM = "autogluon.multimodal"
 
 # environment variables
 AUTOMM_TUTORIAL_MODE = "AUTOMM_TUTORIAL_MODE"


### PR DESCRIPTION
*Issue #, if available:*
#2878 

`automm` is not a recognized name space for AutoGluon, and thus is not part of the overall namespace log formatting that is done in `autogluon.common.utils.log_utils._add_stream_handler()` called during initialization of `autogluon.core`.

*Description of changes:*
Change the logger name to start with `autogluon` to make verbosity work correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
