### PR TITLE
Add s3_download utils

### DIFF
--- a/common/src/autogluon/common/utils/s3_utils.py
+++ b/common/src/autogluon/common/utils/s3_utils.py
@@ -144,6 +144,7 @@ def download_s3_folder(
 ):
     """
     This util function downloads a s3 folder and maintain its structure.
+    Note that empty folders will not be downloaded.
     For example, assuming bucket = bar and prefix = foo, and the bucket structure looks like this
         .
         └── bar/

--- a/common/tests/unittests/test_s3_utils.py
+++ b/common/tests/unittests/test_s3_utils.py
@@ -1,27 +1,26 @@
-from autogluon.common.utils.s3_utils import _get_local_path_to_download_objs_and_local_dir_to_create, _get_local_objs_to_upload_and_s3_prefix
+from autogluon.common.utils.s3_utils import _get_local_path_to_download_objs, _get_local_objs_to_upload_and_s3_prefix
 
 import pytest
 import tempfile
 import os
 
 @pytest.mark.parametrize(
-    "s3_objs,prefix,local_path,expected_objs,expected_dirs",
+    "s3_objs,prefix,local_path,expected_objs",
     [
-        (["foo/"], "foo", ".", [], []),
-        (["foo/", "foo/test.txt"], "foo", ".", ["test.txt"], []),
-        (["foo/test.txt", "foo/test2.txt"], "foo", ".", ["test.txt", "test2.txt"], []),
-        (["foo/temp/", "foo/test.txt"], "foo", ".", ["test.txt"], ["temp"]),
-        (["foo/temp/test.txt", "foo/test2.txt"], "foo", ".", ["temp/test.txt", "test2.txt"], ["temp"]),
-        (["foo/temp/test.txt"], "foo", ".", ["temp/test.txt"], ["temp"]),
-        (["foo/temp/temp2/test.txt"], "foo", ".", ["temp/temp2/test.txt"], ["temp/temp2"]),
-        (["foo/temp/temp2/test.txt", "foo/temp/temp3/test.txt"], "foo", ".", ["temp/temp2/test.txt", "temp/temp3/test.txt"], ["temp/temp2", "temp/temp3"]),
+        ([], "foo", ".", []),
+        (["foo/test.txt"], "foo", ".", ["test.txt"]),
+        (["foo/test.txt", "foo/test2.txt"], "foo", ".", ["test.txt", "test2.txt"]),
+        (["foo/test.txt"], "foo", ".", ["test.txt"]),
+        (["foo/temp/test.txt", "foo/test2.txt"], "foo", ".", ["temp/test.txt", "test2.txt"]),
+        (["foo/temp/test.txt"], "foo", ".", ["temp/test.txt"]),
+        (["foo/temp/temp2/test.txt"], "foo", ".", ["temp/temp2/test.txt"]),
+        (["foo/temp/temp2/test.txt", "foo/temp/temp3/test.txt"], "foo", ".", ["temp/temp2/test.txt", "temp/temp3/test.txt"]),
     ]
 )
-def test_get_local_path_to_download_objs_and_local_dir_to_create(s3_objs, prefix, local_path, expected_objs, expected_dirs):
-    objs, dirs = _get_local_path_to_download_objs_and_local_dir_to_create(s3_objs=s3_objs, prefix=prefix, local_path=local_path)
+def test_get_local_path_to_download_objs(s3_objs, prefix, local_path, expected_objs):
+    objs = _get_local_path_to_download_objs(s3_objs=s3_objs, prefix=prefix, local_path=local_path)
     assert sorted(objs) == sorted(expected_objs)
-    assert sorted(dirs) == sorted(expected_dirs)
-    
+
     
 def test_get_local_objs_to_upload_and_s3_prefix():
     """


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Added logic to download a list of files, and generally added flexibility to our s3 download logic.
- Removed folder creation tracking logic and replaced with calling `mkdir` prior to downloading a given file.

TODO:

- [x] Add unit tests
- [x] Add documentation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
