### PR TITLE
[multimodal] Fix mmcv reference if import failed

### DIFF
--- a/multimodal/src/autogluon/multimodal/data/dataset_mmlab/multi_image_mix_dataset.py
+++ b/multimodal/src/autogluon/multimodal/data/dataset_mmlab/multi_image_mix_dataset.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 try:
     import mmcv
-    import mmcv.utils.config.Config as MMCVConfig
+    from mmcv.utils import Config as MMCVConfig
     from mmdet.core import find_inside_bboxes
     from mmdet.utils import log_img_scale  # inline import to avoid mmdet uninstall error for other tasks
 except:

--- a/multimodal/src/autogluon/multimodal/data/dataset_mmlab/multi_image_mix_dataset.py
+++ b/multimodal/src/autogluon/multimodal/data/dataset_mmlab/multi_image_mix_dataset.py
@@ -15,10 +15,11 @@ logger = logging.getLogger(__name__)
 
 try:
     import mmcv
+    import mmcv.utils.config.Config as MMCVConfig
     from mmdet.core import find_inside_bboxes
     from mmdet.utils import log_img_scale  # inline import to avoid mmdet uninstall error for other tasks
 except:
-    pass
+    MMCVConfig = None
 
 
 class MultiImageMixDataset(torch.utils.data.Dataset):
@@ -34,7 +35,7 @@ class MultiImageMixDataset(torch.utils.data.Dataset):
         data: pd.DataFrame,
         preprocessor: List[MultiModalFeaturePreprocessor],
         processors: List[dict],
-        model_config: mmcv.utils.config.Config,
+        model_config: MMCVConfig,
         id_mappings: Optional[Union[Dict[str, Dict], Dict[str, pd.Series]]] = None,
         is_training: bool = False,
     ):


### PR DESCRIPTION
Error message that guide user to install mmcv won't print before this fix.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
