### PR TITLE
[eda] switch regression analysis in `quick_fit` to use residuals plot

### DIFF
--- a/eda/setup.py
+++ b/eda/setup.py
@@ -30,6 +30,7 @@ install_requires = [
     'seaborn>=0.12.0,<0.13',
     'ipywidgets>=7.7.1,<9.0',  # min versions guidance: 7.7.1 collab/kaggle
     'shap>=0.41,<0.42',
+    'yellowbrick>=1.5,<1.6',
     f'autogluon.core=={version}',
     f'autogluon.common=={version}',
     f'autogluon.features=={version}',

--- a/eda/src/autogluon/eda/analysis/model.py
+++ b/eda/src/autogluon/eda/analysis/model.py
@@ -177,7 +177,8 @@ class AutoGluonModelEvaluator(AbstractAnalysis):
         val_data = args.val_data
         problem_type = predictor.problem_type
         label = predictor.label
-        y_true_val, y_pred_val, highest_error, undecided = self._predict(problem_type, label, predictor, val_data)
+        y_true_train, y_pred_train, _, _ = self._predict(problem_type, predictor, args.train_data)
+        y_true_val, y_pred_val, highest_error, undecided = self._predict(problem_type, predictor, val_data)
         test_data = val_data
         test_data_present = args.test_data is not None and label in args.test_data.columns
 
@@ -185,9 +186,7 @@ class AutoGluonModelEvaluator(AbstractAnalysis):
         y_pred_test = None
         if test_data_present:
             test_data = args.test_data
-            y_true_test, y_pred_test, highest_error, undecided = self._predict(
-                problem_type, label, predictor, test_data
-            )
+            y_true_test, y_pred_test, highest_error, undecided = self._predict(problem_type, predictor, test_data)
 
         importance = predictor.feature_importance(test_data.reset_index(drop=True), silent=True)
         leaderboard = predictor.leaderboard(test_data, silent=True)
@@ -198,6 +197,8 @@ class AutoGluonModelEvaluator(AbstractAnalysis):
             "importance": importance,
             "leaderboard": leaderboard,
             "labels": labels,
+            "y_true_train": y_true_train,
+            "y_pred_train": y_pred_train,
         }
 
         if test_data_present:
@@ -221,7 +222,8 @@ class AutoGluonModelEvaluator(AbstractAnalysis):
 
         state.model_evaluation = s
 
-    def _predict(self, problem_type, label, predictor, val_data):
+    def _predict(self, problem_type, predictor, val_data):
+        label = predictor.label
         y_true_val = val_data[label]
         y_pred_val = predictor.predict(val_data)
         highest_error = None

