### PR TITLE
[eda][api][docs] Introduced dot notation for properties to simplify components customization UX

### DIFF
--- a/docs/tutorials/eda/components/autogluon.eda.explain.md
+++ b/docs/tutorials/eda/components/autogluon.eda.explain.md
@@ -1,0 +1,62 @@
+```{eval-rst}
+.. role:: hidden
+    :class: hidden-section
+```
+
+# Components: explain
+
+## autogluon.eda.visualization.explain
+
+```{eval-rst}
+.. automodule:: autogluon.eda.visualization.explain
+```
+
+```{eval-rst}
+.. currentmodule:: autogluon.eda.visualization.explain
+```
+
+```{eval-rst}
+.. autosummary::
+    :nosignatures:
+
+    ExplainForcePlot
+    ExplainWaterfallPlot
+```
+
+### {hidden}`ExplainForcePlot`
+
+```{eval-rst}
+.. autoclass:: ExplainForcePlot
+   :members: init
+```
+
+### {hidden}`ExplainWaterfallPlot`
+
+```{eval-rst}
+.. autoclass:: ExplainWaterfallPlot
+   :members: init
+```
+
+## autogluon.eda.analysis.explain
+
+```{eval-rst}
+.. automodule:: autogluon.eda.analysis.explain
+```
+
+```{eval-rst}
+.. currentmodule:: autogluon.eda.analysis.explain
+```
+
+```{eval-rst}
+.. autosummary::
+    :nosignatures:
+
+    ShapAnalysis
+```
+
+### {hidden}`ShapAnalysis`
+
+```{eval-rst}
+.. autoclass:: ShapAnalysis
+   :members: init
+```

--- a/docs/tutorials/eda/components/index.md
+++ b/docs/tutorials/eda/components/index.md
@@ -59,4 +59,5 @@ missing <autogluon.eda.missing.md>
 model <autogluon.eda.model.md>
 shift <autogluon.eda.shift.md>
 transform <autogluon.eda.transform.md>
+explain <autogluon.eda.explain.md>
 ```

--- a/docs/tutorials/eda/components/index.md
+++ b/docs/tutorials/eda/components/index.md
@@ -41,6 +41,12 @@ The section contains a reference for low-level components.
    Transformations APIs
 :::
 
+:::{grid-item-card} autogluon.eda.explain
+   :link: autogluon.eda.explain.html
+
+   Explainability APIs
+:::
+
 ::::
 
 ```{toctree}

--- a/docs/tutorials/eda/eda-auto-quick-fit.ipynb
+++ b/docs/tutorials/eda/eda-auto-quick-fit.ipynb
@@ -64,7 +64,6 @@
     "    df_train, \n",
     "    target_col, \n",
     "    return_state=True,\n",
-    "    save_model_to_state=True,\n",
     "    show_feature_importance_barplots=True\n",
     ")"
    ]
@@ -125,8 +124,7 @@
     "## Regression Example\n",
     "\n",
     "In the previous section we tried a classification example. Let's try a regression. It has a few differences.\n",
-    "We are also going to store the fitted model by specifying `return_state` and `save_model_to_state` parameters.\n",
-    "This will allow us to use the model to predict test values later.\n",
+    "We are also going to return the state to retrieve the fitted model and use it to predict test values later.\n",
     "\n",
     "It is a large dataset, so we'll keep only a few columns for this tutorial."
    ]
@@ -151,7 +149,7 @@
     "df_test = df_test[[c for c in df_test.columns if c in keep_cols]][:500]\n",
     "\n",
     "\n",
-    "state = auto.quick_fit(df_train, target_col, return_state=True, save_model_to_state=True)"
+    "state = auto.quick_fit(df_train, target_col, return_state=True)"
    ]
   },
   {

--- a/eda/src/autogluon/eda/analysis/explain.py
+++ b/eda/src/autogluon/eda/analysis/explain.py
@@ -124,7 +124,7 @@ class ShapAnalysis(AbstractAnalysis):
                     row=_row,
                     expected_value=explainer.expected_value,
                     shap_values=ke_shap_values[0],
-                    features=row[args.train_data.columns],
+                    features=row[args.model.original_features],
                     feature_names=None,
                 )
             )

