### PR TITLE
Fix AsTypeFeatureGenerator Edge-case Crash

### DIFF
--- a/features/src/autogluon/features/generators/abstract.py
+++ b/features/src/autogluon/features/generators/abstract.py
@@ -518,7 +518,8 @@ class AbstractFeatureGenerator:
                 self._feature_metadata_before_post = self._feature_metadata_before_post.keep_features(features_to_keep)
 
             self.feature_metadata_in = self.feature_metadata_in.remove_features(features=features)
-            self.features_in = self.feature_metadata_in.get_features()
+            features_in_new = set(self.feature_metadata_in.get_features())
+            self.features_in = [f for f in self.features_in if f in features_in_new]
             if self._pre_astype_generator:
                 self._pre_astype_generator._remove_features_out(features)
 

--- a/features/src/autogluon/features/generators/astype.py
+++ b/features/src/autogluon/features/generators/astype.py
@@ -181,7 +181,10 @@ class AsTypeFeatureGenerator(AbstractFeatureGenerator):
         for feature in self._bool_features_list:
             X_bool_list.append((X[feature] == self._bool_features[feature]).astype(np.int8))
         X_bool = pd.concat(X_bool_list, axis=1)
-        return pd.concat([X[self._non_bool_features_list], X_bool], axis=1)
+
+        # TODO: re-order columns to features_in required because `feature_interactions=False` to avoid error when feature prune.
+        #  Note that this is slower than avoiding the re-order, but avoiding the re-order is very complicated to do correctly.
+        return pd.concat([X[self._non_bool_features_list], X_bool], axis=1)[self.features_in]
 
     def _convert_to_bool_fast_realtime(self, X: DataFrame) -> DataFrame:
         """Optimized for when X is <= 100 rows"""
@@ -189,7 +192,9 @@ class AsTypeFeatureGenerator(AbstractFeatureGenerator):
         X_bool_numpy = X_bool_features_np == self._bool_features_val_np
         X_bool = pd.DataFrame(X_bool_numpy, columns=self._bool_features_list, dtype=np.int8, index=X.index)
 
-        return pd.concat([X[self._non_bool_features_list], X_bool], axis=1)
+        # TODO: re-order columns to features_in required because `feature_interactions=False` to avoid error when feature prune.
+        #  Note that this is slower than avoiding the re-order, but avoiding the re-order is very complicated to do correctly.
+        return pd.concat([X[self._non_bool_features_list], X_bool], axis=1)[self.features_in]
 
     @staticmethod
     def get_default_infer_features_in_args() -> dict:

--- a/features/tests/features/conftest.py
+++ b/features/tests/features/conftest.py
@@ -171,8 +171,8 @@ class DataHelper:
         return pd.to_datetime(DataHelper.generate_datetime_as_object_feature(), errors='coerce')
 
     @staticmethod
-    def generate_bool_feature_int() -> DataFrame:
-        return Series([0, 1, 1, 0, 0, 0, 1, 0, 1], name='int_bool').to_frame()
+    def generate_bool_feature_int(name='int_bool') -> DataFrame:
+        return Series([0, 1, 1, 0, 0, 0, 1, 0, 1], name=name).to_frame()
 
     @staticmethod
     def generate_bool_feature_with_nan() -> DataFrame:
@@ -199,6 +199,42 @@ class DataHelper:
             axis=1,
         )
         df.columns = ['int', 'float', 'obj', 'cat', 'datetime']
+        return df
+
+    @staticmethod
+    def generate_useless_category() -> DataFrame:
+        return Series(
+            [
+                'a',
+                'b',
+                'c',
+                'd',
+                'e',
+                'f',
+                'g',
+                'h',
+                'i',
+            ], name='cat_useless').to_frame()
+
+    @staticmethod
+    def generate_duplicate() -> DataFrame:
+        df_bool_dupes = []
+        for i in range(20):
+            df_bool_dupes.append(DataHelper.generate_bool_feature_int(name=f'int_bool_dup_{i+1}'),)
+
+        df_to_concat = [
+            DataHelper.generate_bool_feature_int(),
+            DataHelper.generate_multi_feature_special(),
+            DataHelper.generate_useless_category(),
+            DataHelper.generate_multi_feature_standard(),
+        ] + df_bool_dupes + [
+            DataHelper.generate_bool_feature_int(name='int_bool_dup_final'),
+        ]
+
+        df = pd.concat(
+            df_to_concat,
+            axis=1,
+        )
         return df
 
     @staticmethod

