### PR TITLE
Add release instructions for modifying notebook paths

### DIFF
--- a/docs/ReleaseInstructions.md
+++ b/docs/ReleaseInstructions.md
@@ -51,6 +51,7 @@
 * Cut a release branch with format `0.x.y` (no v) - this branch is required to publish docs to versioned path
   * Clone from master branch
   * Add 1 commit to the release branch to remove pre-release warnings and update install instructions to remove `--pre`: [Old diff](https://github.com/autogluon/autogluon/commit/1d66194d4685b06e884bbf15dcb97580cbfb9261)
+  * Add 1 commit that converts notebook links from `master` to `stable` by running this command from the root project directory: `LC_ALL=C find docs/tutorials/ -type f -exec sed -i '' 's#blob/master/docs#blob/stable/docs#' {} +`
   * Update links to AG sub-modules website to be stable ones, i.e. cloud
   * Push release branch
   * Build the release branch docs in [CI](https://ci.gluon.ai/job/autogluon/).


### PR DESCRIPTION
*Description of changes:*

During release, the repository notebook paths for Colab and Studio lab links need to be updated in the AutoGluon tutorials. This one line change adds instructions to do this.

Testing:
I tested the command on macOS because I believe that is the OS most developers will be using during release preparation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
