### PR TITLE
[timeseries] Implement OOF prediction caching

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -2,10 +2,11 @@ import copy
 import logging
 import os
 import time
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import autogluon.core as ag
 from autogluon.common.savers import save_pkl
+from autogluon.common.loaders import load_pkl
 from autogluon.core.hpo.exceptions import EmptySearchSpace
 from autogluon.core.hpo.executors import HpoExecutor
 from autogluon.core.models import AbstractModel
@@ -53,6 +54,8 @@ class AbstractTimeSeriesModel(AbstractModel):
         Hyperparameters that will be used by the model (can be search spaces instead of fixed values).
         If None, model defaults are used. This is identical to passing an empty dictionary.
     """
+
+    _oof_filename = "oof.pkl"
 
     # TODO: refactor "pruned" methods after AbstractModel is refactored
     predict_proba = None
@@ -105,9 +108,38 @@ class AbstractTimeSeriesModel(AbstractModel):
             "quantile_levels",
             kwargs.get("quantiles", [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]),
         )
+        self._oof_predictions: Optional[TimeSeriesDataFrame] = None
 
     def __repr__(self) -> str:
         return self.name
+
+    def save(self, path: str = None, verbose=True) -> str:
+        if self._oof_predictions is not None:
+            save_pkl.save(
+                path=os.path.join(self.path + "utils", self._oof_filename),
+                object=self._oof_predictions,
+                verbose=verbose,
+            )
+        return super().save(path=path, verbose=verbose)
+
+    @classmethod
+    def load(
+        cls, path: str, reset_paths: bool = True, load_oof: bool = False, verbose: bool = True
+    ) -> "AbstractTimeSeriesModel":
+        model = super().load(path=path, reset_paths=reset_paths, verbose=verbose)
+        if load_oof and model._oof_predictions is None:
+            model._oof_predictions = cls.load_oof_predictions(path=path, verbose=verbose)
+        return model
+
+    @classmethod
+    def load_oof_predictions(cls, path: str, verbose: bool = True) -> TimeSeriesDataFrame:
+        """Load the cached OOF predictions from disk."""
+        return load_pkl.load(path=os.path.join(path + "utils", cls._oof_filename), verbose=verbose)
+
+    def get_oof_predictions(self):
+        if self._oof_predictions is None:
+            self._oof_predictions = self.load_oof_predictions(self.path)
+        return self._oof_predictions
 
     def _initialize(self, **kwargs) -> None:
         self._init_params_aux()
@@ -166,7 +198,7 @@ class AbstractTimeSeriesModel(AbstractModel):
         train_data : TimeSeriesDataFrame
             The training data provided in the library's `autogluon.timeseries.dataset.TimeSeriesDataFrame`
             format.
-        val_data : TimeSeriesDataFrame
+        val_data : TimeSeriesDataFrame, optional
             The validation data set in the same format as training data.
         time_limit : float, default = None
             Time limit in seconds to adhere to when fitting model.
@@ -198,18 +230,19 @@ class AbstractTimeSeriesModel(AbstractModel):
 
     def _fit(
         self,
-        train_data,
-        val_data=None,
-        time_limit=None,
-        num_cpus=None,
-        num_gpus=None,
-        verbosity=2,
+        train_data: TimeSeriesDataFrame,
+        val_data: Optional[TimeSeriesDataFrame] = None,
+        time_limit: Optional[int] = None,
+        num_cpus: Optional[int] = None,
+        num_gpus: Optional[int] = None,
+        verbosity: int = 2,
         **kwargs,
     ) -> None:
         """Private method for `fit`. See `fit` for documentation of arguments. Apart from
         the model training logic, `fit` additionally implements other logic such as keeping
         track of the time limit, etc.
         """
+        # TODO: Make the models respect `num_cpus` and `num_gpus` parameters
         raise NotImplementedError
 
     def _check_fit_params(self):
@@ -273,39 +306,53 @@ class AbstractTimeSeriesModel(AbstractModel):
         """
         raise NotImplementedError
 
