### PR TITLE
Update scikit-learn-intelex version

### DIFF
--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -50,7 +50,8 @@ extras_require = {
         f'{ag.PACKAGE_NAME}.core[all]=={version}',
     ],
     'skex': [
-        'scikit-learn-intelex>=2021.6,<2021.8',
+        # Note: 2021.7 released on Sep 2022, version 2022.x doesn't exist (went directly from 2021.7 to 2023.0)
+        'scikit-learn-intelex>=2021.7,<2023.1',
     ],
     'imodels': [
         'imodels>=1.3.10,<1.4.0',  # 1.3.8/1.3.9 either remove/renamed attribute `complexity_` causing failures. https://github.com/csinva/imodels/issues/147


### PR DESCRIPTION
*Issue #, if available:*
resolves #2902

*Description of changes:*
- Update to use latest scikit-learn-intelex version (latest release 2023.0.1 tested on linux, worked correctly)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
