### PR TITLE
[timeseries] Allow creating multiple configurations of the same model using `hyperparameters`

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import time
 from typing import Any, Dict, List, Optional, Union
 
@@ -86,6 +87,7 @@ class AbstractTimeSeriesModel(AbstractModel):
         hyperparameters: Dict[str, Union[int, float, str, ag.Space]] = None,
         **kwargs,
     ):
+        name = name or re.sub(r"Model$", "", self.__class__.__name__)
         super().__init__(
             path=path,
             name=name,

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
@@ -1,5 +1,4 @@
 import logging
-import re
 import time
 import warnings
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -69,7 +68,6 @@ class AutoGluonTabularModel(AbstractTimeSeriesModel):
         hyperparameters: Dict[str, Any] = None,
         **kwargs,  # noqa
     ):
-        name = name or re.sub(r"Model$", "", self.__class__.__name__)  # TODO: look name up from presets
         super().__init__(
             path=path,
             freq=freq,

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterator, List, Optional, Type
 
@@ -149,7 +148,6 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         hyperparameters: Dict[str, Any] = None,
         **kwargs,  # noqa
     ):
-        name = name or re.sub(r"Model$", "", self.__class__.__name__)  # TODO: look name up from presets
         super().__init__(
             path=path,
             freq=freq,
@@ -230,6 +228,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         """Gets params that are passed to the inner model."""
         args = super()._get_model_params().copy()
         args.setdefault("batch_size", 64)
+        args.setdefault("context_length", max(10, 2 * self.prediction_length))
         args.update(
             dict(
                 freq=self.freq,

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -50,13 +50,10 @@ class AbstractGluonTSPyTorchModel(AbstractGluonTSModel):
     def _get_estimator_init_args(self) -> Dict[str, Any]:
         """Get GluonTS specific constructor arguments for estimator objects, an alias to
         `self._get_model_params` for better readability."""
-        init_kwargs = self._get_model_params()
-
-        # GluonTS does not handle context_length=1 well, and sets the context to only prediction_length
-        # we set it to a minimum of 10 here.
-        init_kwargs["context_length"] = max(10, init_kwargs.get("context_length", self.prediction_length))
+        init_kwargs = super()._get_estimator_init_args()
+        # Map MXNet kwarg names to PyTorch Lightning kwarg names
         init_kwargs.setdefault("lr", init_kwargs.get("learning_rate", 1e-3))
-
+        init_kwargs.setdefault("max_epochs", init_kwargs.get("epochs"))
         return init_kwargs
 
     def _get_estimator(self) -> GluonTSPyTorchLightningEstimator:
@@ -70,7 +67,7 @@ class AbstractGluonTSPyTorchModel(AbstractGluonTSModel):
         init_args = self._get_estimator_init_args()
 
         trainer_kwargs = {}
-        epochs = init_args.get("max_epochs", init_args.get("epochs"))
+        epochs = init_args.get("max_epochs")
         callbacks = init_args.get("callbacks", [])
 
         # TODO: Provide trainer_kwargs outside the function (e.g., to specify # of GPUs)?
@@ -298,7 +295,7 @@ class TemporalFusionTransformerModel(AbstractGluonTSPyTorchModel):
 
     def _get_estimator_init_args(self) -> Dict[str, Any]:
         init_kwargs = super()._get_estimator_init_args()
-        init_kwargs.setdefault("context_length", max(64, self.prediction_length))
+        init_kwargs["context_length"] = max(64, init_kwargs["context_length"])
         if self.num_feat_dynamic_real > 0:
             init_kwargs["dynamic_dims"] = [self.num_feat_dynamic_real]
         if self.num_past_feat_dynamic_real > 0:

--- a/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
+++ b/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
@@ -1,6 +1,5 @@
 import hashlib
 import logging
-import re
 from multiprocessing import cpu_count
 from typing import Any, Dict, List, Optional, Union
 
@@ -45,7 +44,6 @@ class AbstractLocalModel(AbstractTimeSeriesModel):
         hyperparameters: Dict[str, Any] = None,
         **kwargs,  # noqa
     ):
-        name = name or re.sub(r"Model$", "", self.__class__.__name__)
         super().__init__(
             path=path,
             freq=freq,

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -89,7 +89,6 @@ DEFAULT_CUSTOM_MODEL_PRIORITY = 0
 
 VALID_AG_ARGS_KEYS = {
     "name",
-    "name_main",
     "name_prefix",
     "name_suffix",
 }

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -226,7 +226,9 @@ def get_preset_models(
             ag_args = model_hps.pop(ag.constants.AG_ARGS, {})
             for key in ag_args:
                 if key not in VALID_AG_ARGS_KEYS:
-                    logger.warning(f"WARNING: Unknown ag_args key: {key}")
+                    raise ValueError(
+                        f"Model {model_type} received unknown ag_args key: {key} (valid keys {VALID_AG_ARGS_KEYS})"
+                    )
             model_name_base = get_model_name(ag_args, model_type)
 
             model_type_kwargs = dict(

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -1,6 +1,7 @@
 import copy
 import logging
-from typing import Any, Dict, List, Optional, Union
+import re
+from typing import Any, Dict, List, Optional, Type, Union
 
 import autogluon.core as ag
 import autogluon.timeseries as agts
@@ -85,11 +86,16 @@ DEFAULT_MODEL_PRIORITY = dict(
     MQRNNMXNet=10,
 )
 DEFAULT_CUSTOM_MODEL_PRIORITY = 0
-MINIMUM_CONTEXT_LENGTH = 10
+
+VALID_AG_ARGS_KEYS = {
+    "name",
+    "name_main",
+    "name_prefix",
+    "name_suffix",
+}
 
 
-def get_default_hps(key, prediction_length):
-    context_length = max(prediction_length * 2, MINIMUM_CONTEXT_LENGTH)
+def get_default_hps(key):
     default_model_hps = {
         "local_only": {
             "Naive": {},
@@ -106,9 +112,7 @@ def get_default_hps(key, prediction_length):
             "AutoETS": {},
             "Theta": {},
             "AutoGluonTabular": {},
-            "DeepAR": {
-                "context_length": context_length,
-            },
+            "DeepAR": {},
         },
         "high_quality": {
             "Naive": {},
@@ -119,12 +123,8 @@ def get_default_hps(key, prediction_length):
             "AutoARIMA": {},
             "Theta": {},
             "AutoGluonTabular": {},
-            "DeepAR": {
-                "context_length": context_length,
-            },
-            "SimpleFeedForward": {
-                "context_length": context_length,
-            },
+            "DeepAR": {},
+            "SimpleFeedForward": {},
             "TemporalFusionTransformer": {},
         },
         "best_quality": {
@@ -138,12 +138,10 @@ def get_default_hps(key, prediction_length):
             "Theta": {},
             "AutoGluonTabular": {},
             "DeepAR": {
-                "context_length": context_length,
                 "num_layers": ag.Int(1, 3, default=2),
                 "hidden_size": ag.Int(40, 80, default=40),
             },
             "SimpleFeedForward": {
-                "context_length": context_length,
                 "hidden_dimensions": ag.Categorical([40], [40, 40], [120]),
             },
             "TemporalFusionTransformer": {},
@@ -154,7 +152,7 @@ def get_default_hps(key, prediction_length):
     if agts.MXNET_INSTALLED:
         mxnet_default_updates = {
             "best_quality": {
-                "TransformerMXNet": {"context_length": context_length},
+                "TransformerMXNet": {},
             },
         }
         for k in default_model_hps:
@@ -186,17 +184,11 @@ def get_preset_models(
     models = []
     if hyperparameters is None:
         hp_string = "default_hpo" if hyperparameter_tune else "default"
-        hyperparameters = copy.deepcopy(get_default_hps(hp_string, prediction_length))
+        hyperparameters = copy.deepcopy(get_default_hps(hp_string))
     elif isinstance(hyperparameters, str):
-        hyperparameters = copy.deepcopy(get_default_hps(hyperparameters, prediction_length))
+        hyperparameters = copy.deepcopy(get_default_hps(hyperparameters))
     elif isinstance(hyperparameters, dict):
-        default_hps = copy.deepcopy(get_default_hps("default", prediction_length))
-        updated_hyperparameters = {}
-        # Only train models from `hyperparameters`, overload default HPs if provided
-        for model, hps in hyperparameters.items():
-            updated_hyperparameters[model] = default_hps.get(model, {})
-            updated_hyperparameters[model].update(hps)
-        hyperparameters = copy.deepcopy(updated_hyperparameters)
+        hyperparameters = copy.deepcopy(hyperparameters)
     else:
         raise ValueError(
             f"hyperparameters must be a dict, a string or None (received {type(hyperparameters)}). "
@@ -214,7 +206,6 @@ def get_preset_models(
     model_priority_list = sorted(hyperparameters.keys(), key=lambda x: DEFAULT_MODEL_PRIORITY.get(x, 0), reverse=True)
 
     for model in model_priority_list:
-        model_hps = hyperparameters[model]
         if isinstance(model, str):
             if model not in MODEL_TYPES:
                 raise ValueError(f"Model {model} is not supported yet.")
@@ -228,33 +219,54 @@ def get_preset_models(
             logger.log(20, f"Custom Model Type Detected: {model}")
             model_type = model
 
-        model_type_kwargs = dict(
-            path=path,
-            freq=freq,
-            prediction_length=prediction_length,
-            eval_metric=eval_metric,
-            eval_metric_seasonal_period=eval_metric_seasonal_period,
-            hyperparameters=model_hps,
-            **kwargs,
-        )
+        model_hps_list = hyperparameters[model]
+        if not isinstance(model_hps_list, list):
+            model_hps_list = [model_hps_list]
 
-        # add models while preventing name collisions
-        model = model_type(**model_type_kwargs)
-        name_stem = model.name
+        for model_hps in model_hps_list:
+            ag_args = model_hps.pop(ag.constants.AG_ARGS, {})
+            for key in ag_args:
+                if key not in VALID_AG_ARGS_KEYS:
+                    logger.warning(f"WARNING: Unknown ag_args key: {key}")
+            model_name_base = get_model_name(ag_args, model_type)
 
-        model_type_kwargs.pop("name", None)
-        increment = 1
-        while model.name in all_assigned_names:
-            increment += 1
-            model = model_type(name=f"{name_stem}_{increment}", **model_type_kwargs)
+            model_type_kwargs = dict(
+                name=model_name_base,
+                path=path,
+                freq=freq,
+                prediction_length=prediction_length,
+                eval_metric=eval_metric,
+                eval_metric_seasonal_period=eval_metric_seasonal_period,
+                hyperparameters=model_hps,
+                **kwargs,
+            )
 
-        if multi_window:
-            model = MultiWindowBacktestingModel(model_base=model, name=model.name, **model_type_kwargs)
+            # add models while preventing name collisions
+            model = model_type(**model_type_kwargs)
 
-        all_assigned_names.add(model.name)
-        models.append(model)
+            model_type_kwargs.pop("name", None)
+            increment = 1
+            while model.name in all_assigned_names:
+                increment += 1
+                model = model_type(name=f"{model_name_base}_{increment}", **model_type_kwargs)
+
+            if multi_window:
+                model = MultiWindowBacktestingModel(model_base=model, name=model.name, **model_type_kwargs)
+
+            all_assigned_names.add(model.name)
+            models.append(model)
 
     return models
+
+
+def get_model_name(ag_args: Dict[str, Any], model_type: Type[AbstractTimeSeriesModel]) -> str:
+    name = ag_args.get("name")
+    if name is None:
+        name_stem = re.sub(r"Model$", "", model_type.__name__)
+        name_prefix = ag_args.get("name_prefix", "")
+        name_suffix = ag_args.get("name_suffix", "")
+        name = name_prefix + name_stem + name_suffix
+    return name
 
 
 def contains_searchspace(model_hyperparameters: Dict[str, Any]) -> bool:
@@ -265,18 +277,29 @@ def contains_searchspace(model_hyperparameters: Dict[str, Any]) -> bool:
 
 
 def verify_contains_at_least_one_searchspace(hyperparameters: Dict[str, Dict[str, Any]]):
-    if not any(contains_searchspace(model_hps) for model_hps in hyperparameters.values()):
-        raise ValueError(
-            f"Hyperparameter tuning specified, but no model contains a hyperparameter search space. "
-            f"Please disable hyperparameter tuning with `hyperparameter_tune_kwargs=None` or provide a search space "
-            f"for at least one model."
-        )
+    for model, model_hps_list in hyperparameters.items():
+        if not isinstance(model_hps_list, list):
+            model_hps_list = [model_hps_list]
+
+        for model_hps in model_hps_list:
+            if contains_searchspace(model_hps):
+                return
+
+    raise ValueError(
+        f"Hyperparameter tuning specified, but no model contains a hyperparameter search space. "
+        f"Please disable hyperparameter tuning with `hyperparameter_tune_kwargs=None` or provide a search space "
+        f"for at least one model."
+    )
 
 
 def verify_contains_no_searchspaces(hyperparameters: Dict[str, Dict[str, Any]]):
-    for model, model_hps in hyperparameters.items():
-        if contains_searchspace(model_hps):
-            raise ValueError(
-                f"Hyperparameter tuning not specified, so hyperparameters must have fixed values. "
-                f"However, for model {model} hyperparameters {model_hps} contain a search space."
-            )
+    for model, model_hps_list in hyperparameters.items():
+        if not isinstance(model_hps_list, list):
+            model_hps_list = [model_hps_list]
+
+        for model_hps in model_hps_list:
+            if contains_searchspace(model_hps):
+                raise ValueError(
+                    f"Hyperparameter tuning not specified, so hyperparameters must have fixed values. "
+                    f"However, for model {model} hyperparameters {model_hps} contain a search space."
+                )

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -378,21 +378,25 @@ class TimeSeriesPredictor:
             `autogluon/timeseries/trainer/models/presets.py``.
 
             If dict is provided, the keys are strings or Types that indicate which models to train. Each value is
-            itself a dict containing hyperparameters for each of the trained models. Any omitted hyperparameters not
-            specified here will be set to default. For example::
+            itself a dict containing hyperparameters for each of the trained models, or a list of such dicts. Any
+            omitted hyperparameters not specified here will be set to default. For example::
 
                 predictor.fit(
                     ...
                     hyperparameters={
                         "DeepAR": {},
-                        "ETS": {"seasonal_period": 7},
+                        "ETS": [
+                            {"seasonal": "add"},
+                            {"seasonal": None},
+                        ],
                     }
                 )
 
-            The above example will only train two models:
+            The above example will train three models:
 
-            * ``DeepAR`` (with default hyperparameters)
-            * ``ETS`` (with the given `seasonal_period`; all other parameters set to their defaults)
+            * ``DeepAR`` with default hyperparameters
+            * ``ETS`` with additive seasonality (all other parameters set to their defaults)
+            * ``ETS`` with seasonality disabled (all other parameters set to their defaults)
 
             Full list of available models and their hyperparameters is provided in :ref:`forecasting_zoo`.
 

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -191,6 +191,25 @@ def test_given_hyperparameters_with_spaces_when_trainer_called_then_hpo_is_perfo
     assert all(1 <= config["epochs"] <= 4 for config in config_history)
 
 
+@pytest.mark.parametrize(
+    "hyperparameters, expected_model_names",
+    [
+        ({"Naive": [{}, {}, {"ag_args": {"name_suffix": "_extra"}}]}, ["Naive", "Naive_2", "Naive_extra"]),
+        ({"Naive": [{"ag_args": {"name": "CustomNaive"}}], "SeasonalNaive": {}}, ["CustomNaive", "SeasonalNaive"]),
+    ],
+)
+def test_given_hyperparameters_with_lists_when_trainer_called_then_multiple_models_are_trained(
+    temp_model_path, hyperparameters, expected_model_names
+):
+    trainer = AutoTimeSeriesTrainer(path=temp_model_path, enable_ensemble=False)
+    trainer.fit(train_data=DUMMY_TS_DATAFRAME, hyperparameters=hyperparameters)
+    leaderboard = trainer.leaderboard()
+    print(leaderboard["model"].values)
+    print(expected_model_names)
+    assert len(leaderboard) == len(expected_model_names)
+    assert all(name in leaderboard["model"].values for name in expected_model_names)
+
+
 @pytest.mark.parametrize("eval_metric", ["MAPE", None])
 @pytest.mark.parametrize(
     "hyperparameters, expected_board_length",


### PR DESCRIPTION
*Description of changes:*
- Allow training multiple configurations of the same model using the `hyperparameters` kwarg, similar to how this is done in the `TabularPredictor`. For example, the following code will train 3 models `[ETS, ETS_2, ETS_seasonal]`:
    ```python
    TimeSeriesPredictor().fit(
        data,
        hyperparameters={
            "ETS": [
                {"seasonal": None},  # ETS
                {},  # ETS_2 -> suffix added to avoid name collision
                {"seasonal": "mul", "ag_args": {"name_suffix": "_mul"}},  # ETS_mul -> custom suffix
            ]
        }
    )
    ```
    By default, a suffix `_2`, `_3`, .. is added to avoid name collisions, but custom names/suffixes/prefixes can also be specified using the `ag_args` hyperparameter (just like in Tabular). Currently, only following `ag_args` are supported: `name`, `name_suffix`, `name_prefix`.

   This change will be helpful in the future (e.g., for zero-shot HPO), and brings closer the APIs of TimeSeries and Tabular.
- Move the logic for ensuring that `context_length >= 10` for all GluonTS models from `presets.py` to the `AbstractGluonTSModel` class, where it belongs.
- Set the default model `name` inside `AbstractTimeSeriesModel`, instead of repeating this code in each individual model class.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
