### PR TITLE
Maximum resources

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -550,39 +550,14 @@ class AbstractModel:
             if user_specified_model_level_resource is not None:
                 user_specified_lower_level_resource = min(user_specified_model_level_resource * k_fold, system_resource, user_specified_total_resource)
         return user_specified_lower_level_resource
-
-    def _preprocess_fit_resources(self, silent=False, total_resources=None, parallel_hpo=False, **kwargs):
-        """
-        This function should be called to process user-specified total resources.
-        Sanity checks will be done to user-specified total resources to make sure it's legit.
-        When user-specified resources are not defined, will instead look at model's default resource requirements.
-        """
-        if 'num_cpus' in kwargs and 'num_gpus' in kwargs:
-            # This value will only be passed by autogluon through previous layers(i.e. bagged model to model base).
-            # We respect this value with highest priority
-            # They should always be set to valid values
-            enforced_num_cpus = kwargs.get('num_cpus', None)
-            enforced_num_gpus = kwargs.get('num_gpus', None)
-            assert enforced_num_cpus is not None and enforced_num_cpus != 'auto' and enforced_num_gpus is not None and enforced_num_gpus != 'auto'
-            # The logic below is needed because ray cluster is running some process in the backend even when it's ready to be used
-            # Trying to use all cores on the machine could lead to resource contention situation
-            # TODO: remove this logic if ray team can identify what's going on underneath and how to workaround
-            if DistributedContext.is_distributed_mode():
-                minimum_model_resources = self.get_minimum_resources(
-                    is_gpu_available=(enforced_num_gpus > 0)
-                )
-                minimum_model_num_cpus = minimum_model_resources.get('num_cpus', 1)
-                enforced_num_cpus = max(minimum_model_num_cpus, enforced_num_cpus - 2)  # leave some cpu resources for process running by cluster nodes
-            max_resources = self._get_maximum_resources()
-            max_num_cpus = max_resources.get("num_cpus", None)
-            max_num_gpus = max_resources.get("num_gpus", None)
-            if max_num_cpus is not None:
-                enforced_num_cpus = min(max_num_cpus, enforced_num_cpus)
-            if max_num_gpus is not None:
-                enforced_num_gpus = min(max_num_gpus, enforced_num_gpus)
-            kwargs["num_cpus"] = enforced_num_cpus
-            kwargs["num_gpus"] = enforced_num_gpus
-            return kwargs
+    
+    def _calculate_total_resources(
+        self,
+        silent: bool = False,
+        total_resources: Optional[Dict[str, Union[int, float]]] = None,
+        parallel_hpo: bool = False,
+        **kwargs
+        ):
         resource_manager = get_resource_manager()
         system_num_cpus = resource_manager.get_cpu_count()
         system_num_gpus = resource_manager.get_gpu_count_all()
@@ -676,7 +651,43 @@ class AbstractModel:
         kwargs['num_gpus'] = num_gpus
         if not silent:
             logger.log(15, f"\tFitting {self.name} with 'num_gpus': {kwargs['num_gpus']}, 'num_cpus': {kwargs['num_cpus']}")
+        
         return kwargs
+
+    def _preprocess_fit_resources(self, silent=False, total_resources=None, parallel_hpo=False, **kwargs):
+        """
+        This function should be called to process user-specified total resources.
+        Sanity checks will be done to user-specified total resources to make sure it's legit.
+        When user-specified resources are not defined, will instead look at model's default resource requirements.
+        """
+        if 'num_cpus' in kwargs and 'num_gpus' in kwargs:
+            # This value will only be passed by autogluon through previous layers(i.e. bagged model to model base).
+            # We respect this value with highest priority
+            # They should always be set to valid values
+            enforced_num_cpus = kwargs.get('num_cpus', None)
+            enforced_num_gpus = kwargs.get('num_gpus', None)
+            assert enforced_num_cpus is not None and enforced_num_cpus != 'auto' and enforced_num_gpus is not None and enforced_num_gpus != 'auto'
+            # The logic below is needed because ray cluster is running some process in the backend even when it's ready to be used
+            # Trying to use all cores on the machine could lead to resource contention situation
+            # TODO: remove this logic if ray team can identify what's going on underneath and how to workaround
+            max_resources = self._get_maximum_resources()
+            max_num_cpus = max_resources.get("num_cpus", None)
+            max_num_gpus = max_resources.get("num_gpus", None)
+            if max_num_gpus is not None:
+                enforced_num_gpus = min(max_num_gpus, enforced_num_gpus)
+            if DistributedContext.is_distributed_mode():
+                minimum_model_resources = self.get_minimum_resources(
+                    is_gpu_available=(enforced_num_gpus > 0)
+                )
+                minimum_model_num_cpus = minimum_model_resources.get('num_cpus', 1)
+                enforced_num_cpus = max(minimum_model_num_cpus, enforced_num_cpus - 2)  # leave some cpu resources for process running by cluster nodes
+            if max_num_cpus is not None:
+                enforced_num_cpus = min(max_num_cpus, enforced_num_cpus)
+            kwargs["num_cpus"] = enforced_num_cpus
+            kwargs["num_gpus"] = enforced_num_gpus
+            return kwargs
+        
+        return self._calculate_total_resources(silent=silent, total_resources=total_resources, parallel_hpo=parallel_hpo, **kwargs)
 
     def _register_fit_metadata(self, **kwargs):
         """
@@ -1665,7 +1676,7 @@ class AbstractModel:
         save_json.save(path=json_path, obj=info)
         return info
     
-    def _get_maximum_resources(self) -> Dict[str, Union[int,float]]:
+    def _get_maximum_resources(self) -> Dict[str, Union[int, float]]:
         """
         Get the maximum resources allowed to use for this model.
         This can be useful when model not scale well with resources, i.e. cpu cores.
