### PR TITLE
[tabular] Fix RandomForestQuantileRegressor failing if sklearn >= 1.2.0

### DIFF
--- a/tabular/src/autogluon/tabular/models/rf/rf_quantile.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_quantile.py
@@ -686,7 +686,7 @@ class RandomForestQuantileRegressor(BaseForestQuantileRegressor):
         max_samples=None,
     ):
         super(RandomForestQuantileRegressor, self).__init__(
-            base_estimator=DecisionTreeQuantileRegressor(),
+            DecisionTreeQuantileRegressor(),
             n_estimators=n_estimators,
             estimator_params=(
                 "criterion",
@@ -838,7 +838,7 @@ class ExtraTreesQuantileRegressor(BaseForestQuantileRegressor):
         max_samples=None,
     ):
         super(ExtraTreesQuantileRegressor, self).__init__(
-            base_estimator=ExtraTreeQuantileRegressor(),
+            ExtraTreeQuantileRegressor(),
             n_estimators=n_estimators,
             estimator_params=(
                 "criterion",


### PR DESCRIPTION
*Issue #, if available:* #3176

*Description of changes:*
- Change kwarg to positional argument in `ExtraTreesQuantileRegressor` and `RandomForestQuantileRegressor` to support the API change in sklearn >= 1.2.0.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
