### PR TITLE
Support sample_weight in RMSE

### DIFF
--- a/core/src/autogluon/core/metrics/__init__.py
+++ b/core/src/autogluon/core/metrics/__init__.py
@@ -454,8 +454,11 @@ pearsonr = make_scorer('pearsonr',
                        greater_is_better=True)
 
 
-def rmse_func(y_true, y_pred):
-    return np.sqrt(((y_true - y_pred) ** 2).mean())
+def rmse_func(y_true, y_pred, **kwargs):
+    if kwargs:
+        return sklearn.metrics.mean_squared_error(y_true, y_pred, squared=False, **kwargs)
+    else:
+        return np.sqrt(((y_true - y_pred) ** 2).mean())
 
 
 root_mean_squared_error = make_scorer('root_mean_squared_error',

--- a/core/tests/unittests/metrics/test_metrics.py
+++ b/core/tests/unittests/metrics/test_metrics.py
@@ -2,6 +2,7 @@ from math import isclose
 
 import numpy as np
 import pytest
+import sklearn
 
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION, QUANTILE
 from autogluon.core.metrics import METRICS, Scorer, rmse_func

--- a/core/tests/unittests/metrics/test_metrics.py
+++ b/core/tests/unittests/metrics/test_metrics.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION, QUANTILE
-from autogluon.core.metrics import METRICS, Scorer
+from autogluon.core.metrics import METRICS, Scorer, rmse_func
 
 
 BINARY_METRICS = list(METRICS[BINARY].keys())
@@ -175,3 +175,23 @@ def _assert_imperfect_score(scorer: Scorer, abs_tol=1e-5):
     assert score < scorer.optimum
     assert not isclose(error, 0, abs_tol=abs_tol)
     assert not isclose(score, scorer.optimum, abs_tol=abs_tol)
+
+
+@pytest.mark.parametrize("sample_weight",
+                        [None,
+                        np.array([0.1, 0.1, 0.1, 0.1, 0.1, 0.2, 0.3])])
+def test_rmse_with_sklearn(sample_weight):
+    """
+    Ensure 
+    (1) Without sample_weight, AutoGluon's custom rmse produces the same result as sklearn's rmse
+    (2) With sample_weight, computed wrmse is as expected
+    """
+    y_true = np.array([0, 0, 1, 1, 1, 1, 0])
+    y_pred = np.array([0.13, 0.09, 0.78, 0.43, 0.8, 0.91, 0.32])
+    expected_rmse = sklearn.metrics.mean_squared_error(y_true, y_pred, squared=False, sample_weight=sample_weight)
+
+    kwargs = {"y_true": y_true, "y_pred": y_pred}
+    if sample_weight is not None: kwargs["sample_weight"] = sample_weight
+    computed_rmse = rmse_func(**kwargs)
+
+    assert np.isclose(computed_rmse, expected_rmse)


### PR DESCRIPTION

*Description of changes:*
- Supporting weighted RMSE for evaluation metric - if user specifies kwargs, it will use scikit learn's RMSE function, or else it will use the existing accelerated RMSE computation
- [tested] test-run with the example dataset

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
