### PR TITLE
pin ipython to only supported by project's python version range

### DIFF
--- a/eda/setup.py
+++ b/eda/setup.py
@@ -33,6 +33,7 @@ install_requires = [
     'yellowbrick>=1.5,<1.6',
     'pyod>=1.0,<1.1',
     'suod>=0.0.8,<0.1',
+    'ipython>7.16,<8.13',  # IPython 8.13+ supports Python 3.9 and above; Python 3.7 is supported with IPython >7.16
     f'autogluon.core=={version}',
     f'autogluon.common=={version}',
     f'autogluon.features=={version}',


### PR DESCRIPTION
*Description of changes:*
Pinning ipython version only to the ranges supported by the project's python versions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
