### PR TITLE
[eda][bugfixes] fix `quick_fit` residuals plot to use unseen data for Train

### DIFF
--- a/docs/tutorials/eda/eda-auto-quick-fit.ipynb
+++ b/docs/tutorials/eda/eda-auto-quick-fit.ipynb
@@ -149,7 +149,7 @@
     "df_test = df_test[[c for c in df_test.columns if c in keep_cols]][:500]\n",
     "\n",
     "\n",
-    "state = auto.quick_fit(df_train, target_col, return_state=True)"
+    "state = auto.quick_fit(df_train, target_col, fit_bagging_folds=3, return_state=True)"
    ]
   },
   {

--- a/eda/src/autogluon/eda/visualization/model.py
+++ b/eda/src/autogluon/eda/visualization/model.py
@@ -182,20 +182,30 @@ class RegressionEvaluation(AbstractVisualization, JupyterMixin):
 
     def _render(self, state: AnalysisState) -> None:
         self.render_header_if_needed(state, "Prediction vs Target")
-        ev = state.model_evaluation
         res_plot_kwargs = self._get_plot_mode()
         fig, ax = plt.subplots(**self.fig_args)
+        y_pred_train, y_true_train, y_pred_test, y_true_test = RegressionEvaluation._repack_parameters(
+            state.model_evaluation
+        )
         residuals_plot(
             _YellowbrickAutoGluonWrapper(state.model),
-            ev.y_pred_train,
-            ev.y_true_train,
-            ev.y_pred,
-            ev.y_true,
+            y_pred_train,
+            y_true_train,
+            y_pred_test,
+            y_true_test,
             show=False,
             ax=ax,
             **res_plot_kwargs,
         )
         plt.show(fig)
+
+    @staticmethod
+    def _repack_parameters(ev):
+        y_pred_train = ev.y_pred_train if "y_pred_train" in ev else ev.y_pred_val
+        y_true_train = ev.y_true_train if "y_pred_train" in ev else ev.y_true_val
+        y_pred_test = ev.y_pred_test if "y_true_test" in ev else (ev.y_pred_val if "y_pred_train" in ev else None)
+        y_true_test = ev.y_true_test if "y_true_test" in ev else (ev.y_true_val if "y_pred_train" in ev else None)
+        return y_pred_train, y_true_train, y_pred_test, y_true_test
 
 
 class FeatureImportance(AbstractVisualization, JupyterMixin):

--- a/eda/tests/unittests/analysis/test_model.py
+++ b/eda/tests/unittests/analysis/test_model.py
@@ -25,7 +25,7 @@ def fit_model(path, df_train, target, fit_args=None):
 
 def test_AutoGluonModelEvaluator_regression():
     df_train = pd.read_csv(os.path.join(RESOURCE_PATH, "houses", "train_data.csv")).sample(100, random_state=0)
-    df_test = pd.read_csv(os.path.join(RESOURCE_PATH, "houses", "test_data.csv")).sample(50, random_state=0)
+    df_val = pd.read_csv(os.path.join(RESOURCE_PATH, "houses", "test_data.csv")).sample(50, random_state=0)
     target_col = "SalePrice"
 
     with tempfile.TemporaryDirectory() as path:
@@ -34,21 +34,23 @@ def test_AutoGluonModelEvaluator_regression():
         state = auto.analyze(
             model=predictor,
             train_data=df_train,
-            val_data=df_test,
+            val_data=df_val,
             return_state=True,
             anlz_facets=[eda.model.AutoGluonModelEvaluator(normalize="true")],
         )
 
     assert state.model_evaluation.problem_type == REGRESSION
-    assert len(state.model_evaluation.y_true) == len(df_test)
-    assert len(state.model_evaluation.y_pred) == len(df_test)
+    assert len(state.model_evaluation.y_true_val) == len(df_val)
+    assert len(state.model_evaluation.y_pred_val) == len(df_val)
     expected = [c for c in df_train.columns if c not in ["Street", "Utilities", "SalePrice"]]
     assert sorted(state.model_evaluation.importance.index.to_list()) == sorted(expected)
     _assert_importance_is_present(state)
     assert state.model_evaluation.confusion_matrix is None
     assert state.model_evaluation.confusion_matrix_normalized is None
-    assert state.model_evaluation.y_true_val is None
-    assert state.model_evaluation.y_pred_val is None
+    assert state.model_evaluation.y_true_test is None
+    assert state.model_evaluation.y_pred_test is None
+    assert state.model_evaluation.y_true_train is None
+    assert state.model_evaluation.y_pred_train is None
 
 
 def test_AutoGluonModelEvaluator_regression__with_test_data():
@@ -70,8 +72,8 @@ def test_AutoGluonModelEvaluator_regression__with_test_data():
         )
 
     assert state.model_evaluation.problem_type == REGRESSION
