### PR TITLE
[multimodal] change default inference strategy from dp to ddp

### DIFF
--- a/multimodal/src/autogluon/multimodal/utils/environment.py
+++ b/multimodal/src/autogluon/multimodal/utils/environment.py
@@ -32,7 +32,7 @@ def compute_num_gpus(config_num_gpus: Union[int, float, List], strategy: str):
     config_num_gpus
         The gpu number provided by config.
     strategy
-        A lightning trainer's strategy such as "ddp", "ddp_spawn", and "dp".
+        A lightning trainer's strategy such as "ddp" and "ddp_spawn".
 
     Returns
     -------
@@ -194,8 +194,8 @@ def compute_inference_batch_size(
     else:
         batch_size = per_gpu_batch_size * eval_batch_size_ratio
 
-    if num_gpus > 1 and strategy == "dp":
-        # If using 'dp', the per_gpu_batch_size would be split by all GPUs.
+    if num_gpus > 1 and strategy == "ddp":
+        # If using 'ddp', the per_gpu_batch_size would be split by all GPUs.
         # So, we need to use the GPU number as a multiplier to compute the batch size.
         batch_size = batch_size * num_gpus
 

--- a/multimodal/src/autogluon/multimodal/utils/export.py
+++ b/multimodal/src/autogluon/multimodal/utils/export.py
@@ -256,7 +256,7 @@ class ExportMixin:
         # Perform tracing on cpu
         device_type = "cpu"
         num_gpus = 0
-        strategy = "dp"  # default used in inference.
+        strategy = "ddp"  # default used in inference.
         device = torch.device(device_type)
         dtype = infer_precision(
             num_gpus=num_gpus, precision=self._config.env.precision, cpu_only_warning=False, as_torch=True

--- a/multimodal/src/autogluon/multimodal/utils/inference.py
+++ b/multimodal/src/autogluon/multimodal/utils/inference.py
@@ -153,7 +153,7 @@ def infer_batch(
     device = torch.device(device_type)
     batch_size = len(batch[next(iter(batch))])
     if 1 < num_gpus <= batch_size:
-        model = nn.DataParallel(model)
+        model = nn.parallel.DistributedDataParallel(model)
     model.to(device).eval()
     batch = move_to_device(batch, device=device)
     precision_context = get_precision_context(precision=precision, device_type=device_type)
@@ -162,7 +162,7 @@ def infer_batch(
         if model_postprocess_fn:
             output = model_postprocess_fn(output)
 
-    if isinstance(model, nn.DataParallel):
+    if isinstance(model, nn.parallel.DistributedDataParallel):
         model = model.module
     else:
         model = model

--- a/multimodal/src/autogluon/multimodal/utils/inference.py
+++ b/multimodal/src/autogluon/multimodal/utils/inference.py
@@ -475,7 +475,7 @@ def predict(
             requires_label=requires_label,
         )
 
-    strategy = "dp"  # default used in inference.
+    strategy = "ddp"  # default used in inference.
 
     num_gpus = compute_num_gpus(config_num_gpus=predictor._config.env.num_gpus, strategy=strategy)
 


### PR DESCRIPTION
*Issue #, if available:*

DP strategy has been dropped in latest version of PyTorch Lightning: https://lightning.ai/docs/pytorch/stable/extensions/strategy.html#selecting-a-built-in-strategy

*Description of changes:*

1. change default inference strategy from dp to ddp

![image](https://user-images.githubusercontent.com/857821/225759539-2e6b3908-0de2-44f6-b9d7-7b5cc94c5133.png)


raw evaluation results
```
                     acc    fit_time  evaluation_time   roc_auc        r2
ae_master            NaN  307.421506        27.805263       NaN  0.937194
ae_pr3047            NaN  340.813961        70.293135       NaN  0.937192
airbnb_master   0.314916  253.363260        21.631194       NaN       NaN
airbnb_pr3047   0.314916  277.479965        48.546978       NaN       NaN
book_master          NaN  119.190479         6.441170       NaN  0.306766
book_pr3047          NaN  126.684912        15.015948       NaN  0.306774
channel_master  0.446657  130.281380        11.394986       NaN       NaN
channel_pr3047  0.446460  133.643639         3.094903       NaN       NaN
cloth_master         NaN  141.954339        12.348763       NaN  0.723178
cloth_pr3047         NaN  142.352423        12.727166       NaN  0.723173
fake_master          NaN  197.544991        14.693796  0.910984       NaN
fake_pr3047          NaN  215.588717        34.594925  0.910984       NaN
house_master         NaN  408.529516        45.232907       NaN  0.845168
house_pr3047         NaN  435.222200        99.841003       NaN  0.845169
imdb_master          NaN   77.906789         1.221807  0.787058       NaN
imdb_pr3047          NaN   78.813874         0.838232  0.787108       NaN
jc_master            NaN  137.520359        12.896116       NaN  0.432778
jc_pr3047            NaN  145.400321        19.794474       NaN  0.432788
jigsaw_master        NaN  503.383430        76.045691  0.968950       NaN
jigsaw_pr3047        NaN  518.031339       109.279707  0.968950       NaN
kick_master          NaN  670.409061        97.126594  0.770771       NaN
kick_pr3047          NaN  681.482820       186.496310  0.770769       NaN
mercari_master       NaN  487.284595        79.191702       NaN  0.549995
mercari_pr3047       NaN  487.470524       103.125223       NaN  0.550000
pop_master           NaN  139.576513        13.441159       NaN  0.001726
pop_pr3047           NaN  132.195735         3.661519       NaN  0.001723
prod_master     0.890024   87.615281         3.267418       NaN       NaN
prod_pr3047     0.890024   87.765972         1.532096       NaN       NaN
qaa_master           NaN  118.922404         6.190520       NaN  0.310659
qaa_pr3047           NaN  125.957483        13.558997       NaN  0.310659
qaq_master           NaN  118.171198         6.180685       NaN  0.263055
qaq_pr3047           NaN  124.898776        13.539232       NaN  0.263055
salary_master   0.439283  117.295602         9.111656       NaN       NaN
salary_pr3047   0.439283  114.049922         5.683518       NaN       NaN
wine_master     0.785792  324.635422        49.641939       NaN       NaN
wine_pr3047     0.785745  319.978103        35.149828       NaN       NaN
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
