### PR TITLE
Optimize refit_folds logic

### DIFF
--- a/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
+++ b/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
@@ -622,7 +622,7 @@ class ParallelFoldFittingStrategy(FoldFittingStrategy):
         logger.debug(f'Folding resources per job {resources}')
         train_index, val_index = fold
         fold_ctx_ref = self.ray.put(fold_ctx)
-        save_bag_folds = self.bagged_ensemble_model.params.get('save_bag_folds', True)
+        save_bag_folds = self.save_folds
         kwargs_fold = kwargs.copy()
         is_pseudo = X_pseudo_ref is not None and y_pseudo_ref is not None
         if self.sample_weight is not None:

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -1488,6 +1488,10 @@ class AbstractTrainer:
                 fit_log_message += f' Training model for up to {round(time_limit, 2)}s of the {round(time_left_total, 2)}s of remaining time.'
             logger.log(20, fit_log_message)
 
+            if isinstance(model, BaggedEnsembleModel) and not compute_score:
+                # Do not perform OOF predictions when we don't compute a score.
+                model_fit_kwargs['_skip_oof'] = True
+
             # If model is not bagged model and not stacked then pseudolabeled data needs to be incorporated at this level
             # Bagged model does validation on the fit level where as single models do it separately. Hence this if statement
             # is required


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Optimize refit_folds logic
- This is an updated version of this PR: #1351
- Currently does not enable `refit_folds=True` for any model, but a follow-up PR will test enabling for KNN.
- `refit_folds=True` will fit a bagged ensemble of a given model and then immediately call refit_full, replacing the bag with a single model in a similar manner to `use_child_oof=True`, but supported for any model rather than only models that have `use_child_oof=True` supported.
- Fixed a bug where ParallelBagging ignored `save_folds` (SequentialBagging and ParallelBagging now produce the same result instead of different results when `save_folds=False`, which is relevant to reduce disk usage).
- Removed a redundant predict call on all of the data during refit_full via the new `_skip_oof` argument. This should drastically speed up refit_full for models that are slow in inference, and avoids needlessly storing unused OOF predictions in the model artifact, saving disk space.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
