### PR TITLE
Tabular Distributed HPO, and Distributed HPO + bagging

### DIFF
--- a/common/src/autogluon/common/utils/distribute_utils.py
+++ b/common/src/autogluon/common/utils/distribute_utils.py
@@ -5,6 +5,11 @@ class DistributedContext:
     """Class to manage distributed context"""
     
     @staticmethod
+    def get_util_path() -> str:
+        """Return the S3 path to store utils generated in distributed training"""
+        return os.environ.get("AG_UTIL_PATH")
+    
+    @staticmethod
     def get_model_sync_path() -> str:
         """Return the S3 path to sync the model artifacts generated in distributed training"""
         return os.environ.get("AG_MODEL_SYNC_PATH")

--- a/common/src/autogluon/common/utils/resource_utils.py
+++ b/common/src/autogluon/common/utils/resource_utils.py
@@ -142,8 +142,8 @@ class RayResourceManager:
         if not ray.is_initialized():
             ray.init(
                 address="auto",  # Force ray to connect to an existing cluster. There should be one. Otherwise, something went wrong
-                log_to_driver=True,
-                # logging_level=logging.ERROR
+                log_to_driver=False,
+                logging_level=logging.ERROR
             )
     
     @staticmethod

--- a/common/src/autogluon/common/utils/resource_utils.py
+++ b/common/src/autogluon/common/utils/resource_utils.py
@@ -142,8 +142,8 @@ class RayResourceManager:
         if not ray.is_initialized():
             ray.init(
                 address="auto",  # Force ray to connect to an existing cluster. There should be one. Otherwise, something went wrong
-                log_to_driver=False,
-                logging_level=logging.ERROR
+                log_to_driver=True,
+                # logging_level=logging.ERROR
             )
     
     @staticmethod

--- a/core/src/autogluon/core/hpo/executors.py
+++ b/core/src/autogluon/core/hpo/executors.py
@@ -196,9 +196,8 @@ class HpoExecutor(ABC):
             if minimum_model_num_gpus > 0:
                 num_jobs_in_parallel_with_gpu = num_gpus // minimum_model_num_gpus
             num_jobs_in_parallel = min(num_jobs_in_parallel_with_mem, num_jobs_in_parallel_with_cpu, num_jobs_in_parallel_with_gpu)
-            if k_fold is not None:
+            if k_fold is not None and k_fold > 0:
                 num_jobs_in_parallel = min(num_jobs_in_parallel, self.hyperparameter_tune_kwargs.get("num_trials", math.inf) * k_fold)
-
             system_num_cpu = ResourceManager.get_cpu_count()
             system_num_gpu = ResourceManager.get_gpu_count_all()
             if model_base != initialized_model:

--- a/core/src/autogluon/core/hpo/executors.py
+++ b/core/src/autogluon/core/hpo/executors.py
@@ -197,7 +197,7 @@ class HpoExecutor(ABC):
                 num_jobs_in_parallel_with_gpu = num_gpus // minimum_model_num_gpus
             num_jobs_in_parallel = min(num_jobs_in_parallel_with_mem, num_jobs_in_parallel_with_cpu, num_jobs_in_parallel_with_gpu)
             if k_fold is not None:
-                num_jobs_in_parallel = min(num_jobs_in_parallel, self.hyperparameter_tune_kwargs["num_trials"] * k_fold)
+                num_jobs_in_parallel = min(num_jobs_in_parallel, self.hyperparameter_tune_kwargs.get("num_trials", math.inf) * k_fold)
 
             system_num_cpu = ResourceManager.get_cpu_count()
             system_num_gpu = ResourceManager.get_gpu_count_all()

--- a/core/src/autogluon/core/hpo/executors.py
+++ b/core/src/autogluon/core/hpo/executors.py
@@ -4,17 +4,20 @@ import copy
 import logging
 import math
 import os
+import pandas as pd
 import time
 
 from abc import ABC, abstractmethod
-from typing import Optional, List, Dict, Union, Callable
+from typing import Any, Optional, List, Dict, Union, Callable, Tuple
 from autogluon.common.utils.resource_utils import ResourceManager