-    def predict_for_scoring(self, data: TimeSeriesDataFrame, **kwargs):
-        """Given a dataset, truncate the last `self.prediction_length` time steps and forecast these
-        steps with previous history. This method produces predictions for the *last* `self.prediction_length`
-        steps of the *given* time series, in order to be used for validation or scoring.
+    def slice_data_for_scoring(
+        self, data: TimeSeriesDataFrame
+    ) -> Tuple[TimeSeriesDataFrame, Optional[TimeSeriesDataFrame]]:
+        """Truncate the last `self.prediction_length` time steps of each time series.
+
+        When the output of this method is fed to `predict`, the model will generate predictions for the last
+        `prediction_length` time steps of each time series. These predictions can then be used to evaluate the model.
 
         Parameters
         ----------
-        data: TimeSeriesDataFrame
-            The dataset where each time series is the "context" for predictions.
-
-        Other Parameters
-        ----------------
-        quantile_levels
-            Quantiles of probabilistic forecasts, if probabilistic forecasts are implemented by the
-            corresponding subclass. If None, `self.quantile_levels` will be used instead,
-            if provided during initialization.
+        data : TimeSeriesDataFrame
+            The dataset used for evaluating the model.
 
         Returns
         -------
-        predictions: TimeSeriesDataFrame
-            pandas data frames with a timestamp index, where each input item from the input
-            data is given as a separate forecast item in the dictionary, keyed by the `item_id`s
-            of input items.
+        past_data : TimeSeriesDataFrame
+            Dataset consisting of truncated time series. This is used as "context" for the generating the predictions.
+        known_covariates : TimeSeriesDataFrame or None
+            Values of the known covariates during the forecast horizon, if `known_covariates` are present in the models
+            metadata. If `known_covariates` are absent, this value is equal to `None`.
         """
+
         past_data = data.slice_by_timestep(None, -self.prediction_length)
         if len(self.metadata.known_covariates_real) > 0:
             future_data = data.slice_by_timestep(-self.prediction_length, None)
             known_covariates = future_data[self.metadata.known_covariates_real]
         else:
             known_covariates = None
-        return self.predict(past_data, known_covariates=known_covariates, **kwargs)
+        return past_data, known_covariates
 
-    def score(self, data: TimeSeriesDataFrame, metric: str = None, **kwargs) -> float:
+    def score_with_predictions(
+        self,
+        data: TimeSeriesDataFrame,
+        predictions: TimeSeriesDataFrame,
+        metric: Optional[str] = None,
+    ) -> float:
+        """Compute the score measuring how well the predictions align with the data."""
+        eval_metric = self.eval_metric if metric is None else metric
+        evaluator = TimeSeriesEvaluator(
+            eval_metric=eval_metric,
+            eval_metric_seasonal_period=self.eval_metric_seasonal_period,
+            prediction_length=self.prediction_length,
+            target_column=self.target,
+        )
+        return evaluator(data, predictions) * evaluator.coefficient
+
+    def score(self, data: TimeSeriesDataFrame, metric: Optional[str] = None) -> float:
         """Return the evaluation scores for given metric and dataset. The last
         `self.prediction_length` time steps of each time series in the input data set
         will be held out and used for computing the evaluation score. Time series
