### PR TITLE
Lint error fix

### DIFF
--- a/eda/tests/test_check_style.py
+++ b/eda/tests/test_check_style.py
@@ -11,5 +11,5 @@ def test_check_style():
     lines = flake8_out.splitlines()
     count = int(lines[-1].decode())
     if count > 0:
-        warnings.warn(f"{count} PEP8 warnings remaining")
+        warnings.warn(f"{count} PEP8 warnings remaining", stacklevel=2)
     assert count < 10, "Too many PEP8 warnings found, improve code quality to pass test."


### PR DESCRIPTION
*Description of changes:*
B028: No explicit stacklevel keyword argument found. The warn method from the warnings module uses a stacklevel of 1 by default. This will only show a stack trace for the line on which the warn method is called. It is therefore recommended to use a stacklevel of 2 or greater to provide more information to the user.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
