### PR TITLE
[timeseries] Provide custom seasonal_period for the MASE metric

### DIFF
--- a/timeseries/src/autogluon/timeseries/evaluator.py
+++ b/timeseries/src/autogluon/timeseries/evaluator.py
@@ -15,14 +15,10 @@ from autogluon.timeseries.utils.warning_filters import evaluator_warning_filter
 logger = logging.getLogger(__name__)
 
 
-def in_sample_naive_1_error(*, y_past: pd.Series) -> pd.Series:
-    """Compute the error of naive forecast (predict previous value) for each time series."""
-    diff = y_past.diff()
-    # We ignore the differences between the last value of prev item and the first value of the next item
-    length_per_item = y_past.groupby(level=ITEMID, sort=False).size()
-    first_index_for_each_item = length_per_item.cumsum().values[:-1]
-    diff.iloc[first_index_for_each_item] = np.nan
-    return diff.abs().groupby(level=ITEMID, sort=False).mean()
+def in_sample_seasonal_naive_error(*, y_past: pd.Series, seasonal_period: int = 1) -> pd.Series:
+    """Compute seasonal naive forecast error (predict value from seasonal_period steps ago) for each time series."""
+    seasonal_diffs = y_past.groupby(level=ITEMID, sort=False).diff(seasonal_period).abs()
+    return seasonal_diffs.groupby(level=ITEMID, sort=False).mean().fillna(1.0)
 
 
 def mse_per_item(*, y_true: pd.Series, y_pred: pd.Series) -> pd.Series:
@@ -67,7 +63,7 @@ class TimeSeriesEvaluator:
 
     Parameters
     ----------
-    eval_metric: str
+    eval_metric : str
         Name of the metric to be computed. Available metrics are
 
         * ``MASE``: mean absolute scaled error. See https://en.wikipedia.org/wiki/Mean_absolute_scaled_error
@@ -78,10 +74,13 @@ class TimeSeriesEvaluator:
         * ``MSE``: mean squared error
         * ``RMSE``: root mean squared error
 
-    prediction_length: int
+    prediction_length : int
         Length of the forecast horizon
-    target_column: str
+    target_column : str, default = "target"
         Name of the target column to be forecasting.
