### PR TITLE
Remove extra indent

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabular_nn/hyperparameters/parameters.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/hyperparameters/parameters.py
@@ -132,7 +132,7 @@ def get_param_multiclass(framework, num_classes):
 
 
 def get_param_regression(framework):
-        return get_param_binary(framework)  # Use same hyperparameters as for binary classification for now.
+    return get_param_binary(framework)  # Use same hyperparameters as for binary classification for now.
 
 
 def get_param_quantile(framework):


### PR DESCRIPTION
Minor update: Adjust indentation for return statement of get_param_regression(), such that it conforms with rest of the code


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