@@ -1673,7 +1684,9 @@ class AbstractModel:
         
         Return
         ------
-        Dict[str, Union[int,float]]
+        Dict[str, Union[int, float]]
+            key, name of the resource, i.e. `num_cpus`, `num_gpus`
+            value, maximum amount of resources
         """
         return {}
         

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -568,15 +568,15 @@ class AbstractModel:
             # Trying to use all cores on the machine could lead to resource contention situation
             # TODO: remove this logic if ray team can identify what's going on underneath and how to workaround
             if DistributedContext.is_distributed_mode():
-                max_num_cpus = self._get_maximum_resources().get("num_cpus", None)
-                if max_num_cpus is not None:
-                    enforced_num_cpus = min(max_num_cpus, enforced_num_cpus)
                 minimum_model_resources = self.get_minimum_resources(
                     is_gpu_available=(enforced_num_gpus > 0)
                 )
                 minimum_model_num_cpus = minimum_model_resources.get('num_cpus', 1)
                 enforced_num_cpus = max(minimum_model_num_cpus, enforced_num_cpus - 2)  # leave some cpu resources for process running by cluster nodes
-                kwargs["num_cpus"] = enforced_num_cpus
+            max_num_cpus = self._get_maximum_resources().get("num_cpus", None)
+            if max_num_cpus is not None:
+                enforced_num_cpus = min(max_num_cpus, enforced_num_cpus)
+            kwargs["num_cpus"] = enforced_num_cpus
             return kwargs
         resource_manager = get_resource_manager()
         system_num_cpus = resource_manager.get_cpu_count()

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -557,7 +557,14 @@ class AbstractModel:
         total_resources: Optional[Dict[str, Union[int, float]]] = None,
         parallel_hpo: bool = False,
         **kwargs
-        ):
+    ) -> Dict[str, Any]:
+        """
+        Process user-specified total resources.
+        Sanity checks will be done to user-specified total resources to make sure it's legit.
+        When user-specified resources are not defined, will instead look at model's default resource requirements.
+        
+        Will set the calculated total resources in kwargs and return it
+        """
         resource_manager = get_resource_manager()
         system_num_cpus = resource_manager.get_cpu_count()
         system_num_gpus = resource_manager.get_gpu_count_all()
@@ -654,11 +661,22 @@ class AbstractModel:
         
         return kwargs
 
-    def _preprocess_fit_resources(self, silent=False, total_resources=None, parallel_hpo=False, **kwargs):
+    def _preprocess_fit_resources(
+        self,
+        silent: bool = False,
+        total_resources: Optional[Dict[str, Union[int, float]]] = None,
+        parallel_hpo: bool = False,
+        **kwargs
+    ) -> Dict[str, Any]:
         """
         This function should be called to process user-specified total resources.
         Sanity checks will be done to user-specified total resources to make sure it's legit.
         When user-specified resources are not defined, will instead look at model's default resource requirements.
