### PR TITLE
[timeseries] Cache validation predictions and report accurate prediction times

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -336,7 +336,7 @@ class AbstractTimeSeriesModel(AbstractModel):
         metric = self.eval_metric if metric is None else metric
 
         past_data, known_covariates = self.slice_data_for_scoring(data)
-        predictions = self.predict(data=past_data, known_covariates=known_covariates)
+        predictions = self.predict(past_data, known_covariates=known_covariates)
 
         evaluator = TimeSeriesEvaluator(
             eval_metric=metric,

--- a/timeseries/src/autogluon/timeseries/models/abstract/model_trial.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/model_trial.py
@@ -74,15 +74,17 @@ def fit_and_save_model(model, fit_kwargs, train_data, val_data, eval_metric, tim
     time_fit_start = time.time()
     model.fit(train_data=train_data, val_data=val_data, time_limit=time_left, **fit_kwargs)
     time_fit_end = time.time()
-    model.val_score = model.score(val_data, eval_metric)
+    val_predictions = model.predict_for_scoring(val_data)
     time_pred_end = time.time()
+    model.cache_val_predictions(val_predictions)
+    model.val_score = model.score_with_val_predictions(data=val_data, eval_metric=eval_metric)
 
     logger.debug(f"\tHyperparameter tune run: {model.name}")
     logger.debug(f"\t\t{model.val_score:<7.4f}".ljust(15) + f"= Validation score ({eval_metric})")
     model.fit_time = time_fit_end - time_fit_start
     model.predict_time = time_pred_end - time_fit_end
     logger.debug(f"\t\t{model.fit_time:<7.3f} s".ljust(15) + "= Training runtime")
-    logger.debug(f"\t\t{model.predict_time:<7.3f} s".ljust(15) + "= Training runtime")
+    logger.debug(f"\t\t{model.predict_time:<7.3f} s".ljust(15) + "= Prediction runtime")
     model.save()
     return model
 

--- a/timeseries/src/autogluon/timeseries/models/abstract/model_trial.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/model_trial.py
@@ -74,15 +74,11 @@ def fit_and_save_model(model, fit_kwargs, train_data, val_data, eval_metric, tim
     time_fit_start = time.time()
     model.fit(train_data=train_data, val_data=val_data, time_limit=time_left, **fit_kwargs)
     time_fit_end = time.time()
-    val_predictions = model.predict_for_scoring(val_data)
-    time_pred_end = time.time()
-    model.cache_val_predictions(val_predictions)
-    model.val_score = model.score_with_val_predictions(data=val_data, eval_metric=eval_metric)
+    model.val_score = model.score_on_val_data_and_cache(val_data)
 
     logger.debug(f"\tHyperparameter tune run: {model.name}")
     logger.debug(f"\t\t{model.val_score:<7.4f}".ljust(15) + f"= Validation score ({eval_metric})")
     model.fit_time = time_fit_end - time_fit_start
-    model.predict_time = time_pred_end - time_fit_end
     logger.debug(f"\t\t{model.fit_time:<7.3f} s".ljust(15) + "= Training runtime")
     logger.debug(f"\t\t{model.predict_time:<7.3f} s".ljust(15) + "= Prediction runtime")
     model.save()

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -167,28 +167,30 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         self.num_past_feat_dynamic_real = 0
         self.feat_static_cat_cardinality: List[int] = []
 
-    def save(self, path: str = None, **kwargs) -> str:
-        if path is None:
-            path = self.path
-        path = Path(path)
-        path.mkdir(exist_ok=True)
-
+    def save(self, path: str = None, verbose: bool = True) -> str:
+        # The GluonTS predictor will be serialized using custom logic
         predictor = self.gts_predictor
         self.gts_predictor = None
+        path = Path(super().save(path=path, verbose=verbose))
 
         with disable_root_logger():
             if predictor:
                 Path.mkdir(path / self.gluonts_model_path, exist_ok=True)
                 predictor.serialize(path / self.gluonts_model_path)
 
-        save_pkl.save(path=str(path / self.model_file_name), object=self)
         self.gts_predictor = predictor
-
         return str(path)
 
     @classmethod
-    def load(cls, path: str, reset_paths: bool = True, verbose: bool = True) -> "AbstractGluonTSModel":
-        model = super().load(path, reset_paths, verbose)
+    def load(
+        cls, path: str, reset_paths: bool = True, load_val_predictions: bool = False, verbose: bool = True
+    ) -> "AbstractGluonTSModel":
+        model = super().load(
+            path=path,
+            reset_paths=reset_paths,
+            load_val_predictions=load_val_predictions,
+            verbose=verbose,
+        )
         model.gts_predictor = GluonTSPredictor.deserialize(Path(path) / cls.gluonts_model_path)
         return model
 

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -501,20 +501,10 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
 
             model = self._train_single(train_data, model, val_data=val_data, time_limit=time_limit)
             fit_end_time = time.time()
+            model.fit_time = model.fit_time or (fit_end_time - fit_start_time)
 
             if val_data is not None:
-                val_predictions = model.predict_for_scoring(val_data)
-                pred_end_time = time.time()
-                model.cache_val_predictions(val_predictions)
-                predict_time = pred_end_time - fit_end_time
-                val_score = model.score_with_val_predictions(val_data)
-            else:
-                predict_time = None
-                val_score = None
-
-            model.fit_time = model.fit_time or (fit_end_time - fit_start_time)
-            model.predict_time = model.predict_time or predict_time
-            model.val_score = val_score
+                model.score_on_val_data_and_cache(val_data)
 
             self._log_scores_and_times(model.val_score, model.fit_time, model.predict_time)
 

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -704,14 +704,8 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         time_end = time.time()
         ensemble.fit_time = time_end - time_start
 
-        evaluator = TimeSeriesEvaluator(
-            eval_metric=self.eval_metric,
-            eval_metric_seasonal_period=self.eval_metric_seasonal_period,
-            prediction_length=self.prediction_length,
-            target_column=self.target,
-        )
-        forecasts = ensemble.predict({n: model_preds[n] for n in ensemble.model_names})
-        ensemble.val_score = evaluator(val_data, forecasts) * evaluator.coefficient
+        predictions = ensemble.predict({n: model_preds[n] for n in ensemble.model_names})
+        ensemble.val_score = self.score_with_predictions(val_data, predictions)
 
         predict_time = 0
         for m in ensemble.model_names:

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -742,11 +742,12 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
                 "will be sorted according to test score (`score_test`)."
             )
             past_data, known_covariates = self.slice_data_for_scoring(data)
+            # TODO: Cache predictions for all models using `model_pred_proba_dict` as in Tabular
             for model_name in model_names:
                 try:
-                    time_start_test_score = time.time()
+                    pred_start_time = time.time()
                     predictions = self.predict(data=past_data, known_covariates=known_covariates, model=model_name)
-                    model_info[model_name]["pred_time_test"] = time.time() - time_start_test_score
+                    model_info[model_name]["pred_time_test"] = time.time() - pred_start_time
                     model_info[model_name]["score_test"] = self.score_with_predictions(data, predictions)
                 except Exception as e:  # noqa
                     logger.error(f"Cannot score with model {model_name}. An error occurred: {str(e)}")

--- a/timeseries/tests/unittests/models/gluonts/test_gluonts.py
+++ b/timeseries/tests/unittests/models/gluonts/test_gluonts.py
@@ -232,4 +232,4 @@ def test_when_static_and_dynamic_covariates_present_then_model_trains_normally(m
 
     model = model_class(hyperparameters=DUMMY_HYPERPARAMETERS, metadata=gen.covariate_metadata)
     model.fit(train_data=df)
-    model.predict_for_scoring(df)
+    model.score(df)

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -76,7 +76,11 @@ def test_when_score_called_then_model_receives_truncated_data(model_class, predi
     model = trained_models[(prediction_length, repr(model_class))]
 
     with mock.patch.object(model, "predict") as patch_method:
-        _ = model.score(DUMMY_TS_DATAFRAME)
+        # Mock breaks the internals of the `score` method
+        try:
+            _ = model.score(DUMMY_TS_DATAFRAME)
+        except AttributeError:
+            pass
 
         (call_df,) = patch_method.call_args[0]
 

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -72,13 +72,11 @@ def test_when_fit_called_then_models_train_and_all_scores_can_be_computed(
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
 @pytest.mark.parametrize("prediction_length", [1, 5])
-def test_when_predict_for_scoring_called_then_model_receives_truncated_data(
-    model_class, prediction_length, trained_models
-):
+def test_when_score_called_then_model_receives_truncated_data(model_class, prediction_length, trained_models):
     model = trained_models[(prediction_length, repr(model_class))]
 
     with mock.patch.object(model, "predict") as patch_method:
-        _ = model.predict_for_scoring(DUMMY_TS_DATAFRAME)
+        _ = model.score(DUMMY_TS_DATAFRAME)
 
         (call_df,) = patch_method.call_args[0]
 


### PR DESCRIPTION
*Description of changes:*
- Cache the predictions on the validation set for all time series models (as a model attribute + saved to disk). This ensures that we only call `predict` on the `val_data` once for all models. This saves training time and deals with the fact that predictions are non-deterministic for some models.
- Ensure that the reported prediction time for the test/val sets corresponds to the actual **prediction** time (before it included the time spent slicing the data / computing the metric).

*To do*
- [ ] Add new tests once the overall design is reviewed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
