### PR TITLE
fix that detection configs are missing in pip install

### DIFF
--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -83,6 +83,11 @@ if __name__ == "__main__":
         "configs/environment/*.yaml",
         "configs/distiller/*.yaml",
         "configs/matcher/*.yaml",
+        "configs/pretrain/detection/*.py",
+        "configs/pretrain/detection/faster_rcnn/*.py",
+        "configs/pretrain/detection/voc/*.py",
+        "configs/pretrain/detection/yolox/*.py",
+        "cli/*.py",
     ]
     setup(
         install_requires=install_requires,


### PR DESCRIPTION
Fix for #3152 and #3082 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
