### PR TITLE
AutoMM: Add consistent seed, stratification, alignment with tabular for train-val split

### DIFF
--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -731,9 +731,9 @@ class MultiModalPredictor(ExportMixin):
         )
 
         if tuning_data is None:
-            train_data, tuning_data = self._split_train_tuning(data=train_data,
-                                                               holdout_frac=holdout_frac,
-                                                               random_state=seed)
+            train_data, tuning_data = self._split_train_tuning(
+                data=train_data, holdout_frac=holdout_frac, random_state=seed
+            )
 
             # FIXME: Because output_shape is paired with problem_type detection,
             #  need to do this again in-case output_shape changed when splitting data
@@ -854,10 +854,9 @@ class MultiModalPredictor(ExportMixin):
 
         return self
 
-    def _split_train_tuning(self,
-                            data: pd.DataFrame,
-                            holdout_frac: float = None,
-                            random_state: int = 0) -> (pd.DataFrame, pd.DataFrame):
+    def _split_train_tuning(
+        self, data: pd.DataFrame, holdout_frac: float = None, random_state: int = 0
+    ) -> (pd.DataFrame, pd.DataFrame):
         """
         Splits `data` into `train_data` and `tuning_data`.
         If the problem_type is one of ['binary', 'multiclass']:
@@ -883,8 +882,7 @@ class MultiModalPredictor(ExportMixin):
         Tuple of (train_data, tuning_data) of the split `data`
         """
         if holdout_frac is None:
