### PR TITLE
[timeseries] Fix incorrect device used inside GluonTS QuantileForecast

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -3,7 +3,6 @@ Module including wrappers for PyTorch implementations of models in GluonTS
 """
 import logging
 import shutil
-import warnings
 from datetime import timedelta
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Type
@@ -14,7 +13,6 @@ import pandas as pd
 import torch
 from gluonts.core.component import from_hyperparameters
 from gluonts.model.forecast import QuantileForecast
-from gluonts.torch.distributions import AffineTransformed
 from gluonts.torch.model.deepar import DeepAREstimator
 from gluonts.torch.model.estimator import PyTorchLightningEstimator as GluonTSPyTorchLightningEstimator
 from gluonts.torch.model.forecast import DistributionForecast

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -130,21 +130,16 @@ class AbstractGluonTSPyTorchModel(AbstractGluonTSModel):
         forecast: DistributionForecast, quantile_levels: List[float]
     ) -> QuantileForecast:
         forecast_arrays = [forecast.mean]
+        forecast_keys = ["mean"]
 
-        quantile_keys = [str(q) for q in quantile_levels]
-        if isinstance(forecast.distribution, AffineTransformed):
-            # FIXME: Fix a bug where distribution parameters aren't moved to CPU
-            affine_transform = forecast.distribution.transforms[-1]
-            affine_transform.scale = affine_transform.scale.cpu()
-            affine_transform.loc = affine_transform.loc.cpu()
+        for q in quantile_levels:
+            forecast_arrays.append(forecast.quantile(q))
+            forecast_keys.append(str(q))
 
-        q_transformed = [forecast.quantile(q) for q in quantile_keys]
-
-        forecast_arrays.extend(q_transformed)
         forecast_init_args = dict(
             forecast_arrays=np.array(forecast_arrays),
             start_date=forecast.start_date,
-            forecast_keys=["mean"] + quantile_keys,
+            forecast_keys=forecast_keys,
             item_id=str(forecast.item_id),
         )
         if isinstance(forecast.start_date, pd.Timestamp):  # GluonTS version is <0.10


### PR DESCRIPTION
*Description of changes:*
- Remove workaround for the incorrect device used inside `QuantileForecast`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
