### PR TITLE
Optimize distributed model sync

### DIFF
--- a/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
+++ b/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
@@ -561,9 +561,10 @@ class ParallelFoldFittingStrategy(FoldFittingStrategy):
                                              predict_time=predict_time,
                                              predict_1_time=predict_1_time,
                                              fold_ctx=fold_ctx)
-                model_sync_path: str = self.model_sync_path + fold_model
-                if not model_sync_path.endswith("/"):
-                    model_sync_path += "/"
+                if model_sync_path is not None:
+                    model_sync_path: str = self.model_sync_path + fold_model
+                    if not model_sync_path.endswith("/"):
+                        model_sync_path += "/"
                 self.sync_model_artifact(
                     local_path=os.path.join(self.bagged_ensemble_model.path + fold_model),
                     model_sync_path=model_sync_path

--- a/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
+++ b/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
@@ -561,7 +561,7 @@ class ParallelFoldFittingStrategy(FoldFittingStrategy):
                                              predict_time=predict_time,
                                              predict_1_time=predict_1_time,
                                              fold_ctx=fold_ctx)
-                if model_sync_path is not None:
+                if self.model_sync_path is not None:
                     model_sync_path: str = self.model_sync_path + fold_model
                     if not model_sync_path.endswith("/"):
                         model_sync_path += "/"

--- a/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
+++ b/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
@@ -561,6 +561,7 @@ class ParallelFoldFittingStrategy(FoldFittingStrategy):
                                              predict_time=predict_time,
                                              predict_1_time=predict_1_time,
                                              fold_ctx=fold_ctx)
+                model_sync_path = None
                 if self.model_sync_path is not None:
                     model_sync_path: str = self.model_sync_path + fold_model
                     if not model_sync_path.endswith("/"):

--- a/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
+++ b/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
@@ -539,7 +539,8 @@ class ParallelFoldFittingStrategy(FoldFittingStrategy):
                 fold_ctx=fold_ctx,
                 resources=self.resources,
                 head_node_id=head_node_id,
-                kwargs=self.model_base_kwargs)
+                kwargs=self.model_base_kwargs
+            )
             job_fold_map[ref] = fold_ctx
             job_refs.append(ref)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Add logic to check if the ray task is executed on the head node. If so, avoid uploading/downloading it cause it's already present in the local disk
* Sync on fold level instead of bag level to 1. avoid download duplicate models when training with repeats 2. sync model artifacts when the head is waiting worker nodes to finish

