### PR TITLE
[multimodal] compile without saving to disk

### DIFF
--- a/multimodal/src/autogluon/multimodal/models/utils.py
+++ b/multimodal/src/autogluon/multimodal/models/utils.py
@@ -723,7 +723,11 @@ def run_model(model: nn.Module, batch: dict, trt_model: Optional[nn.Module] = No
         if column_names != [] and column_values != []:
             input_vec.append(column_names)
             input_vec.append(column_values)
-        output_vec = model(*tuple(input_vec))
+        if isinstance(pure_model, OnnxModule):
+            # OnnxModule doesn't support multi-gpu yet
+            output_vec = pure_model(*tuple(input_vec))
+        else:
+            output_vec = model(*tuple(input_vec))
 
         output = pure_model.get_output_dict(*output_vec)
     else:

--- a/multimodal/src/autogluon/multimodal/utils/export.py
+++ b/multimodal/src/autogluon/multimodal/utils/export.py
@@ -193,7 +193,9 @@ class ExportMixin:
                 raise ValueError(f"unsupported column type: {col_type}")
         data = pd.DataFrame.from_dict(data_dict)
 
-        onnx_path = self.export_onnx(data=data, path=self.path, truncate_long_and_double=True)
+        onnx_path = self.export_onnx(
+            data=data, path=os.path.join("/tmp", os.path.basename(self.path)), truncate_long_and_double=True
+        )
         onnx_module = OnnxModule(onnx_path, providers)
         onnx_module.input_keys = self._model.input_keys
         onnx_module.prefix = self._model.prefix

--- a/multimodal/src/autogluon/multimodal/utils/export.py
+++ b/multimodal/src/autogluon/multimodal/utils/export.py
@@ -87,13 +87,16 @@ class ExportMixin:
         """
         Export this predictor's model to ONNX file.
 
+        When `path` argument is not provided, the method would not save the model into disk.
+        Instead, it would export the onnx model into BytesIO and return its binary as bytes.
+
         Parameters
         ----------
         data
             Raw data used to trace and export the model.
             If this is None, will check if a processed batch is provided.
-        path
-            The export path of onnx model.
+        path : str, default=None
+            The export path of onnx model. If path is not provided, the method would export model to memory.
         batch_size
             The batch_size of export model's input.
             Normally the batch_size is a dynamic axis, so we could use a small value for faster export.
@@ -106,8 +109,9 @@ class ExportMixin:
 
         Returns
         -------
-        trt_module : OnnxModule
-            The onnx-based module that can be used to replace predictor._model for model inference.
+        onnx_path : str or bytes
+            A string that indicates location of the exported onnx model, if `path` argument is provided.
+            Otherwise, would return the onnx model as bytes.
         """
 
         import torch.jit
@@ -132,7 +136,7 @@ class ExportMixin:
         input_vec = [batch[k] for k in input_keys]
 
         # Write to BytesIO if path argument is not provided
-        if not path:
+        if path is None:
             onnx_path = io.BytesIO()
         else:
             onnx_path = os.path.join(path, "model.onnx")

--- a/multimodal/src/autogluon/multimodal/utils/onnx.py
+++ b/multimodal/src/autogluon/multimodal/utils/onnx.py
@@ -142,19 +142,3 @@ class OnnxModule(object):
                 pass
 
         return DummyModel
-
-    def parameters(self, *args):
-        """A dummy function that act as torch.nn.Module.parameters() function"""
-        return {}
-
-    def buffers(self, *args):
-        """A dummy function that act as torch.nn.Module.buffers() function"""
-        return {}
-
-    def children(self, *args):
-        """A dummy function that act as torch.nn.Module.children() function"""
-        return []
-
-    def modules(self, *args):
-        """A dummy function that act as torch.nn.Module.modules() function"""
-        return []

--- a/multimodal/src/autogluon/multimodal/utils/onnx.py
+++ b/multimodal/src/autogluon/multimodal/utils/onnx.py
@@ -52,8 +52,8 @@ class OnnxModule(object):
         """
         Parameters
         ----------
-        onnx_path : str
-            The file path of the onnx model that need to be executed in onnxruntime.
+        onnx_path : str or bytes
+            The file path (or bytes) of the onnx model that need to be executed in onnxruntime.
         providers : dict or str, default=None
             A list of execution providers for model prediction in onnxruntime.
         """
@@ -69,7 +69,7 @@ class OnnxModule(object):
             logger.info("Loading ONNX file from path {}...".format(onnx_path))
             onnx_model = onnx.load(onnx_path)
 
-        if providers == None:
+        if providers is None:
             if isinstance(onnx_path, str):
                 dirname = os.path.dirname(os.path.abspath(onnx_path))
                 cache_path = os.path.join(dirname, "model_trt")

--- a/multimodal/src/autogluon/multimodal/utils/onnx.py
+++ b/multimodal/src/autogluon/multimodal/utils/onnx.py
@@ -48,7 +48,7 @@ class OnnxModule(object):
     so that we can predict with TensorRT by simply replacing predictor._model with OnnxModule.
     """
 
-    def __init__(self, onnx_path: str, providers: Optional[Union[dict, List[str]]] = None):
+    def __init__(self, onnx_path: Union[str, bytes], providers: Optional[Union[dict, List[str]]] = None):
         """
         Parameters
         ----------
@@ -60,15 +60,21 @@ class OnnxModule(object):
         import onnx
         import onnxruntime as ort
 
-        if not os.path.exists(onnx_path):
-            raise FileNotFoundError(f"failed to located onnx file at {onnx_path}")
+        if isinstance(onnx_path, bytes):
+            onnx_model = onnx.load_model_from_string(onnx_path)
+        else:
+            if not os.path.exists(onnx_path):
+                raise FileNotFoundError(f"failed to located onnx file at {onnx_path}")
 
-        logger.info("Loading ONNX file from path {}...".format(onnx_path))
-        onnx_model = onnx.load(onnx_path)
+            logger.info("Loading ONNX file from path {}...".format(onnx_path))
+            onnx_model = onnx.load(onnx_path)
 
         if providers == None:
-            dirname = os.path.dirname(os.path.abspath(onnx_path))
-            cache_path = os.path.join(dirname, "model_trt")
+            if isinstance(onnx_path, str):
+                dirname = os.path.dirname(os.path.abspath(onnx_path))
+                cache_path = os.path.join(dirname, "model_trt")
+            else:
+                cache_path = None
             providers = [
                 (
                     "TensorrtExecutionProvider",

--- a/multimodal/src/autogluon/multimodal/utils/onnx.py
+++ b/multimodal/src/autogluon/multimodal/utils/onnx.py
@@ -142,3 +142,19 @@ class OnnxModule(object):
                 pass
 
         return DummyModel
+
+    def parameters(self, *args):
+        """A dummy function that act as torch.nn.Module.parameters() function"""
+        return {}
+
+    def buffers(self, *args):
+        """A dummy function that act as torch.nn.Module.buffers() function"""
+        return {}
+
+    def children(self, *args):
+        """A dummy function that act as torch.nn.Module.children() function"""
+        return []
+
+    def modules(self, *args):
+        """A dummy function that act as torch.nn.Module.modules() function"""
+        return []

--- a/multimodal/tests/unittests/others/test_deployment_onnx.py
+++ b/multimodal/tests/unittests/others/test_deployment_onnx.py
@@ -185,13 +185,7 @@ def test_onnx_optimize_for_inference(dataset_name, model_names, text_backbone, i
         predictor_opt = MultiModalPredictor.load(path=model_path)
         predictor_opt.optimize_for_inference(providers=providers)
 
-        # Check existence of the exported onnx model file and tensorrt cache files
-        export_path = os.path.join("/tmp", os.path.basename(predictor_opt.path))
-        onnx_path = os.path.join(export_path, "model.onnx")
-        assert os.path.exists(onnx_path), f"onnx model file not found at {onnx_path}"
-        if providers == None or providers == ["TensorrtExecutionProvider"]:
-            trt_cache_dir = os.path.join(export_path, "model_trt")
-            assert len(os.listdir(trt_cache_dir)) >= 2, f"tensorrt cache model files are not found in {trt_cache_dir}"
+        # Check module type of optimized predictor
         assert isinstance(
             predictor_opt._model, OnnxModule
         ), f"invalid onnx module type, expected to be OnnxModule, but the model type is {type(predictor._model)}"

--- a/multimodal/tests/unittests/others/test_deployment_onnx.py
+++ b/multimodal/tests/unittests/others/test_deployment_onnx.py
@@ -112,8 +112,36 @@ def test_onnx_export_timm_image(checkpoint_name, num_gpus):
     # predict
     load_proba = loaded_predictor.predict_proba({"image": [image_path_test]})
 
-    # convert
+    # -------------------------------------------------------
+    # convert (no path)
     onnx_path = loaded_predictor.export_onnx({"image": [image_path_export]})
+    assert isinstance(
+        onnx_path, bytes
+    ), f"export_onnx() method should return onnx bytes directly, if path is not provided."
+
+    # create onnx module for evaluation
+    onnx_module = OnnxModule(onnx_path, providers=["CUDAExecutionProvider"])
+    onnx_module.input_keys = loaded_predictor._model.input_keys
+    onnx_module.prefix = loaded_predictor._model.prefix
+    onnx_module.get_output_dict = loaded_predictor._model.get_output_dict
+
+    # simply replace _model in the loaded predictor to predict with onnxruntime
+    loaded_predictor._model = onnx_module
+    onnx_proba = loaded_predictor.predict_proba({"image": [image_path_test]})
+
+    # assert allclose
+    np.testing.assert_allclose(load_proba, onnx_proba, rtol=1e-3, atol=1e-3)
+
+    # -------------------------------------------------------
+    # convert (with path)
+    loaded_predictor = MultiModalPredictor.load(path=model_path)
+    onnx_path = loaded_predictor.export_onnx({"image": [image_path_export]}, path=model_path)
+
+    # Check existence of the exported onnx model file and tensorrt cache files
+    onnx_path_expected = os.path.join(model_path, "model.onnx")
+    assert isinstance(onnx_path, str), "export_onnx() method should return a string, if path argument is provided."
+    assert onnx_path == onnx_path_expected, "onnx_path mismatch"
+    assert os.path.exists(onnx_path), f"onnx model file not found at {onnx_path}"
 
     # create onnx module for evaluation
     onnx_module = OnnxModule(onnx_path, providers=["CUDAExecutionProvider"])

--- a/multimodal/tests/unittests/others/test_deployment_onnx.py
+++ b/multimodal/tests/unittests/others/test_deployment_onnx.py
@@ -186,10 +186,11 @@ def test_onnx_optimize_for_inference(dataset_name, model_names, text_backbone, i
         predictor_opt.optimize_for_inference(providers=providers)
 
         # Check existence of the exported onnx model file and tensorrt cache files
-        onnx_path = os.path.join(predictor_opt.path, "model.onnx")
+        export_path = os.path.join("/tmp", os.path.basename(predictor_opt.path))
+        onnx_path = os.path.join(export_path, "model.onnx")
         assert os.path.exists(onnx_path), f"onnx model file not found at {onnx_path}"
         if providers == None or providers == ["TensorrtExecutionProvider"]:
-            trt_cache_dir = os.path.join(predictor_opt.path, "model_trt")
+            trt_cache_dir = os.path.join(export_path, "model_trt")
             assert len(os.listdir(trt_cache_dir)) >= 2, f"tensorrt cache model files are not found in {trt_cache_dir}"
         assert isinstance(
             predictor_opt._model, OnnxModule


### PR DESCRIPTION
*Issue #, if available:*

the /opt/ml/model directory on sagemaker endpoint is on a read-only file system

*Description of changes:*

1. write onnx model file and tensorrt cache on /tmp directory

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
