### PR TITLE
[tabular] Add quantile regression support for CatBoost

### DIFF
--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -34,7 +34,7 @@ extras_require = {
         'lightgbm>=3.3,<3.4',
     ],
     'catboost': [
-        'catboost>=1.0,<1.2',
+        'catboost>=1.1,<1.2',
     ],
     # FIXME: Debug why xgboost 1.6 has 4x+ slower inference on multiclass datasets compared to 1.4
     #  It is possibly only present on MacOS, haven't tested linux.

--- a/tabular/src/autogluon/tabular/models/catboost/callbacks.py
+++ b/tabular/src/autogluon/tabular/models/catboost/callbacks.py
@@ -139,7 +139,13 @@ class EarlyStoppingCallback:
 
     def after_iteration(self, info):
         is_best_iter = False
-        cur_score = info.metrics[self.compare_key][self.eval_metric_name][-1]
+        if self.eval_metric_name.startswith('MultiQuantile'):
+            # FIXME: CatBoost adds extra ',' in the metric name if quantile levels are not balanced
+            # e.g., 'MultiQuantile:alpha=0.1,0.25,0.5,0.95' becomes 'MultiQuantile:alpha=0.1,,0.25,0.5,0.95'
+            eval_metric_name = [k for k in info.metrics[self.compare_key] if k.startswith('MultiQuantile')][0]
+        else:
+            eval_metric_name = self.eval_metric_name
+        cur_score = info.metrics[self.compare_key][eval_metric_name][-1]
         if not self.is_max_optimal:
             cur_score *= -1
         if self.best_score is None:

--- a/tabular/src/autogluon/tabular/models/catboost/callbacks.py
+++ b/tabular/src/autogluon/tabular/models/catboost/callbacks.py
@@ -4,6 +4,9 @@ import time
 
 from autogluon.common.utils.resource_utils import ResourceManager
 
+from .catboost_utils import CATBOOST_QUANTILE_PREFIX
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -139,10 +142,10 @@ class EarlyStoppingCallback:
 
     def after_iteration(self, info):
         is_best_iter = False
-        if self.eval_metric_name.startswith('MultiQuantile'):
+        if self.eval_metric_name.startswith(CATBOOST_QUANTILE_PREFIX):
             # FIXME: CatBoost adds extra ',' in the metric name if quantile levels are not balanced
             # e.g., 'MultiQuantile:alpha=0.1,0.25,0.5,0.95' becomes 'MultiQuantile:alpha=0.1,,0.25,0.5,0.95'
-            eval_metric_name = [k for k in info.metrics[self.compare_key] if k.startswith('MultiQuantile')][0]
+            eval_metric_name = [k for k in info.metrics[self.compare_key] if k.startswith(CATBOOST_QUANTILE_PREFIX)][0]
         else:
             eval_metric_name = self.eval_metric_name
         cur_score = info.metrics[self.compare_key][eval_metric_name][-1]

--- a/tabular/src/autogluon/tabular/models/catboost/callbacks.py
+++ b/tabular/src/autogluon/tabular/models/catboost/callbacks.py
@@ -139,10 +139,11 @@ class EarlyStoppingCallback:
 
         self.eval_metric_name = eval_metric_name
         self.is_max_optimal = is_max_optimal
+        self.is_quantile = self.eval_metric_name.startswith(CATBOOST_QUANTILE_PREFIX)
 
     def after_iteration(self, info):
         is_best_iter = False
-        if self.eval_metric_name.startswith(CATBOOST_QUANTILE_PREFIX):
+        if self.is_quantile:
             # FIXME: CatBoost adds extra ',' in the metric name if quantile levels are not balanced
             # e.g., 'MultiQuantile:alpha=0.1,0.25,0.5,0.95' becomes 'MultiQuantile:alpha=0.1,,0.25,0.5,0.95'
             eval_metric_name = [k for k in info.metrics[self.compare_key] if k.startswith(CATBOOST_QUANTILE_PREFIX)][0]

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -39,7 +39,8 @@ class CatBoostModel(AbstractModel):
         # Set 'allow_writing_files' to True in order to keep log files created by catboost during training (these will be saved in the directory where AutoGluon stores this model)
         self._set_default_param_value('allow_writing_files', False)  # Disables creation of catboost logging files during training by default
         if self.problem_type != SOFTCLASS:  # TODO: remove this after catboost 0.24
-            self._set_default_param_value('eval_metric', get_catboost_metric_from_ag_metric(self.stopping_metric, self.problem_type, self.quantile_levels))
+            default_eval_metric = get_catboost_metric_from_ag_metric(self.stopping_metric, self.problem_type, self.quantile_levels)
+            self._set_default_param_value('eval_metric', default_eval_metric)
 
     def _get_default_searchspace(self):
         return get_default_searchspace(self.problem_type, num_classes=self.num_classes)

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_utils.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_utils.py
@@ -1,6 +1,6 @@
 import logging
 