+    eval_metric_seasonal_period : int
+        Seasonal period used to compute the mean absolute scaled error (MASE) evaluation metric. This parameter is only
+        used if ``eval_metric="MASE"`. See https://en.wikipedia.org/wiki/Mean_absolute_scaled_error for more details.
 
     Class Attributes
     ----------------
@@ -99,15 +98,22 @@ class TimeSeriesEvaluator:
     METRIC_COEFFICIENTS = {"MASE": -1, "MAPE": -1, "sMAPE": -1, "mean_wQuantileLoss": -1, "MSE": -1, "RMSE": -1}
     DEFAULT_METRIC = "mean_wQuantileLoss"
 
-    def __init__(self, eval_metric: str, prediction_length: int, target_column: str = "target"):
+    def __init__(
+        self,
+        eval_metric: str,
+        prediction_length: int,
+        target_column: str = "target",
+        eval_metric_seasonal_period: int = 1,
+    ):
         assert eval_metric in self.AVAILABLE_METRICS, f"Metric {eval_metric} not available"
 
         self.prediction_length = prediction_length
         self.eval_metric = eval_metric
         self.target_column = target_column
+        self.seasonal_period = eval_metric_seasonal_period
 
         self.metric_method = self.__getattribute__("_" + self.eval_metric.lower())
-        self._past_naive_1_error: Optional[pd.Series] = None
+        self._past_naive_error: Optional[pd.Series] = None
 
     @property
     def coefficient(self) -> int:
@@ -130,7 +136,7 @@ class TimeSeriesEvaluator:
     def _mase(self, y_true: pd.Series, predictions: TimeSeriesDataFrame) -> float:
         y_pred = self._get_median_forecast(predictions)
         mae = mae_per_item(y_true=y_true, y_pred=y_pred)
-        return self._safemean(mae / self._past_naive_1_error)
+        return self._safemean(mae / self._past_naive_error)
 
     def _mape(self, y_true: pd.Series, predictions: TimeSeriesDataFrame) -> float:
         y_pred = self._get_median_forecast(predictions)
@@ -191,7 +197,9 @@ class TimeSeriesEvaluator:
         return metric
 
     def save_past_metrics(self, data_past: TimeSeriesDataFrame):
-        self._past_naive_1_error = in_sample_naive_1_error(y_past=data_past[self.target_column])
+        self._past_naive_error = in_sample_seasonal_naive_error(
+            y_past=data_past[self.target_column], seasonal_period=self.seasonal_period
+        )
 
     def score_with_saved_past_metrics(
         self, data_future: TimeSeriesDataFrame, predictions: TimeSeriesDataFrame
@@ -202,7 +210,7 @@ class TimeSeriesEvaluator:
         it doesn't require splitting the test data into past/future portions each time (e.g., when fitting ensembles).
         """
         assert (predictions.num_timesteps_per_item() == self.prediction_length).all()
-        assert self._past_naive_1_error is not None, "Call save_past_metrics before score_with_saved_past_metrics"
+        assert self._past_naive_error is not None, "Call save_past_metrics before score_with_saved_past_metrics"
         assert data_future.index.equals(predictions.index), "Prediction and data indices do not match."
 
         with evaluator_warning_filter(), warnings.catch_warnings():

--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -29,6 +29,7 @@ class TimeSeriesLearner(AbstractLearner):
         known_covariates_names: Optional[List[str]] = None,
         trainer_type: Type[AbstractTimeSeriesTrainer] = AutoTimeSeriesTrainer,
         eval_metric: Optional[str] = None,
+        eval_metric_seasonal_period: int = 1,
         prediction_length: int = 1,
         validation_splitter: AbstractTimeSeriesSplitter = LastWindowSplitter(),
         ignore_time_index: bool = False,
@@ -36,6 +37,7 @@ class TimeSeriesLearner(AbstractLearner):
     ):
         super().__init__(path_context=path_context)
         self.eval_metric: str = TimeSeriesEvaluator.check_get_evaluation_metric(eval_metric)
+        self.eval_metric_seasonal_period = eval_metric_seasonal_period
         self.trainer_type = trainer_type
         self.target = target
         self.known_covariates_names = [] if known_covariates_names is None else known_covariates_names
@@ -115,6 +117,7 @@ class TimeSeriesLearner(AbstractLearner):
                 path=self.model_context,
                 prediction_length=self.prediction_length,
                 eval_metric=self.eval_metric,
+                eval_metric_seasonal_period=self.eval_metric_seasonal_period,
                 target=self.target,
                 quantile_levels=self.quantile_levels,
                 verbosity=kwargs.get("verbosity", 2),

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -76,6 +76,7 @@ class AbstractTimeSeriesModel(AbstractModel):
         name: Optional[str] = None,
         metadata: Optional[CovariateMetadata] = None,
         eval_metric: Optional[str] = None,
+        eval_metric_seasonal_period: int = 1,
         hyperparameters: Dict[str, Union[int, float, str, ag.Space]] = None,
         **kwargs,
     ):
@@ -87,6 +88,7 @@ class AbstractTimeSeriesModel(AbstractModel):
             hyperparameters=hyperparameters,
         )
         self.eval_metric: str = TimeSeriesEvaluator.check_get_evaluation_metric(eval_metric)
+        self.eval_metric_seasonal_period = eval_metric_seasonal_period
         self.stopping_metric = None
         self.problem_type = "timeseries"
         self.conformalize = False
@@ -328,6 +330,7 @@ class AbstractTimeSeriesModel(AbstractModel):
         metric = self.eval_metric if metric is None else metric
         evaluator = TimeSeriesEvaluator(
             eval_metric=metric,
+            eval_metric_seasonal_period=self.eval_metric_seasonal_period,
             prediction_length=self.prediction_length,
             target_column=self.target,
         )

--- a/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
+++ b/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
@@ -82,6 +82,7 @@ class TimeSeriesGreedyEnsemble(AbstractTimeSeriesEnsembleModel):
     ):
         evaluator = TimeSeriesEvaluator(
             eval_metric=self.eval_metric,
+            eval_metric_seasonal_period=self.eval_metric_seasonal_period,
             prediction_length=self.prediction_length,
             target_column=self.target,
         )

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -187,6 +187,7 @@ def get_preset_models(
     prediction_length: int,
     path: str,
     eval_metric: str,
+    eval_metric_seasonal_period: int,
     hyperparameters: Union[str, Dict],
     hyperparameter_tune: bool,
     invalid_model_names: List[str],
@@ -246,6 +247,7 @@ def get_preset_models(
             freq=freq,
             prediction_length=prediction_length,
             eval_metric=eval_metric,
+            eval_metric_seasonal_period=eval_metric_seasonal_period,
             hyperparameters=model_hps,
             **kwargs,
         )

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -61,6 +61,9 @@ class TimeSeriesPredictor:
         - ``"RMSE"``: root mean squared error
 
         For more information about these metrics, see https://docs.aws.amazon.com/forecast/latest/dg/metrics.html.
+    eval_metric_seasonal_period : int, default = 1
+        Seasonal period used to compute the mean absolute scaled error (MASE) evaluation metric. This parameter is only
+        used if ``eval_metric="MASE"`. See https://en.wikipedia.org/wiki/Mean_absolute_scaled_error for more details.
     known_covariates_names: List[str], optional
         Names of the covariates that are known in advance for all time steps in the forecast horizon. These are also
         known as dynamic features, exogenous variables, additional regressors or related time series. Examples of such
