### PR TITLE
[eda] Partial Dependence Plots - Two-Way Interactions

### DIFF
--- a/docs/tutorials/eda/eda-auto-analyze-interaction.ipynb
+++ b/docs/tutorials/eda/eda-auto-analyze-interaction.ipynb
@@ -146,6 +146,90 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "62e0cc5e",
+   "metadata": {},
+   "source": [
+    "Let's take a look at the two-way partial dependence plots to visualize any potential interactions between the two features. Here are some cases when it's a good idea to two-way PDP:\n",
+    "\n",
+    "* **Suspected interactions**: Even if two features are not highly correlated, they may still interact in the context of the model. If you suspect that there might be interactions between any two features, two-way PDP can help to verify the hypotheses.\n",
+    "\n",
+    "* **Moderate to high correlation**: If two features have a moderate to high correlation, a two-way PDP can show how the combined effect of these features influences the model's predictions. In this case, the plot can help reveal whether the relationship between the features is additive, multiplicative, or more complex.\n",
+    "\n",
+    "* **Complementary features**: If two features provide complementary information, a two-way PDP can help illustrate how the joint effect of these features impacts the model's predictions. For example, if one feature measures the length of an object and another measures its width, a two-way PDP could show how the area affects the predicted outcome.\n",
+    "\n",
+    "* **Domain knowledge**: If domain knowledge suggests that the relationship between two features might be important for the model's output, a two-way PDP can help to explore and validate these hypotheses.\n",
+    "\n",
+    "* **Feature importance**: If feature importance analysis ranks both features high in the leaderboard, it might be beneficial to examine their joint effect on the model's predictions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08827afd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auto.partial_dependence_plots(df_train, label='Survived', features=['Fare', 'Age'], two_way=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7e9b205",
+   "metadata": {},
+   "source": [
+    "We can see these two features interact in the bottom left quadrant of the chart, but have almost no effect on each other in other areas. Areas where `Age < 45` and `Fare < 60` can be explored further."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db4212bc",
+   "metadata": {},
+   "source": [
+    "Let's take a look interactions between the features with the highest importance. To do this, we'll fit a quick model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "745ed086",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "state = auto.quick_fit(train_data=df_train, label='Survived', render_analysis=False, return_state=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8628fe2f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "state.model_evaluation.importance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5204812",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auto.partial_dependence_plots(df_train, label='Survived', features=['Fare', 'SibSp'], two_way=True, show_help_text=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19204bca",
+   "metadata": {},
+   "source": [
+    "On this chart we see the features don't interact at all when `SibSp > 3` (Number of Siblings/Spouses Aboard), but they do have non-linear interaction for smaller groups. Those who were traveling in smaller groups had higher chances to escape. Those chances were even higher if the `Fare` paid was higher.\n",
+    "\n",
+    "Let's analyze other variables higlighted above."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "72b18885",

--- a/docs/tutorials/eda/eda-auto-analyze-interaction.ipynb
+++ b/docs/tutorials/eda/eda-auto-analyze-interaction.ipynb
@@ -150,7 +150,7 @@
    "id": "62e0cc5e",
    "metadata": {},
    "source": [
-    "Let's take a look at the two-way partial dependence plots to visualize any potential interactions between the two features. Here are some cases when it's a good idea to two-way PDP:\n",
+    "Let's take a look at the two-way partial dependence plots to visualize any potential interactions between the two features. Here are some cases when it's a good idea to use two-way PDP:\n",
     "\n",
     "* **Suspected interactions**: Even if two features are not highly correlated, they may still interact in the context of the model. If you suspect that there might be interactions between any two features, two-way PDP can help to verify the hypotheses.\n",
     "\n",


### PR DESCRIPTION
*Description of changes:*

- Partial Dependence Plots now support two modes:
    - regular PDP + ICE plots - this is the default mode of operation
    - two-way PDP plots - this mode can be selected via passing two `features` and setting `two_way = True`

Two-way PDP can visualize potential interactions between any two features. Here are a few cases when two-way PDP can give good results:

- `Suspected interactions`: Even if two features are not highly correlated, they may still interact in the context of the model.
    If you suspect that there might be interactions between any two features, two-way PDP can help to verify the hypotheses.
- `Moderate to high correlation`: If two features have a moderate to high correlation,
    a two-way PDP can show how the combined effect of these features influences the model's predictions.
    In this case, the plot can help reveal whether the relationship between the features is additive, multiplicative, or more complex.
- `Complementary features`: If two features provide complementary information, a two-way PDP can help illustrate how the joint effect
    of these features impacts the model's predictions.
    For example, if one feature measures the length of an object and another measures its width, a two-way PDP could show how the
    combination of these features affects the predicted outcome.
- `Domain knowledge`: If domain knowledge suggests that the relationship between two features might be important for the model's output,
    a two-way PDP can help to explore and validate these hypotheses.
- `Feature importance`: If feature importance analysis ranks both features high in the leaderboard, it might be beneficial
    to examine their joint effect on the model's predictions.

### Examples

```python
import pandas as pd

df_train = pd.read_csv('https://autogluon.s3.amazonaws.com/datasets/titanic/train.csv')
df_test = pd.read_csv('https://autogluon.s3.amazonaws.com/datasets/titanic/test.csv')
target_col = 'Survived'

auto.partial_dependence_plots(
    train_data=df_train,
    label=target_col,
    two_way=True,
    features=['Age', 'Fare']
)
```

![image](https://user-images.githubusercontent.com/10080307/227678402-06dfe132-23db-4365-bbdc-c626061f88f8.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