+        
+        When kwargs contains `num_cpus` and `num_gpus` means this total resources has been calculated by previous layers(i.e. bagged model to model base).
+        Will respect this value and check if there's specific maximum resource requirements and enforce those
+        
+        Will set the calculated resources in kwargs and return it
         """
         if 'num_cpus' in kwargs and 'num_gpus' in kwargs:
             # This value will only be passed by autogluon through previous layers(i.e. bagged model to model base).

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -573,10 +573,15 @@ class AbstractModel:
                 )
                 minimum_model_num_cpus = minimum_model_resources.get('num_cpus', 1)
                 enforced_num_cpus = max(minimum_model_num_cpus, enforced_num_cpus - 2)  # leave some cpu resources for process running by cluster nodes
-            max_num_cpus = self._get_maximum_resources().get("num_cpus", None)
+            max_resources = self._get_maximum_resources()
+            max_num_cpus = max_resources.get("num_cpus", None)
+            max_num_gpus = max_resources.get("num_gpus", None)
             if max_num_cpus is not None:
                 enforced_num_cpus = min(max_num_cpus, enforced_num_cpus)
+            if max_num_gpus is not None:
+                enforced_num_gpus = min(max_num_gpus, enforced_num_gpus)
             kwargs["num_cpus"] = enforced_num_cpus
+            kwargs["num_gpus"] = enforced_num_gpus
             return kwargs
         resource_manager = get_resource_manager()
         system_num_cpus = resource_manager.get_cpu_count()
@@ -1660,11 +1665,15 @@ class AbstractModel:
         save_json.save(path=json_path, obj=info)
         return info
     
-    def _get_maximum_resources(self) -> Dict[str, float]:
+    def _get_maximum_resources(self) -> Dict[str, Union[int,float]]:
         """
         Get the maximum resources allowed to use for this model.
         This can be useful when model not scale well with resources, i.e. cpu cores.
         Return empty dict if no maximum resources needed
