### PR TITLE
Allow no y in leaderboard

### DIFF
--- a/common/src/autogluon/common/loaders/load_s3.py
+++ b/common/src/autogluon/common/loaders/load_s3.py
@@ -2,9 +2,6 @@ import logging
 import os
 import pathlib
 
-from . import load_pd
-from ..utils import s3_utils
-
 logger = logging.getLogger(__name__)
 
 
@@ -74,15 +71,3 @@ def list_bucket_prefix_suffix_contains_s3(bucket, prefix, suffix=None, banned_su
             files.append(object_summary.key)
 
     return files
-
-
-def load_multipart_s3(bucket, prefix, columns_to_keep=None, dtype=None, sample_count=None):
-    files = list_bucket_prefix_s3(bucket, prefix)
-    files_cleaned = [file for file in files if prefix + '/part-' in file]
-    paths_full = [s3_utils.s3_bucket_prefix_to_path(bucket=bucket, prefix=file, version='s3') for file in files_cleaned]
-    if sample_count is not None:
-        logger.log(15, 'Taking sample of ' + str(sample_count) + ' of ' + str(len(paths_full)) + ' s3 files to load')
-        paths_full = paths_full[:sample_count]
-
-    df = load_pd.load(path=paths_full, columns_to_keep=columns_to_keep, dtype=dtype)
-    return df

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -454,7 +454,7 @@ class AbstractTabularLearner(AbstractLearner):
         extra_scores = {}
         for model_name, y_pred_proba_internal in model_pred_proba_dict.items():
             if skip_score:
-                scores[model_name] = None
+                scores[model_name] = np.nan
             else:
                 scores[model_name] = self._score_with_pred_proba(
                     y_pred_proba_internal=y_pred_proba_internal,

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -407,18 +407,22 @@ class AbstractTabularLearner(AbstractLearner):
     # Scores both learner and all individual models, along with computing the optimal ensemble score + weights (oracle)
     def score_debug(self, X: DataFrame, y=None, extra_info=False, compute_oracle=False, extra_metrics=None, skip_score=False, silent=False):
         leaderboard_df = self.leaderboard(extra_info=extra_info, silent=silent)
-        if y is None:
-            X, y = self.extract_label(X)
         if extra_metrics is None:
             extra_metrics = []
-        self._validate_class_labels(y)
+        if y is None:
+            error_if_missing = extra_metrics or not skip_score
+            X, y = self.extract_label(X, error_if_missing=error_if_missing)
         w = None
         if self.weight_evaluation:
             X, w = extract_column(X, self.sample_weight)
 
         X = self.transform_features(X)
-        y_internal = self.label_cleaner.transform(y)
-        y_internal = y_internal.fillna(-1)
+        if y is not None:
+            self._validate_class_labels(y)
+            y_internal = self.label_cleaner.transform(y)
+            y_internal = y_internal.fillna(-1)
+        else:
+            y_internal = None
 
         trainer = self.load_trainer()
         scores = {}
@@ -737,9 +741,12 @@ class AbstractTabularLearner(AbstractLearner):
                     logger.log(20, json.dumps(performance_dict[metric_name], indent=4))
         return performance_dict
 
-    def extract_label(self, X):
+    def extract_label(self, X, error_if_missing=True):
         if self.label not in list(X.columns):
-            raise ValueError(f"Provided DataFrame does not contain label column: {self.label}")
+            if error_if_missing:
+                raise ValueError(f"Provided DataFrame does not contain label column: {self.label}")
+            else:
+                return X, None
         y = X[self.label].copy()
         X = X.drop(self.label, axis=1)
         return X, y

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1525,6 +1525,7 @@ class TabularPredictor:
         ----------
         data : str or :class:`TabularDataset` or :class:`pd.DataFrame` (optional)
             This Dataset must also contain the label-column with the same column-name as specified during fit().
+            If extra_metrics=None and skip_score=True, then the label column is not required.
             If specified, then the leaderboard returned will contain additional columns 'score_test', 'pred_time_test', and 'pred_time_test_marginal'.
                 'score_test': The score of the model on the 'eval_metric' for the data provided.
                     NOTE: Metrics scores always show in higher is better form.


### PR DESCRIPTION
*Issue #, if available:*

#2820 (Part of the process to make the benchmark throughput easy for users to do on their own datasets)

*Description of changes:*
- When skip_score=True and extra_metrics=None during a `predictor.leaderboard(data)` call, this PR allows `data` to not have the label column, since it isn't required (no scoring being done). This enables easier usage of inference speed analysis code that doesn't unnecessarily require the label column.
- Also deleted old unused code from `load_s3.py`, the same code but updated already exists in `load_pd.py`. Removing this code eliminates a circular import that causes ray to error in certain situations (Note: Error situation is outside of normal usage and did not effect users, only occurred when trying to parallelize boto3 calls using ray).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