@@ -331,17 +378,20 @@ class AbstractTimeSeriesModel(AbstractModel):
             The computed forecast evaluation score on the last `self.prediction_length`
             time steps of each time series.
         """
-        metric = self.eval_metric if metric is None else metric
-        evaluator = TimeSeriesEvaluator(
-            eval_metric=metric,
-            eval_metric_seasonal_period=self.eval_metric_seasonal_period,
-            prediction_length=self.prediction_length,
-            target_column=self.target,
-        )
-        predictions = self.predict_for_scoring(data)
-        metric_value = evaluator(data, predictions)
+        past_data, known_covariates = self.slice_data_for_scoring(data)
+        predictions = self.predict(past_data, known_covariates=known_covariates)
+        return self.score_with_predictions(data=data, predictions=predictions, metric=metric)
 
-        return metric_value * evaluator.coefficient
+    def score_and_cache_oof(self, val_data: TimeSeriesDataFrame) -> None:
+        """Compute val_score, predict_time and cache out-of-fold (OOF) predictions."""
+        if self.val_score is not None or self.predict_time is not None or self._oof_predictions is not None:
+            raise ValueError(f"Model {self.name} has already been scored on OOF data!")
+
+        past_data, known_covariates = self.slice_data_for_scoring(val_data)
+        predict_start_time = time.time()
+        self._oof_predictions = self.predict(past_data, known_covariates=known_covariates)
+        self.predict_time = time.time() - predict_start_time
+        self.val_score = self.score_with_predictions(val_data, self._oof_predictions)
 
     def _hyperparameter_tune(
         self,

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -5,8 +5,8 @@ import time
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import autogluon.core as ag
-from autogluon.common.savers import save_pkl
 from autogluon.common.loaders import load_pkl
+from autogluon.common.savers import save_pkl
 from autogluon.core.hpo.exceptions import EmptySearchSpace
 from autogluon.core.hpo.executors import HpoExecutor
 from autogluon.core.models import AbstractModel

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -114,13 +114,18 @@ class AbstractTimeSeriesModel(AbstractModel):
         return self.name
 
     def save(self, path: str = None, verbose=True) -> str:
-        if self._oof_predictions is not None:
+        oof_predictions = self._oof_predictions
+        self._oof_predictions = None
+        # Save self._oof_predictions as a separate file, if present
+        if oof_predictions is not None:
             save_pkl.save(
                 path=os.path.join(self.path + "utils", self._oof_filename),
                 object=self._oof_predictions,
                 verbose=verbose,
             )
-        return super().save(path=path, verbose=verbose)
+        save_path = super().save(path=path, verbose=verbose)
+        self._oof_predictions = oof_predictions
+        return save_path
 
     @classmethod
     def load(

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -114,15 +114,15 @@ class AbstractTimeSeriesModel(AbstractModel):
         return self.name
 
     def save(self, path: str = None, verbose=True) -> str:
-        oof_predictions = self._oof_predictions
-        self._oof_predictions = None
-        # Save self._oof_predictions as a separate file, if present
-        if oof_predictions is not None:
+        # Save self._oof_predictions as a separate file, not model attribute
+        if self._oof_predictions is not None:
             save_pkl.save(
                 path=os.path.join(self.path + "utils", self._oof_filename),
                 object=self._oof_predictions,
                 verbose=verbose,
             )
+        oof_predictions = self._oof_predictions
+        self._oof_predictions = None
         save_path = super().save(path=path, verbose=verbose)
         self._oof_predictions = oof_predictions
         return save_path

--- a/timeseries/src/autogluon/timeseries/models/abstract/model_trial.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/model_trial.py
@@ -74,7 +74,7 @@ def fit_and_save_model(model, fit_kwargs, train_data, val_data, eval_metric, tim
     time_fit_start = time.time()
     model.fit(train_data=train_data, val_data=val_data, time_limit=time_left, **fit_kwargs)
     model.fit_time = time.time() - time_fit_start
-    model.score_and_cache_oof(val_data)
+    model.score_and_cache_oof(val_data, store_val_score=True, store_predict_time=True)
 
     logger.debug(f"\tHyperparameter tune run: {model.name}")
     logger.debug(f"\t\t{model.val_score:<7.4f}".ljust(15) + f"= Validation score ({eval_metric})")

--- a/timeseries/src/autogluon/timeseries/models/abstract/model_trial.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/model_trial.py
@@ -73,14 +73,11 @@ def fit_and_save_model(model, fit_kwargs, train_data, val_data, eval_metric, tim
 
     time_fit_start = time.time()
     model.fit(train_data=train_data, val_data=val_data, time_limit=time_left, **fit_kwargs)
-    time_fit_end = time.time()
-    model.val_score = model.score(val_data, eval_metric)
-    time_pred_end = time.time()
+    model.fit_time = time.time() - time_fit_start
+    model.score_and_cache_oof(val_data)
 
     logger.debug(f"\tHyperparameter tune run: {model.name}")
     logger.debug(f"\t\t{model.val_score:<7.4f}".ljust(15) + f"= Validation score ({eval_metric})")
-    model.fit_time = time_fit_end - time_fit_start
-    model.predict_time = time_pred_end - time_fit_end
     logger.debug(f"\t\t{model.fit_time:<7.3f} s".ljust(15) + "= Training runtime")
     logger.debug(f"\t\t{model.predict_time:<7.3f} s".ljust(15) + "= Training runtime")
     model.save()

--- a/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
+++ b/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
@@ -131,3 +131,8 @@ class TimeSeriesGreedyEnsemble(AbstractTimeSeriesEnsembleModel):
         weights = weights / np.sum(weights)
 
         return sum(pred * w for pred, w in zip(model_preds, weights) if pred is not None)
+
+    def get_info(self) -> dict:
+        info = super().get_info()
+        info["model_weights"] = self.model_to_weight
+        return info

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -168,7 +168,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         self.feat_static_cat_cardinality: List[int] = []
 
     def save(self, path: str = None, verbose: bool = True) -> str:
-        # The GluonTS predictor will be serialized using custom logic
+        # The GluonTS predictor is serialized using custom logic
         predictor = self.gts_predictor
         self.gts_predictor = None
         path = Path(super().save(path=path, verbose=verbose))

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -19,7 +19,6 @@ from autogluon.core.utils.savers import save_json, save_pkl
 from autogluon.timeseries import TimeSeriesDataFrame, TimeSeriesEvaluator
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 from autogluon.timeseries.models.ensemble import AbstractTimeSeriesEnsembleModel, TimeSeriesGreedyEnsemble
-from autogluon.timeseries.models.gluonts.abstract_gluonts import AbstractGluonTSModel
 from autogluon.timeseries.models.presets import contains_searchspace
 from autogluon.timeseries.utils.features import CovariateMetadata
 from autogluon.timeseries.utils.warning_filters import disable_tqdm
@@ -336,6 +335,11 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
 
         self.models = models
 
+    def get_model_oof_predictions(self, model_name: str) -> TimeSeriesDataFrame:
+        model_path = self.get_model_attribute(model=model_name, attribute="path")
+        model_type = self.get_model_attribute(model=model_name, attribute="type")
+        return model_type.load_oof_predictions(path=model_path)
+
     def _add_model(
         self,
         model: AbstractTimeSeriesModel,
@@ -478,8 +482,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         val_data: Optional[TimeSeriesDataFrame] = None,
         time_limit: Optional[float] = None,
     ) -> List[str]:
-        """Fit and save the given model on given training and validation data and save the
-        trained model.
+        """Fit and save the given model on given training and validation data.
 
         Returns
         -------
@@ -495,17 +498,12 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
 
             model = self._train_single(train_data, model, val_data=val_data, time_limit=time_limit)
             fit_end_time = time.time()
-
-            val_score = model.score(val_data) if val_data is not None else None
-            model.val_score = val_score
-
-            pred_end_time = time.time()
-
             model.fit_time = model.fit_time or (fit_end_time - fit_start_time)
-            if model.predict_time is None:
-                model.predict_time = None if val_score is None else (pred_end_time - fit_end_time)
 
-            self._log_scores_and_times(val_score, model.fit_time, model.predict_time)
+            if val_data is not None:
+                model.score_and_cache_oof(val_data)
+
+            self._log_scores_and_times(model.val_score, model.fit_time, model.predict_time)
 
             self.save_model(model=model)
         except (Exception, MemoryError) as err:
@@ -685,11 +683,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
 
         model_preds = {}
         for model_name in model_names:
-            model: AbstractGluonTSModel = self.load_model(model_name=model_name)
-
-            # FIXME: This differs from predictions made to calc val_score for the models. Try to align.
-            #  Can either seed for deterministic results or cache the pred during val_score calc and reuse.
-            model_preds[model_name] = model.predict_for_scoring(data=val_data, quantile_levels=self.quantile_levels)
+            model_preds[model_name] = self.get_model_oof_predictions(model_name=model_name)
 
         time_start = time.time()
         ensemble = self.ensemble_model_type(
@@ -707,19 +701,13 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         time_end = time.time()
         ensemble.fit_time = time_end - time_start
 
-        evaluator = TimeSeriesEvaluator(
-            eval_metric=self.eval_metric,
-            eval_metric_seasonal_period=self.eval_metric_seasonal_period,
-            prediction_length=self.prediction_length,
-            target_column=self.target,
-        )
-        forecasts = ensemble.predict({n: model_preds[n] for n in ensemble.model_names})
-        ensemble.val_score = evaluator(val_data, forecasts) * evaluator.coefficient
-
         predict_time = 0
         for m in ensemble.model_names:
             predict_time += self.get_model_attribute(model=m, attribute="predict_time")
         ensemble.predict_time = predict_time
+
+        predictions = ensemble.predict({n: model_preds[n] for n in ensemble.model_names})
+        ensemble.val_score = self.score_with_predictions(val_data, predictions)
 
         self._log_scores_and_times(
             val_score=ensemble.val_score,
@@ -746,21 +734,23 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
             }
 
         if data is not None:
+            past_data, known_covariates = self.slice_data_for_scoring(data)
             logger.info(
                 "Additional data provided, testing on additional data. Resulting leaderboard "
                 "will be sorted according to test score (`score_test`)."
             )
+            # TODO: Cache predictions for all models using `model_pred_proba_dict` as in Tabular
             for model_name in model_names:
                 try:
-                    # TODO: time only prediction and not score for pred_time_val and pred_time_test
-                    time_start_test_score = time.time()
-                    model_info[model_name]["score_test"] = self.score(data, model_name)
-                    model_info[model_name]["pred_time_test"] = time.time() - time_start_test_score
+                    pred_start_time = time.time()
+                    predictions = self.predict(data=past_data, known_covariates=known_covariates, model=model_name)
+                    model_info[model_name]["pred_time_test"] = time.time() - pred_start_time
+                    model_info[model_name]["score_test"] = self.score_with_predictions(data, predictions)
                 except Exception as e:  # noqa
                     logger.error(f"Cannot score with model {model_name}. An error occurred: {str(e)}")
                     logger.debug(traceback.format_exc())
-                    model_info[model_name]["score_test"] = float("nan")
                     model_info[model_name]["pred_time_test"] = float("nan")
+                    model_info[model_name]["score_test"] = float("nan")
 
         df = pd.DataFrame(model_info.values())
 
@@ -823,38 +813,43 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
                 logger.info(f"\tYou can call predict(data, model) with one of other available models: {other_models}")
             return None
 
+    def slice_data_for_scoring(
+        self, data: TimeSeriesDataFrame
+    ) -> Tuple[TimeSeriesDataFrame, Optional[TimeSeriesDataFrame]]:
+        """Prepare model inputs necessary to predict the last `prediction_length` timesteps of each time series."""
+        past_data = data.slice_by_timestep(None, -self.prediction_length)
+        if len(self.metadata.known_covariates_real) > 0:
+            future_data = data.slice_by_timestep(-self.prediction_length, None)
+            known_covariates = future_data[self.metadata.known_covariates_real]
+        else:
+            known_covariates = None
+        return past_data, known_covariates
+
+    def score_with_predictions(
+        self,
+        data: TimeSeriesDataFrame,
+        predictions: TimeSeriesDataFrame,
+        metric: Optional[str] = None,
+    ) -> float:
+        """Compute the score measuring how well the predictions align with the data."""
+        eval_metric = self.eval_metric if metric is None else metric
+        evaluator = TimeSeriesEvaluator(
+            eval_metric=eval_metric,
+            eval_metric_seasonal_period=self.eval_metric_seasonal_period,
+            prediction_length=self.prediction_length,
+            target_column=self.target,
+        )
+        return evaluator(data, predictions) * evaluator.coefficient
+
     def score(
         self,
         data: TimeSeriesDataFrame,
         model: Optional[Union[str, AbstractTimeSeriesModel]] = None,
         metric: Optional[str] = None,
     ) -> float:
-        model = self._get_model_for_prediction(model)
-        eval_metric = self.eval_metric if metric is None else metric
-
-        if isinstance(model, AbstractTimeSeriesEnsembleModel):
-            evaluator = TimeSeriesEvaluator(
-                eval_metric=eval_metric,
-                eval_metric_seasonal_period=self.eval_metric_seasonal_period,
-                prediction_length=self.prediction_length,
-                target_column=self.target,
-            )
-            model_preds = {}
-            base_models = self.get_minimum_model_set(model, include_self=False)
-            for base_model in base_models:
-                try:
-                    base_model_loaded = self._get_model_for_prediction(base_model)
-                    model_preds[base_model] = base_model_loaded.predict_for_scoring(
-                        data, quantile_levels=self.quantile_levels
-                    )
-                except Exception:
-                    model_preds[base_model] = None
-            forecasts = model.predict(model_preds)
-
-            model_score = evaluator(data, forecasts) * evaluator.coefficient
-            return model_score
-
-        return model.score(data, metric=eval_metric)
+        past_data, known_covariates = self.slice_data_for_scoring(data)
+        predictions = self.predict(data=past_data, known_covariates=known_covariates, model=model)
+        return self.score_with_predictions(data=data, predictions=predictions, metric=metric)
 
     def _predict_model(
         self,

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -335,7 +335,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
 
         self.models = models
 
-    def get_model_oof_predictions(self, model_name: str) -> TimeSeriesDataFrame:
+    def _get_model_oof_predictions(self, model_name: str) -> TimeSeriesDataFrame:
         model_path = self.get_model_attribute(model=model_name, attribute="path")
         model_type = self.get_model_attribute(model=model_name, attribute="type")
         return model_type.load_oof_predictions(path=model_path)
@@ -683,7 +683,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
 
         model_preds = {}
         for model_name in model_names:
-            model_preds[model_name] = self.get_model_oof_predictions(model_name=model_name)
+            model_preds[model_name] = self._get_model_oof_predictions(model_name=model_name)
 
         time_start = time.time()
         ensemble = self.ensemble_model_type(

--- a/timeseries/tests/unittests/models/gluonts/test_gluonts.py
+++ b/timeseries/tests/unittests/models/gluonts/test_gluonts.py
@@ -232,4 +232,4 @@ def test_when_static_and_dynamic_covariates_present_then_model_trains_normally(m
 
     model = model_class(hyperparameters=DUMMY_HYPERPARAMETERS, metadata=gen.covariate_metadata)
     model.fit(train_data=df)
-    model.predict_for_scoring(df)
+    model.score_and_cache_oof(df)

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -72,13 +72,15 @@ def test_when_fit_called_then_models_train_and_all_scores_can_be_computed(
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
 @pytest.mark.parametrize("prediction_length", [1, 5])
-def test_when_predict_for_scoring_called_then_model_receives_truncated_data(
-    model_class, prediction_length, trained_models
-):
+def test_when_score_called_then_model_receives_truncated_data(model_class, prediction_length, trained_models):
     model = trained_models[(prediction_length, repr(model_class))]
 
     with mock.patch.object(model, "predict") as patch_method:
-        _ = model.predict_for_scoring(DUMMY_TS_DATAFRAME)
+        # Mock breaks the internals of the `score` method
+        try:
+            _ = model.score(DUMMY_TS_DATAFRAME)
+        except AttributeError:
+            pass
 
         (call_df,) = patch_method.call_args[0]
 

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -43,6 +43,7 @@ def trained_models():
         )
 
         model.fit(train_data=DUMMY_TS_DATAFRAME)
+        model.score_and_cache_oof(DUMMY_TS_DATAFRAME)
         models[(prediction_length, repr(model_class))] = model
         model_paths.append(temp_model_path)
 
@@ -68,6 +69,26 @@ def test_when_fit_called_then_models_train_and_all_scores_can_be_computed(
     score = model.score(DUMMY_TS_DATAFRAME, metric)
 
     assert isinstance(score, float)
+
+
+@pytest.mark.parametrize("model_class", TESTABLE_MODELS)
+@pytest.mark.parametrize("prediction_length", [1, 5])
+def test_when_score_and_cache_oof_called_then_attributes_are_saved(model_class, prediction_length, temp_model_path):
+    model = trained_models[(prediction_length, repr(model_class))]
+    assert isinstance(model.val_score, float)
+    assert isinstance(model.predict_time, float)
+
+
+@pytest.mark.parametrize("model_class", TESTABLE_MODELS)
+@pytest.mark.parametrize("prediction_length", [1, 5])
+def test_when_score_and_cache_oof_called_then_oof_predictions_are_saved(
+    model_class, prediction_length, temp_model_path
+):
+    model = trained_models[(prediction_length, repr(model_class))]
+    oof_predictions = model.get_oof_predictions()
+    assert isinstance(oof_predictions, TimeSeriesDataFrame)
+    oof_score = model.score_with_predictions(DUMMY_TS_DATAFRAME, oof_predictions)
+    assert isinstance(oof_score, float)
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
@@ -100,6 +121,7 @@ def test_when_models_saved_then_they_can_be_loaded(model_class, trained_models, 
     assert dict_equal_primitive(model.params, loaded_model.params)
     assert dict_equal_primitive(model.params_aux, loaded_model.params_aux)
     assert model.metadata == loaded_model.metadata
+    assert model.get_oof_predictions().equals(loaded_model.get_oof_predictions())
 
 
 @flaky

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -73,7 +73,7 @@ def test_when_fit_called_then_models_train_and_all_scores_can_be_computed(
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
 @pytest.mark.parametrize("prediction_length", [1, 5])
-def test_when_score_and_cache_oof_called_then_attributes_are_saved(model_class, prediction_length, temp_model_path):
+def test_when_score_and_cache_oof_called_then_attributes_are_saved(model_class, prediction_length, trained_models):
     model = trained_models[(prediction_length, repr(model_class))]
     assert isinstance(model.val_score, float)
     assert isinstance(model.predict_time, float)
@@ -82,7 +82,7 @@ def test_when_score_and_cache_oof_called_then_attributes_are_saved(model_class, 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
 @pytest.mark.parametrize("prediction_length", [1, 5])
 def test_when_score_and_cache_oof_called_then_oof_predictions_are_saved(
-    model_class, prediction_length, temp_model_path
+    model_class, prediction_length, trained_models
 ):
     model = trained_models[(prediction_length, repr(model_class))]
     oof_predictions = model.get_oof_predictions()

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -43,7 +43,7 @@ def trained_models():
         )
 
         model.fit(train_data=DUMMY_TS_DATAFRAME)
-        model.score_and_cache_oof(DUMMY_TS_DATAFRAME)
+        model.score_and_cache_oof(DUMMY_TS_DATAFRAME, store_val_score=True, store_predict_time=True)
         models[(prediction_length, repr(model_class))] = model
         model_paths.append(temp_model_path)
 
@@ -87,7 +87,7 @@ def test_when_score_and_cache_oof_called_then_oof_predictions_are_saved(
     model = trained_models[(prediction_length, repr(model_class))]
     oof_predictions = model.get_oof_predictions()
     assert isinstance(oof_predictions, TimeSeriesDataFrame)
-    oof_score = model.score_with_predictions(DUMMY_TS_DATAFRAME, oof_predictions)
+    oof_score = model._score_with_predictions(DUMMY_TS_DATAFRAME, oof_predictions)
     assert isinstance(oof_score, float)
 
 

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -342,7 +342,7 @@ def test_when_trainer_fit_and_deleted_then_oof_predictions_can_be_loaded(temp_mo
 
     for m in model_names:
         if "WeightedEnsemble" not in m:
-            oof_predictions = loaded_trainer.get_model_oof_predictions(m)
+            oof_predictions = loaded_trainer._get_model_oof_predictions(m)
             assert isinstance(oof_predictions, TimeSeriesDataFrame)
             loaded_trainer._score_with_predictions(DUMMY_TS_DATAFRAME, oof_predictions)
 

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -344,7 +344,7 @@ def test_when_trainer_fit_and_deleted_then_oof_predictions_can_be_loaded(temp_mo
         if "WeightedEnsemble" not in m:
             oof_predictions = loaded_trainer.get_model_oof_predictions(m)
             assert isinstance(oof_predictions, TimeSeriesDataFrame)
-            loaded_trainer.score_with_predictions(DUMMY_TS_DATAFRAME, oof_predictions)
+            loaded_trainer._score_with_predictions(DUMMY_TS_DATAFRAME, oof_predictions)
 
 
 @pytest.mark.parametrize("failing_model", ["NaiveModel", "SeasonalNaiveModel"])

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -343,7 +343,7 @@ def test_when_trainer_fit_and_deleted_then_oof_predictions_can_be_loaded(temp_mo
     for m in model_names:
         oof_predictions = loaded_trainer.get_model_oof_predictions(m)
         assert isinstance(oof_predictions, TimeSeriesDataFrame)
-        loaded_trainer.score(DUMMY_TS_DATAFRAME, oof_predictions)
+        loaded_trainer.score_with_predictions(DUMMY_TS_DATAFRAME, oof_predictions)
 
 
 @pytest.mark.parametrize("failing_model", ["NaiveModel", "SeasonalNaiveModel"])

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -329,7 +329,7 @@ def test_when_trainer_fit_and_deleted_then_oof_predictions_can_be_loaded(temp_mo
             "Naive": {},
             "ETS": {},
             "AutoETS": {"n_jobs": 1},
-            "AutoGluonTabular": {},
+            "AutoGluonTabular": {"tabular_hyperparameters": {"GBM"}},
             "DeepAR": {"epochs": 1, "num_batches_per_epoch": 1},
         },
         val_data=DUMMY_TS_DATAFRAME,
@@ -341,9 +341,10 @@ def test_when_trainer_fit_and_deleted_then_oof_predictions_can_be_loaded(temp_mo
     loaded_trainer = AutoTimeSeriesTrainer.load(path=temp_model_path)
 
     for m in model_names:
-        oof_predictions = loaded_trainer.get_model_oof_predictions(m)
-        assert isinstance(oof_predictions, TimeSeriesDataFrame)
-        loaded_trainer.score_with_predictions(DUMMY_TS_DATAFRAME, oof_predictions)
+        if "WeightedEnsemble" not in m:
+            oof_predictions = loaded_trainer.get_model_oof_predictions(m)
+            assert isinstance(oof_predictions, TimeSeriesDataFrame)
+            loaded_trainer.score_with_predictions(DUMMY_TS_DATAFRAME, oof_predictions)
 
 
 @pytest.mark.parametrize("failing_model", ["NaiveModel", "SeasonalNaiveModel"])


### PR DESCRIPTION
This is part 1 of the improved multi-window backtesting for time series (part 2: #3051).

*Description of changes:*
- Cache the predictions on the validation set for all time series models (as a model attribute + saved to disk). This ensures that we only call `predict` on the `val_data` once for all models. This saves training time and deals with the fact that predictions are non-deterministic for some models.
- Ensure that the reported prediction time for the test/val sets corresponds to the actual **prediction** time (before it included the time spent slicing the data / computing the metric).
- Simplify scoring logic in `AbstractTimeSeriesModel` and `AbstractTimeSeriesTrainer`
- Fix the bug where `AutoGluonTabularModel` would create an empty directory at initialization.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
