### PR TITLE
[eda] added `explain_rows` method to `autogluon.eda.auto` - Kernel SHAP visualization

### DIFF
--- a/docs/tutorials/eda/eda-auto-quick-fit.ipynb
+++ b/docs/tutorials/eda/eda-auto-quick-fit.ipynb
@@ -60,7 +60,61 @@
     "df_test = pd.read_csv('https://autogluon.s3.amazonaws.com/datasets/titanic/test.csv')\n",
     "target_col = 'Survived'\n",
     "\n",
-    "auto.quick_fit(df_train, target_col, show_feature_importance_barplots=True)"
+    "state = auto.quick_fit(\n",
+    "    df_train, \n",
+    "    target_col, \n",
+    "    return_state=True,\n",
+    "    save_model_to_state=True,\n",
+    "    show_feature_importance_barplots=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "486d331a",
+   "metadata": {},
+   "source": [
+    "### Explain rows\n",
+    "Let's take a look what were the contibuting factors in the row with the highest error. `auto.explain_rows` can perform SHAP analysis for the specified rows and render it either using `force` or `waterfall` layout."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50bd730b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auto.explain_rows(\n",
+    "    train_data=df_train,\n",
+    "    model=state.model,\n",
+    "    display_rows=True,\n",
+    "    rows=state.model_evaluation.highest_error[:1]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1806eca7",
+   "metadata": {},
+   "source": [
+    "Next we are going to inspect the most undecided rows that were misclassified. This time we will use `waterfall` layout."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ff4802b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auto.explain_rows(\n",
+    "    train_data=df_train,\n",
+    "    model=state.model,\n",
+    "    display_rows=True,\n",
+    "    plot=\"waterfall\",\n",
+    "    rows=state.model_evaluation.undecided[:1],\n",
+    ")"
    ]
   },
   {

--- a/docs/tutorials/eda/eda-auto-target-analysis.ipynb
+++ b/docs/tutorials/eda/eda-auto-target-analysis.ipynb
@@ -71,9 +71,6 @@
     "Next, the report will provide correlation analysis focusing only on highly-correlated features and visualization of\n",
     "their relationships with the target.\n",
     "\n",
-    "The last chart is a feature distance. It measures the similarity between features in a dataset. For example, if two\n",
-    "variables are almost identical, their feature distance will be small. Understanding feature distance is useful in\n",
-    "feature selection, where it can be used to identify which variables are redundant and should be considered for removal.\n",
     "To perform the analysis, we need just one line:"
    ]
   },

--- a/eda/setup.py
+++ b/eda/setup.py
@@ -30,6 +30,7 @@ install_requires = [
     'seaborn>=0.12.0,<0.13',
     'ipywidgets>=7.7.1,<9.0',  # min versions guidance: 7.7.1 collab/kaggle
     'shap>=0.41,<0.42',
+    'fastshap>=0.3,<0.4',
     f'autogluon.core=={version}',
     f'autogluon.common=={version}',
     f'autogluon.features=={version}',

--- a/eda/setup.py
+++ b/eda/setup.py
@@ -30,7 +30,6 @@ install_requires = [
     'seaborn>=0.12.0,<0.13',
     'ipywidgets>=7.7.1,<9.0',  # min versions guidance: 7.7.1 collab/kaggle
     'shap>=0.41,<0.42',
-    'fastshap>=0.3,<0.4',
     f'autogluon.core=={version}',
     f'autogluon.common=={version}',
     f'autogluon.features=={version}',

--- a/eda/setup.py
+++ b/eda/setup.py
@@ -29,6 +29,7 @@ install_requires = [
     'phik>=0.12.2,<0.13',
     'seaborn>=0.12.0,<0.13',
     'ipywidgets>=7.7.1,<9.0',  # min versions guidance: 7.7.1 collab/kaggle
+    'shap>=0.41,<0.42',
     f'autogluon.core=={version}',
     f'autogluon.common=={version}',
     f'autogluon.features=={version}',

--- a/eda/src/autogluon/eda/analysis/__init__.py
+++ b/eda/src/autogluon/eda/analysis/__init__.py
@@ -8,7 +8,7 @@ from .dataset import (
     TrainValidationSplit,
     VariableTypeAnalysis,
 )
-from .explain import FastShapAnalysis, ShapAnalysis
+from .explain import ShapAnalysis
 from .interaction import Correlation, CorrelationSignificance, DistributionFit, FeatureInteraction
 from .missing import MissingValuesAnalysis
 from .model import AutoGluonModelEvaluator, AutoGluonModelQuickFit

--- a/eda/src/autogluon/eda/analysis/__init__.py
+++ b/eda/src/autogluon/eda/analysis/__init__.py
@@ -8,6 +8,7 @@ from .dataset import (
     TrainValidationSplit,
     VariableTypeAnalysis,
 )
+from .explain import FastShapAnalysis, ShapAnalysis
 from .interaction import Correlation, CorrelationSignificance, DistributionFit, FeatureInteraction
 from .missing import MissingValuesAnalysis
 from .model import AutoGluonModelEvaluator, AutoGluonModelQuickFit

--- a/eda/src/autogluon/eda/analysis/explain.py
+++ b/eda/src/autogluon/eda/analysis/explain.py
@@ -37,6 +37,51 @@ class _ShapAutogluonWrapper:
 
 
 class ShapAnalysis(AbstractAnalysis):
+    """
+    Perform Shapley values calculation using `shap` package for the given rows.
+
+    Parameters
+    ----------
+    rows: pd.DataFrame,
+        rows to explain
+    baseline_sample: int, default = 100
+        The background dataset size to use for integrating out features. To determine the impact
+        of a feature, that feature is set to "missing" and the change in the model output
+        is observed.
+    parent: Optional[AbstractAnalysis], default = None
+        parent Analysis
+    children: List[AbstractAnalysis], default = []
+        wrapped analyses; these will receive sampled `args` during `fit` call
+    state: AnalysisState
+        state to be updated by this fit function
+    kwargs
+
+    Examples
+    --------
+    >>> import autogluon.eda.analysis as eda
+    >>> import autogluon.eda.visualization as viz
+    >>> import autogluon.eda.auto as auto
+    >>>
+    >>> auto.analyze(
+    >>>     train_data=..., model=...,
+    >>>     anlz_facets=[
+    >>>         eda.explain.ShapAnalysis(rows, baseline_sample=200),
+    >>>     ],
+    >>>     viz_facets=[
+    >>>         # Visualize the given SHAP values with an additive force layout
+    >>>         viz.explain.ExplainForcePlot(),
+    >>>         # Visualize the given SHAP values with a waterfall layout
+    >>>         viz.explain.ExplainWaterfallPlot(),
+    >>>     ]
+    >>> )
+
+    See Also
+    --------
+    :py:class:`~shap.KernelExplainer`
+    :py:class:`~autogluon.eda.visualization.explain.ExplainForcePlot`
+    :py:class:`~autogluon.eda.visualization.explain.ExplainWaterfallPlot`
+    """
+
     def __init__(
         self,
         rows: pd.DataFrame,
@@ -83,6 +128,51 @@ class ShapAnalysis(AbstractAnalysis):
 
 
 class FastShapAnalysis(AbstractAnalysis):
+    """
+    Perform Shapley values calculation using `fastshap` package for the given rows.
+
+    Parameters
+    ----------
+    rows: pd.DataFrame,
+        rows to explain
+    baseline_sample: int, default = 100
+        The background dataset size to use for integrating out features. To determine the impact
+        of a feature, that feature is set to "missing" and the change in the model output
+        is observed.
+    parent: Optional[AbstractAnalysis], default = None
+        parent Analysis
+    children: List[AbstractAnalysis], default = []
+        wrapped analyses; these will receive sampled `args` during `fit` call
+    state: AnalysisState
+        state to be updated by this fit function
+    kwargs
+
+    Examples
+    --------
+    >>> import autogluon.eda.analysis as eda
+    >>> import autogluon.eda.visualization as viz
+    >>> import autogluon.eda.auto as auto
+    >>>
+    >>> auto.analyze(
+    >>>     train_data=..., model=...,
+    >>>     anlz_facets=[
+    >>>         eda.explain.FastShapAnalysis(rows, baseline_sample=200),
+    >>>     ],
+    >>>     viz_facets=[
+    >>>         # Visualize the given SHAP values with an additive force layout
+    >>>         viz.explain.ExplainForcePlot(),
+    >>>         # Visualize the given SHAP values with a waterfall layout
+    >>>         viz.explain.ExplainWaterfallPlot(),
+    >>>     ]
+    >>> )
+
+    See Also
+    --------
+    :py:class:`~fastshap.KernelExplainer.KernelExplainer`
+    :py:class:`~autogluon.eda.visualization.explain.ExplainForcePlot`
+    :py:class:`~autogluon.eda.visualization.explain.ExplainWaterfallPlot`
+    """
+
     def __init__(
         self,
         rows: pd.DataFrame,

--- a/eda/src/autogluon/eda/analysis/explain.py
+++ b/eda/src/autogluon/eda/analysis/explain.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 import pandas as pd
 import shap
 
+from autogluon.core.constants import REGRESSION
 from autogluon.eda import AnalysisState
 from autogluon.eda.analysis.base import AbstractAnalysis
 
@@ -17,7 +18,7 @@ class _ShapAutogluonWrapper:
         self.ag_model = predictor
         self.feature_names = feature_names
         self.target_class = target_class
-        if target_class is None and predictor.problem_type != "regression":
+        if target_class is None and predictor.problem_type != REGRESSION:
             logging.warning("Since target_class not specified, SHAP will explain predictions for each class")
 
     def predict_proba(self, X):
@@ -25,11 +26,11 @@ class _ShapAutogluonWrapper:
             X = X.values.reshape(1, -1)
         if not isinstance(X, pd.DataFrame):
             X = pd.DataFrame(X, columns=self.feature_names)
-        if self.ag_model.problem_type == "regression":
+        if self.ag_model.problem_type == REGRESSION:
             preds = self.ag_model.predict(X)
         else:
             preds = self.ag_model.predict_proba(X)
-        if self.ag_model.problem_type == "regression" or self.target_class is None:
+        if self.ag_model.problem_type == REGRESSION or self.target_class is None:
             return preds
         else:
             return preds[self.target_class]
@@ -107,7 +108,7 @@ class ShapAnalysis(AbstractAnalysis):
         shap_data = []
         for _, row in self.rows.iterrows():
             _row = pd.DataFrame([row])
-            if args.model.problem_type == "regression":
+            if args.model.problem_type == REGRESSION:
                 predicted_class = 0
             else:
                 predicted_class = args.model.predict(_row).iloc[0]

--- a/eda/src/autogluon/eda/analysis/explain.py
+++ b/eda/src/autogluon/eda/analysis/explain.py
@@ -1,0 +1,132 @@
+from typing import List, Optional
+
+import pandas as pd
+import shap
+from fastshap import KernelExplainer
+
+from autogluon.eda import AnalysisState
+from autogluon.eda.analysis.base import AbstractAnalysis
+
+__all__ = ["ShapAnalysis", "FastShapAnalysis"]
+
+
+class _ShapAutogluonWrapper:
+    def __init__(self, predictor, feature_names, target_class=None):
+        self.ag_model = predictor
+        self.feature_names = feature_names
+        self.target_class = target_class
+        if target_class is None and predictor.problem_type != "regression":
+            print("Since target_class not specified, SHAP will explain predictions for each class")
+
+    def predict_proba(self, X):
+        if isinstance(X, pd.Series):
+            X = X.values.reshape(1, -1)
+        if not isinstance(X, pd.DataFrame):
+            X = pd.DataFrame(X, columns=self.feature_names)
+        if self.ag_model.problem_type == "regression":
+            preds = self.ag_model.predict(X)
+        else:
+            preds = self.ag_model.predict_proba(X)
+        if self.ag_model.problem_type == "regression" or self.target_class is None:
+            return preds
+        else:
+            return preds[self.target_class]
+
+
+class ShapAnalysis(AbstractAnalysis):
+    def __init__(
+        self,
+        rows: pd.DataFrame,
+        baseline_sample: int = 100,
+        parent: Optional[AbstractAnalysis] = None,
+        children: Optional[List[AbstractAnalysis]] = None,
+        state: Optional[AnalysisState] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(parent, children, state, **kwargs)
+        self.rows = rows
+        assert baseline_sample >= 30
+        self.baseline_sample = baseline_sample
+
+    def can_handle(self, state: AnalysisState, args: AnalysisState) -> bool:
+        return self.all_keys_must_be_present(args, "model", "train_data")
+
+    def _fit(self, state: AnalysisState, args: AnalysisState, **fit_kwargs) -> None:
+        baseline = args.train_data.sample(self.baseline_sample, random_state=0)
+        shap_data = []
+        for _, row in self.rows.iterrows():
+            _row = pd.DataFrame([row])
+            predicted_class = (
+                0 if args.model.problem_type == "regression" else args.model.predict_proba(_row)[0].argmax()
+            )
+            ag_wrapper = _ShapAutogluonWrapper(args.model, args.train_data.columns, predicted_class)
+            explainer = shap.KernelExplainer(ag_wrapper.predict_proba, baseline)
+            ke_shap_values = explainer.shap_values(_row[args.train_data.columns], silent=True)
+            shap_data.append(
+                AnalysisState(
+                    row=_row,
+                    expected_value=explainer.expected_value,
+                    shap_values=ke_shap_values[0],
+                    features=row[args.train_data.columns],
+                    feature_names=None,
+                )
+            )
+        state.explain = {"shapley": shap_data}
+
+
+class FastShapAnalysis(AbstractAnalysis):
+    def __init__(
+        self,
+        rows: pd.DataFrame,
+        baseline_sample: int = 100,
+        parent: Optional[AbstractAnalysis] = None,
+        children: Optional[List[AbstractAnalysis]] = None,
+        state: Optional[AnalysisState] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(parent, children, state, **kwargs)
+        self.rows = rows
+        assert baseline_sample >= 30
+        self.baseline_sample = baseline_sample
+
+    def can_handle(self, state: AnalysisState, args: AnalysisState) -> bool:
+        return self.all_keys_must_be_present(args, "model", "train_data")
+
+    def _fit(self, state: AnalysisState, args: AnalysisState, **fit_kwargs) -> None:
+        baseline = args.train_data.sample(self.baseline_sample, random_state=0)
+        data = baseline.drop(columns=args.model.label)
+
+        def predict_fn(x):
+            if args.model.problem_type == "regression":
+                preds = args.model.predict(x, as_pandas=False)
+            else:
+                preds = args.model.predict_proba(x, as_pandas=False)
+            return preds
+
+        shap_data = []
+
+        for _, row in self.rows.iterrows():
+            _row = pd.DataFrame([row])
+            ke = KernelExplainer(predict_fn, data)
+            ke_shap_values = ke.calculate_shap_values(_row[data.columns], verbose=False)
+            if args.model.problem_type == "regression":
+                expected_value = ke_shap_values[0][-1]
+                shap_values = ke_shap_values[0][:-1]
+            else:
+                predicted_class = ke_shap_values[0][-1].argmax()
+                expected_value = ke_shap_values[0][-1][predicted_class]
+                shap_values = ke_shap_values[0][:-1, predicted_class]
+
+            features = _row[data.columns].to_numpy()[0]
+            feature_names = data.columns
+
+            shap_data.append(
+                AnalysisState(
+                    row=_row,
+                    expected_value=expected_value,
+                    shap_values=shap_values,
+                    features=features,
+                    feature_names=feature_names,
+                )
+            )
+        state.explain = {"shapley": shap_data}

--- a/eda/src/autogluon/eda/auto/__init__.py
+++ b/eda/src/autogluon/eda/auto/__init__.py
@@ -3,6 +3,7 @@ from .simple import (
     analyze_interaction,
     covariate_shift_detection,
     dataset_overview,
+    explain_rows,
     missing_values_analysis,
     quick_fit,
     target_analysis,

--- a/eda/src/autogluon/eda/auto/simple.py
+++ b/eda/src/autogluon/eda/auto/simple.py
@@ -13,7 +13,6 @@ from ..analysis import (
     AutoGluonModelQuickFit,
     Correlation,
     DistributionFit,
-    FastShapAnalysis,
     FeatureInteraction,
     MissingValuesAnalysis,
     ProblemTypeControl,
@@ -948,7 +947,6 @@ def explain_rows(
     model: TabularPredictor,
     rows: pd.DataFrame,
     display_rows: bool = False,
-    backend: str = "shap",
     plot: Optional[str] = "force",
     baseline_sample: int = 100,
     return_state: bool = False,
@@ -972,10 +970,6 @@ def explain_rows(
         rows to explain
     display_rows: bool, default = False
         if `True` then display the row before the explanation chart
-    backend: str, default = 'shap'
-        type backend to use for Shapley values calculations. Supported keys:
-        - `shap` - use :py:class:`~autogluon.eda.analysis.explain.ShapAnalysis` backend based on `shap` package
-        - `fastshap` - use :py:class:`~autogluon.eda.analysis.explain.FastShapAnalysis` backend based on `fastshap` package
     plot: Optional[str], default = 'force'
         type of plot to visualize the Shapley values. Supported keys:
         - `force` - Visualize the given SHAP values with an additive force layout
@@ -992,19 +986,10 @@ def explain_rows(
     See Also
     --------
     :py:class:`~shap.KernelExplainer`
-    :py:class:`~fastshap.KernelExplainer.KernelExplainer`
     :py:class:`~autogluon.eda.analysis.explain.ShapAnalysis`
-    :py:class:`~autogluon.eda.analysis.explain.FastShapAnalysis`
     :py:class:`~autogluon.eda.visualization.explain.ExplainForcePlot`
     :py:class:`~autogluon.eda.visualization.explain.ExplainWaterfallPlot`
     """
-
-    supported_backends = {
-        "shap": ShapAnalysis,
-        "fastshap": FastShapAnalysis,
-    }
-    anlz_cls = supported_backends.get(backend, None)
-    assert anlz_cls is not None, f"backend must be one of the following values: {','.join(supported_backends.keys())}"
 
     if plot is None:
         viz_facets = None
@@ -1015,7 +1000,7 @@ def explain_rows(
         }
         viz_cls = supported_plots.get(plot, None)
         assert viz_cls is not None, (
-            f"backend must be one of the following values: {','.join(supported_plots.keys())}. "
+            f"plot must be one of the following values: {','.join(supported_plots.keys())}. "
             f"If no visualization required, then `None` can be passed."
         )
         viz_facets = [viz_cls(display_rows=display_rows, **kwargs)]
@@ -1024,6 +1009,6 @@ def explain_rows(
         train_data=train_data,
         model=model,
         return_state=return_state,
-        anlz_facets=[anlz_cls(rows, baseline_sample=baseline_sample)],  # type: ignore
+        anlz_facets=[ShapAnalysis(rows, baseline_sample=baseline_sample)],  # type: ignore
         viz_facets=viz_facets,  # type: ignore
     )

--- a/eda/src/autogluon/eda/auto/simple.py
+++ b/eda/src/autogluon/eda/auto/simple.py
@@ -978,8 +978,8 @@ def explain_rows(
         - `fastshap` - use :py:class:`~autogluon.eda.analysis.explain.FastShapAnalysis` backend based on `fastshap` package
     plot: Optional[str], default = 'force'
         type of plot to visualize the Shapley values. Supported keys:
-        - `force`
-        - `waterfall`
+        - `force` - Visualize the given SHAP values with an additive force layout
+        - `waterfall` - Visualize the given SHAP values with a waterfall layout
         - `None` - do not use any visualization
     baseline_sample: int, default = 100
         The background dataset size to use for integrating out features. To determine the impact
@@ -992,9 +992,11 @@ def explain_rows(
     See Also
     --------
     :py:class:`~shap.KernelExplainer`
+    :py:class:`~fastshap.KernelExplainer.KernelExplainer`
     :py:class:`~autogluon.eda.analysis.explain.ShapAnalysis`
     :py:class:`~autogluon.eda.analysis.explain.FastShapAnalysis`
-
+    :py:class:`~autogluon.eda.visualization.explain.ExplainForcePlot`
+    :py:class:`~autogluon.eda.visualization.explain.ExplainWaterfallPlot`
     """
 
     supported_backends = {

--- a/eda/src/autogluon/eda/auto/simple.py
+++ b/eda/src/autogluon/eda/auto/simple.py
@@ -6,8 +6,8 @@ import shap
 from shap.plots._waterfall import waterfall_legacy as waterfall_plot
 
 from autogluon.common.utils.log_utils import verbosity2loglevel
-
 from autogluon.tabular import TabularPredictor
+
 from .. import AnalysisState
 from ..analysis import (
     ApplyFeatureGenerator,

--- a/eda/src/autogluon/eda/visualization/__init__.py
+++ b/eda/src/autogluon/eda/visualization/__init__.py
@@ -2,8 +2,8 @@ from .dataset import DatasetStatistics, DatasetTypeMismatch, LabelInsightsVisual
 from .interaction import (
     CorrelationSignificanceVisualization,
     CorrelationVisualization,
+    FeatureDistanceAnalysisVisualization,
     FeatureInteractionVisualization,
-    FeatureDistanceAnalysisVisualization
 )
 from .layouts import (
     MarkdownSectionComponent,

--- a/eda/src/autogluon/eda/visualization/__init__.py
+++ b/eda/src/autogluon/eda/visualization/__init__.py
@@ -1,4 +1,5 @@
 from .dataset import DatasetStatistics, DatasetTypeMismatch, LabelInsightsVisualization
+from .explain import ExplainForcePlot, ExplainWaterfallPlot
 from .interaction import (
     CorrelationSignificanceVisualization,
     CorrelationVisualization,

--- a/eda/src/autogluon/eda/visualization/__init__.py
+++ b/eda/src/autogluon/eda/visualization/__init__.py
@@ -3,6 +3,7 @@ from .interaction import (
     CorrelationSignificanceVisualization,
     CorrelationVisualization,
     FeatureInteractionVisualization,
+    FeatureDistanceAnalysisVisualization
 )
 from .layouts import (
     MarkdownSectionComponent,

--- a/eda/src/autogluon/eda/visualization/explain.py
+++ b/eda/src/autogluon/eda/visualization/explain.py
@@ -12,7 +12,7 @@ from autogluon.eda.visualization.jupyter import JupyterMixin
 
 
 class _AbstractExplainPlot(AbstractVisualization, JupyterMixin, ABC):
-    def __init__(self, display_rows: bool = True, namespace: Optional[str] = None, **kwargs) -> None:
+    def __init__(self, display_rows: bool = False, namespace: Optional[str] = None, **kwargs) -> None:
         super().__init__(namespace, **kwargs)
         self.display_rows = display_rows
 
@@ -35,12 +35,88 @@ class _AbstractExplainPlot(AbstractVisualization, JupyterMixin, ABC):
 
 
 class ExplainForcePlot(_AbstractExplainPlot):
+    """
+    Visualize the given SHAP values with an additive force layout
+
+    Parameters
+    ----------
+    display_rows: bool, default = False
+        if `True` then display the row before the explanation chart
+    headers: bool, default = False
+        if `True` then render headers
+    namespace: str, default = None
+        namespace to use; can be nested like `ns_a.ns_b.ns_c`
+
+    Examples
+    --------
+    >>> import autogluon.eda.analysis as eda
+    >>> import autogluon.eda.visualization as viz
+    >>> import autogluon.eda.auto as auto
+    >>>
+    >>> rows_to_explain = ...  # DataFrame
+    >>>
+    >>> auto.analyze(
+    >>>     train_data=..., model=...,
+    >>>     anlz_facets=[
+    >>>         eda.explain.ShapAnalysis(rows),
+    >>>     ],
+    >>>     viz_facets=[
+    >>>         viz.explain.ExplainForcePlot(text_rotation=45, matplotlib=True),  # defaults used if not specified
+    >>>     ]
+    >>> )
+
+    See Also
+    --------
+    :py:class:`~shap.KernelExplainer`
+    :py:class:`~fastshap.KernelExplainer.KernelExplainer`
+    :py:class:`~autogluon.eda.analysis.explain.ShapAnalysis`
+    :py:class:`~autogluon.eda.analysis.explain.FastShapAnalysis`
+    """
+
     def _render_internal(self, expected_value, shap_values, features, feature_names, **kwargs):
         _kwargs = {**dict(text_rotation=45, matplotlib=True), **kwargs}
         shap.force_plot(expected_value, shap_values, features, feature_names=feature_names, **_kwargs)
 
 
 class ExplainWaterfallPlot(_AbstractExplainPlot):
+    """
+    Visualize the given SHAP values with a waterfall layout
+
+    Parameters
+    ----------
+    display_rows: bool, default = False
+        if `True` then display the row before the explanation chart
+    headers: bool, default = False
+        if `True` then render headers
+    namespace: str, default = None
+        namespace to use; can be nested like `ns_a.ns_b.ns_c`
+
+    Examples
+    --------
+    >>> import autogluon.eda.analysis as eda
+    >>> import autogluon.eda.visualization as viz
+    >>> import autogluon.eda.auto as auto
+    >>>
+    >>> rows_to_explain = ...  # DataFrame
+    >>>
+    >>> auto.analyze(
+    >>>     train_data=..., model=...,
+    >>>     anlz_facets=[
+    >>>         eda.explain.ShapAnalysis(rows_to_explain),
+    >>>     ],
+    >>>     viz_facets=[
+    >>>         viz.explain.ExplainWaterfallPlot(),
+    >>>     ]
+    >>> )
+
+    See Also
+    --------
+    :py:class:`~shap.KernelExplainer`
+    :py:class:`~fastshap.KernelExplainer.KernelExplainer`
+    :py:class:`~autogluon.eda.analysis.explain.ShapAnalysis`
+    :py:class:`~autogluon.eda.analysis.explain.FastShapAnalysis`
+    """
+
     def _render_internal(self, expected_value, shap_values, features, feature_names, **kwargs):
         shap.plots._waterfall.waterfall_legacy(
             expected_value, shap_values, features, feature_names=feature_names, **kwargs

--- a/eda/src/autogluon/eda/visualization/explain.py
+++ b/eda/src/autogluon/eda/visualization/explain.py
@@ -1,0 +1,47 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+
+import shap
+
+from autogluon.eda import AnalysisState
+from autogluon.eda.visualization.base import AbstractVisualization
+
+__all__ = ["ExplainForcePlot", "ExplainWaterfallPlot"]
+
+from autogluon.eda.visualization.jupyter import JupyterMixin
+
+
+class _AbstractExplainPlot(AbstractVisualization, JupyterMixin, ABC):
+    def __init__(self, display_rows: bool = True, namespace: Optional[str] = None, **kwargs) -> None:
+        super().__init__(namespace, **kwargs)
+        self.display_rows = display_rows
+
+    def can_handle(self, state: AnalysisState) -> bool:
+        return self.all_keys_must_be_present(state, "explain") and self.all_keys_must_be_present(
+            state.explain, "shapley"
+        )
+
+    def _render(self, state: AnalysisState) -> None:
+        for s in state.explain.shapley:
+            if self.display_rows:
+                self.display_obj(s.row)
+            self._render_internal(
+                s.expected_value, s.shap_values, s.features, feature_names=s.feature_names, **self._kwargs
+            )
+
+    @abstractmethod
+    def _render_internal(self, expected_value, shap_values, features, feature_names, **kwargs):
+        raise NotImplementedError
+
+
+class ExplainForcePlot(_AbstractExplainPlot):
+    def _render_internal(self, expected_value, shap_values, features, feature_names, **kwargs):
+        _kwargs = {**dict(text_rotation=45, matplotlib=True), **kwargs}
+        shap.force_plot(expected_value, shap_values, features, feature_names=feature_names, **_kwargs)
+
+
+class ExplainWaterfallPlot(_AbstractExplainPlot):
+    def _render_internal(self, expected_value, shap_values, features, feature_names, **kwargs):
+        shap.plots._waterfall.waterfall_legacy(
+            expected_value, shap_values, features, feature_names=feature_names, **kwargs
+        )

--- a/eda/src/autogluon/eda/visualization/explain.py
+++ b/eda/src/autogluon/eda/visualization/explain.py
@@ -68,9 +68,7 @@ class ExplainForcePlot(_AbstractExplainPlot):
     See Also
     --------
     :py:class:`~shap.KernelExplainer`
-    :py:class:`~fastshap.KernelExplainer.KernelExplainer`
     :py:class:`~autogluon.eda.analysis.explain.ShapAnalysis`
-    :py:class:`~autogluon.eda.analysis.explain.FastShapAnalysis`
     """
 
     def _render_internal(self, expected_value, shap_values, features, feature_names, **kwargs):
@@ -112,9 +110,7 @@ class ExplainWaterfallPlot(_AbstractExplainPlot):
     See Also
     --------
     :py:class:`~shap.KernelExplainer`
-    :py:class:`~fastshap.KernelExplainer.KernelExplainer`
     :py:class:`~autogluon.eda.analysis.explain.ShapAnalysis`
-    :py:class:`~autogluon.eda.analysis.explain.FastShapAnalysis`
     """
 
     def _render_internal(self, expected_value, shap_values, features, feature_names, **kwargs):

--- a/eda/src/autogluon/eda/visualization/explain.py
+++ b/eda/src/autogluon/eda/visualization/explain.py
@@ -31,7 +31,7 @@ class _AbstractExplainPlot(AbstractVisualization, JupyterMixin, ABC):
 
     @abstractmethod
     def _render_internal(self, expected_value, shap_values, features, feature_names, **kwargs):
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
 
 class ExplainForcePlot(_AbstractExplainPlot):

--- a/eda/src/autogluon/eda/visualization/interaction.py
+++ b/eda/src/autogluon/eda/visualization/interaction.py
@@ -14,7 +14,7 @@ from ..state import AnalysisState
 from .base import AbstractVisualization
 from .jupyter import JupyterMixin
 
-__all__ = ["CorrelationVisualization", "CorrelationSignificanceVisualization", "FeatureInteractionVisualization"]
+__all__ = ["CorrelationVisualization", "CorrelationSignificanceVisualization", "FeatureInteractionVisualization", "FeatureDistanceAnalysisVisualization"]
 
 
 class _AbstractCorrelationChart(AbstractVisualization, JupyterMixin, ABC):

--- a/eda/src/autogluon/eda/visualization/interaction.py
+++ b/eda/src/autogluon/eda/visualization/interaction.py
@@ -14,7 +14,12 @@ from ..state import AnalysisState
 from .base import AbstractVisualization
 from .jupyter import JupyterMixin
 
-__all__ = ["CorrelationVisualization", "CorrelationSignificanceVisualization", "FeatureInteractionVisualization", "FeatureDistanceAnalysisVisualization"]
+__all__ = [
+    "CorrelationVisualization",
+    "CorrelationSignificanceVisualization",
+    "FeatureInteractionVisualization",
+    "FeatureDistanceAnalysisVisualization",
+]
 
 
 class _AbstractCorrelationChart(AbstractVisualization, JupyterMixin, ABC):

--- a/eda/tests/unittests/analysis/test_explain.py
+++ b/eda/tests/unittests/analysis/test_explain.py
@@ -1,0 +1,58 @@
+import os
+import tempfile
+
+import numpy as np
+import pandas as pd
+import pytest
+from numpy.testing import assert_equal
+from pandas.testing import assert_frame_equal
+
+from autogluon.eda.analysis import FastShapAnalysis, ShapAnalysis
+from autogluon.eda.auto import analyze, quick_fit
+
+RESOURCE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "resources"))
+
+
+@pytest.mark.parametrize(
+    "shap_cls, label, expected_task_type",
+    [
+        (ShapAnalysis, "class", "binary"),
+        (ShapAnalysis, "fnlwgt", "regression"),
+        (FastShapAnalysis, "class", "binary"),
+        (FastShapAnalysis, "fnlwgt", "regression"),
+    ],
+)
+def test_ShapAnalysis(shap_cls, label, expected_task_type, monkeypatch):
+    df_train = pd.read_csv(os.path.join(RESOURCE_PATH, "adult", "train_data.csv")).sample(30, random_state=0)
+    with tempfile.TemporaryDirectory() as path:
+        state = quick_fit(
+            estimator_args=dict(path=path),
+            train_data=df_train,
+            label=label,
+            return_state=True,
+            save_model_to_state=True,
+            render_analysis=False,
+        )
+        assert state.model.problem_type == expected_task_type
+
+        rows = state.model_evaluation.highest_error[:2]
+        s = analyze(train_data=df_train, model=state.model, return_state=True, anlz_facets=[shap_cls(rows)])
+
+        assert len(s.explain.shapley) == 2
+        for i, (_, row) in enumerate(rows.iterrows()):
+            shap_data = s.explain.shapley[i]
+            assert_frame_equal(shap_data["row"], pd.DataFrame([row]))
+            if shap_cls == ShapAnalysis:
+                assert shap_data["feature_names"] is None
+            else:
+                assert_equal(shap_data["feature_names"], list(rows.columns)[: len(shap_data["feature_names"])])
+            np.array_equal(shap_data["features"], row.values[: len(shap_data["features"])])
+            assert sorted(list(shap_data.keys())) == sorted(
+                [
+                    "row",
+                    "expected_value",
+                    "shap_values",
+                    "features",
+                    "feature_names",
+                ]
+            )

--- a/eda/tests/unittests/analysis/test_explain.py
+++ b/eda/tests/unittests/analysis/test_explain.py
@@ -4,25 +4,22 @@ import tempfile
 import numpy as np
 import pandas as pd
 import pytest
-from numpy.testing import assert_equal
 from pandas.testing import assert_frame_equal
 
-from autogluon.eda.analysis import FastShapAnalysis, ShapAnalysis
+from autogluon.eda.analysis import ShapAnalysis
 from autogluon.eda.auto import analyze, quick_fit
 
 RESOURCE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "resources"))
 
 
 @pytest.mark.parametrize(
-    "shap_cls, label, expected_task_type",
+    "label, expected_task_type",
     [
-        (ShapAnalysis, "class", "binary"),
-        (ShapAnalysis, "fnlwgt", "regression"),
-        (FastShapAnalysis, "class", "binary"),
-        (FastShapAnalysis, "fnlwgt", "regression"),
+        ("class", "binary"),
+        ("fnlwgt", "regression"),
     ],
 )
-def test_ShapAnalysis(shap_cls, label, expected_task_type, monkeypatch):
+def test_ShapAnalysis(label, expected_task_type, monkeypatch):
     df_train = pd.read_csv(os.path.join(RESOURCE_PATH, "adult", "train_data.csv")).sample(30, random_state=0)
     with tempfile.TemporaryDirectory() as path:
         state = quick_fit(
@@ -36,16 +33,13 @@ def test_ShapAnalysis(shap_cls, label, expected_task_type, monkeypatch):
         assert state.model.problem_type == expected_task_type
 
         rows = state.model_evaluation.highest_error[:2]
-        s = analyze(train_data=df_train, model=state.model, return_state=True, anlz_facets=[shap_cls(rows)])
+        s = analyze(train_data=df_train, model=state.model, return_state=True, anlz_facets=[ShapAnalysis(rows)])
 
         assert len(s.explain.shapley) == 2
         for i, (_, row) in enumerate(rows.iterrows()):
             shap_data = s.explain.shapley[i]
             assert_frame_equal(shap_data["row"], pd.DataFrame([row]))
-            if shap_cls == ShapAnalysis:
-                assert shap_data["feature_names"] is None
-            else:
-                assert_equal(shap_data["feature_names"], list(rows.columns)[: len(shap_data["feature_names"])])
+            assert shap_data["feature_names"] is None
             np.array_equal(shap_data["features"], row.values[: len(shap_data["features"])])
             assert sorted(list(shap_data.keys())) == sorted(
                 [

--- a/eda/tests/unittests/analysis/test_model.py
+++ b/eda/tests/unittests/analysis/test_model.py
@@ -6,6 +6,7 @@ import pytest
 
 import autogluon.eda.analysis as eda
 import autogluon.eda.auto as auto
+from autogluon.core.constants import REGRESSION
 from autogluon.tabular import TabularPredictor
 
 RESOURCE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "resources"))
@@ -37,7 +38,7 @@ def test_AutoGluonModelEvaluator_regression():
             anlz_facets=[eda.model.AutoGluonModelEvaluator(normalize="true")],
         )
 
-    assert state.model_evaluation.problem_type == "regression"
+    assert state.model_evaluation.problem_type == REGRESSION
     assert len(state.model_evaluation.y_true) == len(df_test)
     assert len(state.model_evaluation.y_pred) == len(df_test)
     expected = [c for c in df_train.columns if c not in ["Street", "Utilities", "SalePrice"]]
@@ -66,7 +67,7 @@ def test_AutoGluonModelEvaluator_regression__with_test_data():
             anlz_facets=[eda.model.AutoGluonModelEvaluator(normalize="true")],
         )
 
-    assert state.model_evaluation.problem_type == "regression"
+    assert state.model_evaluation.problem_type == REGRESSION
     assert len(state.model_evaluation.y_true) == len(df_test)
     assert len(state.model_evaluation.y_pred) == len(df_test)
     assert len(state.model_evaluation.y_true_val) == len(df_val)

--- a/eda/tests/unittests/auto/test_simple.py
+++ b/eda/tests/unittests/auto/test_simple.py
@@ -10,7 +10,7 @@ import pytest
 
 import autogluon.eda as eda
 from autogluon.eda import AnalysisState
-from autogluon.eda.analysis import FastShapAnalysis, Namespace, ShapAnalysis
+from autogluon.eda.analysis import Namespace, ShapAnalysis
 from autogluon.eda.analysis.base import BaseAnalysis
 from autogluon.eda.auto import (
     analyze,
@@ -440,17 +440,14 @@ def test_target_analysis__regression(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "backend, plot",
+    "plot",
     [
-        ("shap", "force"),
-        ("fastshap", "force"),
-        ("shap", "waterfall"),
-        ("fastshap", "waterfall"),
-        ("shap", None),
-        ("fastshap", None),
+        ("force"),
+        ("waterfall"),
+        (None),
     ],
 )
-def test_explain_rows(backend, plot, monkeypatch):
+def test_explain_rows(plot, monkeypatch):
     train_data = MagicMock()
     model = MagicMock()
     rows = MagicMock()
@@ -462,7 +459,6 @@ def test_explain_rows(backend, plot, monkeypatch):
             train_data=train_data,
             model=model,
             rows=rows,
-            backend=backend,
             plot=plot,
             return_state=True,
             baseline_sample=300,
@@ -478,12 +474,8 @@ def test_explain_rows(backend, plot, monkeypatch):
             viz_facets=ANY,
         )
 
-        expected_backend = {
-            "shap": ShapAnalysis,
-            "fastshap": FastShapAnalysis,
-        }.get(backend)
         anlz_facet = call_analyze.call_args.kwargs["anlz_facets"][0]
-        assert type(anlz_facet) is expected_backend
+        assert type(anlz_facet) is ShapAnalysis
         assert anlz_facet.rows == rows
         assert anlz_facet.baseline_sample == 300
 

--- a/eda/tests/unittests/visualization/test_explain.py
+++ b/eda/tests/unittests/visualization/test_explain.py
@@ -1,0 +1,93 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from autogluon.eda import AnalysisState
+from autogluon.eda.visualization import ExplainForcePlot, ExplainWaterfallPlot
+from autogluon.eda.visualization.jupyter import JupyterMixin
+
+
+@pytest.mark.parametrize(
+    "display_rows",
+    [
+        (True),
+        (False),
+    ],
+)
+def test_ExplainForcePlot(display_rows, monkeypatch):
+    state = AnalysisState()
+    state.explain = {
+        "shapley": [
+            AnalysisState(
+                row="row",
+                expected_value="expected_value",
+                shap_values="shap_values",
+                features="features",
+                feature_names="feature_names",
+            )
+        ]
+    }
+    with monkeypatch.context() as m:
+        call_shap_force_plot = MagicMock()
+        call_display_obj = MagicMock()
+        m.setattr("shap.force_plot", call_shap_force_plot)
+        m.setattr(JupyterMixin, "display_obj", call_display_obj)
+
+        ExplainForcePlot(display_rows=display_rows, text_rotation=40, extra_arg="extra_arg").render(state)
+
+        if display_rows:
+            call_display_obj.assert_called_with("row")
+        else:
+            call_display_obj.assert_not_called()
+
+        call_shap_force_plot.assert_called_with(
+            "expected_value",
+            "shap_values",
+            "features",
+            feature_names="feature_names",
+            text_rotation=40,
+            matplotlib=True,
+            extra_arg="extra_arg",
+        )
+
+
+@pytest.mark.parametrize(
+    "display_rows",
+    [
+        (True),
+        (False),
+    ],
+)
+def test_ExplainWaterfallPlot(display_rows, monkeypatch):
+    state = AnalysisState()
+    state.explain = {
+        "shapley": [
+            AnalysisState(
+                row="row",
+                expected_value="expected_value",
+                shap_values="shap_values",
+                features="features",
+                feature_names="feature_names",
+            )
+        ]
+    }
+    with monkeypatch.context() as m:
+        call_shap_waterfall_plot = MagicMock()
+        call_display_obj = MagicMock()
+        m.setattr("shap.plots._waterfall.waterfall_legacy", call_shap_waterfall_plot)
+        m.setattr(JupyterMixin, "display_obj", call_display_obj)
+
+        ExplainWaterfallPlot(display_rows=display_rows, extra_arg="extra_arg").render(state)
+
+        if display_rows:
+            call_display_obj.assert_called_with("row")
+        else:
+            call_display_obj.assert_not_called()
+
+        call_shap_waterfall_plot.assert_called_with(
+            "expected_value",
+            "shap_values",
+            "features",
+            feature_names="feature_names",
+            extra_arg="extra_arg",
+        )


### PR DESCRIPTION
*Description of changes:*
- added `explain_rows` method to `autogluon.eda.auto`; the methods performs Kernel SHAP values analysis and visualization
- `quick_fit`: fixes for highest_error and undecided rows calculations

## Examples

```python
import pandas as pd
import numpy as np
import autogluon.eda.auto as auto

# Load data
df_train = pd.read_csv('https://autogluon.s3.amazonaws.com/datasets/titanic/train.csv')
df_test = pd.read_csv('https://autogluon.s3.amazonaws.com/datasets/titanic/test.csv')
label='Survived'

# Fit model
state = auto.quick_fit(
    train_data=df_train,
    label=label,
    save_model_to_state=True,
    return_state=True,
    render_analysis=False,  # Don't render analysis
)

# Explain the row with highest error
auto.explain_rows(
    train_data=df_train,
    model=state.model,
    backend='shap',  # default | shap/fastshap
    plot='force',  # default | force/waterfall
    rows=state.model_evaluation.highest_error[:1],
)
```

<img width="994" alt="image" src="https://user-images.githubusercontent.com/10080307/223562279-2f28e7e3-a977-428c-8b48-cc9f50118ab8.png">

```python
# Explain the row predicted incorrectly, but closest to the decision boundary as waterfall plot
auto.explain_rows(
    train_data=df_train,
    model=state.model,
    display_rows=True,
    plot='waterfall',
    rows=state.model_evaluation.undecided[:1],
)
```

<img width="986" alt="image" src="https://user-images.githubusercontent.com/10080307/223562521-276afc57-2d42-4238-b745-e7d643653ec5.png">

## Using primitives

```python
s = auto.analyze(
    train_data=df_train, model=state.model, 
    return_state=True, 
    anlz_facets=[
        # Backend using `shap` package
        eda.explain.ShapAnalysis(state.model_evaluation.highest_error[:2]),
        # Backend using `fastshap` package
        # eda.explain.FastShapAnalysis(state.model_evaluation.highest_error[:2]),
    ],
    viz_facets=[
        viz.explain.ExplainForcePlot(),  # Force layout
        viz.explain.ExplainWaterfallPlot(),  # Waterfall layout
    ]
)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