--- a/eda/src/autogluon/eda/analysis/model.py
+++ b/eda/src/autogluon/eda/analysis/model.py
@@ -35,7 +35,6 @@ class AutoGluonModelQuickFit(AbstractAnalysis):
     >>> state = auto.quick_fit(
     >>>     train_data=..., label=...,
     >>>     return_state=True,  # return state object from call
-    >>>     save_model_to_state=True,  # store fitted model into the state
     >>>     hyperparameters={'GBM': {}}  # train specific model
     >>> )
     >>>
@@ -50,7 +49,7 @@ class AutoGluonModelQuickFit(AbstractAnalysis):
         auto means it will be Auto-detected using AutoGluon methods.
     estimator_args: Optional[Dict[str, Any]], default = None,
         kwargs to pass into estimator constructor (`TabularPredictor`)
-    save_model_to_state: bool, default = False,
+    save_model_to_state: bool, default = True,
         save fitted model into `state` under `model` key.
         This functionality might be helpful in cases when the fitted model could be usable for other purposes (i.e. imputers)
     parent: Optional[AbstractAnalysis], default = None
@@ -73,7 +72,7 @@ class AutoGluonModelQuickFit(AbstractAnalysis):
         estimator_args: Optional[Dict[str, Any]] = None,
         parent: Optional[AbstractAnalysis] = None,
         children: Optional[List[AbstractAnalysis]] = None,
-        save_model_to_state: bool = False,
+        save_model_to_state: bool = True,
         **kwargs,
     ) -> None:
         super().__init__(parent, children, **kwargs)

