### PR TITLE
Tabular: Refactor params_aux & memory checks

### DIFF
--- a/core/src/autogluon/core/constants.py
+++ b/core/src/autogluon/core/constants.py
@@ -19,6 +19,7 @@ REFIT_FULL_SUFFIX = "_FULL"  # suffix appended to model name for refit_single_fu
 AG_ARGS = 'ag_args'  # Contains arguments to control model name, model priority, and the valid configurations which it can be used in.
 AG_ARGS_FIT = 'ag_args_fit'  # Contains arguments that impact model training, such as early stopping rounds, #cores, #gpus, max time limit, max memory usage  # TODO
 AG_ARGS_ENSEMBLE = 'ag_args_ensemble'  # Contains arguments that impact model ensembling, such as if an ensemble model is allowed to use the original features.  # TODO: v0.1 add to documentation
+AG_ARG_PREFIX = 'ag.'  # Prefix to add to a hyperparameter to indicate it is an aux param for ag_args_fit.
 
 OBJECTIVES_TO_NORMALIZE = ['log_loss', 'pac_score', 'soft_log_loss']  # do not like predicted probabilities = 0
 

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -149,13 +149,13 @@ class AbstractModel:
         self._compiler = None
 
     @classmethod
-    def _init_user_params(cls, params: Optional[Dict[str, Any]], ag_args_fit: str = AG_ARGS_FIT, ag_arg_prefix: str = AG_ARG_PREFIX) -> (Dict[str, Any], Dict[str, Any]):
+    def _init_user_params(cls, params: Optional[Dict[str, Any]] = None, ag_args_fit: str = AG_ARGS_FIT, ag_arg_prefix: str = AG_ARG_PREFIX) -> (Dict[str, Any], Dict[str, Any]):
         """
         Given the user-specified hyperparameters, split into `params` and `params_aux`.
 
         Parameters
         ----------
-        params : Optional[Dict[str, Any]]
+        params : Optional[Dict[str, Any]], default = None
             The model hyperparameters dictionary
         ag_args_fit : str, default = "ag_args_fit"
             The params key to look for that contains params_aux.

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -200,8 +200,7 @@ class AbstractModel:
                         logger.warning(f'Warning: {cls.__name__} hyperparameter "{k}" is present '
                                        f'in `ag_args_fit` as both "{k}" and "{k_no_prefix}". '
                                        f'Will use "{k}" and ignore "{k_no_prefix}".')
-                    params_aux[k_no_prefix] = params_aux[k]
-                    params_aux.pop(k)
+                    params_aux[k_no_prefix] = params_aux.pop(k)
             param_keys = list(params.keys())
             for k in param_keys:
                 if isinstance(k, str) and k.startswith(ag_arg_prefix):
@@ -210,8 +209,7 @@ class AbstractModel:
                         logger.warning(f'Warning: {cls.__name__} hyperparameter "{k}" is present '
                                        f'in both `ag_args_fit` and `hyperparameters`. '
                                        f'Will use `hyperparameters` value.')
-                    params_aux[k_no_prefix] = params[k]
-                    params.pop(k)
+                    params_aux[k_no_prefix] = params.pop(k)
         return params, params_aux
 
     def _init_params(self):

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -1544,13 +1544,16 @@ class AbstractModel:
         max_memory_usage_error_ratio = mem_error_threshold * max_memory_usage_ratio
         max_memory_usage_warning_ratio = mem_warning_threshold * max_memory_usage_ratio
 
-        log_user_guideline = f'Roughly requires {round(approx_mem_size_req / 1e9, 3)} GB, ' \
-                             f'but only {round(available_mem / 1e9, 3)} GB is available... ' \
-                             f'({round(max_memory_usage_error_ratio*100, 3)}% of avail memory is the max safe size ' \
-                             f'compared to estimated size {round(min_error_memory_ratio*100, 3)}%)'
+        log_ag_args_fit_example = '`predictor.fit(..., ag_args_fit={"ag.max_memory_usage_ratio": VALUE})`'
+        log_ag_args_fit_example = f'\n\t\tTo set the same value for all models, do the following when calling predictor.fit: {log_ag_args_fit_example}'
+
+        log_user_guideline = f'Estimated to require {round(approx_mem_size_req / 1e9, 3)} GB ' \
+                             f'out of {round(available_mem / 1e9, 3)} GB available memory ({round(min_error_memory_ratio*100, 3)}%)... ' \
+                             f'({round(max_memory_usage_error_ratio*100, 3)}% of avail memory is the max safe size)'
         if min_error_memory_ratio > max_memory_usage_error_ratio:
             log_user_guideline += f'\n\tTo force training the model, specify the model hyperparameter "ag.max_memory_usage_ratio" to a larger value ' \
-                                  f'(currently {max_memory_usage_ratio}, set to >{round(min_error_memory_ratio + 0.05, 2)} to avoid the error)'
+                                  f'(currently {max_memory_usage_ratio}, set to >={round(min_error_memory_ratio + 0.05, 2)} to avoid the error)' \
+                                  f'{log_ag_args_fit_example}'
             if min_error_memory_ratio >= 1:
                 log_user_guideline += f'\n\t\tSetting "ag.max_memory_usage_ratio" to values above 1 may result in out-of-memory errors. ' \
                                       f'You may consider using a machine with more memory as a safer alternative.'
@@ -1558,7 +1561,8 @@ class AbstractModel:
             raise NotEnoughMemoryError
         elif min_warning_memory_ratio > max_memory_usage_warning_ratio:
             log_user_guideline += f'\n\tTo avoid this warning, specify the model hyperparameter "ag.max_memory_usage_ratio" to a larger value ' \
-                                  f'(currently {max_memory_usage_ratio}, set to >{round(min_warning_memory_ratio + 0.05, 2)} to avoid the warning)'
+                                  f'(currently {max_memory_usage_ratio}, set to >={round(min_warning_memory_ratio + 0.05, 2)} to avoid the warning)' \
+                                  f'{log_ag_args_fit_example}'
             if min_warning_memory_ratio >= 1:
                 log_user_guideline += f'\n\t\tSetting "ag.max_memory_usage_ratio" to values above 1 may result in out-of-memory errors. ' \
                                       f'You may consider using a machine with more memory as a safer alternative.'

--- a/core/tests/unittests/models/abstract_model/test_init_user_params.py
+++ b/core/tests/unittests/models/abstract_model/test_init_user_params.py
@@ -1,0 +1,153 @@
+
+import copy
+from typing import Any, Dict, Optional
+
+from autogluon.core.models import AbstractModel
+
+
+def _assert_init_user_params(params_og: Optional[Dict[str, Any]], expected_params: Dict[str, Any], expected_params_aux: Dict[str, Any], **kwargs):
+    """
+    Assert that `AbstractModel._init_user_params` works as intended
+    and that `AbstractModel` calls `AbstractModel._init_user_params` in the expected way during init.
+    """
+    expected_params_og = copy.deepcopy(params_og) if params_og is not None else params_og
+    params, params_aux = AbstractModel._init_user_params(params=params_og, **kwargs)
+    assert params_og == expected_params_og  # Ensure no outer context update
+    assert params == expected_params
+    assert params_aux == expected_params_aux
+
+    if kwargs is None or len(kwargs.keys()) == 0:
+        abstract_model = AbstractModel(name='', path='', hyperparameters=params_og)
+        assert params_og == expected_params_og
+        assert abstract_model._user_params == expected_params
+        assert abstract_model._user_params_aux == expected_params_aux
+
+
+def test_init_user_params_none():
+    params_og = None
+    expected_params = {}
+    expected_params_aux = {}
+    _assert_init_user_params(params_og=params_og, expected_params=expected_params, expected_params_aux=expected_params_aux)
+
+
+def test_init_user_params_simple():
+    params_og = {
+        'foo': 1,
+        'bar': 2,
+    }
+    expected_params = {
+        'foo': 1,
+        'bar': 2,
+    }
+    expected_params_aux = {}
+    _assert_init_user_params(params_og=params_og, expected_params=expected_params, expected_params_aux=expected_params_aux)
+
+
+def test_init_user_params_ag_args_fit_none():
+    params_og = {
+        'foo': 1,
+        'bar': 2,
+        'ag_args_fit': None,
+    }
+    expected_params = {
+        'foo': 1,
+        'bar': 2,
+    }
+    expected_params_aux = {}
+    _assert_init_user_params(params_og=params_og, expected_params=expected_params, expected_params_aux=expected_params_aux)
+
+
+def test_init_user_params_with_prefix():
+    params_og = {
+        'foo': 1,
+        'bar': 2,
+        'ag.foo': 3,
+    }
+    expected_params = {
+        'foo': 1,
+        'bar': 2,
+    }
+    expected_params_aux = {
+        'foo': 3
+    }
+    _assert_init_user_params(params_og=params_og, expected_params=expected_params, expected_params_aux=expected_params_aux)
+
+
+def test_init_user_params_with_ag_args_fit():
+    params_og = {
+        'foo': 1,
+        'bar': 2,
+        'ag_args_fit': {'foo': 3},
+    }
+    expected_params = {
+        'foo': 1,
+        'bar': 2,
+    }
+    expected_params_aux = {
+        'foo': 3
+    }
+    _assert_init_user_params(params_og=params_og, expected_params=expected_params, expected_params_aux=expected_params_aux)
+
+
+def test_init_user_params_with_ag_args_fit_and_prefix():
+    params_og = {
+        'foo': 1,
+        'bar': 2,
+        'ag_args_fit': {'foo': 3, 'ag.foo': 4, 'ag.bar': 5, 'ag.ag.bar': 7},
+    }
+    expected_params = {
+        'foo': 1,
+        'bar': 2,
+    }
+    expected_params_aux = {
+        'foo': 4,
+        'bar': 5,
+        'ag.bar': 7,
+    }
+    _assert_init_user_params(params_og=params_og, expected_params=expected_params, expected_params_aux=expected_params_aux)
+
+
+def test_init_user_params_with_all():
+    params_og = {
+        'foo': 1,
+        'bar': 2,
+        'ag.foo': 12,
+        'ag_args_fit': {'foo': 3, 'ag.foo': 4, 'ag.bar': 5, 'ag.ag.bar': 7},
+    }
+    expected_params = {
+        'foo': 1,
+        'bar': 2,
+    }
+    expected_params_aux = {
+        'foo': 12,
+        'bar': 5,
+        'ag.bar': 7,
+    }
+    _assert_init_user_params(params_og=params_og, expected_params=expected_params, expected_params_aux=expected_params_aux)
+
+
+def test_init_user_params_with_all_and_custom():
+    params_og = {
+        'foo': 1,
+        'bar': 2,
+        'custom.': 'hello',
+        'ag.foo': 12,
+        'ag_args_fit': {'foo': 3, 'ag.foo': 4, 'ag.bar': 5, 'ag.ag.bar': 7},
+        'hello': {'custom.5': 22, 'ag.custom.5': 33}
+    }
+    kwargs = {
+        "ag_args_fit": 'hello',
+        "ag_arg_prefix": 'custom.'
+    }
+    expected_params = {
+        'foo': 1,
+        'bar': 2,
+        'ag.foo': 12,
+        'ag_args_fit': {'foo': 3, 'ag.foo': 4, 'ag.bar': 5, 'ag.ag.bar': 7},
+    }
+    expected_params_aux = {
+        '': 'hello',
+        '5': 22,
+        'ag.custom.5': 33,
+    }
+    _assert_init_user_params(params_og=params_og, expected_params=expected_params, expected_params_aux=expected_params_aux, **kwargs)

--- a/tabular/src/autogluon/tabular/models/knn/knn_model.py
+++ b/tabular/src/autogluon/tabular/models/knn/knn_model.py
@@ -106,18 +106,11 @@ class KNNModel(AbstractModel):
         expected_final_model_size_bytes = model_size_bytes * 3.6 # Roughly what can be expected of the final KNN model in memory size
         return expected_final_model_size_bytes
 
-    def _validate_fit_memory_usage(self, **kwargs):
-        max_memory_safety_proportion = 0.2
-        max_memory_usage_ratio = self.params_aux['max_memory_usage_ratio']
-        expected_final_model_size_bytes = self.estimate_memory_usage(**kwargs) 
-        if expected_final_model_size_bytes > 10000000:  # Only worth checking if expected model size is >10MB
-            available_mem = ResourceManager.get_available_virtual_mem()
-            model_memory_ratio = expected_final_model_size_bytes / available_mem
-            if model_memory_ratio > (0.15 * max_memory_usage_ratio):
-                logger.warning(f'\tWarning: Model is expected to require {round(model_memory_ratio * 100, 2)}% of available memory... '
-                               f'({max_memory_safety_proportion*100}% is the max safe size.)')
-            if model_memory_ratio > (max_memory_safety_proportion * max_memory_usage_ratio):
-                raise NotEnoughMemoryError  # don't train full model to avoid OOM error
+    def _validate_fit_memory_usage(self, mem_error_threshold: float = 0.2, mem_warning_threshold: float = 0.15, mem_size_threshold: int = 1e7, **kwargs):
+        return super()._validate_fit_memory_usage(mem_error_threshold=mem_error_threshold,
+                                                  mem_warning_threshold=mem_warning_threshold,
+                                                  mem_size_threshold=mem_size_threshold,
+                                                  **kwargs)
 
     # TODO: Won't work for RAPIDS without modification
     # TODO: Technically isn't OOF, but can be used inplace of OOF. Perhaps rename to something more accurate?

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -128,7 +128,7 @@ class LGBModel(AbstractModel):
         if dataset_val is not None:
             from .callbacks import early_stopping_custom
             # TODO: Better solution: Track trend to early stop when score is far worse than best score, or score is trending worse over time
-            early_stopping_rounds = ag_params.get('ag.early_stop', 'adaptive')
+            early_stopping_rounds = ag_params.get('early_stop', 'adaptive')
             if isinstance(early_stopping_rounds, (str, tuple, list)):
                 early_stopping_rounds = self._get_early_stopping_rounds(num_rows_train=num_rows_train, strategy=early_stopping_rounds)
             if early_stopping_rounds is None:
@@ -358,7 +358,7 @@ class LGBModel(AbstractModel):
         return self._features_internal_list
 
     def _ag_params(self) -> set:
-        return {'ag.early_stop'}
+        return {'early_stop'}
 
     def _more_tags(self):
         # `can_refit_full=True` because num_boost_round is communicated at end of `_fit`

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -131,13 +131,11 @@ class RFModel(AbstractModel):
         expected_min_memory_usage = bytes_per_estimator * n_estimators_minimum
         return expected_min_memory_usage
 
-    def _validate_fit_memory_usage(self, **kwargs):
-        max_memory_usage_ratio = self.params_aux['max_memory_usage_ratio']
-        available_mem = ResourceManager.get_available_virtual_mem()
-        expected_min_memory_usage = self.estimate_memory_usage(**kwargs) / available_mem
-        if expected_min_memory_usage > (0.5 * max_memory_usage_ratio):  # if minimum estimated size is greater than 50% memory
-            logger.warning(f'\tWarning: Model is expected to require {round(expected_min_memory_usage * 100, 2)}% of available memory (Estimated before training)...')
-            raise NotEnoughMemoryError
+    def _validate_fit_memory_usage(self, mem_error_threshold: float = 0.5, mem_warning_threshold: float = 0.4, mem_size_threshold: int = 1e7, **kwargs):
+        return super()._validate_fit_memory_usage(mem_error_threshold=mem_error_threshold,
+                                                  mem_warning_threshold=mem_warning_threshold,
+                                                  mem_size_threshold=mem_size_threshold,
+                                                  **kwargs)
 
     def _expected_mem_usage(self, n_estimators_final, bytes_per_estimator):
         available_mem = ResourceManager.get_available_virtual_mem()

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -9,7 +9,6 @@ from autogluon.core.constants import MULTICLASS, REGRESSION, SOFTCLASS, PROBLEM_
 from autogluon.core.models import AbstractModel
 from autogluon.core.models._utils import get_early_stopping_rounds
 from autogluon.core.utils import try_import_xgboost
-from autogluon.core.utils.exceptions import NotEnoughMemoryError
 
 from . import xgboost_utils
 from .hyperparameters.parameters import get_param_baseline
@@ -110,7 +109,7 @@ class XGBoostModel(AbstractModel):
         else:
             X_val = self.preprocess(X_val, is_train=False)
             eval_set.append((X_val, y_val))
-            early_stopping_rounds = ag_params.get('ag.early_stop', 'adaptive')
+            early_stopping_rounds = ag_params.get('early_stop', 'adaptive')
             if isinstance(early_stopping_rounds, (str, tuple, list)):
                 early_stopping_rounds = self._get_early_stopping_rounds(num_rows_train=num_rows_train, strategy=early_stopping_rounds)
 
@@ -176,7 +175,7 @@ class XGBoostModel(AbstractModel):
         return num_classes
 
     def _ag_params(self) -> set:
-        return {'ag.early_stop'}
+        return {'early_stop'}
 
     def _estimate_memory_usage(self, X, **kwargs):
         num_classes = self.num_classes if self.num_classes else 1  # self.num_classes could be None after initialization if it's a regression problem
@@ -184,18 +183,12 @@ class XGBoostModel(AbstractModel):
         approx_mem_size_req = data_mem_usage * 7 + data_mem_usage / 4 * num_classes  # TODO: Extremely crude approximation, can be vastly improved
         return approx_mem_size_req
 
-    def _validate_fit_memory_usage(self, **kwargs):
-        max_memory_usage_ratio = self.params_aux['max_memory_usage_ratio']
-        approx_mem_size_req = self.estimate_memory_usage(**kwargs)
-        if approx_mem_size_req > 1e9:  # > 1 GB
-            available_mem = ResourceManager.get_available_virtual_mem()
-            ratio = approx_mem_size_req / available_mem
-            if ratio > (1 * max_memory_usage_ratio):
-                logger.warning('\tWarning: Not enough memory to safely train XGBoost model, roughly requires: %s GB, but only %s GB is available...' % (round(approx_mem_size_req / 1e9, 3), round(available_mem / 1e9, 3)))
-                raise NotEnoughMemoryError
-            elif ratio > (0.75 * max_memory_usage_ratio):
-                logger.warning('\tWarning: Potentially not enough memory to safely train XGBoost model, roughly requires: %s GB, but only %s GB is available...' % (round(approx_mem_size_req / 1e9, 3), round(available_mem / 1e9, 3)))
-                
+    def _validate_fit_memory_usage(self, mem_error_threshold: float = 1.0, mem_warning_threshold: float = 0.75, mem_size_threshold: int = 1e9, **kwargs):
+        return super()._validate_fit_memory_usage(mem_error_threshold=mem_error_threshold,
+                                                  mem_warning_threshold=mem_warning_threshold,
+                                                  mem_size_threshold=mem_size_threshold,
+                                                  **kwargs)
+
     def get_minimum_resources(self, is_gpu_available=False):
         minimum_resources = {
             'num_cpus': 1,


### PR DESCRIPTION
*Issue #, if available:*

resolves #3031 

*Description of changes:*

# 1: Refactor params_aux

- Previously it was very confusing how to specify aux hyperparameters of a model.
- Now, we simply prefix the hyperparameter with `ag.` to indicate it as an aux hyperparameter, which is much easier.
- Prior API functionality remains in-tact, this is purely an extra way to pass the arguments.
- Added unit tests for this logic.
- I've added a TODO to expand upon this long term for improved ease of use and extensibility by enabling aux hyperparameters to be part of HPO search spaces. This should be made available by v1.0 release, but is too complicated to make sense including in this PR.

Mainline:

```
hyperparameters = {
    'GBM': {'ag_args_fit': {'max_memory_usage_ratio': 2.5}},
}
```

This PR:

```
hyperparameters = {
    'GBM': {'ag.max_memory_usage_ratio': 2.5}
}
```

# 2: Refactor memory checks

- Previously, it was very unclear what users should do if they run into memory check errors.
- This has been greatly expanded on, and now the logs provide ample information.
- Additionally, the logic has been refactored and standardized to remove code duplication.

Mainline:

```
Fitting model: LightGBM ...
	Warning: Not enough memory to safely train model, roughly requires: 10.0 GB, but only 6.517 GB is available...
	Not enough memory to train LightGBM... Skipping this model.
```

This PR:

```
Fitting model: LightGBM ...
	Warning: Not enough memory to safely train model. Estimated to require 10.0 GB out of 8.273 GB available memory (134.312%)... (90.0% of avail memory is the max safe size)
	To force training the model, specify the model hyperparameter "ag.max_memory_usage_ratio" to a larger value (currently 1.0, set to >=1.39 to avoid the error)
		To set the same value for all models, do the following when calling predictor.fit: `predictor.fit(..., ag_args_fit={"ag.max_memory_usage_ratio": VALUE})`
		Setting "ag.max_memory_usage_ratio" to values above 1 may result in out-of-memory errors. You may consider using a machine with more memory as a safer alternative.
	Not enough memory to train LightGBM... Skipping this model.
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
