### PR TITLE
[timeseries] Cache OOF predictions and train multiple models for multi-window backtesting

### DIFF
--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -4,7 +4,7 @@ import copy
 import itertools
 import warnings
 from collections.abc import Iterable
-from typing import Any, Optional, Tuple, Type, Union, List
+from typing import Any, List, Optional, Tuple, Type, Union
 
 import numpy as np
 import pandas as pd

--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -78,6 +78,7 @@ class TimeSeriesLearner(AbstractLearner):
         hyperparameters: Union[str, Dict] = None,
         hyperparameter_tune_kwargs: Optional[Union[str, dict]] = None,
         time_limit: Optional[int] = None,
+        num_val_windows: int = 1,
         **kwargs,
     ) -> None:
         self._time_limit = time_limit
@@ -111,7 +112,7 @@ class TimeSeriesLearner(AbstractLearner):
                 verbosity=kwargs.get("verbosity", 2),
                 enable_ensemble=kwargs.get("enable_ensemble", True),
                 metadata=self.feature_generator.covariate_metadata,
-                num_val_windows=kwargs.get("num_val_windows", 1),
+                num_val_windows=num_val_windows,
             )
         )
         self.trainer = self.trainer_type(**trainer_init_kwargs)

--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -78,7 +78,6 @@ class TimeSeriesLearner(AbstractLearner):
         hyperparameters: Union[str, Dict] = None,
         hyperparameter_tune_kwargs: Optional[Union[str, dict]] = None,
         time_limit: Optional[int] = None,
-        num_val_windows: int = 1,
         **kwargs,
     ) -> None:
         self._time_limit = time_limit
@@ -112,6 +111,7 @@ class TimeSeriesLearner(AbstractLearner):
                 verbosity=kwargs.get("verbosity", 2),
                 enable_ensemble=kwargs.get("enable_ensemble", True),
                 metadata=self.feature_generator.covariate_metadata,
+                num_val_windows=kwargs.get("num_val_windows", 1),
             )
         )
         self.trainer = self.trainer_type(**trainer_init_kwargs)
@@ -124,7 +124,6 @@ class TimeSeriesLearner(AbstractLearner):
             hyperparameters=hyperparameters,
             hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
             time_limit=time_limit,
-            num_val_windows=num_val_windows,
         )
         self.save_trainer(trainer=self.trainer)
 

--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -80,6 +80,7 @@ class TimeSeriesLearner(AbstractLearner):
         hyperparameters: Union[str, Dict] = None,
         hyperparameter_tune_kwargs: Optional[Union[str, dict]] = None,
         time_limit: Optional[int] = None,
+        num_val_windows: int = 1,
         **kwargs,
     ) -> None:
         self._time_limit = time_limit
@@ -101,15 +102,15 @@ class TimeSeriesLearner(AbstractLearner):
         if val_data is not None:
             val_data = self.feature_generator.transform(val_data, data_frame_name="tuning_data")
 
-        # Train / validation split
-        if val_data is None:
-            logger.warning(
-                "tuning_data is None. "
-                + self.validation_splitter.describe_validation_strategy(prediction_length=self.prediction_length)
-            )
-            train_data, val_data = self.validation_splitter.split(
-                ts_dataframe=train_data, prediction_length=self.prediction_length
-            )
+        # # Train / validation split
+        # if val_data is None:
+        #     logger.warning(
+        #         "tuning_data is None. "
+        #         + self.validation_splitter.describe_validation_strategy(prediction_length=self.prediction_length)
+        #     )
+        #     train_data, val_data = self.validation_splitter.split(
+        #         ts_dataframe=train_data, prediction_length=self.prediction_length
+        #     )
 
         trainer_init_kwargs = kwargs.copy()
         trainer_init_kwargs.update(
@@ -135,6 +136,7 @@ class TimeSeriesLearner(AbstractLearner):
             hyperparameters=hyperparameters,
             hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
             time_limit=time_limit,
+            num_val_windows=num_val_windows,
         )
         self.save_trainer(trainer=self.trainer)
 

--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -31,7 +31,6 @@ class TimeSeriesLearner(AbstractLearner):
         eval_metric: Optional[str] = None,
         eval_metric_seasonal_period: Optional[int] = None,
         prediction_length: int = 1,
-        validation_splitter: AbstractTimeSeriesSplitter = LastWindowSplitter(),
         ignore_time_index: bool = False,
         **kwargs,
     ):
@@ -46,7 +45,6 @@ class TimeSeriesLearner(AbstractLearner):
             "quantile_levels",
             kwargs.get("quantiles", [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]),
         )
