### PR TITLE
Remove .doctrees build artifacts before s3 upload

### DIFF
--- a/.github/workflow_scripts/build_all_docs.sh
+++ b/.github/workflow_scripts/build_all_docs.sh
@@ -61,6 +61,8 @@ LOCAL_DOC_PATH=_build/html
 cd docs
 sphinx-build -D nb_execution_mode=off -b html . $LOCAL_DOC_PATH
 
+rm -rf "$LOCAL_DOC_PATH/.doctrees/" # remove build artifacts that are not needed to serve webpage
+
 # Overwrite un-executed tutorials w/ executed versions (with images) from other build jobs
 aws s3 cp $BUILD_DOCS_PATH/tutorials/ $LOCAL_DOC_PATH/tutorials/ --recursive --exclude "*/index.html"
 aws s3 cp $BUILD_DOCS_PATH/_images/ $LOCAL_DOC_PATH/_images/ --recursive

--- a/.github/workflow_scripts/build_doc.sh
+++ b/.github/workflow_scripts/build_doc.sh
@@ -46,6 +46,8 @@ function build_doc {
         exit COMMAND_EXIT_CODE
     fi
 
+    rm -rf "$BUILD_DIR/.doctrees/" # remove build artifacts that are not needed to serve webpage
+
     write_to_s3 $BUCKET $LOCAL_DOC_PATH $S3_DOC_PATH
     write_to_s3 $BUCKET $LOCAL_IMG_PATH $S3_IMG_PATH
 


### PR DESCRIPTION
*Description of changes:*

I was cleaning up our `dev/` website S3 resources and observed that the S3 folder is ~70MBs, and ~28MBs of it is a directory called `.doctrees`. This directory is full of binary files names `*.doctree`. I determined that these files are created and used during the Sphinx build process but are not required for serving or viewing the generated webpage. See this [StackOverflow answer](https://stackoverflow.com/questions/33904042/is-doctrees-folder-required-for-displaying-html-docs-with-sphinx) and the related [Sphinx Docs](https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-d).

In this change, I delete these files from our CI build steps before doing `aws s3 cp` so that we don't waste S3 space, which will become more important when we move to GitHub Pages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
