### PR TITLE
[CI] Remove vestigial root_index.html operations from doc build steps

### DIFF
--- a/.github/workflow_scripts/build_all_docs.sh
+++ b/.github/workflow_scripts/build_all_docs.sh
@@ -72,8 +72,4 @@ fi
 
 # Write docs to s3
 write_to_s3 $BUCKET $LOCAL_DOC_PATH $S3_PATH
-# Write root_index to s3 if master
-if [[ ($BRANCH == 'master') && ($GIT_REPO == autogluon/autogluon) ]]
-then
-    write_to_s3 $BUCKET root_index.html s3://$BUCKET/build_docs/$BRANCH/$COMMIT_SHA/root_index.html
-fi
+

--- a/.github/workflow_scripts/copy_docs.sh
+++ b/.github/workflow_scripts/copy_docs.sh
@@ -45,8 +45,3 @@ fi
 aws s3 sync ${flags} ${BUILD_DOCS_PATH}/all/ s3://${bucket}/${path} --acl public-read ${cacheControl}
 echo "Uploaded doc to http://${site}/index.html"
 
-if [[ ($BRANCH == 'master') && ($GIT_REPO == autogluon/autogluon) ]]
-then
-    aws s3 cp ${BUILD_DOCS_PATH}/root_index.html s3://${bucket}/index.html --acl public-read ${cacheControl}
-    echo "Uploaded root_index.html s3://${bucket}/index.html"
-fi


### PR DESCRIPTION
*Description of changes:*

The old AutoGluon website used the `root_index.html` file to add a header with links to every page. The new website handles this natively during the Sphinx build process.

There were steps in the AutoGluon CI related to copying this file under certain conditions. These steps failed after merge to `master` because the file no longer exists. This issue was not uncovered during development of the new website because the logic is only executed when the `master` branch is being built.

All lines referencing this vestigial file need to be removed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
