### PR TITLE
[tabular] fix compile_models error when onnxruntime is missing

### DIFF
--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -66,7 +66,8 @@ extras_require = {
         # Therefore, we install onnxruntime explicitly here just for macOS.
         'onnxruntime>=1.13.0,<1.14.0'
     ] if sys.platform == 'darwin' else [
-        'skl2onnx>=1.13.0,<1.14.0'
+        'skl2onnx>=1.13.0,<1.14.0',
+        'onnxruntime-gpu>=1.13.0,<1.14.0'
     ]
 }
 

--- a/tabular/src/autogluon/tabular/models/rf/compilers/onnx.py
+++ b/tabular/src/autogluon/tabular/models/rf/compilers/onnx.py
@@ -58,6 +58,8 @@ class RFOnnxCompiler:
         """Verify whether the required package has been installed."""
         try:
             import skl2onnx
+            import onnxruntime
+
             return True
         except ImportError:
             return False


### PR DESCRIPTION
*Issue #, if available:*

#2922

*Description of changes:*

* fix onnxruntime installation in setup.py
* fix compile_models error when onnxruntime is missing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
