### PR TITLE
[eda] Partial Dependence Plots support

### DIFF
--- a/docs/tutorials/eda/components/autogluon.eda.interaction.md
+++ b/docs/tutorials/eda/components/autogluon.eda.interaction.md
@@ -22,6 +22,7 @@
     CorrelationVisualization
     CorrelationSignificanceVisualization
     FeatureInteractionVisualization
+    FeatureDistanceAnalysisVisualization
     PDPInteractions
 ```
 
@@ -45,6 +46,22 @@
 
 ```{eval-rst}
 .. autoclass:: FeatureInteractionVisualization
+   :members: init
+
+```
+
+### {hidden}`FeatureDistanceAnalysisVisualization`
+
+```{eval-rst}
+.. autoclass:: FeatureDistanceAnalysisVisualization
+   :members: init
+
+```
+
+### {hidden}`PDPInteractions`
+
+```{eval-rst}
+.. autoclass:: PDPInteractions
    :members: init
 
 ```

--- a/docs/tutorials/eda/components/autogluon.eda.interaction.md
+++ b/docs/tutorials/eda/components/autogluon.eda.interaction.md
@@ -22,6 +22,7 @@
     CorrelationVisualization
     CorrelationSignificanceVisualization
     FeatureInteractionVisualization
+    PDPInteractions
 ```
 
 ### {hidden}`CorrelationVisualization`

--- a/docs/tutorials/eda/eda-auto-analyze-interaction.ipynb
+++ b/docs/tutorials/eda/eda-auto-analyze-interaction.ipynb
@@ -142,7 +142,7 @@
     "A few observations can be made from the charts above:\n",
     "- `Sex` feature has a very strong impact on the prediction result\n",
     "- `Parch` has almost no impact on the outcome except when it is `0` or `1` - this is a candidate for clipping\n",
