### PR TITLE
[NER] Use BertPreTokenizer for pre-tokenization

### DIFF
--- a/multimodal/src/autogluon/multimodal/data/utils.py
+++ b/multimodal/src/autogluon/multimodal/data/utils.py
@@ -14,6 +14,7 @@ from timm.data.constants import (
     IMAGENET_INCEPTION_MEAN,
     IMAGENET_INCEPTION_STD,
 )
+from tokenizers import pre_tokenizers
 from torchvision import transforms
 
 from ..constants import CLIP_IMAGE_MEAN, CLIP_IMAGE_STD, IDENTIFIER, IMAGE, MMLAB_MODELS
@@ -326,7 +327,7 @@ def tokenize_ner_text(text, tokenizer):
     The output of tokenizer and word offsets.
     """
     # pre-tokenization is required for NER token-level label generation.
-    words_with_offsets = tokenizer.backend_tokenizer.pre_tokenizer.pre_tokenize_str(text)
+    words_with_offsets = pre_tokenizers.BertPreTokenizer().pre_tokenize_str(text)
     words_with_offsets = is_space_counted(words_with_offsets) if len(words_with_offsets) > 1 else words_with_offsets
     words = [word for word, offset in words_with_offsets]
     word_offsets = np.array([[offset[0], offset[1]] for word, offset in words_with_offsets], dtype=np.int32)

--- a/multimodal/src/autogluon/multimodal/utils/misc.py
+++ b/multimodal/src/autogluon/multimodal/utils/misc.py
@@ -1,3 +1,4 @@
+import collections
 import json
 import logging
 import os
@@ -161,6 +162,7 @@ class NERVisualizer:
         self.sent = sent
         self.colors = {}
         self.spans = merge_spans(sent, pred, for_visualizer=True)
+        self.spans = collections.OrderedDict(sorted(self.spans.items()))
         self.rng = np.random.RandomState(seed)
 
     @staticmethod
@@ -189,8 +191,8 @@ class NERVisualizer:
         color
             The background color of the mark tag.
         """
-        text = '<mark style="background-color:{}; color:white; border-radius: 1em .1em; padding: .3em;">{} \
-         <b style="background-color:white; color:black; font-size:x-small; border-radius: 0.3em .3em; padding: .1em;">{} </b> \
+        text = '<mark style="background-color:{}; color:white; border-radius: .6em .6em; padding: .1em;">{} \
+         <b style="background-color:white; color:black; font-size:x-small; border-radius: 0.5em .5em; padding: .0em;">{} </b> \
          </mark>'.format(
             color, self.escape_html(text), self.escape_html(label)
         )

--- a/multimodal/tests/unittests/others/test_utils.py
+++ b/multimodal/tests/unittests/others/test_utils.py
@@ -229,7 +229,7 @@ def test_process_ner_annotations():
     tokenizer = AutoTokenizer.from_pretrained("microsoft/deberta-v3-small")
     tokenizer.model_max_length = 512
     res = process_ner_annotations(annotation, text, entity_map, tokenizer, is_eval=True)[0]
-    assert res == [3, 4, 1, 1, 1, 1, 5, 6, 7, 8], "Labelling is wrong!"
+    assert res == [3, 4, 1, 1, 1, 1, 1, 5, 6, 1, 1, 1, 7, 8, 8, 8], "Labelling is wrong!"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The backend pretokenizer will not split punctuation, so we switch it to BertPreTokenizer which will consider both space and punctuation when doing pre-tokenization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
