### PR TITLE
[eda] Add shift analysis descriptive information to state object

### DIFF
--- a/eda/src/autogluon/eda/analysis/shift.py
+++ b/eda/src/autogluon/eda/analysis/shift.py
@@ -23,13 +23,22 @@ class XShiftDetector(AbstractAnalysis, StateCheckMixin):
 
     State attributes
 
-    - `state.xshift_results`: outputs the results of XShift detection,
-        dict of
-            - `detection_status`: bool, True if detected
-            - `test_statistic`: float, the C2ST statistic
-            - `pvalue`: float, the p-value using permutation test
-            - `pvalue_threshold`: float, the decision p-value threshold
-            - `feature_importance`: DataFrame, the feature importance dataframe, if computed
+    - `xshift_results.detection_status`:
+        bool, True if detected
+    - `xshift_results.test_statistic`: float
+        Classifier Two-Sample Test (C2ST) statistic. It is a measure how well a classifier distinguishes between the samples from the training and test sets.
+        If the classifier can accurately separate the samples, it suggests that the input distributions differ significantly, indicating the presence of
+        covariate shift. A C2ST value close to 0.5 implies that the classifier struggles to differentiate between the sets, indicating minimal covariate shift.
+        In contrast, a value significantly different from 0.5 suggests the presence of covariate shift, warranting further investigation and potential
+        adjustments to the model or data preprocessing.
+    - `xshift_results.pvalue`: float
+        p-value using permutation test
+    - `xshift_results.pvalue_threshold`: float,
+        decision boundary of p-value threshold
+    - `xshift_results.feature_importance`: DataFrame,
+        the feature importance dataframe, if computed
+    - `xshift_results.shift_features`
+        list of features whose contribution is statistically significant; only present if `xshift_results.detection_status = True`
 
     Parameters
     ----------
@@ -41,7 +50,7 @@ class XShiftDetector(AbstractAnalysis, StateCheckMixin):
         The threshold for the pvalue
     eval_metric : str, default = 'balanced_accuracy'
         The metric used for the C2ST, it must be one of the binary metrics from autogluon.core.metrics
-    sample_label : str, default = 'i2vkyc0p64'
+    sample_label : str, default = '__label__'
         The label internally used for the classifier 2 sample test, the only reason to change it is in the off chance
         that the default value is a column in the data.
     classifier_kwargs : dict, default = {}
@@ -61,7 +70,7 @@ class XShiftDetector(AbstractAnalysis, StateCheckMixin):
         compute_fi: bool = True,
         pvalue_thresh: float = 0.01,
         eval_metric: str = "roc_auc",
-        sample_label: str = "i2vkyc0p64",
+        sample_label: str = "__label__",
         classifier_kwargs: Optional[dict] = None,
         classifier_fit_kwargs: Optional[dict] = None,
         num_permutations: int = 1000,
@@ -125,14 +134,22 @@ class XShiftDetector(AbstractAnalysis, StateCheckMixin):
         else:
             fi_scores = None
         pvalue = self.C2ST.pvalue(num_permutations=self.num_permutations)
+
+        detection_status = bool(pvalue <= self.pvalue_thresh)  # numpy.bool_ -> bool
+
         state.xshift_results = {
-            "detection_status": bool(pvalue <= self.pvalue_thresh),  # numpy.bool_ -> bool
+            "detection_status": detection_status,
             "test_statistic": self.C2ST.test_stat,
             "pvalue": pvalue,
             "pvalue_threshold": self.pvalue_thresh,
             "eval_metric": self.eval_metric.name,
             "feature_importance": fi_scores,
         }
+
+        if detection_status:
+            fi_scores = fi_scores[fi_scores.p_value <= self.pvalue_thresh]
+            shift_features = fi_scores.index.tolist()
+            state.xshift_results["shift_features"] = shift_features
 
 
 def post_fit(func):

--- a/eda/src/autogluon/eda/auto/simple.py
+++ b/eda/src/autogluon/eda/auto/simple.py
@@ -747,11 +747,10 @@ def covariate_shift_detection(
 
     # Plot distribution differences between datasets
     # TODO: move `vars_to_plot` calculation to analysis
-    xshift_results: AnalysisState = state.xshift_results  # type: ignore # state is always present
-    if xshift_results.detection_status:
-        fi = xshift_results.feature_importance
-        fi = fi[fi.p_value <= xshift_results.pvalue_threshold]
-        vars_to_plot = fi.index.tolist()[: XShiftSummary.MAX_FEATURES_TO_DISPLAY]
+    # type: ignore # state is always present
+    xshift: AnalysisState = state.xshift_results  # type: ignore[union-attr]  # state is not none
+    if xshift.detection_status:
+        vars_to_plot = xshift.shift_features[: XShiftSummary.MAX_FEATURES_TO_DISPLAY]
         if len(vars_to_plot) > 0:
             _train_data = train_data[vars_to_plot].copy()
             _train_data["__dataset__"] = "train_data"
@@ -761,7 +760,7 @@ def covariate_shift_detection(
 
             for var in vars_to_plot:
                 if state.variable_type.train_data[var] != "category":  # type: ignore
-                    pvalue = fi.loc[var]["p_value"]
+                    pvalue = xshift.feature_importance.loc[var]["p_value"]
                     analyze(
                         viz_facets=[
                             MarkdownSectionComponent(


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/autogluon/autogluon/issues/3133

*Description of changes:*

- `XShiftDetector` now produces `xshift_results.shift_features` which contain a list of features whose contribution is statistically significant; only present if `xshift_results.detection_status = True`. Please note, unlike visualization, this property is not trimmed to max number of elements to display; it contains only statistically significant features in the decreasing order of importance.
- docs improvements


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