-            holdout_frac = default_holdout_frac(num_train_rows=len(data),
-                                                hyperparameter_tune=False)
+            holdout_frac = default_holdout_frac(num_train_rows=len(data), hyperparameter_tune=False)
 
         # TODO: Hack since the recognized problem types are only binary, multiclass, and regression
         #  Problem types used for purpose of stratification, so regression = no stratification

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -838,7 +838,7 @@ class MultiModalPredictor(ExportMixin):
 
     # FIXME: Avoid having separate logic for inferring features and label column that is combined together
     def _infer_column_types(
-            self, train_data: pd.DataFrame, tuning_data: pd.DataFrame = None, column_types: dict = None
+        self, train_data: pd.DataFrame, tuning_data: pd.DataFrame = None, column_types: dict = None
     ) -> dict:
         column_types = infer_column_types(
             data=train_data,
@@ -859,7 +859,9 @@ class MultiModalPredictor(ExportMixin):
     #  don't combine output_shape and problem_type detection, make them separate
     #  Use autogluon.core.utils.utils.infer_problem_type
     def _infer_problem_type(self, train_data: pd.DataFrame, column_types: dict = None) -> str:
-        column_types_label = self._infer_column_types(train_data=train_data[[self._label_column]], column_types=column_types)
+        column_types_label = self._infer_column_types(
+            train_data=train_data[[self._label_column]], column_types=column_types
+        )
 
         problem_type, _ = infer_problem_type_output_shape(
             label_column=self._label_column,

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -845,6 +845,7 @@ class MultiModalPredictor(ExportMixin):
             label_columns=self._label_column,
             provided_column_types=column_types,
             valid_data=tuning_data,
+            problem_type=self._problem_type,
         )
         column_types = infer_label_column_type_by_problem_type(
             column_types=column_types,

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -26,7 +26,9 @@ from packaging import version
 from torch import nn
 
 from autogluon.common.utils.log_utils import set_logger_verbosity, verbosity2loglevel
+from autogluon.core.utils import default_holdout_frac, generate_train_test_split_combined
 from autogluon.core.utils.loaders import load_pd
+from autogluon.multimodal.utils.log import get_fit_complete_message, get_fit_start_message
 
 from . import version as ag_version
 from .constants import (
@@ -153,7 +155,6 @@ from .utils import (
     setup_detection_train_tuning_data,
     setup_save_path,
     split_hyperparameters,
-    split_train_tuning_data,
     tensor_to_ndarray,
     try_to_infer_pos_label,
     turn_on_off_feature_column_info,
@@ -533,7 +534,7 @@ class MultiModalPredictor(ExportMixin):
         column_types: Optional[dict] = None,
         holdout_frac: Optional[float] = None,
         teacher_predictor: Union[str, MultiModalPredictor] = None,
-        seed: Optional[int] = 123,
+        seed: Optional[int] = 0,
         standalone: Optional[bool] = True,
         hyperparameter_tune_kwargs: Optional[dict] = None,
         clean_ckpts: Optional[bool] = True,
@@ -622,6 +623,7 @@ class MultiModalPredictor(ExportMixin):
             knowledge to a student predictor, i.e., the current predictor.
         seed
             The random seed to use for this training run.
+            Defaults to 0
         standalone
             Whether to save the enire model for offline deployment or only trained parameters of parameter-efficient fine-tuning strategy.
         hyperparameter_tune_kwargs
@@ -695,15 +697,6 @@ class MultiModalPredictor(ExportMixin):
             fit_called=fit_called,
         )
 
-        train_data, tuning_data = split_train_tuning_data(
-            train_data=train_data,
-            tuning_data=tuning_data,
-            holdout_frac=holdout_frac,
-            is_classification=self.problem_property and self.problem_property.is_classification,
-            label_column=self._label_column,
-            seed=seed,
-        )
-
         column_types = infer_column_types(
             data=train_data,
             valid_data=tuning_data,
@@ -728,14 +721,28 @@ class MultiModalPredictor(ExportMixin):
         if self._config is not None:  # continuous training
             config = self._config
 
-        problem_type, output_shape = infer_problem_type_output_shape(
+        # FIXME: Align logic with Tabular,
+        #  don't combine output_shape and problem_type detection, make them separate
+        self._problem_type, output_shape = infer_problem_type_output_shape(
             label_column=self._label_column,
             column_types=column_types,
             data=train_data,
             provided_problem_type=self._problem_type,
         )
-        if problem_type is not None:
-            self._problem_type = problem_type  # In case problem type isn't provided in __init__().
+
+        if tuning_data is None:
+            train_data, tuning_data = self._split_train_tuning(data=train_data,
+                                                               holdout_frac=holdout_frac,
+                                                               random_state=seed)
+
+            # FIXME: Because output_shape is paired with problem_type detection,
+            #  need to do this again in-case output_shape changed when splitting data
+            self._problem_type, output_shape = infer_problem_type_output_shape(
+                label_column=self._label_column,
+                column_types=column_types,
+                data=train_data,
+                provided_problem_type=self._problem_type,
+            )
 
         # Determine data scarcity mode, i.e. a few-shot scenario
         scarcity_mode = infer_scarcity_mode_by_data_size(
@@ -768,7 +775,7 @@ class MultiModalPredictor(ExportMixin):
 
         if self._validation_metric_name is None or self._eval_metric_name is None:
             validation_metric_name, eval_metric_name = infer_metrics(
-                problem_type=problem_type,
+                problem_type=self._problem_type,
                 eval_metric_name=self._eval_metric_name,
                 validation_metric_name=self._validation_metric_name,
             )
@@ -846,6 +853,54 @@ class MultiModalPredictor(ExportMixin):
         logger.info(get_fit_complete_message(self._save_path))
 
         return self
+
+    def _split_train_tuning(self,
+                            data: pd.DataFrame,
+                            holdout_frac: float = None,
+                            random_state: int = 0) -> (pd.DataFrame, pd.DataFrame):
+        """
+        Splits `data` into `train_data` and `tuning_data`.
+        If the problem_type is one of ['binary', 'multiclass']:
+            The split will be done with stratification on the label column.
+            Will guarantee at least 1 sample of every class in `data` will be present in `train_data`.
+                If only 1 sample of a class exists, it will always be put in `train_data` and not `tuning_data`.
+
+        Parameters
+        ----------
+        data : pd.DataFrame
+            The data to be split
+        holdout_frac : float, default = None
+            The ratio of data to use as validation.
+            If 0.2, 20% of the data will be used for validation, and 80% for training.
+            If None, the ratio is automatically determined,
+            ranging from 0.2 for small row count to 0.01 for large row count.
+        random_state : int, default = 0
+            The random state to use when splitting the data, to make the splitting process deterministic.
+            If None, a random value is used.
+
+        Returns
+        -------
+        Tuple of (train_data, tuning_data) of the split `data`
+        """
+        if holdout_frac is None:
+            holdout_frac = default_holdout_frac(num_train_rows=len(data),
+                                                hyperparameter_tune=False)
+
+        # TODO: Hack since the recognized problem types are only binary, multiclass, and regression
+        #  Problem types used for purpose of stratification, so regression = no stratification
+        if self._problem_type in [BINARY, MULTICLASS]:
+            problem_type_for_split = self._problem_type
+        else:
+            problem_type_for_split = REGRESSION
+
+        train_data, tuning_data = generate_train_test_split_combined(
+            data=data,
+            label=self.label,
+            test_size=holdout_frac,
+            problem_type=problem_type_for_split,
+            random_state=random_state,
+        )
+        return train_data, tuning_data
 
     def _verify_inference_ready(self):
         if not self._fit_called:


### PR DESCRIPTION
*Issue #, if available:*

#3003

*Description of changes:*

- Previously AutoMM would split the same data differently even with the same seed when calling fit multiple times. Now it will use the same split if called with same data and same seed.
- Changed default seed to 0 to align with Tabular
- Changed splitting logic to be identical to Tabular, including adding stratification and other guardrails such as ensuring at least 1 sample per class exists in train data after split. Stratification should help improve AutoMM's test scores, especially when train_data has a small amount of rows.

## Reproducing

### Tabular & MultiModal Identical Result

Now the following code produces identical results for Tabular and AutoMM (previously did not due to (1) seed difference, (2) data split logic difference:

```python3
from autogluon.core.utils.loaders import load_pd

train_data = load_pd.load('https://autogluon-text.s3-accelerate.amazonaws.com/glue/sst/train.parquet')
test_data = load_pd.load('https://autogluon-text.s3-accelerate.amazonaws.com/glue/sst/dev.parquet')
subsample_size = 1000  # subsample data for faster demo, try setting this to larger values
train_data = train_data.sample(n=subsample_size, random_state=0)

label = 'label'
eval_metric = 'accuracy'

from autogluon.tabular import TabularPredictor
predictor = TabularPredictor(label=label, eval_metric=eval_metric)
predictor.fit(
    train_data,
    hyperparameters={'AG_AUTOMM': {
        "optimization.max_epochs": 2,
    }},
    fit_weighted_ensemble=False,
)

test_score = predictor.evaluate(test_data)
print(test_score)

from autogluon.multimodal import MultiModalPredictor
predictor = MultiModalPredictor(label=label, eval_metric=eval_metric)
predictor.fit(
    train_data,
    hyperparameters={
        "optimization.max_epochs": 2,
    }
)

test_score = predictor.evaluate(test_data)
print(test_score)

```

Output:

```
# TabularPredictor
{'accuracy': 0.8279816513761468, 'balanced_accuracy': 0.8292708596446914, 'mcc': 0.6639300307917014, 'roc_auc': 0.9188057800791447, 'f1': 0.8179611650485437, 'precision': 0.8868421052631579, 'recall': 0.759009009009009}
# MultiModalPredictor
{'accuracy': 0.8279816513761468}
```

### MultiModalPredictor Continuous Training Identical Split

Now AutoMM uses the same train/val split when passed the same training data across multiple fit calls with the same seed. This avoids corrupting the validation score across multiple fit calls (#3003)

You can check the difference by running this code (Note: You'll need to add print statements to the train/val data rows or enter debugger to see that they are misaligned in mainline, and aligned in this PR):

```python3
from autogluon.core.utils.loaders import load_pd

train_data = load_pd.load('https://autogluon-text.s3-accelerate.amazonaws.com/glue/sst/train.parquet')
test_data = load_pd.load('https://autogluon-text.s3-accelerate.amazonaws.com/glue/sst/dev.parquet')
subsample_size = 1000  # subsample data for faster demo, try setting this to larger values
train_data = train_data.sample(n=subsample_size, random_state=0)

label = 'label'
eval_metric = 'accuracy'

from autogluon.multimodal import MultiModalPredictor
predictor = MultiModalPredictor(label=label, eval_metric=eval_metric)

predictor.fit(
    train_data,
    hyperparameters={
        "optimization.max_epochs": 2,
    }
)

predictor.fit(
    train_data,
    hyperparameters={
        "optimization.max_epochs": 2,
    }
)
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