-    assert len(state.model_evaluation.y_true) == len(df_test)
-    assert len(state.model_evaluation.y_pred) == len(df_test)
+    assert len(state.model_evaluation.y_true_test) == len(df_test)
+    assert len(state.model_evaluation.y_pred_test) == len(df_test)
     assert len(state.model_evaluation.y_true_val) == len(df_val)
     assert len(state.model_evaluation.y_pred_val) == len(df_val)
     expected = [c for c in df_train.columns if c not in ["Street", "Utilities", "SalePrice"]]
@@ -83,7 +85,7 @@ def test_AutoGluonModelEvaluator_regression__with_test_data():
 
 def test_AutoGluonModelEvaluator_classification():
     df_train = pd.read_csv(os.path.join(RESOURCE_PATH, "adult", "train_data.csv")).sample(100, random_state=0)
-    df_test = pd.read_csv(os.path.join(RESOURCE_PATH, "adult", "test_data.csv")).sample(50, random_state=0)
+    df_val = pd.read_csv(os.path.join(RESOURCE_PATH, "adult", "test_data.csv")).sample(50, random_state=0)
     target_col = "class"
 
     with tempfile.TemporaryDirectory() as path:
@@ -92,14 +94,14 @@ def test_AutoGluonModelEvaluator_classification():
         state = auto.analyze(
             model=predictor,
             train_data=df_train,
-            val_data=df_test,
+            val_data=df_val,
             return_state=True,
             anlz_facets=[eda.model.AutoGluonModelEvaluator(normalize="true")],
         )
 
     assert state.model_evaluation.problem_type == "binary"
-    assert len(state.model_evaluation.y_true) == len(df_test)
-    assert len(state.model_evaluation.y_pred) == len(df_test)
+    assert len(state.model_evaluation.y_true_val) == len(df_val)
+    assert len(state.model_evaluation.y_pred_val) == len(df_val)
     expected = [c for c in df_train.columns if c not in ["class"]]
     assert sorted(state.model_evaluation.importance.index.to_list()) == sorted(expected)
     _assert_importance_is_present(state)
@@ -138,8 +140,8 @@ def test_AutoGluonModelQuickFit(save_model_to_state):
         )
 
     assert state.model_evaluation.problem_type == "binary"
-    assert len(state.model_evaluation.y_true) == int(len(df_train) * 0.3)
-    assert len(state.model_evaluation.y_pred) == int(len(df_train) * 0.3)
+    assert len(state.model_evaluation.y_true_val) == int(len(df_train) * 0.3)
+    assert len(state.model_evaluation.y_pred_val) == int(len(df_train) * 0.3)
     expected = [c for c in df_train.columns if c not in ["class"]]
     assert sorted(state.model_evaluation.importance.index.to_list()) == sorted(expected)
     _assert_importance_is_present(state)

--- a/eda/tests/unittests/auto/test_simple.py
+++ b/eda/tests/unittests/auto/test_simple.py
@@ -149,7 +149,7 @@ def test_quick_fit(monkeypatch):
         with tempfile.TemporaryDirectory() as path:
             quick_fit(path=path, train_data=df_train, label="class")
 
-    assert call_md_render.call_count == 7
+    assert call_md_render.call_count == 9
     assert call_prc_render.call_count == 2
     call_cm_render.assert_called_once()
     call_reg_render.assert_called_once()


### PR DESCRIPTION
*Description of changes:*
- fix `quick_fit` residuals plot to use unseen data for Train
- added `fit_bagging_folds` argument to support baging in `quick_fit` and allow OOF usage in regression residuals
- Added information what part of the dataset is used for Test points

The updated code will use `test_data` true/predicted values if available to render Test points. If these not available, but `quick_fit` is called with `fit_bagging_folds` to enable OOF predictions, then Train wil use OOF predictions and Test will be validation data hold-off (automated within `quick_fit`). If no OOF available then only validation data points will be rendered.

```python
state = auto.quick_fit(
    train_data=df_train,
    label=target_col, 
    fit_bagging_folds=3,  # enable OOF predictions
    return_state=True
)
```

#### Note when validation data is used as Test points:

<img width="200" alt="image" src="https://user-images.githubusercontent.com/10080307/229679160-3af87d25-a1c5-480f-ac69-2adb14fd0e5f.png">

#### Note when `test_data` is used as Test points:

<img width="200" alt="image" src="https://user-images.githubusercontent.com/10080307/229678563-ada6c360-5fcc-45f0-aa0b-7c85f901eece.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
