### PR TITLE
[timeseries] Parallelize TimeSeriesDataFrame construction from iterable dataset

### DIFF
--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -260,7 +260,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
 
     @classmethod
     def _construct_pandas_frame_from_iterable_dataset(cls, iterable_dataset: Iterable) -> pd.DataFrame:
-        def load_single_df(item_id: int, ts: dict) -> pd.DataFrame:
+        def load_single_item(item_id: int, ts: dict) -> pd.DataFrame:
             start_timestamp = ts["start"]
             freq = start_timestamp.freq
             if isinstance(start_timestamp, pd.Period):
@@ -272,7 +272,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
 
         cls._validate_iterable(iterable_dataset)
         all_ts = Parallel(n_jobs=-1)(
-            delayed(load_single_df)(item_id, ts) for item_id, ts in enumerate(iterable_dataset)
+            delayed(load_single_item)(item_id, ts) for item_id, ts in enumerate(iterable_dataset)
         )
         return pd.concat(all_ts)
 


### PR DESCRIPTION
*Description of changes:*
- Parallelize the construction of `TimeSeriesDataFrame` from GluonTS-style iterable dataset. Instead of processing the items sequentially with a single core, parallelize the work across items with joblib.
  - This significantly reduces the processing times for large datasets (e.g., for `electricity` we go from 337s -> 30s).
  - This speeds up our benchmarking & positively affects users who store their datasets in GluonTS format.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