-    "- `Fare` and `Age`: bot have a non-linear relationship with the outcome; `Fare` and has two modes (density of blue lines) - these are good candidates to explore for feature interaction with other properties"
+    "- `Fare` and `Age`: both have a non-linear relationship with the outcome; `Fare` has two modes (density of blue lines) - these are good candidates to explore for feature interaction with other properties"
    ]
   },
   {

--- a/docs/tutorials/eda/eda-auto-analyze-interaction.ipynb
+++ b/docs/tutorials/eda/eda-auto-analyze-interaction.ipynb
@@ -44,7 +44,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aa00faab-252f-44c9-b8f7-57131aa8251c",
+   "id": "0611db8c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +152,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "auto.analyze_interaction(x='Parch', hue='Survived', train_data=data)"
+    "auto.analyze_interaction(x='Parch', hue='Survived', train_data=df_train)"
    ]
   },
   {

--- a/docs/tutorials/eda/eda-auto-analyze-interaction.ipynb
+++ b/docs/tutorials/eda/eda-auto-analyze-interaction.ipynb
@@ -127,6 +127,37 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "40d16e12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "state = auto.partial_dependence_plots(df_train, label='Survived', return_state=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19ad3184",
+   "metadata": {},
+   "source": [
+    "A few observations can be made from the charts above:\n",
+    "- `Sex` feature has a very strong impact on the prediction result\n",
+    "- `Parch` has almost no impact on the outcome except when it is `0` or `1` - this is a candidate for clipping\n",
+    "- `Fare` and `Age`: bot have a non-linear relationship with the outcome; `Fare` and has two modes (density of blue lines) - these are good candidates to explore for feature interaction with other properties"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72b18885",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auto.analyze_interaction(x='Parch', hue='Survived', train_data=data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "89b61529-8a63-40b6-b894-ebfebd2bcb6a",
    "metadata": {},
    "outputs": [],
@@ -141,6 +172,22 @@
    "source": [
     "It looks like `63%` of first class passengers survived, while; `48%` of second class and only `24%` of third class \n",
     "passengers survived. Similar information is visible via `Fare` variable:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64bb054c",
+   "metadata": {},
+   "source": [
+    "### `Fare` and `Age` features exploration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a9cbcc5",
+   "metadata": {},
+   "source": [
+    "Because PDP plots hinted non-linear interaction in these two variables, let's take a closer look and visualize them individually and in jointly."
    ]
   },
   {

--- a/docs/tutorials/eda/references/autogluon.eda.auto.md
+++ b/docs/tutorials/eda/references/autogluon.eda.auto.md
@@ -28,6 +28,8 @@ This section is a reference for high-level composite components showcased in sec
     covariate_shift_detection
     analyze_interaction
     analyze
+    explain_rows
+    partial_dependence_plots
 ```
 
 ### {hidden}`dataset_overview`
@@ -71,4 +73,16 @@ This section is a reference for high-level composite components showcased in sec
 
 ```{eval-rst}
 .. autofunction:: analyze
+```
+
+### {hidden}`explain_rows`
+
+```{eval-rst}
+.. autofunction:: explain_rows
+```
+
+### {hidden}`partial_dependence_plots`
+
+```{eval-rst}
+.. autofunction:: partial_dependence_plots
 ```

--- a/docs/tutorials/eda/references/autogluon.eda.base-apis.md
+++ b/docs/tutorials/eda/references/autogluon.eda.base-apis.md
@@ -75,6 +75,7 @@ and **val_data** arguments in the scope of calling children's **fit()**.
    :nosignatures:
 
    AbstractAnalysis
+   BaseAnalysis
    Namespace
 ```
 
@@ -84,6 +85,13 @@ and **val_data** arguments in the scope of calling children's **fit()**.
 .. autoclass:: AbstractAnalysis
    :members:
    :inherited-members:
+```
+
+### {hidden}`BaseAnalysis`
+
+```{eval-rst}
+.. autoclass:: BaseAnalysis
+   :members: init
 ```
 
 ### {hidden}`Namespace`

--- a/eda/src/autogluon/eda/analysis/base.py
+++ b/eda/src/autogluon/eda/analysis/base.py
@@ -12,6 +12,43 @@ logger = logging.getLogger(__name__)
 
 
 class AbstractAnalysis(ABC, StateCheckMixin):
+    """
+    Base class for analysis functionality.
+
+    Provides basic functionality for state/args management in analysis hierarchy
+    and helper method to access frequently-used methods.
+
+    Analyses can be nested; the hierarchical relationships can be navigated via `parent` and `children` properties.
+
+    The main entry method of analysis is `fit` function. This `_fit` method is designed to be overridden
+    by the component developer and should encapsulate all the outputs into `state` object provided.
+    When called, the execution flow is the following:
+    - gather `args` from the parent levels of analysis hierarchy; this is done to avoid referencing same args on each
+        nested component (i.e. `train_data` can be specified at the top and all the children will be able to access it
+        via `args` on all levels (unless overriden by one of the components in the hierarchy)
+    - call `_fit` function for each component that returned `True` from `can_handle` call
+
+    Please note: `state` is shared across the whole analysis hierarchy. If two components change the same space, then
+    it will be overridden by each consecutive update. If same component have to be reused and requires writing different
+    outputs, please use :py:class:`~autogluon.eda.analysis.base.Namespace` wrapper to isolate the components.
+
+    Parameters
+    ----------
+    parent: Optional[AbstractAnalysis], default = None
+        parent Analysis
+    children: Optional[List[AbstractAnalysis]], default None
+        wrapped analyses; these will receive sampled `args` during `fit` call
+    state: Optional[AnalysisState], default = None
+        state object to perform check on; if not provided a new state will be created during the `fit` call
+    kwargs
+        arguments to pass into the component
+
+    See Also
+    --------
+    :py:class:`~autogluon.eda.analysis.base.Namespace`
+
+    """
+
     def __init__(
         self,
         parent: Optional[AbstractAnalysis] = None,
@@ -133,6 +170,23 @@ class AbstractAnalysis(ABC, StateCheckMixin):
 
 
 class BaseAnalysis(AbstractAnalysis):
+    """
+    Simple implementation of :py:class:`~autogluon.eda.analysis.base.AbstractAnalysis`
+
+    Parameters
+    ----------
+    parent: Optional[AbstractAnalysis], default = None
+        parent Analysis
+    children: Optional[List[AbstractAnalysis]], default None
+        wrapped analyses; these will receive sampled `args` during `fit` call
+    kwargs
+
+    See Also
+    --------
+    :py:class:`~autogluon.eda.analysis.base.AbstractAnalysis`
+
+    """
+
     def __init__(
         self, parent: Optional[AbstractAnalysis] = None, children: Optional[List[AbstractAnalysis]] = None, **kwargs
     ) -> None:

--- a/eda/src/autogluon/eda/analysis/explain.py
+++ b/eda/src/autogluon/eda/analysis/explain.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 from typing import List, Optional
 
 import pandas as pd
@@ -119,9 +118,7 @@ class ShapAnalysis(AbstractAnalysis):
                 predicted_class = args.model.predict(_row).iloc[0]
             ag_wrapper = _ShapAutoGluonWrapper(args.model, args.train_data.columns, predicted_class)
             explainer = shap.KernelExplainer(ag_wrapper.predict_proba, baseline)
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore")
-                ke_shap_values = explainer.shap_values(_row[args.train_data.columns], silent=True)
+            ke_shap_values = explainer.shap_values(_row[args.train_data.columns], silent=True)
             shap_data.append(
                 AnalysisState(
                     row=_row,

--- a/eda/src/autogluon/eda/analysis/explain.py
+++ b/eda/src/autogluon/eda/analysis/explain.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from typing import List, Optional
 
 import pandas as pd
@@ -118,7 +119,9 @@ class ShapAnalysis(AbstractAnalysis):
                 predicted_class = args.model.predict(_row).iloc[0]
             ag_wrapper = _ShapAutoGluonWrapper(args.model, args.train_data.columns, predicted_class)
             explainer = shap.KernelExplainer(ag_wrapper.predict_proba, baseline)
-            ke_shap_values = explainer.shap_values(_row[args.train_data.columns], silent=True)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore")
+                ke_shap_values = explainer.shap_values(_row[args.train_data.columns], silent=True)
             shap_data.append(
                 AnalysisState(
                     row=_row,

--- a/eda/src/autogluon/eda/auto/__init__.py
+++ b/eda/src/autogluon/eda/auto/__init__.py
@@ -5,6 +5,7 @@ from .simple import (
     dataset_overview,
     explain_rows,
     missing_values_analysis,
+    partial_dependence_plots,
     quick_fit,
     target_analysis,
 )

--- a/eda/src/autogluon/eda/auto/simple.py
+++ b/eda/src/autogluon/eda/auto/simple.py
@@ -1094,6 +1094,7 @@ def explain_rows(
 def partial_dependence_plots(
     train_data: pd.DataFrame,
     label: str,
+    target: Optional[Any] = None,
     features: Optional[Union[str, List[str]]] = None,
     path: Optional[str] = None,
     max_ice_lines: int = 300,
@@ -1139,9 +1140,11 @@ def partial_dependence_plots(
     ----------
     train_data: DataFrame
         training dataset
-    train_data
     label: str
         target variable
+    target: Optional[Any], default = None
+        In a multiclass setting, specifies the class for which the PDPs should be computed.
+        Ignored in binary classification or classical regression settings
     features: Optional[Union[str, List[str]]], default = None
         feature to display on the plots
     path: Optional[str], default = None
@@ -1167,7 +1170,11 @@ def partial_dependence_plots(
 
     Returns
     -------
+    state after `fit` call if `return_state` is `True`; `None` otherwise
 
+    See Also
+    --------
+    :py:class:`~autogluon.eda.visualization.interaction.PDPInteractions`
     """
 
     chart_args, fig_args, features = _validate_and_normalize_pdp_args(
@@ -1222,7 +1229,7 @@ def partial_dependence_plots(
                 "If the ICE lines change significantly when comparing two features, this might suggest an interaction effect.",
                 condition_fn=lambda _: show_help_text,
             ),
-            PDPInteractions(features=features, fig_args=fig_args, sample=max_ice_lines, **chart_args),  # type: ignore
+            PDPInteractions(features=features, fig_args=fig_args, sample=max_ice_lines, target=target, **chart_args),  # type: ignore
             MarkdownSectionComponent(
                 f"The following variable(s) are categorical: {cats}. They are represented as the numbers in the figures above. "
                 f"Mappings are available in `state.pdp_id_to_category_mappings`. The`state` can be returned from this call via adding `return_state=True`.",

--- a/eda/src/autogluon/eda/auto/simple.py
+++ b/eda/src/autogluon/eda/auto/simple.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Union
 import pandas as pd
 
 from autogluon.common.utils.log_utils import verbosity2loglevel
+from autogluon.features import CategoryFeatureGenerator
 from autogluon.tabular import TabularPredictor
 
 from .. import AnalysisState
@@ -20,7 +21,7 @@ from ..analysis import (
     TrainValidationSplit,
     XShiftDetector,
 )
-from ..analysis.base import AbstractAnalysis, BaseAnalysis
+from ..analysis.base import AbstractAnalysis, BaseAnalysis, SaveArgsToState
 from ..analysis.dataset import (
     DatasetSummary,
     LabelInsightsAnalysis,
@@ -50,7 +51,7 @@ from ..visualization import (
     XShiftSummary,
 )
 from ..visualization.base import AbstractVisualization
-from ..visualization.interaction import FeatureDistanceAnalysisVisualization
+from ..visualization.interaction import FeatureDistanceAnalysisVisualization, PDPInteractions
 from ..visualization.layouts import SimpleVerticalLinearLayout
 
 logger = logging.getLogger(__name__)
@@ -64,6 +65,7 @@ __all__ = [
     "quick_fit",
     "target_analysis",
     "explain_rows",
+    "partial_dependence_plots",
 ]
 
 
@@ -1087,3 +1089,184 @@ def explain_rows(
         anlz_facets=[ShapAnalysis(rows, baseline_sample=baseline_sample, **fit_args)],  # type: ignore
         viz_facets=viz_facets,  # type: ignore
     )
+
+
+def partial_dependence_plots(
+    train_data: pd.DataFrame,
+    label: str,
+    features: Optional[Union[str, List[str]]] = None,
+    path: Optional[str] = None,
+    max_ice_lines: int = 300,
+    sample: Optional[Union[int, float]] = None,
+    fig_args: Optional[Dict[str, Dict[str, Any]]] = None,
+    chart_args: Optional[Dict[str, Dict[str, Any]]] = None,
+    show_help_text: bool = True,
+    return_state: bool = False,
+    col_number_warning: int = 20,
+    **fit_args,
+):
+    """
+    Display Partial Dependence Plots (PDP) with Individual Conditional Expectation (ICE)
+
+    ICE plots complement PDP by showing the relationship between a feature and the model's output for each individual instance in the dataset.
+    ICE lines (blue) can be overlaid on PDPs (red) to provide a more detailed view of how the model behaves for specific instances.
+    Here are some points on how to interpret PDPs with ICE lines:
+
+    - `Central tendency`
+        The PDP line represents the average prediction for different values of the feature of interest.
+        Look for the overall trend of the PDP line to understand the average effect of the feature on the model's output.
+    - `Variability`
+        The ICE lines represent the predicted outcomes for individual instances as the feature of interest changes.
+        Examine the spread of ICE lines around the PDP line to understand the variability in predictions for different instances.
+    - `Non-linear relationships`
+        Look for any non-linear patterns in the PDP and ICE lines.
+        This may indicate that the model captures a non-linear relationship between the feature and the model's output.
+    - `Heterogeneity`
+        Check for instances where ICE lines have widely varying slopes, indicating different relationships between the feature and
+        the model's output for individual instances. This may suggest interactions between the feature of interest and other features.
+    - `Outliers`
+        Look for any ICE lines that are very different from the majority of the lines.
+        This may indicate potential outliers or instances that have unique relationships with the feature of interest.
+    - `Confidence intervals`
+        If available, examine the confidence intervals around the PDP line. Wider intervals may indicate a less certain relationship
+        between the feature and the model's output, while narrower intervals suggest a more robust relationship.
+    - `Interactions`
+        By comparing PDPs and ICE plots for different features, you may detect potential interactions between features.
+        If the ICE lines change significantly when comparing two features, this might suggest an interaction effect.
+
+
+    Parameters
+    ----------
+    train_data: DataFrame
+        training dataset
+    train_data
+    label: str
+        target variable
+    features: Optional[Union[str, List[str]]], default = None
+        feature to display on the plots
+    path: Optional[str], default = None
+        location to store the model trained for this task
+    max_ice_lines: int, default = 300
+        max number of ice lines to display for each sub-plot
+    sample: Union[None, int, float], default = None
+        sample size; if `int`, then row number is used;
+        `float` must be between 0.0 and 1.0 and represents fraction of dataset to sample;
+        `None` means no sampling
+        See also :func:`autogluon.eda.analysis.dataset.Sampler`
+    fig_args: Optional[Dict[str, Any]], default = None
+        kwargs to pass into chart figure
+    chart_args: Optional[dict], default = None
+        kwargs to pass into visualization component
+    show_help_text:bool, default = True
+    return_state: bool, default = False
+        return state if `True`
+    col_number_warning: int, default = 20
+        number of features to visualize after which the warning will be displayed to warn about rendering time
+    fit_args: Optional[Dict[str, Dict[str, Any]]], default = None,
+        kwargs to pass into `TabularPredictor` fit.
+
+    Returns
+    -------
+
+    """
+
+    fig_args = get_empty_dict_if_none(fig_args)
+    chart_args = get_empty_dict_if_none(chart_args)
+
+    if features is None and len(train_data.columns) > col_number_warning:
+        logger.warning(
+            f"This visualization will render {len(train_data.columns)} charts. "
+            f"This can take a while. This warning can be disabled by setting `col_number_warning` to a higher value."
+        )
+
+    pdp_data, state, id_to_category_mappings = _prepare_pdp_data(train_data, label, sample)
+
+    state = quick_fit(
+        path=path,
+        train_data=state.pdp_train_data,
+        label=label,
+        return_state=True,
+        render_analysis=False,
+        sample=sample,
+        **fit_args,
+    )
+    state.pdp_data = pdp_data
+    state.pdp_id_to_category_mappings = id_to_category_mappings
+
+    if features is None:
+        features = state.model_evaluation.importance.index.tolist()
+    elif type(features) is not list:
+        features = [features]  # type: ignore
+
+    if len(id_to_category_mappings) > 0:
+        cats = ", ".join([f"`{c}`" for c in id_to_category_mappings.keys()])
+    else:
+        cats = ""
+
+    analyze(
+        model=state.model,
+        state=state,
+        viz_facets=[
+            MarkdownSectionComponent("### Partial Dependence Plots"),
+            MarkdownSectionComponent(
+                "Individual Conditional Expectation (ICE) plots complement Partial Dependence Plots (PDP) by showing the "
+                "relationship between a feature and the model's output for each individual instance in the dataset. ICE lines (blue) "
+                "can be overlaid on PDPs (red) to provide a more detailed view of how the model behaves for specific instances. "
+                "Here are some points on how to interpret PDPs with ICE lines:\n\n"
+                "* **Central tendency**: The PDP line represents the average prediction for different values of the feature of interest. "
+                "Look for the overall trend of the PDP line to understand the average effect of the feature on the model's output.\n"
+                "* **Variability**: The ICE lines represent the predicted outcomes for individual instances as the feature of interest changes. "
+                "Examine the spread of ICE lines around the PDP line to understand the variability in predictions for different instances.\n"
+                "* **Non-linear relationships**: Look for any non-linear patterns in the PDP and ICE lines. This may indicate that the model "
+                "captures a non-linear relationship between the feature and the model's output.\n"
+                "* **Heterogeneity**: Check for instances where ICE lines have widely varying slopes, indicating different relationships "
+                "between the feature and the model's output for individual instances. This may suggest interactions between the feature "
+                "of interest and other features.\n"
+                "* **Outliers**: Look for any ICE lines that are very different from the majority of the lines. This may indicate potential "
+                "outliers or instances that have unique relationships with the feature of interest.\n"
+                "* **Confidence** intervals: If available, examine the confidence intervals around the PDP line. Wider intervals may indicate "
+                "a less certain relationship between the feature and the model's output, while narrower intervals suggest a more robust relationship.\n"
+                "* **Interactions**: By comparing PDPs and ICE plots for different features, you may detect potential interactions between features. "
+                "If the ICE lines change significantly when comparing two features, this might suggest an interaction effect.",
+                condition_fn=lambda _: show_help_text,
+            ),
+            PDPInteractions(features=features, fig_args=fig_args, sample=max_ice_lines, **chart_args),  # type: ignore
+            MarkdownSectionComponent(
+                f"The following variable(s) are categorical: {cats}. They are represented as the numbers in the figures above. "
+                f"Mappings are available in `state.pdp_id_to_category_mappings`. The`state` can be returned from this call via adding `return_state=True`.",
+                condition_fn=lambda _: len(id_to_category_mappings) > 0,
+            ),
+        ],
+    )
+
+    s = AnalysisState({"pdp_id_to_category_mappings": id_to_category_mappings})
+
+    return s if return_state else None
+
+
+def _prepare_pdp_data(train_data, label, sample):
+    apply_gen = ApplyFeatureGenerator(
+        category_to_numbers=True,
+        children=[
+            SaveArgsToState(
+                params_mapping={
+                    "train_data": "pdp_train_data",
+                }
+            )
+        ],
+    )
+    state = analyze(
+        train_data=train_data,
+        label=label,
+        return_state=True,
+        anlz_facets=[apply_gen],
+        sample=sample,
+    )
+    pdp_data = state.pdp_train_data  # type: ignore
+    id_to_category_mappings = {}
+    for gen in [item for sublist in apply_gen.feature_generator.generators for item in sublist]:
+        if type(gen) is CategoryFeatureGenerator:
+            id_to_category_mappings = {
+                k: {i: v for i, v in enumerate(v.tolist())} for k, v in gen.category_map.items()
+            }
+    return pdp_data, state, id_to_category_mappings

--- a/eda/src/autogluon/eda/auto/simple.py
+++ b/eda/src/autogluon/eda/auto/simple.py
@@ -1146,7 +1146,7 @@ def partial_dependence_plots(
         In a multiclass setting, specifies the class for which the PDPs should be computed.
         Ignored in binary classification or classical regression settings
     features: Optional[Union[str, List[str]]], default = None
-        feature to display on the plots
+        feature subset to display; `None` means all features will be rendered.
     path: Optional[str], default = None
         location to store the model trained for this task
     max_ice_lines: int, default = 300
@@ -1261,7 +1261,6 @@ def _validate_and_normalize_pdp_args(
             len(features_not_present) == 0
         ), f"Features {', '.join(features_not_present)} are not present in train_data: {', '.join(train_data.columns)}"
     if features is None and len(train_data.columns) > col_number_warning:
-        print("qqq")
         logger.warning(
             f"This visualization will render {len(train_data.columns)} charts. "
             f"This can take a while. This warning can be disabled by setting `col_number_warning` to a higher value."

--- a/eda/src/autogluon/eda/visualization/__init__.py
+++ b/eda/src/autogluon/eda/visualization/__init__.py
@@ -7,6 +7,7 @@ from .interaction import (
     CorrelationVisualization,
     FeatureDistanceAnalysisVisualization,
     FeatureInteractionVisualization,
+    PDPInteractions,
 )
 from .layouts import (
     MarkdownSectionComponent,

--- a/eda/src/autogluon/eda/visualization/base.py
+++ b/eda/src/autogluon/eda/visualization/base.py
@@ -8,14 +8,30 @@ logger = logging.getLogger(__name__)
 
 
 class AbstractVisualization(ABC, StateCheckMixin):
+    """
+    Base class for visualization functionality.
+
+    Provides basic functionality for namespace management and helper method to access frequently-used methods.
+
+    Specifying namespace would narrow visibility scope to specific subspace of `state`. Namespaces
+    can be specified in a nested form: `ns_a.ns_b.ns_c`. Please see :py:class:`~autogluon.eda.analysis.base.Namespace`
+    wrapper on how to create namespaces.
+
+    The main entry method of analysis is `render` function. When called, the execution flow is the following:
+    - narrow `state` scope to specified `namespace`
+    - call `_render` function for each component that returned `True` from `can_handle` call
+
+    Parameters
+    ----------
+    namespace: str
+        namespace to use; can be nested like `ns_a.ns_b.ns_c`
+    kwargs
+
+    See Also
+    --------
+    :py:class:`~autogluon.eda.analysis.base.Namespace`
+    """
     def __init__(self, namespace: Optional[str] = None, **kwargs) -> None:
-        """
-        Parameters
-        ----------
-        namespace: str
-            namespace to use; can be nested like `ns_a.ns_b.ns_c`
-        kwargs
-        """
         super().__init__()
         self.namespace: List[str] = []
         self._kwargs = kwargs

--- a/eda/src/autogluon/eda/visualization/base.py
+++ b/eda/src/autogluon/eda/visualization/base.py
@@ -31,6 +31,7 @@ class AbstractVisualization(ABC, StateCheckMixin):
     --------
     :py:class:`~autogluon.eda.analysis.base.Namespace`
     """
+
     def __init__(self, namespace: Optional[str] = None, **kwargs) -> None:
         super().__init__()
         self.namespace: List[str] = []

--- a/eda/src/autogluon/eda/visualization/explain.py
+++ b/eda/src/autogluon/eda/visualization/explain.py
@@ -114,6 +114,12 @@ class ExplainWaterfallPlot(_AbstractExplainPlot):
     """
 
     def _render_internal(self, expected_value, shap_values, features, feature_names, **kwargs):
-        shap.plots._waterfall.waterfall_legacy(
-            expected_value, shap_values, features, feature_names=feature_names, **kwargs
-        )
+        shap.plots.waterfall(_ShapInput(expected_value, shap_values, features, feat_names=features.index), **kwargs)
+
+
+class _ShapInput(object):
+    def __init__(self, expectation, shap_values, features, feat_names):
+        self.base_values = expectation
+        self.values = shap_values
+        self.display_data = features.values
+        self.feature_names = list(feat_names)

--- a/eda/src/autogluon/eda/visualization/interaction.py
+++ b/eda/src/autogluon/eda/visualization/interaction.py
@@ -149,6 +149,10 @@ class CorrelationSignificanceVisualization(_AbstractCorrelationChart):
 
 class FeatureDistanceAnalysisVisualization(AbstractVisualization, JupyterMixin):
     """
+    Feature distance visualization.
+
+    This component renders graphical representations of distances between features to highlight features that can be
+    either simplified or completely removed.
 
     Parameters
     ----------
@@ -452,6 +456,33 @@ class FeatureInteractionVisualization(AbstractVisualization, JupyterMixin):
 
 
 class PDPInteractions(AbstractVisualization, JupyterMixin):
+    """
+    Display Partial Dependence Plots (PDP) with Individual Conditional Expectation (ICE)
+
+    ICE plots complement PDP by showing the relationship between a feature and the model's output for each individual instance in the dataset.
+    ICE lines (blue) can be overlaid on PDPs (red) to provide a more detailed view of how the model behaves for specific instances.
+
+    Parameters
+    ----------
+    features: Union[str, List[str]]
+        feature to display on the plots
+    target: Optional[Any], default = None
+        In a multiclass setting, specifies the class for which the PDPs should be computed.
+        Ignored in binary classification or classical regression settings
+    namespace: Optional[str], default = None
+        namespace to use; can be nested like `ns_a.ns_b.ns_c`
+    fig_args: Optional[Dict[str, Any]] = None,
+        kwargs to pass into chart figure
+    headers: bool, default = False
+        if `True` then render headers
+    sample: Union[None, int, float], default = None
+        sample size; if `int`, then row number is used;
+        `float` must be between 0.0 and 1.0 and represents fraction of dataset to sample;
+        `None` means no sampling
+        See also :func:`autogluon.eda.analysis.dataset.Sampler`
+    kwargs
+    """
+
     MAX_CHARTS_PER_ROW = 2
 
     def __init__(

--- a/eda/src/autogluon/eda/visualization/interaction.py
+++ b/eda/src/autogluon/eda/visualization/interaction.py
@@ -20,6 +20,7 @@ __all__ = [
     "CorrelationSignificanceVisualization",
     "FeatureInteractionVisualization",
     "FeatureDistanceAnalysisVisualization",
+    "PDPInteractions",
 ]
 
 

--- a/eda/src/autogluon/eda/visualization/shift.py
+++ b/eda/src/autogluon/eda/visualization/shift.py
@@ -8,13 +8,13 @@ __all__ = ["XShiftSummary"]
 
 
 class XShiftSummary(AbstractVisualization, JupyterMixin):
-    MAX_FEATURES_TO_DISPLAY = 5
-
     """
     Summarize the results of the XShiftDetector.  It will render the results as markdown in jupyter.
     This will contain the detection status (True if detected), the details of the hypothesis test (test
     statistic, pvalue), and the feature importances for the detection.
     """
+
+    MAX_FEATURES_TO_DISPLAY = 5
 
     def __init__(self, headers: bool = False, namespace: Optional[str] = None, **kwargs) -> None:
         super().__init__(namespace, **kwargs)


### PR DESCRIPTION
*Description of changes:*
- **Partial Dependence Plots**: Individual Conditional Expectation (ICE) plots complement Partial Dependence Plots (PDP) by showing the relationship between a feature and the model's output for each individual instance in the dataset. ICE lines (blue) can be overlaid on PDPs (red) to provide a more detailed view of how the model behaves for specific instances
- Migrated `explain_rows` from legacy APIs to the new ones
- Updated docs/tutorials to include new functionality

### Partial Dependence Plots Support
```python
import pandas as pd
import autogluon.eda.auto as auto

df_train = pd.read_csv('https://autogluon.s3.amazonaws.com/datasets/AmesHousingPriceRegression/train_data.csv')
target_col = 'SalePrice'

keep_cols = [
    'Overall.Qual', 'Gr.Liv.Area', 'Neighborhood', 'Total.Bsmt.SF', 'BsmtFin.SF.1',
    'X1st.Flr.SF', 'Bsmt.Qual', 'Garage.Cars', 'Half.Bath', 'Year.Remod.Add', target_col
]

state = auto.partial_dependence_plots(
    train_data=df_train[keep_cols],
    label=target_col,
    return_state=True,
    features=['Overall.Qual', 'Gr.Liv.Area', 'Neighborhood',  'Total.Bsmt.SF']
)
```

<img width="780" alt="image" src="https://user-images.githubusercontent.com/10080307/226793918-e6ff7e55-0e7e-4d81-969a-363fbdb7b050.png">

### `explain_rows` waterfall charts - migration from legacy APIs

Updated visualizations:

![image](https://user-images.githubusercontent.com/10080307/226794712-d4a39464-26db-473d-b466-731096c70487.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