-        self.validation_splitter = validation_splitter
         self.ignore_time_index = ignore_time_index
 
         self.feature_generator = TimeSeriesFeatureGenerator(
@@ -101,16 +99,6 @@ class TimeSeriesLearner(AbstractLearner):
         train_data = self.feature_generator.fit_transform(train_data, data_frame_name="train_data")
         if val_data is not None:
             val_data = self.feature_generator.transform(val_data, data_frame_name="tuning_data")
-
-        # # Train / validation split
-        # if val_data is None:
-        #     logger.warning(
-        #         "tuning_data is None. "
-        #         + self.validation_splitter.describe_validation_strategy(prediction_length=self.prediction_length)
-        #     )
-        #     train_data, val_data = self.validation_splitter.split(
-        #         ts_dataframe=train_data, prediction_length=self.prediction_length
-        #     )
 
         trainer_init_kwargs = kwargs.copy()
         trainer_init_kwargs.update(

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -392,6 +392,9 @@ class AbstractTimeSeriesModel(AbstractModel):
 
         return metric_value * evaluator.coefficient
 
+    def _update_hpo_train_fn_kwargs(self, train_fn_kwargs: dict) -> dict:
+        return train_fn_kwargs
+
     def _hyperparameter_tune(
         self,
         train_data: TimeSeriesDataFrame,
@@ -419,7 +422,9 @@ class AbstractTimeSeriesModel(AbstractModel):
         val_path = os.path.join(self.path, dataset_val_filename)
         save_pkl.save(path=val_path, object=val_data)
 
-        fit_kwargs = dict()
+        fit_kwargs = dict(
+            num_val_windows=kwargs.get("num_val_windows", 1),
+        )
         train_fn_kwargs = dict(
             model_cls=self.__class__,
             init_params=self.get_params(),
@@ -430,6 +435,7 @@ class AbstractTimeSeriesModel(AbstractModel):
             val_path=val_path,
             hpo_executor=hpo_executor,
         )
+        train_fn_kwargs = self._update_hpo_train_fn_kwargs(train_fn_kwargs)
 
         model_estimate_memory_usage = None
         if self.estimate_memory_usage is not None:

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -2,9 +2,10 @@ import copy
 import logging
 import os
 import time
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import autogluon.core as ag
+from autogluon.common.loaders import load_pkl
 from autogluon.common.savers import save_pkl
 from autogluon.core.hpo.exceptions import EmptySearchSpace
 from autogluon.core.hpo.executors import HpoExecutor
@@ -53,6 +54,8 @@ class AbstractTimeSeriesModel(AbstractModel):
         Hyperparameters that will be used by the model (can be search spaces instead of fixed values).
         If None, model defaults are used. This is identical to passing an empty dictionary.
     """
+
+    _oof_filename = "oof.pkl"
 
     # TODO: refactor "pruned" methods after AbstractModel is refactored
     predict_proba = None
@@ -105,6 +108,7 @@ class AbstractTimeSeriesModel(AbstractModel):
             "quantile_levels",
             kwargs.get("quantiles", [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]),
         )
+        self._oof_predictions: Optional[TimeSeriesDataFrame] = None
 
     def __repr__(self) -> str:
         return self.name
@@ -122,6 +126,34 @@ class AbstractTimeSeriesModel(AbstractModel):
     def _validate_fit_memory_usage(self, **kwargs):
         # memory usage handling not implemented for timeseries models
         pass
+
+    def save(self, path: str = None, verbose=True) -> str:
+        if self._oof_predictions is not None:
+            save_pkl.save(
+                path=os.path.join(self.path + "utils", self._oof_filename),
+                object=self._oof_predictions,
+                verbose=verbose,
+            )
+        return super().save(path=path, verbose=verbose)
+
+    @classmethod
+    def load(
+        cls, path: str, reset_paths: bool = True, load_oof: bool = False, verbose: bool = True
+    ) -> "AbstractTimeSeriesModel":
+        model = super().load(path=path, reset_paths=reset_paths, verbose=verbose)
+        if load_oof and model._oof_predictions is None:
+            model._oof_predictions = cls.load_oof_predictions(path=path, verbose=verbose)
+        return model
+
+    @classmethod
+    def load_oof_predictions(cls, path: str, verbose: bool = True) -> TimeSeriesDataFrame:
+        """Load the cached OOF predictions from disk."""
+        return load_pkl.load(path=os.path.join(path + "utils", cls._oof_filename), verbose=verbose)
+
+    def get_oof_predictions(self):
+        if self._oof_predictions is None:
+            self._oof_predictions = self.load_oof_predictions(self.path)
+        return self._oof_predictions
 
     def get_params(self) -> dict:
         params = super().get_params()
@@ -166,7 +198,7 @@ class AbstractTimeSeriesModel(AbstractModel):
         train_data : TimeSeriesDataFrame
             The training data provided in the library's `autogluon.timeseries.dataset.TimeSeriesDataFrame`
             format.
-        val_data : TimeSeriesDataFrame
+        val_data : TimeSeriesDataFrame, optional
             The validation data set in the same format as training data.
         time_limit : float, default = None
             Time limit in seconds to adhere to when fitting model.
@@ -196,14 +228,15 @@ class AbstractTimeSeriesModel(AbstractModel):
         """
         return super().fit(**kwargs)
 
+    # TODO: Make the models respect `num_cpus` and `num_gpus` parameters
     def _fit(
         self,
-        train_data,
-        val_data=None,
-        time_limit=None,
+        train_data: TimeSeriesDataFrame,
+        val_data: Optional[TimeSeriesDataFrame] = None,
+        time_limit: Optional[int] = None,
         num_cpus=None,
         num_gpus=None,
-        verbosity=2,
+        verbosity: int = 2,
         **kwargs,
     ) -> None:
         """Private method for `fit`. See `fit` for documentation of arguments. Apart from
@@ -219,6 +252,24 @@ class AbstractTimeSeriesModel(AbstractModel):
                 "Hyperparameter spaces provided to `fit`. Please provide concrete values "
                 "as hyperparameters when initializing or use `hyperparameter_tune` instead."
             )
+
+    def score_and_cache_oof(self, val_data: TimeSeriesDataFrame) -> None:
+        """Compute val_score, predict_time and cache out-of-fold (OOF) predictions."""
+        if self.val_score is not None or self.predict_time is not None or self._oof_predictions is not None:
+            raise ValueError(f"Model {self.name} has already been scored on OOF data!")
+
+        past_data, known_covariates = self.slice_data_for_scoring(val_data)
+        predict_start_time = time.time()
+        self._oof_predictions = self.predict(past_data, known_covariates=known_covariates)
+        self.predict_time = time.time() - predict_start_time
+
+        evaluator = TimeSeriesEvaluator(
+            eval_metric=self.eval_metric,
+            eval_metric_seasonal_period=self.eval_metric_seasonal_period,
+            prediction_length=self.prediction_length,
+            target_column=self.target,
+        )
+        self.val_score = evaluator(val_data, self._oof_predictions) * evaluator.coefficient
 
     def _check_predict_inputs(
         self,
@@ -273,37 +324,34 @@ class AbstractTimeSeriesModel(AbstractModel):
         """
         raise NotImplementedError
 
-    def predict_for_scoring(self, data: TimeSeriesDataFrame, **kwargs):
-        """Given a dataset, truncate the last `self.prediction_length` time steps and forecast these
-        steps with previous history. This method produces predictions for the *last* `self.prediction_length`
-        steps of the *given* time series, in order to be used for validation or scoring.
+    def slice_data_for_scoring(
+        self, data: TimeSeriesDataFrame
+    ) -> Tuple[TimeSeriesDataFrame, Optional[TimeSeriesDataFrame]]:
+        """Truncate the last `self.prediction_length` time steps of each time series.
+        When the output of this method is fed to `predict`, the model will generate predictions for the last
+        `prediction_length` time steps of each time series. These predictions can then be used to evaluate the model.
 
         Parameters
         ----------
-        data: TimeSeriesDataFrame
-            The dataset where each time series is the "context" for predictions.
-
-        Other Parameters
-        ----------------
-        quantile_levels
-            Quantiles of probabilistic forecasts, if probabilistic forecasts are implemented by the
-            corresponding subclass. If None, `self.quantile_levels` will be used instead,
-            if provided during initialization.
+        data : TimeSeriesDataFrame
+            The dataset used for evaluating the model.
 
         Returns
         -------
-        predictions: TimeSeriesDataFrame
-            pandas data frames with a timestamp index, where each input item from the input
-            data is given as a separate forecast item in the dictionary, keyed by the `item_id`s
-            of input items.
+        past_data : TimeSeriesDataFrame
+            Dataset consisting of truncated time series. This is used as "context" for the generating the predictions.
+        known_covariates : TimeSeriesDataFrame or None
+            Values of the known covariates during the forecast horizon, if `known_covariates` are present in the models
+            metadata. If `known_covariates` are absent, this value is equal to `None`.
         """
+
         past_data = data.slice_by_timestep(None, -self.prediction_length)
         if len(self.metadata.known_covariates_real) > 0:
             future_data = data.slice_by_timestep(-self.prediction_length, None)
             known_covariates = future_data[self.metadata.known_covariates_real]
         else:
             known_covariates = None
-        return self.predict(past_data, known_covariates=known_covariates, **kwargs)
+        return past_data, known_covariates
 
     def score(self, data: TimeSeriesDataFrame, metric: str = None, **kwargs) -> float:
         """Return the evaluation scores for given metric and dataset. The last
@@ -338,7 +386,8 @@ class AbstractTimeSeriesModel(AbstractModel):
             prediction_length=self.prediction_length,
             target_column=self.target,
         )
-        predictions = self.predict_for_scoring(data)
+        past_data, known_covariates = self.slice_data_for_scoring(data)
+        predictions = self.predict(past_data, known_covariates=known_covariates)
         metric_value = evaluator(data, predictions)
 
         return metric_value * evaluator.coefficient

--- a/timeseries/src/autogluon/timeseries/models/abstract/model_trial.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/model_trial.py
@@ -18,6 +18,7 @@ def model_trial(
     val_path,
     time_start,
     hpo_executor,
+    is_bagged_model=False,
     reporter=None,  # reporter only used by custom strategy, hence optional
     time_limit=None,
     fit_kwargs=None,
@@ -26,7 +27,9 @@ def model_trial(
     `core.models.abstract.model_trial.model_trial` for timeseries models.
     """
     try:
-        model = init_model(args, model_cls, init_params, backend=hpo_executor.executor_type)
+        model = init_model(
+            args, model_cls, init_params, backend=hpo_executor.executor_type, is_bagged_model=is_bagged_model
+        )
         model.set_contexts(path_context=model.path_root + model.name + os.path.sep)
 
         train_data = load_pkl.load(train_path)

--- a/timeseries/src/autogluon/timeseries/models/abstract/model_trial.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/model_trial.py
@@ -73,14 +73,11 @@ def fit_and_save_model(model, fit_kwargs, train_data, val_data, eval_metric, tim
 
     time_fit_start = time.time()
     model.fit(train_data=train_data, val_data=val_data, time_limit=time_left, **fit_kwargs)
-    time_fit_end = time.time()
-    model.val_score = model.score(val_data, eval_metric)
-    time_pred_end = time.time()
+    model.fit_time = time.time() - time_fit_start
+    model.score_and_cache_oof(val_data)
 
     logger.debug(f"\tHyperparameter tune run: {model.name}")
     logger.debug(f"\t\t{model.val_score:<7.4f}".ljust(15) + f"= Validation score ({eval_metric})")
-    model.fit_time = time_fit_end - time_fit_start
-    model.predict_time = time_pred_end - time_fit_end
     logger.debug(f"\t\t{model.fit_time:<7.3f} s".ljust(15) + "= Training runtime")
     logger.debug(f"\t\t{model.predict_time:<7.3f} s".ljust(15) + "= Training runtime")
     model.save()

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
@@ -86,13 +86,7 @@ class AutoGluonTabularModel(AbstractTimeSeriesModel):
         self._time_features: List[Callable] = None
         self._available_features: pd.Index = None
         self.quantile_adjustments: Dict[str, float] = {}
-
-        self.tabular_predictor = TabularPredictor(
-            path=self.path,
-            label=self.target,
-            problem_type=ag.constants.REGRESSION,
-            eval_metric=self.TIMESERIES_METRIC_TO_TABULAR_METRIC.get(self.eval_metric),
-        )
+        self.tabular_predictor: TabularPredictor = None
 
     def _get_features_dataframe(
         self,
@@ -280,7 +274,7 @@ class AutoGluonTabularModel(AbstractTimeSeriesModel):
     ) -> None:
         self._check_fit_params()
         start_time = time.time()
-        if self.tabular_predictor._learner.is_fit:
+        if self.tabular_predictor is not None:
             raise AssertionError(f"{self.name} predictor has already been fit!")
         verbosity = kwargs.get("verbosity", 2)
         self._target_lag_indices = np.array(get_lags_for_frequency(train_data.freq), dtype=np.int64)
@@ -325,6 +319,14 @@ class AutoGluonTabularModel(AbstractTimeSeriesModel):
         time_elapsed = time.time() - start_time
         autogluon_logger = logging.getLogger("autogluon")
         logging_level = autogluon_logger.level
+
+        self.tabular_predictor = TabularPredictor(
+            path=self.path,
+            label=self.target,
+            problem_type=ag.constants.REGRESSION,
+            eval_metric=self.TIMESERIES_METRIC_TO_TABULAR_METRIC.get(self.eval_metric),
+        )
+
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             self.tabular_predictor.fit(

--- a/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
+++ b/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
@@ -131,3 +131,8 @@ class TimeSeriesGreedyEnsemble(AbstractTimeSeriesEnsembleModel):
         weights = weights / np.sum(weights)
 
         return sum(pred * w for pred, w in zip(model_preds, weights) if pred is not None)
+
+    def get_info(self) -> dict:
+        info = super().get_info()
+        info["model_weights"] = self.model_to_weight
+        return info

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -140,6 +140,7 @@ class AbstractGluonTSPyTorchModel(AbstractGluonTSModel):
             forecast_keys=forecast_keys,
             item_id=str(forecast.item_id),
         )
+
         if isinstance(forecast.start_date, pd.Timestamp):  # GluonTS version is <0.10
             forecast_init_args.update({"freq": forecast.freq})
         return QuantileForecast(**forecast_init_args)

--- a/timeseries/src/autogluon/timeseries/models/multi_window/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/multi_window/__init__.py
@@ -1,0 +1,1 @@
+from .multi_window_model import MultiWindowModel

--- a/timeseries/src/autogluon/timeseries/models/multi_window/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/multi_window/__init__.py
@@ -1,1 +1,1 @@
-from .multi_window_model import MultiWindowModel
+from .multi_window_model import MultiWindowBacktestingModel

--- a/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
+++ b/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
@@ -1,0 +1,93 @@
+import logging
+import copy
+import time
+from typing import Optional
+import numpy as np
+import pandas as pd
+
+from autogluon.timeseries.dataset.ts_dataframe import TimeSeriesDataFrame
+from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
+
+logger = logging.getLogger(__name__)
+
+
+class MultiWindowModel(AbstractTimeSeriesModel):
+    def __init__(self, model_base: AbstractTimeSeriesModel, num_val_windows: int = 1, **kwargs):
+        super().__init__(
+            freq=model_base.freq,
+            name=model_base.name,
+            prediction_length=model_base.prediction_length,
+            path=model_base.path,
+            metadata=model_base.metadata,
+            eval_metric=model_base.eval_metric,
+            eval_metric_seasonal_period=model_base.eval_metric_seasonal_period,
+        )
+        self.model_base = model_base
+        self.num_val_windows = num_val_windows
+        self.most_recent_model: AbstractTimeSeriesModel = None
+        self.info_per_fold = []
+
+    def _fit(
+        self,
+        train_data: TimeSeriesDataFrame,
+        val_data: Optional[TimeSeriesDataFrame] = None,
+        time_limit: Optional[int] = None,
+        **kwargs,
+    ):
+        if val_data is not None:
+            raise ValueError(f"{self.name}.fit() does not ")
+
+        trained_models = []
+        fit_start_time = time.time()
+        for window_idx in range(self.num_val_windows):
+            model_fit_start_time = time.time()
+            train_fold, val_fold = train_data.train_test_split(
+                prediction_length=self.prediction_length,
+                window_idx=window_idx,
+                suffix=f"_fold_{window_idx}",
+            )
+            model = copy.deepcopy(self.model_base)
+            logger.debug(f"\tFitting fold {window_idx + 1}")
+
+            model.fit(
+                train_data=train_fold,
+                val_data=val_fold,
+                time_limit=None if time_limit is None else time_limit - (model_fit_start_time - fit_start_time),
+            )
+            model.fit_time = time.time() - model_fit_start_time
+
+            model.score_and_cache_oof(val_fold)
+            trained_models.append(model)
+            self.info_per_fold.append(
+                {
+                    "window_idx": window_idx,
+                    "fit_time": model.fit_time,
+                    "val_score": model.val_score,
+                    "predict_time": model.predict_time,
+                }
+            )
+
+        self.fit_time = sum(model.fit_time for model in trained_models)
+        self.most_recent_model = trained_models[0]
+        self.predict_time = self.most_recent_model.predict_time
+        self._oof_predictions = pd.concat([model.get_oof_predictions() for model in trained_models])
+        self.val_score = np.mean([model.val_score for model in trained_models])
+
+    def get_info(self) -> dict:
+        info = super().get_info()
+        info["info_per_fold"] = self.info_per_fold
+        return info
+
+    def predict(
+        self,
+        data: TimeSeriesDataFrame,
+        known_covariates: Optional[TimeSeriesDataFrame] = None,
+        **kwargs,
+    ) -> TimeSeriesDataFrame:
+        if self.most_recent_model is None:
+            raise ValueError(f"{self.name} must be fit before predicting")
+        return self.most_recent_model.predict(data, known_covariates, **kwargs)
+
+    def score_and_cache_oof(self, val_data: TimeSeriesDataFrame) -> None:
+        # self.val_score, self.predict_time, self._oof_predictions saved during _fit()
+        pass

--- a/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
+++ b/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
@@ -1,23 +1,37 @@
-import logging
 import copy
+import logging
+import os
 import time
 from typing import Optional
+
 import numpy as np
 import pandas as pd
 
+from autogluon.common.utils.log_utils import set_logger_verbosity
 from autogluon.timeseries.dataset.ts_dataframe import TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 
 logger = logging.getLogger(__name__)
 
 
-class MultiWindowModel(AbstractTimeSeriesModel):
+class MultiWindowBacktestingModel(AbstractTimeSeriesModel):
+    """
+    A meta-model that trains the base model multiple times using different train/validation splits.
+
+    Parameters
+    ----------
+    model_base : AbstractModel
+        The base model to repeatedly train.
+    num_val_windows : int, default = 1
+        Number of windows to use for backtesting, starting from the end of the training data.
+    """
+
     def __init__(self, model_base: AbstractTimeSeriesModel, num_val_windows: int = 1, **kwargs):
         super().__init__(
             freq=model_base.freq,
             name=model_base.name,
             prediction_length=model_base.prediction_length,
-            path=model_base.path,
+            path=model_base.path_root,
             metadata=model_base.metadata,
             eval_metric=model_base.eval_metric,
             eval_metric_seasonal_period=model_base.eval_metric_seasonal_period,
@@ -25,7 +39,7 @@ class MultiWindowModel(AbstractTimeSeriesModel):
         self.model_base = model_base
         self.num_val_windows = num_val_windows
         self.most_recent_model: AbstractTimeSeriesModel = None
-        self.info_per_fold = []
+        self.info_per_val_window = []
 
     def _fit(
         self,
@@ -34,31 +48,42 @@ class MultiWindowModel(AbstractTimeSeriesModel):
         time_limit: Optional[int] = None,
         **kwargs,
     ):
+        # TODO: use incremental training for GluonTS models?
+        # TODO: implement parallel fitting similar to ParallelLocalFoldFittingStrategy in tabular?
+        verbosity = kwargs.get("verbosity", 2)
+        set_logger_verbosity(verbosity, logger=logger)
+
         if val_data is not None:
-            raise ValueError(f"{self.name}.fit() does not ")
+            raise ValueError(f"val_data should not be passed to {self.name}.fit()")
 
         trained_models = []
-        fit_start_time = time.time()
+        global_fit_start_time = time.time()
         for window_idx in range(self.num_val_windows):
-            model_fit_start_time = time.time()
             train_fold, val_fold = train_data.train_test_split(
                 prediction_length=self.prediction_length,
                 window_idx=window_idx,
                 suffix=f"_fold_{window_idx}",
             )
             model = copy.deepcopy(self.model_base)
-            logger.debug(f"\tFitting fold {window_idx + 1}")
+            model.path = self.path + f"W{window_idx + 1}" + os.sep
 
+            logger.debug(f"\tWindow {window_idx + 1}")
+            model_fit_start_time = time.time()
             model.fit(
                 train_data=train_fold,
                 val_data=val_fold,
-                time_limit=None if time_limit is None else time_limit - (model_fit_start_time - fit_start_time),
+                time_limit=None if time_limit is None else time_limit - (model_fit_start_time - global_fit_start_time),
+                **kwargs,
             )
             model.fit_time = time.time() - model_fit_start_time
-
             model.score_and_cache_oof(val_fold)
             trained_models.append(model)
-            self.info_per_fold.append(
+
+            logger.debug(f"\t\t{model.val_score:<7.4f}".ljust(15) + f"= Validation score ({model.eval_metric})")
+            logger.debug(f"\t\t{model.fit_time:<7.3f} s".ljust(15) + "= Training runtime")
+            logger.debug(f"\t\t{model.predict_time:<7.3f} s".ljust(15) + "= Training runtime")
+
+            self.info_per_val_window.append(
                 {
                     "window_idx": window_idx,
                     "fit_time": model.fit_time,
@@ -67,15 +92,16 @@ class MultiWindowModel(AbstractTimeSeriesModel):
                 }
             )
 
-        self.fit_time = sum(model.fit_time for model in trained_models)
+        # Only the model trained on most recent data is saved & used for prediction
         self.most_recent_model = trained_models[0]
         self.predict_time = self.most_recent_model.predict_time
+        self.fit_time = time.time() - global_fit_start_time - self.predict_time
         self._oof_predictions = pd.concat([model.get_oof_predictions() for model in trained_models])
         self.val_score = np.mean([model.val_score for model in trained_models])
 
     def get_info(self) -> dict:
         info = super().get_info()
-        info["info_per_fold"] = self.info_per_fold
+        info["info_per_val_window"] = self.info_per_val_window
         return info
 
     def predict(
@@ -89,5 +115,5 @@ class MultiWindowModel(AbstractTimeSeriesModel):
         return self.most_recent_model.predict(data, known_covariates, **kwargs)
 
     def score_and_cache_oof(self, val_data: TimeSeriesDataFrame) -> None:
-        # self.val_score, self.predict_time, self._oof_predictions saved during _fit()
+        # self.val_score, self.predict_time, self._oof_predictions already saved during _fit()
         pass

--- a/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
+++ b/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
@@ -73,7 +73,7 @@ class MultiWindowBacktestingModel(AbstractTimeSeriesModel):
             train_fold, val_fold = train_data.train_test_split(
                 prediction_length=self.prediction_length,
                 window_idx=window_idx,
-                suffix=f"_F{window_idx}",
+                suffix=f"_W{window_idx + 1}",
             )
 
             logger.debug(f"\tWindow {window_idx + 1}")
@@ -127,7 +127,7 @@ class MultiWindowBacktestingModel(AbstractTimeSeriesModel):
     ) -> TimeSeriesDataFrame:
         if self.most_recent_model is None:
             raise ValueError(f"{self.name} must be fit before predicting")
-        return self.most_recent_model.predict(data, known_covariates, **kwargs)
+        return self.most_recent_model.predict(data, known_covariates=known_covariates, **kwargs)
 
     def score_and_cache_oof(self, val_data: TimeSeriesDataFrame) -> None:
         # self.val_score, self.predict_time, self._oof_predictions already saved during _fit()

--- a/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
+++ b/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
@@ -64,10 +64,9 @@ class MultiWindowBacktestingModel(AbstractTimeSeriesModel):
                 window_idx=window_idx,
                 suffix=f"_fold_{window_idx}",
             )
-            model = copy.deepcopy(self.model_base)
-            model.path = self.path + f"W{window_idx + 1}" + os.sep
 
             logger.debug(f"\tWindow {window_idx + 1}")
+            model = self.get_child_model(window_idx)
             model_fit_start_time = time.time()
             model.fit(
                 train_data=train_fold,
@@ -103,6 +102,11 @@ class MultiWindowBacktestingModel(AbstractTimeSeriesModel):
         info = super().get_info()
         info["info_per_val_window"] = self.info_per_val_window
         return info
+
+    def get_child_model(self, window_idx: int) -> AbstractTimeSeriesModel:
+        model = copy.deepcopy(self.model_base)
+        model.path = self.path + f"W{window_idx + 1}" + os.sep
+        return model
 
     def predict(
         self,

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -266,7 +266,7 @@ def get_preset_models(
             model = model_type(name=f"{name_stem}_{increment}", **model_type_kwargs)
 
         if multi_window:
-            model = MultiWindowBacktestingModel(model_base=model, name=model.name + "_MW", **model_type_kwargs)
+            model = MultiWindowBacktestingModel(model_base=model, name=model.name, **model_type_kwargs)
         all_assigned_names.add(model.name)
         models.append(model)
 

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -20,6 +20,7 @@ from . import (
     ThetaModel,
 )
 from .abstract import AbstractTimeSeriesModel, AbstractTimeSeriesModelFactory
+from .multi_window.multi_window_model import MultiWindowBacktestingModel
 
 logger = logging.getLogger(__name__)
 
@@ -192,6 +193,7 @@ def get_preset_models(
     hyperparameters: Union[str, Dict],
     hyperparameter_tune: bool,
     invalid_model_names: List[str],
+    multi_window: bool = False,
     **kwargs,
 ):
     """
@@ -263,6 +265,8 @@ def get_preset_models(
             increment += 1
             model = model_type(name=f"{name_stem}_{increment}", **model_type_kwargs)
 
+        if multi_window:
+            model = MultiWindowBacktestingModel(model_base=model, name=model.name + "_MW", **model_type_kwargs)
         all_assigned_names.add(model.name)
         models.append(model)
 

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -16,7 +16,6 @@ from autogluon.core.utils.savers import save_pkl
 from autogluon.timeseries.configs import TIMESERIES_PRESETS_CONFIGS
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP, TimeSeriesDataFrame
 from autogluon.timeseries.learner import AbstractLearner, TimeSeriesLearner
-from autogluon.timeseries.splitter import AbstractTimeSeriesSplitter, LastWindowSplitter, MultiWindowSplitter
 from autogluon.timeseries.trainer import AbstractTimeSeriesTrainer
 from autogluon.timeseries.utils.random import set_random_seed
 
@@ -94,14 +93,6 @@ class TimeSeriesPredictor:
         If True, the predictor will ignore the datetime indexes during both training and testing, and will replace
         the data indexes with dummy timestamps in second frequency. In this case, the forecast output time indexes will
         be arbitrary values, and seasonality will be turned off for local models.
-    validation_splitter : Union[str, AbstractTimeSeriesSplitter], default = "last_window"
-        Strategy for splitting ``train_data`` into training and validation parts during
-        :meth:`~autogluon.timeseries.TimeSeriesPredictor.fit`. If ``tuning_data`` is passed to
-        :meth:`~autogluon.timeseries.TimeSeriesPredictor.fit`, validation_splitter is ignored. Possible choices:
-
-        - ``"last_window"``: use last ``prediction_length`` time steps of each time series for validation.
-        - ``"multi_window"``: use last 3 non-overlapping windows of length ``prediction_length`` of each time series for validation.
-        - object of type :class:`~autogluon.timeseries.splitter.AbstractTimeSeriesSplitter` implementing a custom splitting strategy (for advanced users only).
 
     Other Parameters
     ----------------
@@ -131,7 +122,6 @@ class TimeSeriesPredictor:
         verbosity: int = 2,
         quantile_levels: Optional[List[float]] = None,
         ignore_time_index: bool = False,
-        validation_splitter: Union[str, AbstractTimeSeriesSplitter] = "last_window",
         **kwargs,
     ):
         self.verbosity = verbosity
@@ -161,17 +151,10 @@ class TimeSeriesPredictor:
         self.quantile_levels = quantile_levels or kwargs.get(
             "quantiles", [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
         )
-        if validation_splitter == "last_window":
-            splitter = LastWindowSplitter()
-        elif validation_splitter == "multi_window":
-            splitter = MultiWindowSplitter()
-        elif isinstance(validation_splitter, AbstractTimeSeriesSplitter):
-            splitter = validation_splitter
-        else:
-            raise ValueError(
-                f"`validation_splitter` must be one of 'last_window', 'multi_window', or an object of type "
-                f"`autogluon.timeseries.splitter.AbstractTimeSeriesSplitter` "
-                f"(received {validation_splitter} of type {type(validation_splitter)})."
+        if "validation_splitter" in kwargs:
+            warnings.warn(
+                "validation_splitter argument has been deprecated as of v0.8.0. "
+                "Please user the `num_val_windows` argument of `TimeSeriesPredictor.fit` instead."
             )
 
         learner_type = kwargs.pop("learner_type", TimeSeriesLearner)
@@ -186,7 +169,6 @@ class TimeSeriesPredictor:
                 known_covariates_names=self.known_covariates_names,
                 prediction_length=self.prediction_length,
                 quantile_levels=self.quantile_levels,
-                validation_splitter=splitter,
                 ignore_time_index=ignore_time_index,
             )
         )
@@ -196,10 +178,6 @@ class TimeSeriesPredictor:
     @property
     def _trainer(self) -> AbstractTimeSeriesTrainer:
         return self._learner.load_trainer()  # noqa
-
-    @property
-    def validation_splitter(self) -> AbstractTimeSeriesSplitter:
-        return self._learner.validation_splitter
 
     def _check_and_prepare_data_frame(self, df: Union[TimeSeriesDataFrame, pd.DataFrame]) -> TimeSeriesDataFrame:
         """Ensure that TimeSeriesDataFrame has a frequency, or replace its time index with a dummy if
@@ -229,6 +207,7 @@ class TimeSeriesPredictor:
                 "This will lead to TimeSeriesPredictor not working as intended. "
                 "Please make sure that the timestamps are sorted in increasing order for all time series."
             )
+        # TODO: Make sure that entries for each item_id are contiguous -> https://github.com/autogluon/autogluon/issues/3036
         if df.freq is None:
             raise ValueError(
                 "Frequency not provided and cannot be inferred. This is often due to the "
@@ -252,11 +231,49 @@ class TimeSeriesPredictor:
                 "Please make sure that the provided data contains no NaNs."
             )
         if (df.num_timesteps_per_item() <= 2).any():
-            warnings.warn(
-                "Detected time series with length <= 2 in data. "
-                "Please remove them from the dataset or TimeSeriesPredictor likely won't work as intended."
-            )
+            raise ValueError("Detected time series with length <= 2 in data. Please remove them from the dataset.")
         return df
+
+    def _validate_num_val_windows(
+        self,
+        train_data: TimeSeriesDataFrame,
+        tuning_data: Optional[TimeSeriesDataFrame],
+        num_val_windows: int,
+    ) -> int:
+        """Check if given num_val_windows is suitable for given data and validate length of training time series.
+
+        Returns
+        -------
+        num_val_windows : int
+            Number of cross validation windows adjusted based on the length of training time series.
+        """
+        shortest_ts_length = train_data.num_timesteps_per_item().min()
+        if tuning_data is None:
+            recommended_ts_length = 2 * self.prediction_length + 1
+            recommended_ts_length_str = "2 * prediction_length + 1"
+        else:
+            recommended_ts_length = self.prediction_length + 1
+            recommended_ts_length_str = "prediction_length + 1"
+
+        if shortest_ts_length < recommended_ts_length:
+            logger.warning(
+                f"\nIt is recommended that all time series in train_data have length >= {recommended_ts_length_str} "
+                f"(at least {recommended_ts_length}). "
+                "Otherwise the predictor may not work as expected. "
+                "\nPlease reduce prediction_length or provide longer time series as train_data. "
+            )
+
+        max_possible_num_val_windows = int((shortest_ts_length - 1) / self.prediction_length)
+        if num_val_windows > max_possible_num_val_windows:
+            logger.warning(
+                f"\nTime series in train_data are too short for the given num_val_windows = {num_val_windows}. "
+                f"Setting num_val_windows = {max_possible_num_val_windows}"
+            )
+            num_val_windows = max_possible_num_val_windows
+        if num_val_windows == 0 and tuning_data is None:
+            raise ValueError("Training is impossible since all time series in the dataset are too short")
+
+        return num_val_windows
 
     @apply_presets(TIMESERIES_PRESETS_CONFIGS)
     def fit(
@@ -267,9 +284,9 @@ class TimeSeriesPredictor:
         presets: Optional[str] = None,
         hyperparameters: Dict[Union[str, Type], Any] = None,
         hyperparameter_tune_kwargs: Optional[Union[str, Dict]] = None,
+        num_val_windows: int = 1,
         enable_ensemble: bool = True,
         random_seed: Optional[int] = None,
-        num_val_windows: int = 1,
         **kwargs,
     ) -> "TimeSeriesPredictor":
         """Fit probabilistic forecasting models to the given time series dataset.
@@ -304,13 +321,11 @@ class TimeSeriesPredictor:
             used to compute the validation scores. Note that only the last ``prediction_length`` time steps of each
             time series are used for computing the validation score.
 
+            If ``tuning_data`` is provided, multi-window backtesting on training data will be disabled and the
+            ``num_val_windows`` argument will be ignored.
+
             Leaving this argument empty and letting AutoGluon automatically generate the validation set from
             ``train_data`` is a good default.
-
-            If not provided, AutoGluon will split :attr:`train_data` into training and tuning subsets using
-            ``validation_splitter``. If ``tuning_data`` is provided, ``validation_splitter`` will be ignored.
-            See the description of ``validation_splitter`` in the docstring for
-            :class:`~autogluon.timeseries.TimeSeriesPredictor` for more details.
 
             If ``known_covariates_names`` were specified when creating the predictor, ``tuning_data`` must also include
             the columns listed in ``known_covariates_names`` with the covariates values aligned with the target time
@@ -422,6 +437,9 @@ class TimeSeriesPredictor:
                     }
                 )
 
+        num_val_windows : int, default = 1
+            Number of backtests done on ``train_data`` for each trained model to estimate the validation performance.
+            When ``num_val_windows = k``, training time is increased roughly by a factor of ``k``.
         enable_ensemble : bool, default = True
             If True, the ``TimeSeriesPredictor`` will fit a simple weighted ensemble on top of the models specified via
             ``hyperparameters``.
@@ -463,7 +481,8 @@ class TimeSeriesPredictor:
         logger.info(f"{pprint.pformat(fit_args)}")
         logger.info(
             f"Provided training data set with {len(train_data)} rows, {train_data.num_items} items (item = single time series). "
-            f"Average time series length is {len(train_data) / train_data.num_items:.1f}."
+            f"Average time series length is {len(train_data) / train_data.num_items:.1f}. "
+            f"Data frequency is '{train_data.freq}'"
         )
         if tuning_data is not None:
             logger.info(
@@ -473,21 +492,7 @@ class TimeSeriesPredictor:
             )
             num_val_windows = 0
 
-        max_num_train_test_splits = train_data.max_num_train_test_splits(self.prediction_length)
-        if num_val_windows > max_num_train_test_splits:
-            if max_num_train_test_splits == 0:
-                raise ValueError(
-                    "All time series in train_data should have length at least > 2 * prediction_length "
-                    f"(at least {2 * self.prediction_length + 1}). "
-                    "Please reduce prediction_length or provide longer time series as train_data."
-                )
-            else:
-                logger.info(
-                    f"\nTime series in train_data are too short for the given num_val_windows = {num_val_windows}. "
-                    f"Setting num_val_windows = {max_num_train_test_splits}"
-                )
-                num_val_windows = max_num_train_test_splits
-
+        num_val_windows = self._validate_num_val_windows(train_data, tuning_data, num_val_windows)
         logger.info("=====================================================")
 
         if random_seed is not None:

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -271,7 +271,7 @@ class TimeSeriesPredictor:
             )
             num_val_windows = max_possible_num_val_windows
         if num_val_windows == 0 and tuning_data is None:
-            raise ValueError("Training is impossible since all time series in the dataset are too short")
+            raise ValueError("Training is impossible because num_val_windows = 0 and no tuning_data is provided")
 
         return num_val_windows
 

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -482,7 +482,7 @@ class TimeSeriesPredictor:
         logger.info(
             f"Provided training data set with {len(train_data)} rows, {train_data.num_items} items (item = single time series). "
             f"Average time series length is {len(train_data) / train_data.num_items:.1f}. "
-            f"Data frequency is '{train_data.freq}'"
+            f"Data frequency is '{train_data.freq}'."
         )
         if tuning_data is not None:
             logger.info(

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -680,7 +680,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         """Stack validation data for all windows into a single dataframe"""
         return pd.concat(
             [
-                train_data.train_test_split(self.prediction_length, window_idx, suffix=f"_F{window_idx}")[1]
+                train_data.train_test_split(self.prediction_length, window_idx, suffix=f"_W{window_idx + 1}")[1]
                 for window_idx in range(self.num_val_windows)
             ]
         )

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -19,7 +19,7 @@ from autogluon.core.utils.savers import save_json, save_pkl
 from autogluon.timeseries import TimeSeriesDataFrame, TimeSeriesEvaluator
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 from autogluon.timeseries.models.ensemble import AbstractTimeSeriesEnsembleModel, TimeSeriesGreedyEnsemble
-from autogluon.timeseries.models.multi_window.multi_window_model import MultiWindowModel
+from autogluon.timeseries.models.multi_window.multi_window_model import MultiWindowBacktestingModel
 from autogluon.timeseries.models.presets import contains_searchspace
 from autogluon.timeseries.utils.features import CovariateMetadata
 from autogluon.timeseries.utils.warning_filters import disable_tqdm
@@ -583,7 +583,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
                 assert (
                     val_data is None
                 ), "val_data should not be passed to {self.__class__.__name__}._train_multi if num_val_windows >= 1"
-                model = MultiWindowModel(model_base=model, num_val_windows=num_val_windows)
+                model = MultiWindowBacktestingModel(model_base=model, num_val_windows=num_val_windows)
 
             if hyperparameter_tune_kwargs is not None:
                 time_left = time_limit_model_split

--- a/timeseries/src/autogluon/timeseries/trainer/auto_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/auto_trainer.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 class AutoTimeSeriesTrainer(AbstractTimeSeriesTrainer):
-    def construct_model_templates(self, hyperparameters, multi_window: bool, **kwargs):
+    def construct_model_templates(self, hyperparameters, multi_window: bool = False, **kwargs):
         path = kwargs.pop("path", self.path)
         eval_metric = kwargs.pop("eval_metric", self.eval_metric)
         eval_metric_seasonal_period = kwargs.pop("eval_metric", self.eval_metric_seasonal_period)

--- a/timeseries/src/autogluon/timeseries/trainer/auto_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/auto_trainer.py
@@ -35,6 +35,7 @@ class AutoTimeSeriesTrainer(AbstractTimeSeriesTrainer):
         val_data: Optional[TimeSeriesDataFrame] = None,
         hyperparameter_tune_kwargs: Optional[Union[str, Dict]] = None,
         time_limit: float = None,
+        num_val_windows: int = 1,
     ):
         """
         Fit a set of timeseries models specified by the `hyperparameters`
@@ -61,4 +62,5 @@ class AutoTimeSeriesTrainer(AbstractTimeSeriesTrainer):
             hyperparameters=hyperparameters,
             hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
             time_limit=time_limit,
+            num_val_windows=num_val_windows,
         )

--- a/timeseries/src/autogluon/timeseries/trainer/auto_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/auto_trainer.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 class AutoTimeSeriesTrainer(AbstractTimeSeriesTrainer):
-    def construct_model_templates(self, hyperparameters, **kwargs):
+    def construct_model_templates(self, hyperparameters, multi_window: bool, **kwargs):
         path = kwargs.pop("path", self.path)
         eval_metric = kwargs.pop("eval_metric", self.eval_metric)
         eval_metric_seasonal_period = kwargs.pop("eval_metric", self.eval_metric_seasonal_period)
@@ -26,6 +26,7 @@ class AutoTimeSeriesTrainer(AbstractTimeSeriesTrainer):
             invalid_model_names=self._get_banned_model_names(),
             target=self.target,
             metadata=self.metadata,
+            multi_window=multi_window,
         )
 
     def fit(
@@ -35,7 +36,6 @@ class AutoTimeSeriesTrainer(AbstractTimeSeriesTrainer):
         val_data: Optional[TimeSeriesDataFrame] = None,
         hyperparameter_tune_kwargs: Optional[Union[str, Dict]] = None,
         time_limit: float = None,
-        num_val_windows: int = 1,
     ):
         """
         Fit a set of timeseries models specified by the `hyperparameters`
@@ -62,5 +62,4 @@ class AutoTimeSeriesTrainer(AbstractTimeSeriesTrainer):
             hyperparameters=hyperparameters,
             hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
             time_limit=time_limit,
-            num_val_windows=num_val_windows,
         )

