### PR TITLE
[multimodal] fix num_gpus

### DIFF
--- a/multimodal/src/autogluon/multimodal/utils/inference.py
+++ b/multimodal/src/autogluon/multimodal/utils/inference.py
@@ -482,7 +482,7 @@ def predict(
     if predictor._problem_type == OBJECT_DETECTION:
         strategy = "ddp"
 
-    if strategy == "ddp" and predictor._fit_called:
+    if strategy == "ddp" and predictor._fit_called and predictor._problem_type == OBJECT_DETECTION:
         num_gpus = 1  # While using DDP, we can only use single gpu after fit is called
 
     if num_gpus <= 1:


### PR DESCRIPTION
*Issue #, if available:*

num_gpus always become 1 when calling predictor.evaluate after fit, therefore prevent us from supporting multi-gpu.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