+        
+        Return
+        ------
+        Dict[str, Union[int,float]]
         """
         return {}
         

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -532,6 +532,7 @@ class NNFastAiTabularModel(AbstractModel):
         return RAY_BACKEND
     
     def _get_maximum_resources(self) -> Dict[str, float]:
+        # fastai model trains slower when utilizing virtual cores and this issue scale up when the number of cpu cores increases
         return {
             "num_cpus": ResourceManager.get_cpu_count_psutil(logical=False)
         }

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -3,6 +3,7 @@ import logging
 import time
 from builtins import classmethod
 from pathlib import Path
+from typing import Dict
 
 import numpy as np
 import pandas as pd
@@ -529,6 +530,11 @@ class NNFastAiTabularModel(AbstractModel):
     def _get_hpo_backend(self):
         """Choose which backend(Ray or Custom) to use for hpo"""
         return RAY_BACKEND
+    
+    def _get_maximum_resources(self) -> Dict[str, float]:
+        return {
+            "num_cpus": ResourceManager.get_cpu_count_psutil(logical=False)
+        }
 
     def get_minimum_resources(self, is_gpu_available=False):
         minimum_resources = {

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -3,7 +3,7 @@ import logging
 import time
 from builtins import classmethod
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Union
 
 import numpy as np
 import pandas as pd
@@ -531,7 +531,7 @@ class NNFastAiTabularModel(AbstractModel):
         """Choose which backend(Ray or Custom) to use for hpo"""
         return RAY_BACKEND
     
-    def _get_maximum_resources(self) -> Dict[str, float]:
+    def _get_maximum_resources(self) -> Dict[str, Union[int, float]]:
         # fastai model trains slower when utilizing virtual cores and this issue scale up when the number of cpu cores increases
         return {
             "num_cpus": ResourceManager.get_cpu_count_psutil(logical=False)

--- a/tabular/src/autogluon/tabular/models/knn/knn_model.py
+++ b/tabular/src/autogluon/tabular/models/knn/knn_model.py
@@ -246,13 +246,14 @@ class KNNModel(AbstractModel):
         return self.model
     
     def _get_maximum_resources(self) -> Dict[str, float]:
+        # use at most 32 cpus to avoid OpenBLAS error: https://github.com/autogluon/autogluon/issues/1020
         return {
-            "num_cpus": min(32, ResourceManager.get_cpu_count())
+            "num_cpus": 32
         }
 
     def _get_default_resources(self):
         # use at most 32 cpus to avoid OpenBLAS error: https://github.com/autogluon/autogluon/issues/1020
-        num_cpus = min(32, ResourceManager.get_cpu_count())
+        num_cpus = ResourceManager.get_cpu_count()
         num_gpus = 0
         return num_cpus, num_gpus
 

--- a/tabular/src/autogluon/tabular/models/knn/knn_model.py
+++ b/tabular/src/autogluon/tabular/models/knn/knn_model.py
@@ -4,7 +4,7 @@ import numpy as np
 import math
 import time
 
-from typing import Dict
+from typing import Dict, Union
 
 from autogluon.common.features.types import R_INT, R_FLOAT, S_BOOL
 from autogluon.common.utils.resource_utils import ResourceManager
@@ -245,7 +245,7 @@ class KNNModel(AbstractModel):
             self._X_unused_index = [i for i in range(num_rows_max) if i not in idx]
         return self.model
     
-    def _get_maximum_resources(self) -> Dict[str, float]:
+    def _get_maximum_resources(self) -> Dict[str, Union[int, float]]:
         # use at most 32 cpus to avoid OpenBLAS error: https://github.com/autogluon/autogluon/issues/1020
         return {
             "num_cpus": 32

--- a/tabular/src/autogluon/tabular/models/knn/knn_model.py
+++ b/tabular/src/autogluon/tabular/models/knn/knn_model.py
@@ -4,6 +4,8 @@ import numpy as np
 import math
 import time
 
+from typing import Dict
+
 from autogluon.common.features.types import R_INT, R_FLOAT, S_BOOL
 from autogluon.common.utils.resource_utils import ResourceManager
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION
@@ -242,6 +244,11 @@ class KNNModel(AbstractModel):
             idx = set(idx)
             self._X_unused_index = [i for i in range(num_rows_max) if i not in idx]
         return self.model
+    
+    def _get_maximum_resources(self) -> Dict[str, float]:
+        return {
+            "num_cpus": min(32, ResourceManager.get_cpu_count())
+        }
 
     def _get_default_resources(self):
         # use at most 32 cpus to avoid OpenBLAS error: https://github.com/autogluon/autogluon/issues/1020

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -551,6 +551,7 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
         return self.eval_metric
     
     def _get_maximum_resources(self) -> Dict[str, float]:
+        # torch model trains slower when utilizing virtual cores and this issue scale up when the number of cpu cores increases
         return {
             "num_cpus": ResourceManager.get_cpu_count_psutil(logical=False)
         }

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -7,6 +7,8 @@ import warnings
 import numpy as np
 import pandas as pd
 
+from typing import Dict
+
 from autogluon.common.features.types import R_BOOL, R_INT, R_FLOAT, R_CATEGORY, S_TEXT_NGRAM, S_TEXT_AS_CATEGORY
 from autogluon.common.utils.resource_utils import ResourceManager
 from autogluon.common.utils.try_import import try_import_torch
@@ -547,6 +549,11 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
 
     def _get_default_stopping_metric(self):
         return self.eval_metric
+    
+    def _get_maximum_resources(self) -> Dict[str, float]:
+        return {
+            "num_cpus": ResourceManager.get_cpu_count_psutil(logical=False)
+        }
 
     def _get_default_resources(self):
         # logical=False is faster in training

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -7,7 +7,7 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from typing import Dict
+from typing import Dict, Union
 
 from autogluon.common.features.types import R_BOOL, R_INT, R_FLOAT, R_CATEGORY, S_TEXT_NGRAM, S_TEXT_AS_CATEGORY
 from autogluon.common.utils.resource_utils import ResourceManager
@@ -550,7 +550,7 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
     def _get_default_stopping_metric(self):
         return self.eval_metric
     
-    def _get_maximum_resources(self) -> Dict[str, float]:
+    def _get_maximum_resources(self) -> Dict[str, Union[int, float]]:
         # torch model trains slower when utilizing virtual cores and this issue scale up when the number of cpu cores increases
         return {
             "num_cpus": ResourceManager.get_cpu_count_psutil(logical=False)


### PR DESCRIPTION
*Issue #, if available:*
torch models training will be slowed by the usage of virtual cores.

*Description of changes:*
* Add maximum resources check when in distributed mode

Example run output with a newly launched cluster of 8 m5.24xlarge machine:
The training time matches a local run and appear to be normal now
```bash
Fitting 1 L1 models ...
Fitting model: NeuralNetFastAI_BAG_L1 ...
        Fitting 8 child models (S1F1 - S1F8) | Fitting with ParallelDistributedFoldFittingStrategy
        0.9224   = Validation score   (accuracy)
        286.06s  = Training   runtime
        3.44s    = Validation runtime
Fitting model: WeightedEnsemble_L2 ...
        0.9224   = Validation score   (accuracy)
        0.08s    = Training   runtime
        0.04s    = Validation runtime
AutoGluon training complete, total runtime = 298.45s ... Best model: "WeightedEnsemble_L2"
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
