### PR TITLE
[timeseries] Update high_quality presets

### DIFF
--- a/timeseries/src/autogluon/timeseries/configs/presets_configs.py
+++ b/timeseries/src/autogluon/timeseries/configs/presets_configs.py
@@ -12,14 +12,7 @@ TIMESERIES_PRESETS_CONFIGS = dict(
             "num_trials": 10,
         },
     },
-    high_quality={
-        "hyperparameters": "high_quality",
-        "hyperparameter_tune_kwargs": {
-            "scheduler": "local",
-            "searcher": "auto",
-            "num_trials": 5,
-        },
-    },
+    high_quality={"hyperparameters": "high_quality"},
     medium_quality={"hyperparameters": "medium_quality"},
     fast_training={"hyperparameters": "local_only"},
 )

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
@@ -40,11 +40,10 @@ class AutoGluonTabularModel(AbstractTimeSeriesModel):
         exceeds ``max_train_size``, then ``max_train_size`` many rows are subsampled from the dataframe.
     tabular_hyperparameters : Dict[Dict[str, Any]], optional
         Hyperparameters dictionary passed to `TabularPredictor.fit`. Contains the names of models that should be fit.
-        Defaults to ``{"XGB": {}, "CAT": {}, "GBM" :{}}``.
+        Defaults to ``{"CAT": {}, "GBM" :{}}``.
     """
 
     default_tabular_hyperparameters = {
-        "XGB": {},
         "CAT": {},
         "GBM": {},
     }

--- a/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
+++ b/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
@@ -33,6 +33,7 @@ class AbstractLocalModel(AbstractTimeSeriesModel):
     allowed_local_model_args: List[str] = []
     # Use 50% of the cores since some models rely on parallel ops and are actually slower if n_jobs=-1
     DEFAULT_N_JOBS: Union[float, int] = 0.5
+    MAX_TS_LENGTH: Optional[int] = None
 
     def __init__(
         self,
@@ -110,6 +111,9 @@ class AbstractLocalModel(AbstractTimeSeriesModel):
                 f"{self.name} has frequency '{self.freq}', which doesn't match the frequency "
                 f"of the dataset '{data.freq}'."
             )
+        if self.MAX_TS_LENGTH is not None:
+            logger.debug(f"Shortening all time series to at most {self.MAX_TS_LENGTH}")
+            data = data.groupby(level=ITEMID, sort=False).tail(self.MAX_TS_LENGTH)
 
         self._fit_and_cache_predictions(data, quantile_levels=quantile_levels)
         item_id_to_prediction = {}

--- a/timeseries/src/autogluon/timeseries/models/local/statsforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/local/statsforecast.py
@@ -6,7 +6,7 @@ import pandas as pd
 from autogluon.core.utils.exceptions import TimeLimitExceeded
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP, TimeSeriesDataFrame
 from autogluon.timeseries.models.local.abstract_local_model import AbstractLocalModel, hash_ts_dataframe_items
-from autogluon.timeseries.utils.warning_filters import statsmodels_warning_filter
+from autogluon.timeseries.utils.warning_filters import statsmodels_warning_filter, statsmodels_joblib_warning_filter
 
 logger = logging.getLogger(__name__)
 
@@ -89,7 +89,7 @@ class AbstractStatsForecastModel(AbstractLocalModel):
             levels = sorted(list(set(levels)))
             chosen_columns = list(new_column_names.values())
 
-            with statsmodels_warning_filter():
+            with statsmodels_warning_filter(), statsmodels_joblib_warning_filter():
                 raw_predictions = sf.forecast(
                     df=self._to_statsforecast_dataframe(data_to_fit),
                     h=self.prediction_length,
@@ -185,6 +185,7 @@ class AutoARIMAModel(AbstractStatsForecastModel):
         "allowmean",
         "seasonal_period",
     ]
+    MAX_TS_LENGTH = 3000
 
     def _update_local_model_args(self, local_model_args: dict, data: TimeSeriesDataFrame) -> dict:
         local_model_args.setdefault("approximation", True)

--- a/timeseries/src/autogluon/timeseries/models/local/statsforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/local/statsforecast.py
@@ -6,7 +6,7 @@ import pandas as pd
 from autogluon.core.utils.exceptions import TimeLimitExceeded
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP, TimeSeriesDataFrame
 from autogluon.timeseries.models.local.abstract_local_model import AbstractLocalModel, hash_ts_dataframe_items
-from autogluon.timeseries.utils.warning_filters import statsmodels_warning_filter, statsmodels_joblib_warning_filter
+from autogluon.timeseries.utils.warning_filters import statsmodels_joblib_warning_filter, statsmodels_warning_filter
 
 logger = logging.getLogger(__name__)
 

--- a/timeseries/src/autogluon/timeseries/models/local/statsmodels.py
+++ b/timeseries/src/autogluon/timeseries/models/local/statsmodels.py
@@ -200,6 +200,7 @@ class ARIMAModel(AbstractLocalModel):
         "enforce_invertibility",
         "maxiter",
     ]
+    MAX_TS_LENGTH = 3000
 
     def _update_local_model_args(
         self, local_model_args: Dict[str, Any], data: TimeSeriesDataFrame, **kwargs

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -28,7 +28,6 @@ MODEL_TYPES = dict(
     SimpleFeedForward=SimpleFeedForwardModel,
     DeepAR=DeepARModel,
     TemporalFusionTransformer=TemporalFusionTransformerModel,
-    # Prophet=ProphetModel,
     ETS=ETSModel,
     ARIMA=ARIMAModel,
     Theta=ThetaModel,
@@ -115,9 +114,7 @@ def get_default_hps(key, prediction_length):
             "ETS": {},
             "AutoETS": {},
             "AutoARIMA": {},
-            "Theta": {
-                "deseasonalize": ag.Categorical(True, False),
-            },
+            "Theta": {},
             "AutoGluonTabular": {},
             "DeepAR": {
                 "context_length": context_length,
@@ -135,9 +132,7 @@ def get_default_hps(key, prediction_length):
             "AutoETS": {},
             "AutoARIMA": {},
             "DynamicOptimizedTheta": {},
-            "Theta": {
-                "deseasonalize": ag.Categorical(True, False),
-            },
+            "Theta": {},
             "AutoGluonTabular": {},
             "DeepAR": {
                 "context_length": context_length,


### PR DESCRIPTION
*Description of changes:*
- Several minor optimizations done to speed up the training time of `high_quality` presets
  - Remove XGBoost model from AutoGluonTabular model
  - Remove HPO for Theta
  - Cap maximum time series length for ARIMA


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