@@ -122,6 +125,7 @@ class TimeSeriesPredictor:
         known_covariates_names: Optional[List[str]] = None,
         prediction_length: int = 1,
         eval_metric: Optional[str] = None,
+        eval_metric_seasonal_period: int = 1,
         path: Optional[str] = None,
         verbosity: int = 2,
         quantile_levels: Optional[List[float]] = None,
@@ -152,6 +156,7 @@ class TimeSeriesPredictor:
 
         self.prediction_length = prediction_length
         self.eval_metric = eval_metric
+        self.eval_metric_seasonal_period = eval_metric_seasonal_period
         self.quantile_levels = quantile_levels or kwargs.get(
             "quantiles", [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
         )
@@ -175,6 +180,7 @@ class TimeSeriesPredictor:
             dict(
                 path_context=self.path,
                 eval_metric=eval_metric,
+                eval_metric_seasonal_period=eval_metric_seasonal_period,
                 target=self.target,
                 known_covariates_names=self.known_covariates_names,
                 prediction_length=self.prediction_length,

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -273,6 +273,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         path: str,
         prediction_length: Optional[int] = 1,
         eval_metric: Optional[str] = None,
+        eval_metric_seasonal_period: int = 1,
         save_data: bool = True,
         enable_ensemble: bool = True,
         verbosity: int = 2,
@@ -301,6 +302,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         # Dict of FULL model -> normal model validation score in case the normal model had been deleted.
         self._model_full_dict_val_score = {}
         self.eval_metric = TimeSeriesEvaluator.check_get_evaluation_metric(eval_metric)
+        self.eval_metric_seasonal_period = eval_metric_seasonal_period
         self.hpo_results = {}
 
     def save_train_data(self, data: TimeSeriesDataFrame, verbose: bool = True) -> None:
@@ -693,6 +695,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         ensemble = self.ensemble_model_type(
             name=self._get_ensemble_model_name(),
             eval_metric=self.eval_metric,
+            eval_metric_seasonal_period=self.eval_metric_seasonal_period,
             target=self.target,
             prediction_length=self.prediction_length,
             path=self.path,
@@ -706,6 +709,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
 
         evaluator = TimeSeriesEvaluator(
             eval_metric=self.eval_metric,
+            eval_metric_seasonal_period=self.eval_metric_seasonal_period,
             prediction_length=self.prediction_length,
             target_column=self.target,
         )
@@ -831,6 +835,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         if isinstance(model, AbstractTimeSeriesEnsembleModel):
             evaluator = TimeSeriesEvaluator(
                 eval_metric=eval_metric,
+                eval_metric_seasonal_period=self.eval_metric_seasonal_period,
                 prediction_length=self.prediction_length,
                 target_column=self.target,
             )

--- a/timeseries/src/autogluon/timeseries/trainer/auto_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/auto_trainer.py
@@ -11,11 +11,13 @@ class AutoTimeSeriesTrainer(AbstractTimeSeriesTrainer):
     def construct_model_templates(self, hyperparameters, **kwargs):
         path = kwargs.pop("path", self.path)
         eval_metric = kwargs.pop("eval_metric", self.eval_metric)
+        eval_metric_seasonal_period = kwargs.pop("eval_metric", self.eval_metric_seasonal_period)
         quantile_levels = kwargs.pop("quantile_levels", self.quantile_levels)
         hyperparameter_tune = kwargs.get("hyperparameter_tune", False)
         return get_preset_models(
             path=path,
             eval_metric=eval_metric,
+            eval_metric_seasonal_period=eval_metric_seasonal_period,
             prediction_length=self.prediction_length,
             freq=kwargs.get("freq"),
             hyperparameters=hyperparameters,

--- a/timeseries/tests/unittests/test_evaluator.py
+++ b/timeseries/tests/unittests/test_evaluator.py
@@ -6,7 +6,7 @@ from gluonts.evaluation import make_evaluation_predictions
 from gluonts.model.forecast import SampleForecast
 
 from autogluon.timeseries import TimeSeriesPredictor
-from autogluon.timeseries.evaluator import TimeSeriesEvaluator
+from autogluon.timeseries.evaluator import TimeSeriesEvaluator, in_sample_seasonal_naive_error
 from autogluon.timeseries.models.gluonts.abstract_gluonts import AbstractGluonTSModel
 
 from .common import DUMMY_TS_DATAFRAME
@@ -190,3 +190,11 @@ def test_given_historic_data_not_cached_when_scoring_then_exception_is_raised(ev
     predictions = data_future.rename({"target": "mean"}, axis=1)
     with pytest.raises(AssertionError, match="Call save_past_metrics before"):
         evaluator.score_with_saved_past_metrics(data_future=data_future, predictions=predictions)
+
+
+def test_when_eval_metric_seasonal_period_is_longer_than_ts_then_scale_is_set_to_1():
+    seasonal_period = max(DUMMY_TS_DATAFRAME.num_timesteps_per_item())
+    naive_error_per_item = in_sample_seasonal_naive_error(
+        y_past=DUMMY_TS_DATAFRAME["target"], seasonal_period=seasonal_period
+    )
+    assert (naive_error_per_item == 1.0).all()


### PR DESCRIPTION
In many time series benchmarks (e.g., M4 competition), the MASE error is computed using a `seasonal_period` that depends on the data frequency (e.g., 24 for hourly data). Currently, AGTS always assumes `seasonal_period=1` when computing MASE. This leads to the ensemble optimizing the wrong objective, and therefore achieving suboptimal results on external benchmarks (e.g., measured by GluonTS, AF or the official M4 competition code).

Training AGTS with the correct `seasonal_period` can significantly boost the performance. For example, test set MASE on M4 daily
- using `eval_metric_seasonal_period=1` (current master branch): 1.35
- using `eval_metric_seasonal_period=24` (this PR): 1.06

*Description of changes:*
- This PR provides an option to change the `seasonal_period` used for computing `MASE` by specifying the `eval_meric_seasonal_period: int` argument when creating the `TimeSeriesPredictor`. 
  - This information is propagated to learner/trainer/individual models, since `eval_meric_seasonal_period` must always be known when creating a `TimeSeriesPredictor`. The only alternative I see is to refactor the `TimeSeriesEvaluator` class completely to act similar to the `Scorer` class in Tabular, but that would be an even bigger (potentially breaking) change to the code.
- This is intended as functionality for advanced users who want to get competitive results on benchmarks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