--- a/eda/src/autogluon/eda/auto/simple.py
+++ b/eda/src/autogluon/eda/auto/simple.py
@@ -288,7 +288,7 @@ def quick_fit(
     Supported `fig_args`/`chart_args` keys:
         - `confusion_matrix.<property>` - confusion matrix chart for classification predictor
         - `regression_eval.<property>` - regression predictor results chart
-        - `feature_importance.<property> - feature importance barplot chart
+        - `feature_importance.<property>` - feature importance barplot chart
 
     Parameters
     ----------

--- a/eda/src/autogluon/eda/auto/simple.py
+++ b/eda/src/autogluon/eda/auto/simple.py
@@ -315,7 +315,7 @@ def quick_fit(
         pass prior state if necessary; the object will be updated during `anlz_facets` `fit` call.
     return_state: bool, default = False
         return state if `True`
-    save_model_to_state: bool, default = False,
+    save_model_to_state: bool, default = True,
         save fitted model into `state` under `model` key.
         This functionality might be helpful in cases when the fitted model could be usable for other purposes (i.e. imputers)
     verbosity: int, default = 0
@@ -349,7 +349,6 @@ def quick_fit(
     >>> state = auto.quick_fit(
     >>>     train_data=..., label=...,
     >>>     return_state=True,  # return state object from call
-    >>>     save_model_to_state=True,  # store fitted model into the state
     >>>     hyperparameters={'GBM': {}}  # train specific model
     >>> )
     >>>

--- a/eda/src/autogluon/eda/visualization/interaction.py
+++ b/eda/src/autogluon/eda/visualization/interaction.py
@@ -95,7 +95,10 @@ class CorrelationVisualization(_AbstractCorrelationChart):
         return "correlations" in state
 
     def _render(self, state: AnalysisState) -> None:
-        args = {"vmin": 0 if state.correlations_method == "phik" else -1, "vmax": 1, "center": 0, "cmap": "Spectral"}
+        args = {
+            **{"vmin": 0 if state.correlations_method == "phik" else -1, "vmax": 1, "center": 0, "cmap": "Spectral"},
+            **self._kwargs,
+        }
         self._render_internal(state, "correlations", "correlation matrix", args)
 
 

--- a/eda/src/autogluon/eda/visualization/shift.py
+++ b/eda/src/autogluon/eda/visualization/shift.py
@@ -39,7 +39,7 @@ class XShiftSummary(AbstractVisualization, JupyterMixin):
         return ret_md
 
     def _render_feature_importance_if_needed(self, state):
-        if "feature_importance" in state:
+        if "feature_importance" in state and state["detection_status"]:
             fi = state["feature_importance"]
             fi = fi[fi.p_value <= state["pvalue_threshold"]]
             if len(fi) > 0:
@@ -52,8 +52,7 @@ class XShiftSummary(AbstractVisualization, JupyterMixin):
         return self.at_least_one_key_must_be_present(state, "xshift_results")
 
     def _render(self, state: AnalysisState) -> None:
-        res_md = self._summary(state.xshift_results)
         header_text = "Detecting distribution shift"
         self.render_header_if_needed(state, header_text)
-        self.render_markdown(res_md)
+        self.render_markdown(self._summary(state.xshift_results))
         self._render_feature_importance_if_needed(state.xshift_results)

--- a/eda/tests/unittests/analysis/test_explain.py
+++ b/eda/tests/unittests/analysis/test_explain.py
@@ -27,7 +27,6 @@ def test_ShapAnalysis(label, expected_task_type, monkeypatch):
             train_data=df_train,
             label=label,
             return_state=True,
-            save_model_to_state=True,
             render_analysis=False,
         )
         assert state.model.problem_type == expected_task_type

--- a/eda/tests/unittests/auto/test_simple.py
+++ b/eda/tests/unittests/auto/test_simple.py
@@ -467,7 +467,7 @@ def test_explain_rows(plot, monkeypatch):
         assert result == "result"
 
         call_analyze.assert_called_with(
-            train_data=train_data,
+            train_data=train_data[model.original_features],
             model=model,
             return_state=True,
             anlz_facets=ANY,

--- a/eda/tests/unittests/test_state.py
+++ b/eda/tests/unittests/test_state.py
@@ -1,4 +1,6 @@
-from autogluon.eda.state import AnalysisState, StateCheckMixin
+import pytest
+
+from autogluon.eda.state import AnalysisState, StateCheckMixin, expand_nested_args_into_nested_maps
 
 
 def test_analysis_state():
@@ -53,3 +55,18 @@ def test_statecheckmixin_all_keys_must_be_present():
     assert StateCheckMixin().all_keys_must_be_present(AnalysisState(q=42, w=43), "w") is True
     assert StateCheckMixin().all_keys_must_be_present(AnalysisState(q=42, w=43), "q", "w") is True
     assert StateCheckMixin().all_keys_must_be_present(AnalysisState(q=42, w=43), "q", "missing") is False
+
+
+def test_expand_nested_args_into_nested_maps():
+    assert expand_nested_args_into_nested_maps({"a": 1, "b.a": 3, "c.a.b": 4}) == {
+        "a": 1,
+        "b": {"a": 3},
+        "c": {"a": {"b": 4}},
+    }
+
+
+def test_expand_nested_args_into_nested_maps__namespaces_overlap():
+    with pytest.raises(ValueError):
+        expand_nested_args_into_nested_maps({"a": 1, "a.b": 2})
+    with pytest.raises(ValueError):
+        expand_nested_args_into_nested_maps({"a.b": 1, "a.b.c": 2})


### PR DESCRIPTION
*Description of changes:*
- added support for dot-notation config to pass `fig_args` and `chart_args`; updated docs to document supported properties
- updated `quick_fit` to save model to state by default
- `covariate_shift` doesn't render categorical variables to highlight shift since they are not helpful
- updated docs to include `explain` modules
- [bugfix] `explain`: fixed columns handling when `rows` have different column order than the originally trained model so that `shap` doesn't complain

### Examples

Dot notation for composite components now is more compact:
```python
auto.target_analysis(
    train_data=df_train, 
    label=target_col,
    fig_args={
        f'chart.{target_col}.figsize': (4,4),
        'chart.Sex.figsize': (4,4),
        'correlation.figsize': (1,1),
    },
    chart_args={
        f'chart.{target_col}.color': 'orange',
        'chart.Sex.color': 'green',
        'correlation.cmap': 'coolwarm',
    },
)
```

![image](https://user-images.githubusercontent.com/10080307/225772636-45fa39cc-a990-4a78-bef0-0e6ad0ee8744.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
