### PR TITLE
[Tabular] generating jupyterlite based tabular tutorials

### DIFF
--- a/.github/workflow_scripts/build_tabular_lite.sh
+++ b/.github/workflow_scripts/build_tabular_lite.sh
@@ -39,13 +39,17 @@ function build_doc_lite {
     LOCAL_IMG_PATH="$BUILD_DIR/_images"
 
     rm -rf "$BUILD_DIR"
-    export WHEEL_DIR="$LOCAL_IMG_PATH/wheel"
+    LITE_DIR="$LOCAL_IMG_PATH/lite"
+    WHEEL_DIR="$LITE_DIR/pypi"
+    mkdir -p $WHEEL_DIR
+    LITE_DIR=$(realpath $LITE_DIR)
+    export WHEEL_DIR=$(realpath $WHEEL_DIR)
     build_tabular_lite
 
     CONTENTS_DIR=$(pwd)/docs/tutorials/tabular
     mkdir -p $LOCAL_IMG_PATH
     cd $LOCAL_IMG_PATH
-    jupyter lite build --content $CONTENTS_DIR --output-dir dist
+    jupyter lite build --contents $CONTENTS_DIR --output-dir dist --lite-dir $LITE_DIR
     cd -
 
     COMMAND_EXIT_CODE=$?

--- a/.github/workflow_scripts/build_tabular_lite.sh
+++ b/.github/workflow_scripts/build_tabular_lite.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+function build_tabular_lite {
+    export AUTOGLUON_PACKAGE_NAME="autogluon-lite"
+
+    setup_build_env
+    install_local_packages "common/[tests]" "core/[all,tests]" "features/" "tabular/[all,tests]"
+    build_pkg "common" "core" "features" "tabular" "autogluon"
+}
+
+function build_doc_lite {
+    BRANCH="$1"
+    GIT_REPO="$2"
+    COMMIT_SHA="$3"
+    PR_NUMBER="$4"  # For push events, PR_NUMBER will be empty
+
+    DOC="tabular"
+    SUB_DOC="lite"
+
+    source $(dirname "$0")/write_to_s3.sh
+
+    setup_build_contrib_env
+    setup_build_jupyterlite_env
+
+    bash docs/build_pip_install.sh
+
+    if [[ -n $PR_NUMBER ]]; then
+        BUCKET="autogluon-ci"
+        S3_PATH="s3://$BUCKET/build_docs/$PR_NUMBER/$COMMIT_SHA"
+    else
+        BUCKET="autogluon-ci-push"
+        S3_PATH="s3://$BUCKET/build_docs/$BRANCH/$COMMIT_SHA"
+    fi
+
+    S3_IMG_PATH="$S3_PATH/_images"
+
+    BUILD_DIR="_build/html"
+
+    LOCAL_IMG_PATH="$BUILD_DIR/_images"
+
+    rm -rf "$BUILD_DIR"
+    export WHEEL_DIR="$LOCAL_IMG_PATH/wheel"
+    build_tabular_lite
+
+    CONTENTS_DIR=$(pwd)/docs/tutorials/tabular
+    mkdir -p $LOCAL_IMG_PATH
+    cd $LOCAL_IMG_PATH
+    jupyter lite build --content $CONTENTS_DIR --output-dir dist
+    cd -
+
+    COMMAND_EXIT_CODE=$?
+    if [ $COMMAND_EXIT_CODE -ne 0 ]; then
+        exit COMMAND_EXIT_CODE
+    fi
+
+    write_to_s3 $BUCKET $LOCAL_IMG_PATH $S3_IMG_PATH
+}

--- a/.github/workflow_scripts/build_tabular_lite.sh
+++ b/.github/workflow_scripts/build_tabular_lite.sh
@@ -48,7 +48,7 @@ function build_doc_lite {
     build_tabular_lite
 
     CONTENTS_DIR=$(pwd)/docs/tutorials/tabular
-    SUPPORTED_NOTEBOOKS="tabular-quick-start.ipynb tabular-indepth.ipynb tabular-feature-engineering.ipynb advanced/tabular-custom-metric.ipynb advanced/tabular-custom-model-advanced.ipynb advanced/tabular-custom-model.ipynb advanced/tabular-multilabel.ipynb"
+    SUPPORTED_NOTEBOOKS="tabular-quick-start.ipynb"
     for nb in $SUPPORTED_NOTEBOOKS
     do
         cp ${CONTENTS_DIR}/$nb ${FILES_DIR}

--- a/.github/workflow_scripts/build_tabular_lite.sh
+++ b/.github/workflow_scripts/build_tabular_lite.sh
@@ -39,17 +39,25 @@ function build_doc_lite {
     LOCAL_IMG_PATH="$BUILD_DIR/_images"
 
     rm -rf "$BUILD_DIR"
-    LITE_DIR="$LOCAL_IMG_PATH/lite"
+    LITE_DIR="$BUILD_DIR/_lite"
     WHEEL_DIR="$LITE_DIR/pypi"
-    mkdir -p $WHEEL_DIR
+    FILES_DIR="$LITE_DIR/files"
+    mkdir -p $WHEEL_DIR $FILES_DIR
     LITE_DIR=$(realpath $LITE_DIR)
     export WHEEL_DIR=$(realpath $WHEEL_DIR)
     build_tabular_lite
 
     CONTENTS_DIR=$(pwd)/docs/tutorials/tabular
+    SUPPORTED_NOTEBOOKS="tabular-quick-start.ipynb tabular-indepth.ipynb tabular-feature-engineering.ipynb advanced/tabular-custom-metric.ipynb advanced/tabular-custom-model-advanced.ipynb advanced/tabular-custom-model.ipynb advanced/tabular-multilabel.ipynb"
+    for nb in $SUPPORTED_NOTEBOOKS
+    do
+        cp ${CONTENTS_DIR}/$nb ${FILES_DIR}
+    done
+
     mkdir -p $LOCAL_IMG_PATH
     cd $LOCAL_IMG_PATH
-    jupyter lite build --contents $CONTENTS_DIR --output-dir dist --lite-dir $LITE_DIR
+    jupyter lite build --output-dir dist --lite-dir $LITE_DIR
+    rm -f .jupyterlite.doit.db
     cd -
 
     COMMAND_EXIT_CODE=$?

--- a/.github/workflow_scripts/build_tabular_prediction_tutorial.sh
+++ b/.github/workflow_scripts/build_tabular_prediction_tutorial.sh
@@ -10,8 +10,10 @@ PR_NUMBER=$4  # For push events, PR_NUMBER will be empty
 
 source $(dirname "$0")/env_setup.sh
 source $(dirname "$0")/build_doc.sh
+source $(dirname "$0")/build_tabular_lite.sh
 
 setup_torch_gpu
 export CUDA_VISIBLE_DEVICES=0
 
 build_doc tabular $BRANCH $GIT_REPO $COMMIT_SHA $PR_NUMBER
+build_doc_lite $BRANCH $GIT_REPO $COMMIT_SHA $PR_NUMBER

--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -74,7 +74,7 @@ function install_all_no_tests {
 
 function build_pkg {
     while(($#)) ; do
-        if [ -n $WHEEL_DIR ]; then
+        if [[ -n $WHEEL_DIR ]]; then
             BDIST_DIR=$WHEEL_DIR
         else
             BDIST_DIR="dist"

--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -15,6 +15,11 @@ function setup_build_contrib_env {
     export AUTOMM_TUTORIAL_MODE=1 # Disable progress bar in AutoMMPredictor
 }
 
+function setup_build_jupyterlite_env {
+    python3 -m pip install --upgrade pip
+    python3 -m pip install -r $(dirname "$0")/../../docs/requirements_jupyterlite.txt
+}
+
 function setup_torch_gpu {
     # Security-patched torch.
     python3 -m pip install torch==1.13.1+cu116 torchvision==0.14.1+cu116 torchaudio==0.13.1+cu116 --extra-index-url https://download.pytorch.org/whl/cu116
@@ -69,8 +74,13 @@ function install_all_no_tests {
 
 function build_pkg {
     while(($#)) ; do
+        if [ -n $WHEEL_DIR ]; then
+            BDIST_DIR="dist"
+        else
+            BDIST_DIR=$(pwd)/$WHEEL_DIR
+        fi
         cd "$1"/
-        python setup.py sdist bdist_wheel
+        python setup.py sdist bdist_wheel -d $BDIST_DIR
         cd ..
         shift
     done

--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -75,9 +75,9 @@ function install_all_no_tests {
 function build_pkg {
     while(($#)) ; do
         if [ -n $WHEEL_DIR ]; then
-            BDIST_DIR="dist"
+            BDIST_DIR=$WHEEL_DIR
         else
-            BDIST_DIR=$(pwd)/$WHEEL_DIR
+            BDIST_DIR="dist"
         fi
         cd "$1"/
         python setup.py sdist bdist_wheel -d $BDIST_DIR

--- a/.github/workflow_scripts/test_tabular_lite.sh
+++ b/.github/workflow_scripts/test_tabular_lite.sh
@@ -3,12 +3,10 @@
 set -ex
 
 source $(dirname "$0")/env_setup.sh
+source $(dirname "$0")/build_tabular_lite.sh
 
 setup_build_env
-export AUTOGLUON_PACKAGE_NAME="autogluon-lite"
-
-install_local_packages "common/[tests]" "core/[all,tests]" "features/" "tabular/[all,tests]"
-build_pkg "common" "core" "features" "tabular" "autogluon"
+build_tabular_lite
 
 PYODIDE_DIR=/src/pyodide
 

--- a/common/src/autogluon/common/loaders/load_pd.py
+++ b/common/src/autogluon/common/loaders/load_pd.py
@@ -154,3 +154,15 @@ def _load_multipart_s3(bucket, prefix, columns_to_keep=None, dtype=None, sample_
     df = load(path=paths_full, columns_to_keep=columns_to_keep, dtype=dtype, filters=filters,
               worker_count=worker_count, multiprocessing_method=multiprocessing_method)
     return df
+
+async def _emscripten_fetch(data_url):
+    import io
+    import sys
+    from js import fetch
+    if sys.platform == "emscripten":
+        res = await fetch(data_url)
+        text = await res.text()
+        df = pd.read_csv(io.StringIO(text))
+    else:
+        df = pd.read_csv(data_url)
+    return df

--- a/docs/requirements_jupyterlite.txt
+++ b/docs/requirements_jupyterlite.txt
@@ -1,0 +1,10 @@
+# Core modules (mandatory)
+jupyterlite-core==0.1.0b21
+jupyterlab~=3.5.1
+
+# Python kernel (optional)
+jupyterlite-pyodide-kernel==0.0.5
+
+# Language support (optional)
+jupyterlab-language-pack-fr-FR
+jupyterlab-language-pack-zh-CN

--- a/docs/tutorials/tabular/tabular-quick-start.ipynb
+++ b/docs/tutorials/tabular/tabular-quick-start.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -31,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,8 +59,37 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_url = 'https://raw.githubusercontent.com/mli/ag-docs/main/knot_theory/'\n",
-    "train_data = TabularDataset(f'{data_url}train.csv')\n",
+    "data_url = 'https://raw.githubusercontent.com/mli/ag-docs/main/knot_theory'\n",
+    "train_input, test_input = f\"{data_url}/train.csv\", f\"{data_url}/test.csv\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following code block is only necessary when running on JupyterLite. It would load HTTP based dataset, since Pyodide is not able to load remove content directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "if sys.platform == \"emscripten\":\n",
+    "    from autogluon.common.loaders.load_pd import _emscripten_fetch\n",
+    "    train_input = await _emscripten_fetch(f\"{data_url}/train.csv\")\n",
+    "    test_input = await _emscripten_fetch(f\"{data_url}/test.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_data = TabularDataset(train_input)\n",
     "train_data.head()"
    ]
   },
@@ -127,7 +155,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test_data = TabularDataset(f'{data_url}test.csv')\n",
+    "test_data = TabularDataset(test_input)\n",
     "\n",
     "y_pred = predictor.predict(test_data.drop(columns=[label]))\n",
     "y_pred.head()"

--- a/docs/tutorials/tabular/tabular-quick-start.ipynb
+++ b/docs/tutorials/tabular/tabular-quick-start.ipynb
@@ -24,8 +24,16 @@
    },
    "outputs": [],
    "source": [
-    "!python -m pip install --upgrade pip\n",
-    "!python -m pip install autogluon"
+    "import sys\n",
+    "if sys.platform == \"emscripten\":\n",
+    "    %pip install autogluon-lite-common\n",
+    "    %pip install autogluon-lite-core\n",
+    "    %pip install autogluon-lite-core\n",
+    "    %pip install autogluon-lite-tabular\n",
+    "    %pip install autogluon-lite\n",
+    "else:\n",
+    "    !python -m pip install --upgrade pip\n",
+    "    !python -m pip install autogluon"
    ]
   },
   {
@@ -76,7 +84,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sys\n",
     "if sys.platform == \"emscripten\":\n",
     "    from autogluon.common.loaders.load_pd import _emscripten_fetch\n",
     "    train_input = await _emscripten_fetch(f\"{data_url}/train.csv\")\n",


### PR DESCRIPTION
*Issue #, if available:*

Demonstrate 9 out of 12 tabular tutorials via JupyterLite from https://github.com/autogluon/autogluon/pull/2384

*Description of changes:*

See JupyterLite-based interactive demo:
http://autogluon-staging.s3-website-us-west-2.amazonaws.com/PR-3088/03a88b3/_images/dist/lab/

Adding
```python
%pip install autogluon-lite-common
%pip install autogluon-lite-core
%pip install autogluon-lite-core
%pip install autogluon-lite-tabular
%pip install autogluon-lite
```
would install required packages for supported Jupyter notebooks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