+from autogluon.common.utils.s3_utils import is_s3_url
 
 from .constants import RAY_BACKEND, CUSTOM_BACKEND
 from .exceptions import EmptySearchSpace
 from .. import Space
 from ..ray.resources_calculator import ResourceCalculator
 from ..scheduler.scheduler_factory import scheduler_factory
+from ..utils.savers import save_pkl
 
 from typing import TYPE_CHECKING
 
@@ -193,6 +196,11 @@ class HpoExecutor(ABC):
             if minimum_model_num_gpus > 0:
                 num_jobs_in_parallel_with_gpu = num_gpus // minimum_model_num_gpus
             num_jobs_in_parallel = min(num_jobs_in_parallel_with_mem, num_jobs_in_parallel_with_cpu, num_jobs_in_parallel_with_gpu)
+            if k_fold is not None:
+                num_jobs_in_parallel = min(num_jobs_in_parallel, self.hyperparameter_tune_kwargs["num_trials"] * k_fold)
+            # 
+            system_num_cpu = ResourceManager.get_cpu_count()
+            system_num_gpu = ResourceManager.get_gpu_count_all()
             if model_base != initialized_model:
                 # bagged model
                 if num_jobs_in_parallel // k_fold < 1:
@@ -203,15 +211,17 @@ class HpoExecutor(ABC):
                 if self.executor_type == 'custom':
                     # custom backend runs sequentially
                     num_trials_in_parallel = 1
