### PR TITLE
Tabular: Add available disk logging + warning

### DIFF
--- a/common/src/autogluon/common/utils/resource_utils.py
+++ b/common/src/autogluon/common/utils/resource_utils.py
@@ -114,21 +114,6 @@ class ResourceManager:
         """
         return shutil.disk_usage(path=path)
 
-    @classmethod
-    def get_disk_usage_free(cls, path: str) -> int:
-        """Get free disk space in bytes"""
-        return cls.get_disk_usage(path=path).free
-
-    @classmethod
-    def get_disk_usage_used(cls, path: str) -> int:
-        """Get used disk space in bytes"""
-        return cls.get_disk_usage(path=path).used
-
-    @classmethod
-    def get_disk_usage_total(cls, path: str) -> int:
-        """Get total disk space in bytes"""
-        return cls.get_disk_usage(path=path).total
-
     @staticmethod
     def _get_gpu_count_cuda():
         # FIXME: Sometimes doesn't detect GPU on Windows

--- a/common/src/autogluon/common/utils/resource_utils.py
+++ b/common/src/autogluon/common/utils/resource_utils.py
@@ -1,5 +1,6 @@
 import multiprocessing
 import os
+import shutil
 import subprocess
 
 from .utils import bytes_to_mega_bytes
@@ -103,6 +104,30 @@ class ResourceManager:
             return bytes_to_mega_bytes(available_blocks)
         except Exception:
             return None
+
+    @staticmethod
+    def get_disk_usage(path: str):
+        """
+        Gets the disk usage information for the given path
+
+        Returns obj with variables `free`, `total`, `used`, representing bytes as integers.
+        """
+        return shutil.disk_usage(path=path)
+
+    @classmethod
+    def get_disk_usage_free(cls, path: str) -> int:
+        """Get free disk space in bytes"""
+        return cls.get_disk_usage(path=path).free
+
+    @classmethod
+    def get_disk_usage_used(cls, path: str) -> int:
+        """Get used disk space in bytes"""
+        return cls.get_disk_usage(path=path).used
+
+    @classmethod
+    def get_disk_usage_total(cls, path: str) -> int:
+        """Get total disk space in bytes"""
+        return cls.get_disk_usage(path=path).total
 
     @staticmethod
     def _get_gpu_count_cuda():

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -86,6 +86,8 @@ class DefaultLearner(AbstractTabularLearner):
                        f'Disk Space Avail:   {disk_free_gb:.2f} GB / {disk_total_gb:.2f} GB '
                        f'({disk_proportion_avail * 100:.1f}%){disk_log_extra}')
         except Exception as e:
+            # Note: using a broad exception catch as it is unknown what scenarios an exception would be raised, and what exception type would be used.
+            #  The broad exception ensures that we don't completely break AutoGluon for users who may be running on strange hardware or environments.
             logger.log(30,
                        f'Disk Space Avail:   WARNING, an exception ({e.__class__.__name__}) occurred while attempting to get available disk space. '
                        f'Consider opening a GitHub Issue.')

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -9,6 +9,7 @@ import pandas as pd
 from pandas import DataFrame
 
 from autogluon.common.utils.log_utils import convert_time_in_s_to_log_friendly
+from autogluon.common.utils.resource_utils import ResourceManager
 
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION, QUANTILE, AUTO_WEIGHT, BALANCE_WEIGHT
 from autogluon.core.data import LabelCleaner
@@ -65,6 +66,29 @@ class DefaultLearner(AbstractTabularLearner):
         logger.log(20, f'Operating System:   {platform.system()}')
         logger.log(20, f'Platform Machine:   {platform.machine()}')
         logger.log(20, f'Platform Version:   {platform.version()}')
+        try:
+            # TODO: Make this logic smarter, incorporate training data size and potentially models to train into the logic to define the recommended disk space.
+            #  For example, `best_quality` will require more disk space than `medium_quality`, and HPO would require additional disk space.
+            disk_stats = ResourceManager.get_disk_usage(path=self.path)
+            disk_free_gb = disk_stats.free / 1e9
+            disk_total_gb = disk_stats.total / 1e9
+            disk_proportion_avail = disk_stats.free / disk_stats.total
+            disk_log_extra = ''
+            disk_free_gb_warning_threshold = 10
+            disk_verbosity = 20
+            if disk_free_gb <= disk_free_gb_warning_threshold:
+                disk_log_extra += f'\n\tWARNING: Available disk space is low and there is a risk that ' \
+                                  f'AutoGluon will run out of disk during fit, causing an exception. ' \
+                                  f'\n\tWe recommend a minimum available disk space of {disk_free_gb_warning_threshold} GB, ' \
+                                  f'and large datasets may require more.'
+                disk_verbosity = 30
+            logger.log(disk_verbosity,
+                       f'Disk Space Avail:   {disk_free_gb:.2f} GB / {disk_total_gb:.2f} GB '
+                       f'({disk_proportion_avail * 100:.1f}%){disk_log_extra}')
+        except Exception as e:
+            logger.log(30,
+                       f'Disk Space Avail:   WARNING, an exception ({e.__class__.__name__}) occurred while attempting to get available disk space. '
+                       f'Consider opening a GitHub Issue.')
         logger.log(20, f'Train Data Rows:    {len(X)}')
         logger.log(20, f'Train Data Columns: {len([column for column in X.columns if column != self.label])}')
         if X_val is not None:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add available disk logging + warning to TabularPredictor.fit call.
- This will highlight to the user when they have small amounts of disk space available.
- If logic errors for whatever reason due to a strange env, it will fallback to a warning message that we were unable to calculating available disk space and asks to submit a GitHub issue and continue.
- Note that the current threshold is 10 GB. This is too high for small datasets, and too low for large datasets, but properly calculating the expected disk space requirement is complex. 10 GB is a good initial value, however it depends on how many models are being trained and what presets are being used. I've added a TODO to improve this estimate in future.

Example:

Low Available Disk:
```
Beginning AutoGluon training ...
AutoGluon will save models to "AutogluonModels/ag-20230321_214349/"
AutoGluon Version:  0.6.2b20230103
Python Version:     3.8.10
Operating System:   Darwin
Platform Machine:   x86_64
Platform Version:   Darwin Kernel Version 21.6.0: Mon Dec 19 20:44:01 PST 2022; root:xnu-8020.240.18~2/RELEASE_X86_64
Disk Space Avail:   1.50 GB / 499.96 GB (0.3%)
	WARNING: Available disk space is low and there is a risk that AutoGluon will run out of disk during fit, causing an exception. 
	We recommend a minimum available disk space of 10 GB, and large datasets may require more.
Train Data Rows:    39073
Train Data Columns: 14
```

Standard (sufficient disk space):
```
Beginning AutoGluon training ...
AutoGluon will save models to "AutogluonModels/ag-20230321_214455/"
AutoGluon Version:  0.6.2b20230103
Python Version:     3.8.10
Operating System:   Darwin
Platform Machine:   x86_64
Platform Version:   Darwin Kernel Version 21.6.0: Mon Dec 19 20:44:01 PST 2022; root:xnu-8020.240.18~2/RELEASE_X86_64
Disk Space Avail:   332.76 GB / 499.96 GB (66.6%)
Train Data Rows:    39073
Train Data Columns: 14
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