--- a/features/tests/features/generators/test_auto_ml_pipeline.py
+++ b/features/tests/features/generators/test_auto_ml_pipeline.py
@@ -120,6 +120,8 @@ def test_auto_ml_pipeline_feature_generator_raw_text(generator_helper, data_help
 
     toy_vectorizer = CountVectorizer(min_df=2, ngram_range=(1, 3), max_features=10, dtype=np.uint8)
 
+    from autogluon.common.utils.log_utils import set_logger_verbosity
+    set_logger_verbosity(3)
     generator = AutoMLPipelineFeatureGenerator(enable_raw_text_features=True, vectorizer=toy_vectorizer)
 
     for generator_stage in generator.generators:
@@ -249,3 +251,155 @@ def test_auto_ml_pipeline_feature_generator_only_raw_text(generator_helper, data
     )
 
     assert list(input_data['text'].values) == list(output_data['text_raw_text'].values)
+
+
+def test_auto_ml_pipeline_feature_generator_duplicates(generator_helper, data_helper):
+    """
+    Test the most complicated situation: Many duplicate features, useless features, and all dtypes at once
+    This test ensures the fix in https://github.com/autogluon/autogluon/pull/2986 works, test failed prior to fix
+    """
+    # Given
+    input_data = data_helper.generate_duplicate()
+
+    toy_vectorizer = CountVectorizer(min_df=2, ngram_range=(1, 3), max_features=10, dtype=np.uint8)
+
+    with pytest.raises(KeyError):
+        # generators is an invalid argument
+        AutoMLPipelineFeatureGenerator(generators=[], vectorizer=toy_vectorizer)
+
+    generator = AutoMLPipelineFeatureGenerator(vectorizer=toy_vectorizer)
+
+    for generator_stage in generator.generators:
+        for generator_inner in generator_stage:
+            if isinstance(generator_inner, TextNgramFeatureGenerator):
+                # Necessary in test to avoid CI non-deterministically pruning ngram counts.
+                generator_inner.max_memory_ratio = None
+
+    expected_feature_metadata_in_full = {
+        ('category', ()): ['cat'],
+        ('datetime', ()): ['datetime'],
+        ('float', ()): ['float'],
+        ('int', ()): ['int_bool',
+                      'int',
+                      'int_bool_dup_1',
+                      'int_bool_dup_2',
+                      'int_bool_dup_3',
+                      'int_bool_dup_4',
+                      'int_bool_dup_5',
+                      'int_bool_dup_6',
+                      'int_bool_dup_7',
+                      'int_bool_dup_8',
+                      'int_bool_dup_9',
+                      'int_bool_dup_10',
+                      'int_bool_dup_11',
+                      'int_bool_dup_12',
+                      'int_bool_dup_13',
+                      'int_bool_dup_14',
+                      'int_bool_dup_15',
+                      'int_bool_dup_16',
+                      'int_bool_dup_17',
+                      'int_bool_dup_18',
+                      'int_bool_dup_19',
+                      'int_bool_dup_20',
+                      'int_bool_dup_final'],
+        ('object', ()): ['obj'],
+        ('object', ('datetime_as_object',)): ['datetime_as_object'],
+        ('object', ('text',)): ['text']
+    }
+
+    expected_feature_metadata_full = {
+        ('category', ()): ['obj', 'cat'],
+        ('float', ()): ['float'],
+        ('int', ()): ['int'],
+        ('int', ('binned', 'text_special')): [
+            'text.char_count',
+            'text.word_count',
+            'text.lower_ratio',
+            'text.special_ratio',
+            'text.symbol_ratio. '
+        ],
+        ('int', ('bool',)): ['int_bool',
+                             'int_bool_dup_1',
+                             'int_bool_dup_2',
+                             'int_bool_dup_3',
+                             'int_bool_dup_4',
+                             'int_bool_dup_5',
+                             'int_bool_dup_6',
+                             'int_bool_dup_7',
+                             'int_bool_dup_8',
+                             'int_bool_dup_9',
+                             'int_bool_dup_10',
+                             'int_bool_dup_11',
+                             'int_bool_dup_12',
+                             'int_bool_dup_13',
+                             'int_bool_dup_14',
+                             'int_bool_dup_15',
+                             'int_bool_dup_16',
+                             'int_bool_dup_17',
+                             'int_bool_dup_18',
+                             'int_bool_dup_19',
+                             'int_bool_dup_20',
+                             'int_bool_dup_final'],
+        ('int', ('datetime_as_int',)): ['datetime_as_object',
+                                        'datetime_as_object.year',
+                                        'datetime_as_object.month',
+                                        'datetime_as_object.day',
+                                        'datetime_as_object.dayofweek',
+                                        'datetime',
+                                        'datetime.year',
+                                        'datetime.month',
+                                        'datetime.day',
+                                        'datetime.dayofweek'],
+        ('int', ('text_ngram',)): ['__nlp__.breaks',
+                                   '__nlp__.end',
+                                   '__nlp__.end of',
+                                   '__nlp__.end of the',
+                                   '__nlp__.of',
+                                   '__nlp__.sentence',
+                                   '__nlp__.sentence breaks',
+                                   '__nlp__.the',
+                                   '__nlp__.the end',
+                                   '__nlp__.world',
+                                   '__nlp__._total_']
+    }
+
+    expected_output_data_feat_datetime = [
+        1533140820000000000,
+        1301322000000000000,
+        1301322000000000000,
+        1524238620000000000,
+        1524238620000000000,
+        -5364662400000000000,
+        7289654340000000000,
+        1301322000000000000,
+        1301322000000000000
+    ]
+
+    expected_output_data_feat_lower_ratio = [3, 2, 0, 3, 3, 3, 3, 3, 1]
+    expected_output_data_feat_total = [1, 3, 0, 0, 7, 1, 3, 7, 3]
+
+    # When
+    output_data = generator_helper.fit_transform_assert(
+        input_data=input_data,
+        generator=generator,
+        expected_feature_metadata_in_full=expected_feature_metadata_in_full,
+        expected_feature_metadata_full=expected_feature_metadata_full,
+    )
+
+    # int and float checks
+    assert output_data['int'].equals(input_data['int'])
+    assert output_data['float'].equals(input_data['float'])
+
+    # object and category checks
+    assert list(output_data['obj'].values) == [1, np.nan, 1, 2, 2, 2, np.nan, 0, 0]
+    assert list(output_data['cat'].values) == [0, np.nan, 0, 1, 1, 1, np.nan, np.nan, np.nan]
+
+    # datetime checks.  There are further checks in test_datetime.py
+    assert list(output_data['datetime'].values) == list(output_data['datetime_as_object'].values)
+    assert expected_output_data_feat_datetime == list(output_data['datetime'].values)
+
+    # text_special checks
+    assert expected_output_data_feat_lower_ratio == list(output_data['text.lower_ratio'].values)
+
+    # text_ngram checks
+    assert expected_output_data_feat_total == list(output_data['__nlp__._total_'].values)

--- a/features/tests/features/generators/test_auto_ml_pipeline.py
+++ b/features/tests/features/generators/test_auto_ml_pipeline.py
@@ -120,8 +120,6 @@ def test_auto_ml_pipeline_feature_generator_raw_text(generator_helper, data_help
 
     toy_vectorizer = CountVectorizer(min_df=2, ngram_range=(1, 3), max_features=10, dtype=np.uint8)
 
-    from autogluon.common.utils.log_utils import set_logger_verbosity
-    set_logger_verbosity(3)
     generator = AutoMLPipelineFeatureGenerator(enable_raw_text_features=True, vectorizer=toy_vectorizer)
 
     for generator_stage in generator.generators:

--- a/features/tests/features/generators/test_bulk.py
+++ b/features/tests/features/generators/test_bulk.py
@@ -103,9 +103,9 @@ def test_bulk_feature_generator(generator_helper, data_helper):
     )
 
     assert list(output_data.columns) == [
+        'int_bool',
         'int',
         'float',
-        'int_bool',  # Notably, this is now the 3rd feature rather than the 1st because we used "v2" which shifts the position of the boolean feature
         'obj',
         'cat',
         'datetime',


### PR DESCRIPTION
*Issue #, if available:*

Fix bug introduced in #2944 

*Description of changes:*

- Fix bug when useless features are present (aka categorical with each value only appearing once) and boolean features >= 15, causing crash during inference in some cases.
- Technically this slows down preprocessing in this situation, but avoiding the slow down is massively complicated and not worth implementing.
- Added unit test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