-                cpu_per_trial = int(num_cpus // num_trials_in_parallel)
-                gpu_per_trial = num_gpus // num_trials_in_parallel
+                # In distributed setting, a single trial could be scheduled with resources that's more than a single node causing hanging
+                # Force it to be less than the current node. This works under the assumption that all nodes are of the same type
+                cpu_per_trial = min(int(num_cpus // num_trials_in_parallel), system_num_cpu)
+                gpu_per_trial = min(num_gpus // num_trials_in_parallel, system_num_gpu)
             else:
                 num_trials = self.hyperparameter_tune_kwargs.get('num_trials', math.inf)
                 if self.executor_type == 'custom':
                     # custom backend runs sequentially
                     num_jobs_in_parallel = 1
-                cpu_per_trial = int(num_cpus // min(num_jobs_in_parallel, num_trials))
-                gpu_per_trial = num_gpus / min(num_jobs_in_parallel, num_trials)
+                cpu_per_trial = min(int(num_cpus // min(num_jobs_in_parallel, num_trials)), system_num_cpu)
+                gpu_per_trial = min(num_gpus / min(num_jobs_in_parallel, num_trials), system_num_gpu)
                 
             self.hyperparameter_tune_kwargs['resources_per_trial'] = {
                 'num_cpus': cpu_per_trial,
@@ -219,8 +229,7 @@ class HpoExecutor(ABC):
             }
 
         self.resources = dict(num_gpus=num_gpus, num_cpus=num_cpus)
-        print(self.resources)
-    
+
     @abstractmethod
     def validate_search_space(
             self,
@@ -238,6 +247,51 @@ class HpoExecutor(ABC):
             The model name of the hpo experiment is tuning. This is only used for logging purpose
         """
         raise NotImplementedError
+
+    def prepare_data(
+        self,
+        X: pd.DataFrame,
+        y: pd.Series,
+        X_val: pd.DataFrame,
+        y_val: pd.Series,
+        path_prefix: str
+    ) -> Tuple[str, str]:
+        """
+        Prepare data as pickle files for hpo trials.
+        If path_prefix is a s3 url, will store to s3. Otherwise, store in local disk
+        
+        Parameters
+        ----------
+        X: pd.DataFrame
+            Training data
+        y: pd.Series
+            Training label
+        X_val: pd.DataFrame
+            Validation data
+        y_val: pd.Series
+            Validation label
+        path_prefix: str
+            path prefix to store the data artifacts
+        
+        Return
+        ------
+        Tuple[str, str]:
+            Path to both the training and validation data
+        """
+        def save_data(data: Any, path_prefix: str, filename: str) -> str:
+            if is_s3_url(path_prefix):
+                path = path_prefix + filename if path_prefix.endswith("/") else path_prefix + f"/{filename}"
+            else:
+                path = os.path.join(path_prefix, filename)
+            save_pkl.save(path=path, object=data, verbose=False)
+            return path
+
+        dataset_train_filename = 'dataset_train.pkl'
+        dataset_val_filename = 'dataset_val.pkl'
+        train_path = save_data(data=(X, y), path_prefix=path_prefix, filename=dataset_train_filename)
+        val_path = save_data(data=(X_val, y_val), path_prefix=path_prefix, filename=dataset_val_filename)
+
+        return train_path, val_path
     
     @abstractmethod
     def execute(self, **kwargs):
@@ -388,7 +442,7 @@ class RayHpoExecutor(HpoExecutor):
             minimum_gpu_per_trial=minimum_gpu_per_trial,
             model_estimate_memory_usage=model_estimate_memory_usage,
             time_budget_s=self.time_limit,
-            verbose=0,
+            verbose=1,
         )
         os.environ.pop('TUNE_DISABLE_AUTO_CALLBACK_LOGGERS', None)
         self.analysis = analysis

--- a/core/src/autogluon/core/hpo/executors.py
+++ b/core/src/autogluon/core/hpo/executors.py
@@ -219,6 +219,7 @@ class HpoExecutor(ABC):
             }
 
         self.resources = dict(num_gpus=num_gpus, num_cpus=num_cpus)
+        print(self.resources)
     
     @abstractmethod
     def validate_search_space(

--- a/core/src/autogluon/core/hpo/executors.py
+++ b/core/src/autogluon/core/hpo/executors.py
@@ -197,7 +197,8 @@ class HpoExecutor(ABC):
                 num_jobs_in_parallel_with_gpu = num_gpus // minimum_model_num_gpus
             num_jobs_in_parallel = min(num_jobs_in_parallel_with_mem, num_jobs_in_parallel_with_cpu, num_jobs_in_parallel_with_gpu)
             if k_fold is not None and k_fold > 0:
-                num_jobs_in_parallel = min(num_jobs_in_parallel, self.hyperparameter_tune_kwargs.get("num_trials", math.inf) * k_fold)
+                max_models = self.hyperparameter_tune_kwargs.get("num_trials", math.inf) * k_fold
+                num_jobs_in_parallel = min(num_jobs_in_parallel, max_models)
             system_num_cpu = ResourceManager.get_cpu_count()
             system_num_gpu = ResourceManager.get_gpu_count_all()
             if model_base != initialized_model:

--- a/core/src/autogluon/core/hpo/ray_hpo.py
+++ b/core/src/autogluon/core/hpo/ray_hpo.py
@@ -257,8 +257,8 @@ def run(
         model_estimate_memory_usage=model_estimate_memory_usage,
         wrap_resources_per_job_into_placement_group=trainable_is_parallel,
     )
-    print(f"resources: {resources_per_trial}")
     resources_per_trial = _validate_resources_per_trial(resources_per_trial)
+    logger.debug(resources_per_trial)
     ray_tune_adapter.resources_per_trial = resources_per_trial
     trainable_args = ray_tune_adapter.trainable_args_update_method(trainable_args)
     
@@ -286,10 +286,7 @@ def run(
         run_config=air.RunConfig(
             name=os.path.basename(save_dir),
             local_dir=os.path.dirname(save_dir),
-            verbose=2,
-            sync_config=tune.SyncConfig(
-                upload_dir="s3://weisy-personal/test_distributed_predictor_hpo/utils/"
-            ),
+            verbose=verbose,
             **run_config_kwargs
         ),
         _tuner_kwargs={

--- a/core/src/autogluon/core/hpo/ray_hpo.py
+++ b/core/src/autogluon/core/hpo/ray_hpo.py
@@ -258,7 +258,7 @@ def run(
         wrap_resources_per_job_into_placement_group=trainable_is_parallel,
     )
     resources_per_trial = _validate_resources_per_trial(resources_per_trial)
-    logger.debug(resources_per_trial)
+    logger.debug(f"resources_per_trial to be dispatched by ray tune: {resources_per_trial}")
     ray_tune_adapter.resources_per_trial = resources_per_trial
     trainable_args = ray_tune_adapter.trainable_args_update_method(trainable_args)
     

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -1354,6 +1354,7 @@ class AbstractModel:
         self._register_fit_metadata(**kwargs)
         self._validate_fit_memory_usage(**kwargs)
         kwargs = self._preprocess_fit_resources(parallel_hpo=hpo_executor.executor_type=='ray', **kwargs)
+        print("FFFFFKFKFKFKF")
         self.validate_fit_resources(**kwargs)
         hpo_executor.register_resources(self, **kwargs)
         return self._hyperparameter_tune(hpo_executor=hpo_executor, **kwargs)

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -22,6 +22,7 @@ from autogluon.common.utils.lite import disable_if_lite_mode
 from autogluon.common.utils.log_utils import DuplicateFilter
 from autogluon.common.utils.resource_utils import ResourceManager, RayResourceManager
 from autogluon.common.utils.resource_utils import get_resource_manager
+from autogluon.common.utils.distribute_utils import DistributedContext
 
 from .model_trial import model_trial, skip_hpo
 from ._tags import _DEFAULT_CLASS_TAGS, _DEFAULT_TAGS
@@ -1354,7 +1355,6 @@ class AbstractModel:
         self._register_fit_metadata(**kwargs)
         self._validate_fit_memory_usage(**kwargs)
         kwargs = self._preprocess_fit_resources(parallel_hpo=hpo_executor.executor_type=='ray', **kwargs)
-        print("FFFFFKFKFKFKF")
         self.validate_fit_resources(**kwargs)
         hpo_executor.register_resources(self, **kwargs)
         return self._hyperparameter_tune(hpo_executor=hpo_executor, **kwargs)
@@ -1377,15 +1377,13 @@ class AbstractModel:
 
         # Use absolute path here because ray tune will change the working directory
         self.set_contexts(os.path.abspath(self.path) + os.path.sep)
-        directory = self.path  # also create model directory if it doesn't exist
-        # TODO: This will break on S3. Use tabular/utils/savers for datasets, add new function
-        dataset_train_filename = 'dataset_train.pkl'
-        train_path = os.path.join(directory, dataset_train_filename)
-        save_pkl.save(path=train_path, object=(X, y))
 
-        dataset_val_filename = 'dataset_val.pkl'
-        val_path = os.path.join(directory, dataset_val_filename)
-        save_pkl.save(path=val_path, object=(X_val, y_val))
+        directory = self.path
+        os.makedirs(directory, exist_ok=True)
+        data_path = directory
+        if DistributedContext.is_distributed_mode():
+            data_path = DistributedContext.get_util_path()
+        train_path, val_path = hpo_executor.prepare_data(X=X, y=y, X_val=X_val, y_val=y_val, path_prefix=data_path)
 
         model_cls = self.__class__
         init_params = self.get_params()
@@ -1442,6 +1440,8 @@ class AbstractModel:
     
     def _get_hpo_backend(self):
         """Choose which backend(Ray or Custom) to use for hpo"""
+        if DistributedContext.is_distributed_mode():
+            return RAY_BACKEND
         return CUSTOM_BACKEND
 
     def _get_default_hpo_executor(self) -> HpoExecutor:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Enable distributed HPO and Distributed HPO + bagging for Tabular

Log from example run with 8 trials, each being a bagged model consists of 8 folds, training in parallel in a cluster of 8 m5.2xlarge machine.

```bash
Fitting 1 L1 models ...
Hyperparameter tuning model: NeuralNetFastAI_BAG_L1 ...
== Status ==
Current time: 2023-04-26 21:33:53 (running for 00:00:02.87)
Memory usage on this node: 1.6/30.9 GiB 
Using FIFO scheduling algorithm.
Resources requested: 8.0/64 CPUs, 0/0 GPUs, 0.0/174.34 GiB heap, 0.0/70.76 GiB objects
Result logdir: /tmp/ray/session_2023-04-26_21-30-34_117853_27096/runtime_resources/working_dir_files/_ray_pkg_8885f3ae4fb837d6/AutogluonModels/ag-20230426_213349/models/NeuralNetFastAI_BAG_L1
Number of trials: 1/8 (1 RUNNING)


== Status ==
Current time: 2023-04-26 21:33:58 (running for 00:00:08.32)
Memory usage on this node: 1.6/30.9 GiB 
Using FIFO scheduling algorithm.
Resources requested: 40.0/64 CPUs, 0/0 GPUs, 0.0/174.34 GiB heap, 0.0/70.76 GiB objects
Result logdir: /tmp/ray/session_2023-04-26_21-30-34_117853_27096/runtime_resources/working_dir_files/_ray_pkg_8885f3ae4fb837d6/AutogluonModels/ag-20230426_213349/models/NeuralNetFastAI_BAG_L1
Number of trials: 5/8 (5 RUNNING)


== Status ==
Current time: 2023-04-26 21:34:04 (running for 00:00:14.49)
Memory usage on this node: 1.8/30.9 GiB 
Using FIFO scheduling algorithm.
Resources requested: 48.0/64 CPUs, 0/0 GPUs, 0.0/174.34 GiB heap, 0.0/70.76 GiB objects
Current best trial: 164e3c3a with validation_performance=0.842 and parameters={'layers': None, 'emb_drop': 0.1, 'ps': 0.1, 'bs': 256, 'lr': 0.01, 'epochs': 30, 'early.stopping.min_delta': 0.0001, 'early.stopping.patience': 20, 'smoothing': 0.0, 'num_epochs': 10, 'learning_rate': 0.0005, 'activation': 'relu', 'dropout_prob': 0.1}
Result logdir: /tmp/ray/session_2023-04-26_21-30-34_117853_27096/runtime_resources/working_dir_files/_ray_pkg_8885f3ae4fb837d6/AutogluonModels/ag-20230426_213349/models/NeuralNetFastAI_BAG_L1
Number of trials: 8/8 (1 PENDING, 6 RUNNING, 1 TERMINATED)



== Status ==
Current time: 2023-04-26 21:34:10 (running for 00:00:19.82)
Memory usage on this node: 1.8/30.9 GiB 
Using FIFO scheduling algorithm.
Resources requested: 40.0/64 CPUs, 0/0 GPUs, 0.0/174.34 GiB heap, 0.0/70.76 GiB objects
Current best trial: f1c1c24e with validation_performance=0.86 and parameters={'layers': (1000, 500), 'emb_drop': 0.15201944925480249, 'ps': 0.4187612771721835, 'bs': 256, 'lr': 0.029533957578207624, 'epochs': 30, 'early.stopping.min_delta': 0.0001, 'early.stopping.patience': 20, 'smoothing': 0.0, 'num_epochs': 10, 'learning_rate': 0.0021074502225949952, 'activation': 'softrelu', 'dropout_prob': 0.06302284671855163}
Result logdir: /tmp/ray/session_2023-04-26_21-30-34_117853_27096/runtime_resources/working_dir_files/_ray_pkg_8885f3ae4fb837d6/AutogluonModels/ag-20230426_213349/models/NeuralNetFastAI_BAG_L1
Number of trials: 8/8 (5 RUNNING, 3 TERMINATED)


== Status ==
Current time: 2023-04-26 21:34:15 (running for 00:00:25.26)
Memory usage on this node: 1.9/30.9 GiB 
Using FIFO scheduling algorithm.
Resources requested: 24.0/64 CPUs, 0/0 GPUs, 0.0/174.34 GiB heap, 0.0/70.76 GiB objects
Current best trial: f1c1c24e with validation_performance=0.86 and parameters={'layers': (1000, 500), 'emb_drop': 0.15201944925480249, 'ps': 0.4187612771721835, 'bs': 256, 'lr': 0.029533957578207624, 'epochs': 30, 'early.stopping.min_delta': 0.0001, 'early.stopping.patience': 20, 'smoothing': 0.0, 'num_epochs': 10, 'learning_rate': 0.0021074502225949952, 'activation': 'softrelu', 'dropout_prob': 0.06302284671855163}
Result logdir: /tmp/ray/session_2023-04-26_21-30-34_117853_27096/runtime_resources/working_dir_files/_ray_pkg_8885f3ae4fb837d6/AutogluonModels/ag-20230426_213349/models/NeuralNetFastAI_BAG_L1
Number of trials: 8/8 (3 RUNNING, 5 TERMINATED)


== Status ==
Current time: 2023-04-26 21:34:21 (running for 00:00:30.60)
Memory usage on this node: 1.9/30.9 GiB 
Using FIFO scheduling algorithm.
Resources requested: 0/64 CPUs, 0/0 GPUs, 0.0/174.34 GiB heap, 0.0/70.76 GiB objects
Current best trial: b3b5953e with validation_performance=0.864 and parameters={'layers': (1000, 500, 200), 'emb_drop': 0.16326137932493823, 'ps': 0.07573195581645337, 'bs': 1024, 'lr': 0.042738427971420245, 'epochs': 29, 'early.stopping.min_delta': 0.0001, 'early.stopping.patience': 20, 'smoothing': 0.0, 'num_epochs': 10, 'learning_rate': 0.0004787024097994504, 'activation': 'relu', 'dropout_prob': 0.25849267730526676}
Result logdir: /tmp/ray/session_2023-04-26_21-30-34_117853_27096/runtime_resources/working_dir_files/_ray_pkg_8885f3ae4fb837d6/AutogluonModels/ag-20230426_213349/models/NeuralNetFastAI_BAG_L1
Number of trials: 8/8 (8 TERMINATED)


== Status ==
Current time: 2023-04-26 21:34:21 (running for 00:00:30.61)
Memory usage on this node: 1.9/30.9 GiB 
Using FIFO scheduling algorithm.
Resources requested: 0/64 CPUs, 0/0 GPUs, 0.0/174.34 GiB heap, 0.0/70.76 GiB objects
Current best trial: b3b5953e with validation_performance=0.864 and parameters={'layers': (1000, 500, 200), 'emb_drop': 0.16326137932493823, 'ps': 0.07573195581645337, 'bs': 1024, 'lr': 0.042738427971420245, 'epochs': 29, 'early.stopping.min_delta': 0.0001, 'early.stopping.patience': 20, 'smoothing': 0.0, 'num_epochs': 10, 'learning_rate': 0.0004787024097994504, 'activation': 'relu', 'dropout_prob': 0.25849267730526676}
Result logdir: /tmp/ray/session_2023-04-26_21-30-34_117853_27096/runtime_resources/working_dir_files/_ray_pkg_8885f3ae4fb837d6/AutogluonModels/ag-20230426_213349/models/NeuralNetFastAI_BAG_L1
Number of trials: 8/8 (8 TERMINATED)


Fitted model: NeuralNetFastAI_BAG_L1/164e3c3a ...
        0.842    = Validation score   (accuracy)
        7.14s    = Training   runtime
        0.0s     = Validation runtime
Fitted model: NeuralNetFastAI_BAG_L1/f1c1c24e ...
        0.86     = Validation score   (accuracy)
        7.9s     = Training   runtime
        0.0s     = Validation runtime
Fitted model: NeuralNetFastAI_BAG_L1/b3b5953e ...
        0.864    = Validation score   (accuracy)
        17.19s   = Training   runtime
        0.0s     = Validation runtime
Fitted model: NeuralNetFastAI_BAG_L1/779a4822 ...
        0.848    = Validation score   (accuracy)
        7.52s    = Training   runtime
        0.0s     = Validation runtime
Fitted model: NeuralNetFastAI_BAG_L1/9081165e ...
        0.826    = Validation score   (accuracy)
        9.02s    = Training   runtime
        0.0s     = Validation runtime
Fitted model: NeuralNetFastAI_BAG_L1/63102c55 ...
        0.856    = Validation score   (accuracy)
        10.6s    = Training   runtime
        0.0s     = Validation runtime
Fitted model: NeuralNetFastAI_BAG_L1/f61a7fb8 ...
        0.852    = Validation score   (accuracy)
        8.57s    = Training   runtime
        0.0s     = Validation runtime
Fitted model: NeuralNetFastAI_BAG_L1/815f4587 ...
        0.838    = Validation score   (accuracy)
        7.31s    = Training   runtime
        0.0s     = Validation runtime
Fitting model: WeightedEnsemble_L2 ...
        WARNING: Setting `self._oof_pred_proba` by predicting on train directly! This is probably a bug and should be investigated...
        0.864    = Validation score   (accuracy)
        0.35s    = Training   runtime
        0.0s     = Validation runtime
AutoGluon training complete, total runtime = 32.48s ... Best model: "WeightedEnsemble_L2"

```

Notice how more than 8 cpus were utilized (logs from training that took longer where you can see all cpus being utilized is too long to copy over).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