--- a/timeseries/tests/smoketests/test_features_and_covariates.py
+++ b/timeseries/tests/smoketests/test_features_and_covariates.py
@@ -58,14 +58,12 @@ def generate_train_and_test_data(
 @pytest.mark.parametrize("use_static_features_continuous", [True, False])
 @pytest.mark.parametrize("use_static_features_categorical", [True, False])
 @pytest.mark.parametrize("ignore_time_index", [True, False])
-@pytest.mark.parametrize("validation_splitter", ["last_window", "multi_window"])
 def test_predictor_smoke_test(
     use_known_covariates,
     use_past_covariates,
     use_static_features_continuous,
     use_static_features_categorical,
     ignore_time_index,
-    validation_splitter,
 ):
     prediction_length = 5
     hyperparameters = {
@@ -95,7 +93,6 @@ def test_predictor_smoke_test(
         prediction_length=prediction_length,
         known_covariates_names=known_covariates_names if len(known_covariates_names) > 0 else None,
         ignore_time_index=ignore_time_index,
-        validation_splitter=validation_splitter,
     )
     predictor.fit(
         train_data,

--- a/timeseries/tests/unittests/models/gluonts/test_gluonts.py
+++ b/timeseries/tests/unittests/models/gluonts/test_gluonts.py
@@ -232,4 +232,4 @@ def test_when_static_and_dynamic_covariates_present_then_model_trains_normally(m
 
     model = model_class(hyperparameters=DUMMY_HYPERPARAMETERS, metadata=gen.covariate_metadata)
     model.fit(train_data=df)
-    model.predict_for_scoring(df)
+    model.score(df)

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -72,13 +72,15 @@ def test_when_fit_called_then_models_train_and_all_scores_can_be_computed(
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
 @pytest.mark.parametrize("prediction_length", [1, 5])
-def test_when_predict_for_scoring_called_then_model_receives_truncated_data(
-    model_class, prediction_length, trained_models
-):
+def test_when_score_called_then_model_receives_truncated_data(model_class, prediction_length, trained_models):
     model = trained_models[(prediction_length, repr(model_class))]
 
     with mock.patch.object(model, "predict") as patch_method:
-        _ = model.predict_for_scoring(DUMMY_TS_DATAFRAME)
+        # Mock breaks the internals of the `score` method
+        try:
+            _ = model.score(DUMMY_TS_DATAFRAME)
+        except AttributeError:
+            pass
 
         (call_df,) = patch_method.call_args[0]
 

--- a/timeseries/tests/unittests/test_evaluator.py
+++ b/timeseries/tests/unittests/test_evaluator.py
@@ -22,8 +22,9 @@ def deepar_trained() -> AbstractGluonTSModel:
     pred = TimeSeriesPredictor(prediction_length=2, verbosity=4)
     pred.fit(
         DUMMY_TS_DATAFRAME,
+        tuning_data=DUMMY_TS_DATAFRAME,
         hyperparameters={
-            "DeepAR": dict(epochs=2),
+            "DeepAR": dict(epochs=1),
         },
     )
     return pred._trainer.load_model("DeepAR")
@@ -37,8 +38,9 @@ def deepar_trained_zero_data() -> AbstractGluonTSModel:
 
     pred.fit(
         data,
+        tuning_data=data,
         hyperparameters={
-            "DeepAR": dict(epochs=2),
+            "DeepAR": dict(epochs=1),
         },
     )
     return pred._trainer.load_model("DeepAR")

--- a/timeseries/tests/unittests/test_learner.py
+++ b/timeseries/tests/unittests/test_learner.py
@@ -38,7 +38,6 @@ def trained_learners():
         learner.fit(
             train_data=DUMMY_TS_DATAFRAME,
             hyperparameters=hp,
-            val_data=DUMMY_TS_DATAFRAME,
         )
         learners[repr(hp)] = learner
         model_paths.append(temp_model_path)
@@ -108,7 +107,6 @@ def test_given_hyperparameters_with_spaces_when_learner_called_then_hpo_is_perfo
         learner.fit(
             train_data=DUMMY_TS_DATAFRAME,
             hyperparameters=hyperparameters,
-            val_data=DUMMY_TS_DATAFRAME,
             hyperparameter_tune_kwargs={
                 "searcher": "random",
                 "scheduler": "local",
@@ -147,7 +145,6 @@ def test_given_hyperparameters_and_custom_models_when_learner_called_then_leader
     learner.fit(
         train_data=DUMMY_TS_DATAFRAME,
         hyperparameters=hyperparameters,
-        val_data=DUMMY_TS_DATAFRAME,
     )
     leaderboard = learner.leaderboard()
 
@@ -169,7 +166,6 @@ def test_given_hyperparameters_when_learner_called_and_loaded_back_then_all_mode
     learner.fit(
         train_data=DUMMY_TS_DATAFRAME,
         hyperparameters=hyperparameters,
-        val_data=DUMMY_TS_DATAFRAME,
     )
     learner.save()
     del learner
@@ -194,7 +190,7 @@ def test_when_static_features_in_tuning_data_are_missing_then_exception_is_raise
     val_data = get_data_frame_with_variable_lengths({"B": 25, "A": 20}, static_features=None)
     learner = TimeSeriesLearner(path_context=temp_model_path)
     with pytest.raises(ValueError, match="Provided tuning_data must contain static_features"):
-        learner.fit(train_data=train_data, val_data=val_data)
+        learner.fit(train_data=train_data, val_data=val_data, num_val_windows=0)
 
 
 def test_when_static_features_columns_in_tuning_data_are_missing_then_exception_is_raised(temp_model_path):
@@ -206,7 +202,7 @@ def test_when_static_features_columns_in_tuning_data_are_missing_then_exception_
     )
     learner = TimeSeriesLearner(path_context=temp_model_path)
     with pytest.raises(KeyError, match="required columns are missing from the provided"):
-        learner.fit(train_data=train_data, val_data=val_data)
+        learner.fit(train_data=train_data, val_data=val_data, num_val_windows=0)
 
 
 def test_when_train_data_has_no_static_features_but_val_data_has_static_features_then_val_data_features_get_removed(

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -386,17 +386,6 @@ def test_when_predictor_called_and_loaded_back_then_ignore_time_index_persists(t
     assert loaded_predictor.ignore_time_index == ignore_time_index
 
 
-@pytest.mark.parametrize(
-    "splitter_string, expected_splitter_class",
-    [("last_window", LastWindowSplitter), ("multi_window", MultiWindowSplitter)],
-)
-def test_when_passing_magic_string_as_validation_splitter_then_correct_splitter_object_is_created(
-    splitter_string, expected_splitter_class
-):
-    predictor = TimeSeriesPredictor(validation_splitter=splitter_string)
-    assert isinstance(predictor.validation_splitter, expected_splitter_class)
-
-
 def test_given_enable_ensemble_true_when_predictor_called_then_ensemble_is_fitted(temp_model_path):
     predictor = TimeSeriesPredictor(
         path=temp_model_path,

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -17,10 +17,10 @@ from autogluon.timeseries.trainer.auto_trainer import AutoTimeSeriesTrainer
 
 from .common import DATAFRAME_WITH_COVARIATES, DUMMY_TS_DATAFRAME, get_data_frame_with_item_index
 
-DUMMY_TRAINER_HYPERPARAMETERS = {"SimpleFeedForward": {"epochs": 1}}
+DUMMY_TRAINER_HYPERPARAMETERS = {"SimpleFeedForward": {"epochs": 1, "num_batches_per_epoch": 1}}
 TEST_HYPERPARAMETER_SETTINGS = [
-    {"SimpleFeedForward": {"epochs": 1}},
-    {"DeepAR": {"epochs": 1}, "ETS": {}},
+    {"SimpleFeedForward": {"epochs": 1, "num_batches_per_epoch": 1}},
+    {"DeepAR": {"epochs": 1, "num_batches_per_epoch": 1}, "Naive": {}},
 ]
 TEST_HYPERPARAMETER_SETTINGS_EXPECTED_LB_LENGTHS = [1, 2]
 
@@ -38,7 +38,6 @@ def trained_trainers():
         )
         trainer.fit(
             train_data=DUMMY_TS_DATAFRAME,
-            val_data=DUMMY_TS_DATAFRAME,
             hyperparameters=hp,
         )
         trainers[repr(hp)] = trainer
@@ -73,7 +72,6 @@ def test_given_hyperparameters_when_trainer_called_then_leaderboard_is_correct(
     trainer.fit(
         train_data=DUMMY_TS_DATAFRAME,
         hyperparameters=hyperparameters,
-        val_data=DUMMY_TS_DATAFRAME,
     )
     leaderboard = trainer.leaderboard()
 
@@ -159,7 +157,6 @@ def test_given_hyperparameters_when_trainer_fit_then_freq_set_correctly(temp_mod
     trainer.fit(
         train_data=DUMMY_TS_DATAFRAME,
         hyperparameters=hyperparameters,
-        val_data=DUMMY_TS_DATAFRAME,
     )
 
     for model_name in trainer.get_model_names():
@@ -178,7 +175,6 @@ def test_given_hyperparameters_with_spaces_when_trainer_called_then_hpo_is_perfo
         trainer.fit(
             train_data=DUMMY_TS_DATAFRAME,
             hyperparameters=hyperparameters,
-            val_data=DUMMY_TS_DATAFRAME,
             hyperparameter_tune_kwargs={
                 "num_trials": 2,
                 "searcher": "random",
@@ -216,7 +212,6 @@ def test_given_hyperparameters_and_custom_models_when_trainer_called_then_leader
     trainer.fit(
         train_data=DUMMY_TS_DATAFRAME,
         hyperparameters=hyperparameters,
-        val_data=DUMMY_TS_DATAFRAME,
     )
     leaderboard = trainer.leaderboard()
 
@@ -269,7 +264,6 @@ def test_given_repeating_model_when_trainer_called_incrementally_then_name_colli
         trainer.fit(
             train_data=DUMMY_TS_DATAFRAME,
             hyperparameters=hp,
-            val_data=DUMMY_TS_DATAFRAME,
         )
 
     model_names = trainer.get_model_names()
@@ -298,7 +292,6 @@ def test_when_trainer_fit_and_deleted_models_load_back_correctly_and_can_predict
     trainer.fit(
         train_data=DUMMY_TS_DATAFRAME,
         hyperparameters=hyperparameters,
-        val_data=DUMMY_TS_DATAFRAME,
     )
     model_names = copy.copy(trainer.get_model_names())
     trainer.save()


### PR DESCRIPTION
PR split into two parts - wait for #3062 to be merged first.

-----

Current implementation of multi-window backtesting in AG-TS 1/ provides an overly pessimistic estimate of the model performance and 2/ results in models not being trained on the most recent data.

This PR changes the multi-window backtesting logic & addresses this problem.

<details><summary>Description of the proposed approach</summary> 

Assume the dataset contains a single time series:
```
[x x x x x x x x x x x x x x]
```
**Current approach:**  train single model & evaluate on multiple windows
```
[x x x x x x x x] - train data

[x x x x x x x x x x x ? ? ?]  - val_data (last 3 values used for eval)
[x x x x x x x x ? ? ?]
```

**Proposed approach**: train a separate model for each window

Model 1
```
[x x x x x x x x x x x] - train data
[x x x x x x x x x x x ? ? ?]  - val data
```
Model 2
```
[x x x x x x x x] - train data
[x x x x x x x x ? ? ?]  - val data
```
</details>

*Description of changes:*
- Introduce parameter `num_val_windows: int = 1` to `TimeSeriesPredictor.fit` that controls how many windows are used for multi-window backtesting.
- Introduce a meta-model `MultiWindowBacktestingModel` that trains multiple copies of a base model under the hood and uses different windows to evaluate the performance.
- Ensure that `predict` is only called once for all models during fitting.
    - Cache OOF predictions for all model as `model._oof_predictions`
    - Use cached predictions when fitting ensemble

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
