### PR TITLE
[eda] set default sample to 10k for eda.auto functions

### DIFF
--- a/eda/src/autogluon/eda/auto/simple.py
+++ b/eda/src/autogluon/eda/auto/simple.py
@@ -68,6 +68,8 @@ __all__ = [
     "partial_dependence_plots",
 ]
 
+DEFAULT_SAMPLE_SIZE = 10000
+
 
 def analyze(
     train_data: Optional[pd.DataFrame] = None,
@@ -76,7 +78,7 @@ def analyze(
     model=None,
     label: Optional[str] = None,
     state: Union[None, dict, AnalysisState] = None,
-    sample: Union[None, int, float] = None,
+    sample: Union[None, int, float] = DEFAULT_SAMPLE_SIZE,
     anlz_facets: Optional[List[AbstractAnalysis]] = None,
     viz_facets: Optional[List[AbstractVisualization]] = None,
     return_state: bool = False,
@@ -101,7 +103,7 @@ def analyze(
         target variable
     state: Union[None, dict, AnalysisState], default = None
         pass prior state if necessary; the object will be updated during `anlz_facets` `fit` call.
-    sample: Union[None, int, float], default = None
+    sample: Union[None, int, float], default = 10000
         sample size; if `int`, then row number is used;
         `float` must be between 0.0 and 1.0 and represents fraction of dataset to sample;
         `None` means no sampling
@@ -258,7 +260,7 @@ def quick_fit(
     path: Optional[str] = None,
     val_size: float = 0.3,
     problem_type: str = "auto",
-    sample: Union[None, int, float] = None,
+    sample: Union[None, int, float] = DEFAULT_SAMPLE_SIZE,
     state: Union[None, dict, AnalysisState] = None,
     return_state: bool = False,
     save_model_to_state: bool = True,
@@ -305,7 +307,7 @@ def quick_fit(
     problem_type: str, default = 'auto'
         problem type to use. Valid problem_type values include ['auto', 'binary', 'multiclass', 'regression', 'quantile', 'softclass']
         auto means it will be Auto-detected using AutoGluon methods.
-    sample: Union[None, int, float], default = None
+    sample: Union[None, int, float], default = 10000
         sample size; if `int`, then row number is used;
         `float` must be between 0.0 and 1.0 and represents fraction of dataset to sample;
         `None` means no sampling
@@ -459,7 +461,7 @@ def dataset_overview(
     label: Optional[str] = None,
     state: Union[None, dict, AnalysisState] = None,
     return_state: bool = False,
-    sample: Union[None, int, float] = None,
+    sample: Union[None, int, float] = DEFAULT_SAMPLE_SIZE,
     fig_args: Optional[Dict[str, Dict[str, Any]]] = None,
     chart_args: Optional[Dict[str, Dict[str, Any]]] = None,
 ):
@@ -484,7 +486,7 @@ def dataset_overview(
         pass prior state if necessary; the object will be updated during `anlz_facets` `fit` call.
     return_state: bool, default = False
         return state if `True`
-    sample: Union[None, int, float], default = None
+    sample: Union[None, int, float], default = 10000
         sample size; if `int`, then row number is used;
         `float` must be between 0.0 and 1.0 and represents fraction of dataset to sample;
         `None` means no sampling
@@ -578,7 +580,7 @@ def covariate_shift_detection(
     train_data: pd.DataFrame,
     test_data: pd.DataFrame,
     label: str,
-    sample: Union[None, int, float] = None,
+    sample: Union[None, int, float] = DEFAULT_SAMPLE_SIZE,
     path: Optional[str] = None,
     state: Union[None, dict, AnalysisState] = None,
     return_state: bool = False,
@@ -607,7 +609,7 @@ def covariate_shift_detection(
         target variable
     state: Union[None, dict, AnalysisState], default = None
         pass prior state if necessary; the object will be updated during `anlz_facets` `fit` call.
-    sample: Union[None, int, float], default = None
+    sample: Union[None, int, float], default = 10000
         sample size; if `int`, then row number is used;
         `float` must be between 0.0 and 1.0 and represents fraction of dataset to sample;
         `None` means no sampling
@@ -740,7 +742,7 @@ def target_analysis(
     test_data: Optional[pd.DataFrame] = None,
     problem_type: str = "auto",
     fit_distributions: Union[bool, str, List[str]] = True,
-    sample: Union[None, int, float] = None,
+    sample: Union[None, int, float] = DEFAULT_SAMPLE_SIZE,
     state: Union[None, dict, AnalysisState] = None,
     return_state: bool = False,
     fig_args: Optional[Dict[str, Any]] = None,
@@ -775,7 +777,7 @@ def target_analysis(
         If `True`, or list of distributions is provided, then fit distributions. Performed only if `y` and `hue` are not present.
     state: Union[None, dict, AnalysisState], default = None
         pass prior state if necessary; the object will be updated during `anlz_facets` `fit` call.
-    sample: Union[None, int, float], default = None
+    sample: Union[None, int, float], default = 10000
         sample size; if `int`, then row number is used;
         `float` must be between 0.0 and 1.0 and represents fraction of dataset to sample;
         `None` means no sampling
@@ -938,7 +940,7 @@ def missing_values_analysis(
     val_data: Optional[pd.DataFrame] = None,
     state: Union[None, dict, AnalysisState] = None,
     return_state: bool = False,
-    sample: Union[None, int, float] = None,
+    sample: Union[None, int, float] = DEFAULT_SAMPLE_SIZE,
     **chart_args,
 ):
     """
@@ -972,7 +974,7 @@ def missing_values_analysis(
         pass prior state if necessary; the object will be updated during `anlz_facets` `fit` call.
     return_state: bool, default = False
         return state if `True`
-    sample: Union[None, int, float], default = None
+    sample: Union[None, int, float], default = 10000
         sample size; if `int`, then row number is used;
         `float` must be between 0.0 and 1.0 and represents fraction of dataset to sample;
         `None` means no sampling
@@ -1099,7 +1101,7 @@ def partial_dependence_plots(
     two_way: bool = False,
     path: Optional[str] = None,
     max_ice_lines: int = 300,
-    sample: Optional[Union[int, float]] = None,
+    sample: Optional[Union[int, float]] = DEFAULT_SAMPLE_SIZE,
     fig_args: Optional[Dict[str, Dict[str, Any]]] = None,
     chart_args: Optional[Dict[str, Dict[str, Any]]] = None,
     show_help_text: bool = True,
@@ -1172,7 +1174,7 @@ def partial_dependence_plots(
         location to store the model trained for this task
     max_ice_lines: int, default = 300
         max number of ice lines to display for each sub-plot
-    sample: Union[None, int, float], default = None
+    sample: Union[None, int, float], default = 10000
         sample size; if `int`, then row number is used;
         `float` must be between 0.0 and 1.0 and represents fraction of dataset to sample;
         `None` means no sampling

--- a/eda/tests/unittests/analysis/test_dataset.py
+++ b/eda/tests/unittests/analysis/test_dataset.py
@@ -242,9 +242,10 @@ def test_LabelInsightsAnalysis__classification__low_cardinality_classes(threshol
         assert state == {
             "label_insights": {"low_cardinality_classes": {"instances": {2: 190}, "threshold": 191}},
             "problem_type": "binary",
+            "sample_size": 10000,
         }
     else:
-        assert state == {"problem_type": "binary"}
+        assert state == {"problem_type": "binary", "sample_size": 10000}
 
 
 @pytest.mark.parametrize("n_c1, n_c2, is_warning_expected", [(100, 100, False), (100, 39, True)])
@@ -270,9 +271,10 @@ def test_LabelInsightsAnalysis__classification__class_imbalance(n_c1, n_c2, is_w
                 "minority_class_imbalance": {"majority_class": 1, "minority_class": 2, "ratio": 0.39},
             },
             "problem_type": "binary",
+            "sample_size": 10000,
         }
     else:
-        assert state == {"problem_type": "binary"}
+        assert state == {"problem_type": "binary", "sample_size": 10000}
 
 
 def test_LabelInsightsAnalysis__classification__not_present_in_train():
@@ -292,7 +294,11 @@ def test_LabelInsightsAnalysis__classification__not_present_in_train():
         ],
     )
 
-    assert state == {"label_insights": {"not_present_in_train": {3, 4}}, "problem_type": "binary"}
+    assert state == {
+        "label_insights": {"not_present_in_train": {3, 4}},
+        "problem_type": "binary",
+        "sample_size": 10000,
+    }
 
 
 def test_LabelInsightsAnalysis__regression__no_ood():
@@ -310,7 +316,7 @@ def test_LabelInsightsAnalysis__regression__no_ood():
         ],
     )
 
-    assert state == {"problem_type": "regression"}
+    assert state == {"problem_type": "regression", "sample_size": 10000}
 
 
 @pytest.mark.parametrize("threshold, is_warning_expected", [(None, True), (0.02, False)])
@@ -340,6 +346,7 @@ def test_LabelInsightsAnalysis__regression__ood(threshold, is_warning_expected):
                 "ood": {"count": 12, "test_range": [-15, 1014], "threshold": 0.01, "train_range": [0, 999]}
             },
             "problem_type": "regression",
+            "sample_size": 10000,
         }
     else:
-        assert state == {"problem_type": "regression"}
+        assert state == {"problem_type": "regression", "sample_size": 10000}

--- a/eda/tests/unittests/analysis/test_interaction.py
+++ b/eda/tests/unittests/analysis/test_interaction.py
@@ -48,6 +48,7 @@ def test_Correlation_spearman():
                 )
             },
             "correlations_method": "spearman",
+            "sample_size": 10000,
         }
     )
     __compare_outputs(expected, state)
@@ -70,6 +71,7 @@ def test_Correlation_pearson():
                 )
             },
             "correlations_method": "pearson",
+            "sample_size": 10000,
         }
     )
     __compare_outputs(expected, state)
@@ -92,6 +94,7 @@ def test_Correlation_kendall():
                 )
             },
             "correlations_method": "kendall",
+            "sample_size": 10000,
         }
     )
     __compare_outputs(expected, state)
@@ -116,6 +119,7 @@ def test_Correlation_phik():
                 )
             },
             "correlations_method": "phik",
+            "sample_size": 10000,
         }
     )
     __compare_outputs(expected, state)
@@ -146,6 +150,7 @@ def test_Correlation_focus():
             "correlations_focus_field": "c",
             "correlations_focus_field_threshold": 0.5,
             "correlations_focus_high_corr": {"train_data": pd.DataFrame(index=list("ad"), data={"c": [0.88, -1.00]})},
+            "sample_size": 10000,
         }
     )
     assert actual.correlations_focus_high_corr.train_data.equals(
@@ -427,5 +432,6 @@ def test_FeatureDistanceAnalysis__happy_path():
                 {"distance": 0.8306, "nodes": ["age", "capital-gain"]},
             ],
             "near_duplicates_threshold": 0.85,
-        }
+        },
+        "sample_size": 10000,
     }

--- a/eda/tests/unittests/auto/test_simple.py
+++ b/eda/tests/unittests/auto/test_simple.py
@@ -99,18 +99,18 @@ def test_analyze():
 
 
 def test_analyze_return_state():
-    state = {"some_previous_state": {"arg": 1}}
+    state = {"sample_size": 10000, "some_previous_state": {"arg": 1}}
     assert analyze(state=state) is None
     assert analyze(state=state, return_state=True) == state
 
 
 def test_analyze_None_state():
     state = None
-    assert analyze(state=state, return_state=True) == {}
+    assert analyze(state=state, return_state=True) == {"sample_size": 10000}
 
 
 def test_analyze_state_dict_convert():
-    state = {"some_previous_state": {"arg": 1}}
+    state = {"sample_size": 10000, "some_previous_state": {"arg": 1}}
     assert not isinstance(state, AnalysisState)
     _state = analyze(state=state, return_state=True)
     assert _state == state
@@ -356,6 +356,7 @@ def test_target_analysis__classification(monkeypatch):
         "missing_statistics",
         "problem_type",
         "raw_type",
+        "sample_size",
         "special_types",
         "variable_type",
     ]
@@ -426,6 +427,7 @@ def test_target_analysis__regression(monkeypatch):
         "missing_statistics",
         "problem_type",
         "raw_type",
+        "sample_size",
         "special_types",
         "variable_type",
     ]

--- a/eda/tests/unittests/visualization/test_interaction.py
+++ b/eda/tests/unittests/visualization/test_interaction.py
@@ -51,7 +51,7 @@ def test_CorrelationVisualization_phik(monkeypatch):
         state,
         heatmap_args,
         CorrelationVisualization,
-        "**`train_data` - `phik` correlation matrix**",
+        "**`train_data` - `phik` correlation matrix (sample size: 10000)**",
         headers=True,
     )
 
@@ -73,7 +73,7 @@ def test_CorrelationVisualization_focus(monkeypatch):
         state,
         heatmap_args,
         CorrelationVisualization,
-        "**`train_data` - `spearman` correlation matrix; focus: absolute correlation for `c` >= `0.6`**",
+        "**`train_data` - `spearman` correlation matrix; focus: absolute correlation for `c` >= `0.6` (sample size: 10000)**",
         headers=True,
     )
 
@@ -215,9 +215,11 @@ def test_FeatureInteractionVisualization__headers(monkeypatch, is_single, header
     if not header:
         viz.render_markdown.assert_not_called()
     elif is_single:
-        viz.render_markdown.assert_called_with("**`a` in `train_data`**")
+        viz.render_markdown.assert_called_with("**`a` in `train_data` (sample size: 10000)**")
     else:
-        viz.render_markdown.assert_called_with("**Feature interaction between `a`/`b` in `train_data`**")
+        viz.render_markdown.assert_called_with(
+            "**Feature interaction between `a`/`b` in `train_data` (sample size: 10000)**"
+        )
 
 
 def test_FeatureInteractionVisualization__state_different_key(monkeypatch):


### PR DESCRIPTION
*Description of changes:*
Set default sample to 10k for `eda.auto` functions. This is to cap time needed to run the analysis and encourage fast iterations. The sample can be set to a higher value via `sample` parameter or removed via setting to `None`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