--- a/eda/src/autogluon/eda/auto/simple.py
+++ b/eda/src/autogluon/eda/auto/simple.py
@@ -295,6 +295,8 @@ def quick_fit(
     ----------
     train_data: DataFrame
         training dataset
+    test_data: DataFrame
+        test dataset
     label: str
         target variable
     path: Optional[str], default = None,
@@ -390,7 +392,7 @@ def quick_fit(
             ),
             RegressionEvaluation(
                 fig_args=fig_args.get("regression_eval", {}),
-                **chart_args.get("regression_eval", dict(marker="o", scatter_kws={"s": 5})),
+                **chart_args.get("regression_eval", {}),
             ),
             MarkdownSectionComponent(markdown="### Model Leaderboard"),
             ModelLeaderboard(),

--- a/eda/src/autogluon/eda/auto/simple.py
+++ b/eda/src/autogluon/eda/auto/simple.py
@@ -259,7 +259,7 @@ def quick_fit(
     sample: Union[None, int, float] = None,
     state: Union[None, dict, AnalysisState] = None,
     return_state: bool = False,
-    save_model_to_state: bool = False,
+    save_model_to_state: bool = True,
     verbosity: int = 0,
     show_feature_importance_barplots: bool = False,
     estimator_args: Optional[Dict[str, Dict[str, Any]]] = None,

--- a/eda/src/autogluon/eda/visualization/__init__.py
+++ b/eda/src/autogluon/eda/visualization/__init__.py
@@ -1,3 +1,5 @@
+from yellowbrick.style.rcmod import reset_orig
+
 from .dataset import DatasetStatistics, DatasetTypeMismatch, LabelInsightsVisualization
 from .explain import ExplainForcePlot, ExplainWaterfallPlot
 from .interaction import (
@@ -16,3 +18,6 @@ from .layouts import (
 from .missing import MissingValues
 from .model import ConfusionMatrix, FeatureImportance, ModelLeaderboard, RegressionEvaluation
 from .shift import XShiftSummary
+
+# Reset plotting styles back to original style; this is to prevent issues with missing fonts
+reset_orig()

--- a/eda/src/autogluon/eda/visualization/model.py
+++ b/eda/src/autogluon/eda/visualization/model.py
@@ -3,6 +3,8 @@ from typing import Any, Dict, Optional
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
+from yellowbrick.contrib.wrapper import REGRESSOR, ContribEstimator
+from yellowbrick.regressor import residuals_plot
 
 from autogluon.core.constants import REGRESSION
 
@@ -95,14 +97,32 @@ class ConfusionMatrix(AbstractVisualization, JupyterMixin):
         plt.show(fig)
 
 
+class _YellowbrickAutoGluonWrapper(ContribEstimator):
+    _estimator_type = REGRESSOR
+
+    def score(self, y_pred, y_true, **kwargs):
+        # note: it's this is not conventional use of API: we pass y_pred since we already have predictions done
+        return self.estimator.evaluate_predictions(y_pred, y_true)["r2"]
+
+    def predict(self, y_pred, **kwargs):
+        # note: it's this is not conventional use of API: we pass y_pred since we already have predictions done
+        return y_pred
+
+
 class RegressionEvaluation(AbstractVisualization, JupyterMixin):
     """
-    Render predictions vs ground truth chart for regressor.
+    The residuals plot shows the difference between residuals on the vertical axis and the dependent variable on
 
     This visualization depends on :py:class:`~autogluon.eda.analysis.model.AutoGluonModelEvaluator` analysis.
 
     Parameters
     ----------
+    residuals_plot_mode: Optional[str], default = 'qoq'
+        Additional plot to render to the right of the main plot. The supported values:
+        - `qoq` (default) - Q-Q plot, which is a common way to check that residuals are normally distributed. If the residuals are normally distributed,
+        then their quantiles when plotted against quantiles of normal distribution should form a straight line.
+        - `hist` - display histogram that our error is normally distributed around zero, which also generally indicates a well fitted model
+        - any other value - don't render additional details
     headers: bool, default = False
         if `True` then render headers
     namespace: str, default = None
@@ -133,6 +153,7 @@ class RegressionEvaluation(AbstractVisualization, JupyterMixin):
 
     def __init__(
         self,
+        residuals_plot_mode: Optional[str] = "qoq",
         fig_args: Optional[Dict[str, Any]] = None,
         headers: bool = False,
         namespace: Optional[str] = None,
@@ -140,6 +161,7 @@ class RegressionEvaluation(AbstractVisualization, JupyterMixin):
     ) -> None:
         super().__init__(namespace, **kwargs)
         self.headers = headers
+        self.residuals_analysis_mode = residuals_plot_mode
 
         if fig_args is None:
             fig_args = {}
@@ -148,19 +170,30 @@ class RegressionEvaluation(AbstractVisualization, JupyterMixin):
     def can_handle(self, state: AnalysisState) -> bool:
         return "model_evaluation" in state and state.model_evaluation.problem_type == REGRESSION
 
+    def _get_plot_mode(self):
+        res_plot_kwargs = {
+            "hist": dict(hist=True, qqplot=False),
+            "qoq": dict(hist=False, qqplot=True),
+        }.get(
+            self.residuals_analysis_mode, dict(hist=False, qqplot=False)  # type: ignore
+        )
+        return res_plot_kwargs
+
     def _render(self, state: AnalysisState) -> None:
         self.render_header_if_needed(state, "Prediction vs Target")
-        data = pd.DataFrame({"y_true": state.model_evaluation.y_true, "y_pred": state.model_evaluation.y_pred})
-
+        ev = state.model_evaluation
+        res_plot_kwargs = self._get_plot_mode()
         fig, ax = plt.subplots(**self.fig_args)
-        label = "test" if "y_true_val" in state.model_evaluation else "validation"
-        sns.regplot(ax=ax, data=data, x="y_true", y="y_pred", label=label, **self._kwargs)
-        if "y_true_val" in state.model_evaluation:
-            data = pd.DataFrame(
-                {"y_true": state.model_evaluation.y_true_val, "y_pred": state.model_evaluation.y_pred_val}
-            )
-            sns.regplot(ax=ax, data=data, x="y_true", y="y_pred", label="validation", **self._kwargs)
-            plt.legend()
+        residuals_plot(
+            _YellowbrickAutoGluonWrapper(state.model),
+            ev.y_pred_train,
+            ev.y_true_train,
+            ev.y_pred,
+            ev.y_true,
+            show=False,
+            ax=ax,
+            **res_plot_kwargs,
+        )
         plt.show(fig)
 
 

--- a/eda/src/autogluon/eda/visualization/model.py
+++ b/eda/src/autogluon/eda/visualization/model.py
@@ -101,17 +101,17 @@ class _YellowbrickAutoGluonWrapper(ContribEstimator):
     _estimator_type = REGRESSOR
 
     def score(self, y_pred, y_true, **kwargs):
-        # note: it's this is not conventional use of API: we pass y_pred since we already have predictions done
+        # note: this is not conventional use of API: we pass y_pred since we already have predictions done
         return self.estimator.evaluate_predictions(y_pred, y_true)["r2"]
 
     def predict(self, y_pred, **kwargs):
-        # note: it's this is not conventional use of API: we pass y_pred since we already have predictions done
+        # note: this is not conventional use of API: we pass y_pred since we already have predictions done
         return y_pred
 
 
 class RegressionEvaluation(AbstractVisualization, JupyterMixin):
     """
-    The residuals plot shows the difference between residuals on the vertical axis and the dependent variable on
+    This plot shows residuals on the vertical axis vs prediction on horizontal axis.
 
     This visualization depends on :py:class:`~autogluon.eda.analysis.model.AutoGluonModelEvaluator` analysis.
 

--- a/eda/src/autogluon/eda/visualization/model.py
+++ b/eda/src/autogluon/eda/visualization/model.py
@@ -165,6 +165,7 @@ class RegressionEvaluation(AbstractVisualization, JupyterMixin):
 
         if fig_args is None:
             fig_args = {}
+        fig_args = {**{"figsize": (12, 6)}, **fig_args}
         self.fig_args = fig_args
 
     def can_handle(self, state: AnalysisState) -> bool:

--- a/eda/tests/unittests/analysis/test_model.py
+++ b/eda/tests/unittests/analysis/test_model.py
@@ -33,6 +33,7 @@ def test_AutoGluonModelEvaluator_regression():
 
         state = auto.analyze(
             model=predictor,
+            train_data=df_train,
             val_data=df_test,
             return_state=True,
             anlz_facets=[eda.model.AutoGluonModelEvaluator(normalize="true")],
@@ -61,6 +62,7 @@ def test_AutoGluonModelEvaluator_regression__with_test_data():
 
         state = auto.analyze(
             model=predictor,
+            train_data=df_train,
             val_data=df_val,
             test_data=df_test,
             return_state=True,
@@ -89,6 +91,7 @@ def test_AutoGluonModelEvaluator_classification():
 
         state = auto.analyze(
             model=predictor,
+            train_data=df_train,
             val_data=df_test,
             return_state=True,
             anlz_facets=[eda.model.AutoGluonModelEvaluator(normalize="true")],

--- a/eda/tests/unittests/visualization/test_model.py
+++ b/eda/tests/unittests/visualization/test_model.py
@@ -72,6 +72,8 @@ def test_RegressionEvaluation(monkeypatch):
         {
             "model_evaluation": {
                 "problem_type": "regression",
+                "y_true_train": pd.Series([0, 1, 0, 0]),
+                "y_pred_train": pd.Series([1, 0, 1, 1]),
                 "y_true": pd.Series([0, 1, 0, 1]),
                 "y_pred": pd.Series([1, 0, 1, 0]),
             }
@@ -80,18 +82,29 @@ def test_RegressionEvaluation(monkeypatch):
 
     call_plt_subplots = MagicMock(return_value=("fig", "ax"))
     call_plt_show = MagicMock()
-    call_sns_regplot = MagicMock()
+    call_residuals_plot = MagicMock()
     call_render_markdown = MagicMock()
     with monkeypatch.context() as m:
         m.setattr(plt, "subplots", call_plt_subplots)
         m.setattr(plt, "show", call_plt_show)
-        m.setattr(sns, "regplot", call_sns_regplot)
+        m.setattr("autogluon.eda.visualization.model.residuals_plot", call_residuals_plot)
         viz = RegressionEvaluation(headers=True, fig_args=dict(a=1, b=2), some_kwarg=123)
+        viz.residuals_plot = call_residuals_plot
         viz.render_markdown = call_render_markdown
         viz.render(state)
     call_plt_subplots.assert_called_with(a=1, b=2)
     call_plt_show.assert_called_with("fig")
-    call_sns_regplot.assert_called_with(ax="ax", data=ANY, x="y_true", y="y_pred", label="validation", some_kwarg=123)
+    call_residuals_plot.assert_called_with(
+        ANY,
+        state.model_evaluation.y_pred_train,
+        state.model_evaluation.y_true_train,
+        state.model_evaluation.y_pred,
+        state.model_evaluation.y_true,
+        show=False,
+        ax="ax",
+        hist=False,
+        qqplot=True,
+    )
     call_render_markdown.assert_called_with("**Prediction vs Target**")
 
 

--- a/eda/tests/unittests/visualization/test_model.py
+++ b/eda/tests/unittests/visualization/test_model.py
@@ -92,7 +92,7 @@ def test_RegressionEvaluation(monkeypatch):
         viz.residuals_plot = call_residuals_plot
         viz.render_markdown = call_render_markdown
         viz.render(state)
-    call_plt_subplots.assert_called_with(a=1, b=2)
+    call_plt_subplots.assert_called_with(figsize=(12, 6), a=1, b=2)
     call_plt_show.assert_called_with("fig")
     call_residuals_plot.assert_called_with(
         ANY,
@@ -136,9 +136,10 @@ def test_RegressionEvaluation__can_handle():
     assert RegressionEvaluation().can_handle(AnalysisState({"some_args": {}})) is False
 
 
-def test_ConfusionMatrix__handle_None_fig_args():
-    assert RegressionEvaluation(fig_args={"abc": 1}).fig_args == {"abc": 1}
-    assert RegressionEvaluation(fig_args=None).fig_args == {}
+def test_RegressionEvaluation__handle_None_fig_args():
+    assert RegressionEvaluation(fig_args={"abc": 1}).fig_args == {"abc": 1, "figsize": (12, 6)}
+    assert RegressionEvaluation(fig_args=None).fig_args == {"figsize": (12, 6)}
+    assert RegressionEvaluation(fig_args={"figsize": (6, 6)}).fig_args == {"figsize": (6, 6)}
 
 
 def test_FeatureImportance__can_handle():


### PR DESCRIPTION
*Description of changes:*

Regression: switched prediction analysis from diagonal `y` vs `y^` to residuals plot with option to add Q-Q analysis (default) or histogram.

### Usage

```python
import pandas as pd
import autogluon.eda.auto as auto

df_train = pd.read_csv('https://autogluon.s3.amazonaws.com/datasets/AmesHousingPriceRegression/train_data.csv')
df_test = pd.read_csv('https://autogluon.s3.amazonaws.com/datasets/AmesHousingPriceRegression/test_data.csv')
target_col = 'SalePrice'

keep_cols = [
  'Overall.Qual', 'Gr.Liv.Area', 'Neighborhood', 'Total.Bsmt.SF', 'BsmtFin.SF.1',
  'X1st.Flr.SF', 'Bsmt.Qual', 'Garage.Cars', 'Half.Bath', 'Year.Remod.Add', target_col
]

auto.quick_fit(
    train_data=df_train[keep_cols],
    test_data=df_test[keep_cols],
    label=target_col,
)
```

<img width="987" alt="image" src="https://user-images.githubusercontent.com/10080307/225175418-b62a0cbc-9cdc-4be9-8a76-79144a513991.png">
...

Customizing residuals outputs

```python
auto.quick_fit(
    train_data=df_train[keep_cols],
    test_data=df_test[keep_cols],
    label=target_col,
    fig_args={
        "regression_eval": {  # figure arguments for regression_eval components
            "figsize": (12,6)
        }
    },
    chart_args=dict(
        regression_eval = dict(  # chart arguments for regression_eval components
            residuals_plot_mode="hist"  # use histogram instead of Q-Q plot
        )
    )
)
```

<img width="996" alt="image" src="https://user-images.githubusercontent.com/10080307/225176039-2a1ba9d6-2429-4202-bc49-31186de8ffd3.png">
...

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