-from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION, SOFTCLASS
+from autogluon.core.constants import BINARY, MULTICLASS, QUANTILE, REGRESSION, SOFTCLASS
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ class CustomMetric:
         raise NotImplementedError
 
 
-def get_catboost_metric_from_ag_metric(metric, problem_type):
+def get_catboost_metric_from_ag_metric(metric, problem_type, quantile_levels=None):
     if problem_type == SOFTCLASS:
         from .catboost_softclass_utils import SoftclassCustomMetric
         if metric.name != 'soft_log_loss':
@@ -65,6 +65,11 @@ def get_catboost_metric_from_ag_metric(metric, problem_type):
             r2='R2',
         )
         metric_class = metric_map.get(metric.name, 'RMSE')
+    elif problem_type == QUANTILE:
+        if quantile_levels is None or not all(0 < q < 1 for q in quantile_levels):
+            raise AssertionError(f'quantile_levels must fulfill 0 < q < 1')
+        quantile_string = ','.join(str(q) for q in quantile_levels)
+        metric_class = f'MultiQuantile:alpha={quantile_string}'
     else:
         raise AssertionError(f'CatBoost does not support {problem_type} problem type.')
 

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_utils.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_utils.py
@@ -5,6 +5,9 @@ from autogluon.core.constants import BINARY, MULTICLASS, QUANTILE, REGRESSION, S
 logger = logging.getLogger(__name__)
 
 
+CATBOOST_QUANTILE_PREFIX = 'MultiQuantile:'
+
+
 # TODO: Add weight support?
 # TODO: Can these be optimized? What computational cost do they have compared to the default catboost versions?
 class CustomMetric:
@@ -66,10 +69,12 @@ def get_catboost_metric_from_ag_metric(metric, problem_type, quantile_levels=Non
         )
         metric_class = metric_map.get(metric.name, 'RMSE')
     elif problem_type == QUANTILE:
-        if quantile_levels is None or not all(0 < q < 1 for q in quantile_levels):
+        if quantile_levels is None:
+            raise AssertionError(f'quantile_levels must be provided for problem_type = {problem_type}')
+        if not all(0 < q < 1 for q in quantile_levels):
             raise AssertionError(f'quantile_levels must fulfill 0 < q < 1')
         quantile_string = ','.join(str(q) for q in quantile_levels)
-        metric_class = f'MultiQuantile:alpha={quantile_string}'
+        metric_class = f'{CATBOOST_QUANTILE_PREFIX}alpha={quantile_string}'
     else:
         raise AssertionError(f'CatBoost does not support {problem_type} problem type.')
 

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_utils.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_utils.py
@@ -72,7 +72,7 @@ def get_catboost_metric_from_ag_metric(metric, problem_type, quantile_levels=Non
         if quantile_levels is None:
             raise AssertionError(f'quantile_levels must be provided for problem_type = {problem_type}')
         if not all(0 < q < 1 for q in quantile_levels):
-            raise AssertionError(f'quantile_levels must fulfill 0 < q < 1')
+            raise AssertionError(f'quantile_levels must fulfill 0 < q < 1, provided quantile_levels: {quantile_levels}')
         quantile_string = ','.join(str(q) for q in quantile_levels)
         metric_class = f'{CATBOOST_QUANTILE_PREFIX}alpha={quantile_string}'
     else:

--- a/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
+++ b/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
@@ -62,7 +62,7 @@ DEFAULT_SOFTCLASS_PRIORITY = dict(
 DEFAULT_CUSTOM_MODEL_PRIORITY = 0
 
 # FIXME: v0.7 : Remove this, it is a hack. Model classes should define what problem types they support instead of using this
-DEFAULT_QUANTILE_MODEL = ['DUMMY', 'RF', 'XT', 'FASTAI', 'NN_TORCH', 'ENS_WEIGHTED']  # TODO: OTHERS will be added
+DEFAULT_QUANTILE_MODEL = ['DUMMY', 'RF', 'XT', 'FASTAI', 'NN_TORCH', 'ENS_WEIGHTED', 'CAT']  # TODO: OTHERS will be added
 
 MODEL_TYPES = dict(
     RF=RFModel,

--- a/tabular/tests/unittests/models/test_catboost.py
+++ b/tabular/tests/unittests/models/test_catboost.py
@@ -25,3 +25,13 @@ def test_catboost_regression(fit_helper):
     )
     dataset_name = 'ames'
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
+
+
+def test_catboost_quantile(fit_helper):
+    fit_args = dict(
+        hyperparameters={'CAT': {}},
+        time_limit=10,  # CatBoost trains for a very long time on ames (many iterations)
+    )
+    dataset_name = 'ames'
+    init_args = dict(problem_type='quantile', quantile_levels=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, init_args=init_args)


### PR DESCRIPTION
*Description of changes:*
- Add support for `problem_type=QUANTILE` for CatBoost using the [`MultiQuantile` metric](https://catboost.ai/en/docs/concepts/loss-functions-regression#MultiQuantile) added in [v1.1](https://github.com/catboost/catboost/releases/tag/v1.1).

*To Do:*
- [x] Add tests?


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