Example run with some logs enabled:
```bash
Fitting 1 L1 models ...
Fitting model: LightGBM_BAG_L1 ... Training model for up to 599.77s of the 599.77s of remaining time.
        Fitting 2 child models (S1F1 - S1F2) | Fitting with ParallelDistributedFoldFittingStrategy
Will download 0 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S1F1/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S1F1
['model.pkl']
Will download 1 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S1F2/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S1F2
['model.pkl']
        0.8714   = Validation score   (accuracy)
        0.76s    = Training   runtime
        0.1s     = Validation runtime
Repeating k-fold bagging: 2/20
Fitting model: LightGBM_BAG_L1 ... Training model for up to 596.57s of the 596.57s of remaining time.
        Fitting 2 child models (S2F1 - S2F2) | Fitting with ParallelDistributedFoldFittingStrategy
Will download 0 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S2F1/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S2F1
['model.pkl']
Will download 1 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S2F2/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S2F2
['model.pkl']
        0.8724   = Validation score   (accuracy)
        1.46s    = Training   runtime
        0.2s     = Validation runtime
Repeating k-fold bagging: 3/20
Fitting model: LightGBM_BAG_L1 ... Training model for up to 593.33s of the 593.33s of remaining time.
        Fitting 2 child models (S3F1 - S3F2) | Fitting with ParallelDistributedFoldFittingStrategy
Will download 0 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S3F1/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S3F1
['model.pkl']
Will download 1 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S3F2/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S3F2
['model.pkl']
        0.8723   = Validation score   (accuracy)
        2.14s    = Training   runtime
        0.3s     = Validation runtime
Repeating k-fold bagging: 4/20
Fitting model: LightGBM_BAG_L1 ... Training model for up to 590.21s of the 590.21s of remaining time.
        Fitting 2 child models (S4F1 - S4F2) | Fitting with ParallelDistributedFoldFittingStrategy
Will download 0 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S4F1/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S4F1
['model.pkl']
Will download 1 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S4F2/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S4F2
['model.pkl']
        0.8732   = Validation score   (accuracy)
        2.81s    = Training   runtime
        0.38s    = Validation runtime
Repeating k-fold bagging: 5/20
Fitting model: LightGBM_BAG_L1 ... Training model for up to 587.21s of the 587.21s of remaining time.
        Fitting 2 child models (S5F1 - S5F2) | Fitting with ParallelDistributedFoldFittingStrategy
Will download 0 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S5F1/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S5F1
['model.pkl']
Will download 1 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S5F2/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S5F2
['model.pkl']
        0.8729   = Validation score   (accuracy)
        3.55s    = Training   runtime
        0.5s     = Validation runtime
Repeating k-fold bagging: 6/20
Fitting model: LightGBM_BAG_L1 ... Training model for up to 584.08s of the 584.08s of remaining time.
        Fitting 2 child models (S6F1 - S6F2) | Fitting with ParallelDistributedFoldFittingStrategy
Will download 0 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S6F1/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S6F1
['model.pkl']
Will download 1 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S6F2/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S6F2
['model.pkl']
        0.8733   = Validation score   (accuracy)
        4.18s    = Training   runtime
        0.59s    = Validation runtime
Repeating k-fold bagging: 7/20
Fitting model: LightGBM_BAG_L1 ... Training model for up to 580.99s of the 580.99s of remaining time.
        Fitting 2 child models (S7F1 - S7F2) | Fitting with ParallelDistributedFoldFittingStrategy
Will download 0 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S7F1/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S7F1
['model.pkl']
Will download 1 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S7F2/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S7F2
['model.pkl']
        0.8736   = Validation score   (accuracy)
        4.85s    = Training   runtime
        0.69s    = Validation runtime
Repeating k-fold bagging: 8/20
Fitting model: LightGBM_BAG_L1 ... Training model for up to 577.96s of the 577.96s of remaining time.
        Fitting 2 child models (S8F1 - S8F2) | Fitting with ParallelDistributedFoldFittingStrategy
Will download 0 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S8F1/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S8F1
['model.pkl']
Will download 1 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S8F2/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S8F2
['model.pkl']
        0.8736   = Validation score   (accuracy)
        5.55s    = Training   runtime
        0.8s     = Validation runtime
Repeating k-fold bagging: 9/20
Fitting model: LightGBM_BAG_L1 ... Training model for up to 574.88s of the 574.88s of remaining time.
        Fitting 2 child models (S9F1 - S9F2) | Fitting with ParallelDistributedFoldFittingStrategy
Will download 0 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S9F1/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S9F1
['model.pkl']
Will download 1 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S9F2/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S9F2
['model.pkl']
        0.8737   = Validation score   (accuracy)
        6.43s    = Training   runtime
        0.93s    = Validation runtime
Repeating k-fold bagging: 10/20
Fitting model: LightGBM_BAG_L1 ... Training model for up to 571.79s of the 571.79s of remaining time.
        Fitting 2 child models (S10F1 - S10F2) | Fitting with ParallelDistributedFoldFittingStrategy
Will download 0 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S10F1/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S10F1
['model.pkl']
Will download 1 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S10F2/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S10F2
['model.pkl']
        0.8739   = Validation score   (accuracy)
        7.08s    = Training   runtime
        1.0s     = Validation runtime
Repeating k-fold bagging: 11/20
Fitting model: LightGBM_BAG_L1 ... Training model for up to 568.87s of the 568.87s of remaining time.
        Fitting 2 child models (S11F1 - S11F2) | Fitting with ParallelDistributedFoldFittingStrategy
Will download 0 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S11F1/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S11F1
['model.pkl']
Will download 1 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S11F2/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S11F2
['model.pkl']
        0.8739   = Validation score   (accuracy)
        7.79s    = Training   runtime
        1.12s    = Validation runtime
Repeating k-fold bagging: 12/20
Fitting model: LightGBM_BAG_L1 ... Training model for up to 565.77s of the 565.77s of remaining time.
        Fitting 2 child models (S12F1 - S12F2) | Fitting with ParallelDistributedFoldFittingStrategy
Will download 0 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S12F1/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S12F1
['model.pkl']
Will download 1 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S12F2/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S12F2
['model.pkl']
        0.8736   = Validation score   (accuracy)
        8.45s    = Training   runtime
        1.2s     = Validation runtime
Repeating k-fold bagging: 13/20
Fitting model: LightGBM_BAG_L1 ... Training model for up to 562.76s of the 562.76s of remaining time.
        Fitting 2 child models (S13F1 - S13F2) | Fitting with ParallelDistributedFoldFittingStrategy
Will download 0 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S13F1/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S13F1
['model.pkl']
Will download 1 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S13F2/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S13F2
['model.pkl']
        0.8738   = Validation score   (accuracy)
        9.09s    = Training   runtime
        1.28s    = Validation runtime
Repeating k-fold bagging: 14/20
Fitting model: LightGBM_BAG_L1 ... Training model for up to 559.75s of the 559.75s of remaining time.
        Fitting 2 child models (S14F1 - S14F2) | Fitting with ParallelDistributedFoldFittingStrategy
Will download 0 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S14F1/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S14F1
['model.pkl']
Will download 1 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S14F2/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S14F2
['model.pkl']
        0.8737   = Validation score   (accuracy)
        9.76s    = Training   runtime
        1.38s    = Validation runtime
Repeating k-fold bagging: 15/20
Fitting model: LightGBM_BAG_L1 ... Training model for up to 556.59s of the 556.59s of remaining time.
        Fitting 2 child models (S15F1 - S15F2) | Fitting with ParallelDistributedFoldFittingStrategy
Will download 0 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S15F1/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S15F1
['model.pkl']
Will download 1 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S15F2/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S15F2
['model.pkl']
        0.874    = Validation score   (accuracy)
        10.49s   = Training   runtime
        1.51s    = Validation runtime
Repeating k-fold bagging: 16/20
Fitting model: LightGBM_BAG_L1 ... Training model for up to 552.89s of the 552.89s of remaining time.
        Fitting 2 child models (S16F1 - S16F2) | Fitting with ParallelDistributedFoldFittingStrategy
Will download 0 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S16F1/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S16F1
['model.pkl']
Will download 1 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S16F2/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S16F2
['model.pkl']
        0.8739   = Validation score   (accuracy)
        11.2s    = Training   runtime
        1.62s    = Validation runtime
Repeating k-fold bagging: 17/20
Fitting model: LightGBM_BAG_L1 ... Training model for up to 549.7s of the 549.7s of remaining time.
        Fitting 2 child models (S17F1 - S17F2) | Fitting with ParallelDistributedFoldFittingStrategy
Will download 0 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S17F1/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S17F1
['model.pkl']
Will download 1 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S17F2/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S17F2
['model.pkl']
        0.8738   = Validation score   (accuracy)
        12.03s   = Training   runtime
        1.74s    = Validation runtime
Repeating k-fold bagging: 18/20
Fitting model: LightGBM_BAG_L1 ... Training model for up to 546.6s of the 546.59s of remaining time.
        Fitting 2 child models (S18F1 - S18F2) | Fitting with ParallelDistributedFoldFittingStrategy
Will download 0 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S18F1/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S18F1
['model.pkl']
Will download 1 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S18F2/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S18F2
['model.pkl']
        0.8742   = Validation score   (accuracy)
        12.78s   = Training   runtime
        1.87s    = Validation runtime
Repeating k-fold bagging: 19/20
Fitting model: LightGBM_BAG_L1 ... Training model for up to 543.33s of the 543.33s of remaining time.
        Fitting 2 child models (S19F1 - S19F2) | Fitting with ParallelDistributedFoldFittingStrategy
Will download 0 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S19F1/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S19F1
['model.pkl']
Will download 1 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S19F2/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S19F2
['model.pkl']
        0.874    = Validation score   (accuracy)
        13.38s   = Training   runtime
        1.94s    = Validation runtime
Repeating k-fold bagging: 20/20
Fitting model: LightGBM_BAG_L1 ... Training model for up to 540.34s of the 540.34s of remaining time.
        Fitting 2 child models (S20F1 - S20F2) | Fitting with ParallelDistributedFoldFittingStrategy
Will download 0 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S20F1/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S20F1
['model.pkl']
Will download 1 objects from s3://weisy-personal/test_distributed/utils/LightGBM_BAG_L1/S20F2/ to AutogluonModels/ag-20230411_204255/models/LightGBM_BAG_L1/S20F2
['model.pkl']
        0.874    = Validation score   (accuracy)
        14.28s   = Training   runtime
        2.11s    = Validation runtime
Completed 20/20 k-fold bagging repeats ...
Fitting model: WeightedEnsemble_L2 ... Training model for up to 360.0s of the 537.07s of remaining time.
        0.874    = Validation score   (accuracy)
        0.01s    = Training   runtime
        0.05s    = Validation runtime
AutoGluon training complete, total runtime = 63.01s ... Best model: "WeightedEnsemble_L2"
TabularPredictor saved. To load, use: predictor = TabularPredictor.load("AutogluonModels/ag-20230411_204255/")
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
