### PR TITLE
Update tabular tutorial pip installs

### DIFF
--- a/docs/tutorials/tabular/advanced/tabular-custom-metric.ipynb
+++ b/docs/tutorials/tabular/advanced/tabular-custom-metric.ipynb
@@ -33,7 +33,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install autogluon.tabular\n"
+    "!pip install autogluon.tabular[all]\n"
    ]
   },
   {

--- a/docs/tutorials/tabular/advanced/tabular-custom-model-advanced.ipynb
+++ b/docs/tutorials/tabular/advanced/tabular-custom-model-advanced.ipynb
@@ -35,7 +35,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install autogluon.tabular\n"
+    "!pip install autogluon.tabular[all]\n"
    ]
   },
   {

--- a/docs/tutorials/tabular/advanced/tabular-custom-model.ipynb
+++ b/docs/tutorials/tabular/advanced/tabular-custom-model.ipynb
@@ -59,7 +59,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install autogluon.tabular\n"
+    "!pip install autogluon.tabular[all]\n"
    ]
   },
   {

--- a/docs/tutorials/tabular/advanced/tabular-deployment.ipynb
+++ b/docs/tutorials/tabular/advanced/tabular-deployment.ipynb
@@ -35,7 +35,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install autogluon.tabular\n"
+    "!pip install autogluon.tabular[all]\n"
    ]
   },
   {

--- a/docs/tutorials/tabular/advanced/tabular-gpu.ipynb
+++ b/docs/tutorials/tabular/advanced/tabular-gpu.ipynb
@@ -82,7 +82,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install autogluon.tabular\n"
+    "!pip install autogluon.tabular[all]\n"
    ]
   },
   {

--- a/docs/tutorials/tabular/advanced/tabular-multilabel.ipynb
+++ b/docs/tutorials/tabular/advanced/tabular-multilabel.ipynb
@@ -31,7 +31,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install autogluon.tabular\n"
+    "!pip install autogluon.tabular[all]\n"
    ]
   },
   {

--- a/docs/tutorials/tabular/tabular-essentials.ipynb
+++ b/docs/tutorials/tabular/tabular-essentials.ipynb
@@ -28,7 +28,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install autogluon.tabular\n"
+    "!pip install autogluon.tabular[all]\n"
    ]
   },
   {

--- a/docs/tutorials/tabular/tabular-feature-engineering.ipynb
+++ b/docs/tutorials/tabular/tabular-feature-engineering.ipynb
@@ -125,7 +125,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install autogluon.tabular\n"
+    "!pip install autogluon.tabular[all]\n"
    ]
   },
   {

--- a/docs/tutorials/tabular/tabular-indepth.ipynb
+++ b/docs/tutorials/tabular/tabular-indepth.ipynb
@@ -30,7 +30,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install autogluon.tabular\n"
+    "!pip install autogluon.tabular[all]\n"
    ]
   },
   {

--- a/docs/tutorials/tabular/tabular-multimodal.ipynb
+++ b/docs/tutorials/tabular/tabular-multimodal.ipynb
@@ -38,7 +38,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install autogluon.tabular\n"
+    "!pip install autogluon\n"
    ]
   },
   {


### PR DESCRIPTION
*Description of changes:*
The `pip install` cell for the tabular tutorials should be `autogluon.tabular[all]` for all the notebooks except `tabular-multimodal` which should be `pip install autogluon` since AutoMM is needed as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
