### PR TITLE
[timeseries] Deprecate quantiles argument to TimeSeriesPredictor

### DIFF
--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -102,8 +102,6 @@ class TimeSeriesPredictor:
         If ``path`` and ``eval_metric`` are re-specified within ``learner_kwargs``, these are ignored.
     label : str, optional
         Alias for :attr:`target`.
-    quantiles : List[float], optional
-        Alias for :attr:`quantile_levels`.
     """
 
     predictor_file_name = "predictor.pkl"
@@ -149,16 +147,19 @@ class TimeSeriesPredictor:
         self.prediction_length = prediction_length
         self.eval_metric = eval_metric
         self.eval_metric_seasonal_period = eval_metric_seasonal_period
-        if quantile_levels is not None and quantiles is not None:
-            raise ValueError(
-                "Both `quantile_levels` and `quantiles` are specified. Please specify at most one of these arguments."
-            )
-        self.quantile_levels = quantile_levels or quantiles or [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+        if quantile_levels is None:
+            quantile_levels = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+        self.quantile_levels = quantile_levels
 
         if validation_splitter is not None:
             warnings.warn(
-                "validation_splitter argument has been deprecated as of v0.8.0. "
-                "Please user the `num_val_windows` argument of `TimeSeriesPredictor.fit` instead."
+                "`validation_splitter` argument has been deprecated as of v0.8.0. "
+                "Please use the `num_val_windows` argument of `TimeSeriesPredictor.fit` instead."
+            )
+        if quantiles is not None:
+            warnings.warn(
+                "`quantiles` argument has been deprecated as of v0.8.0. "
+                "Please use the `quantile_levels` argument instead."
             )
 
         if learner_kwargs is None:

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -97,13 +97,15 @@ def test_given_no_tuning_data_when_predictor_called_then_model_can_predict(temp_
 
 
 @pytest.mark.parametrize("hyperparameters", TEST_HYPERPARAMETER_SETTINGS)
-@pytest.mark.parametrize("quantile_kwarg_name", ["quantiles", "quantile_levels"])
 def test_given_hyperparameters_and_quantiles_when_predictor_called_then_model_can_predict(
-    temp_model_path, hyperparameters, quantile_kwarg_name
+    temp_model_path, hyperparameters
 ):
-    predictor_init_kwargs = dict(path=temp_model_path, eval_metric="MAPE", prediction_length=3)
-    predictor_init_kwargs[quantile_kwarg_name] = [0.1, 0.4, 0.9]
-    predictor = TimeSeriesPredictor(**predictor_init_kwargs)
+    predictor = TimeSeriesPredictor(
+        path=temp_model_path,
+        eval_metric="MAPE",
+        prediction_length=3,
+        quantile_levels=[0.1, 0.4, 0.9],
+    )
 
     predictor.fit(
         train_data=DUMMY_TS_DATAFRAME,
@@ -583,17 +585,9 @@ def test_given_data_cannot_be_interpreted_as_tsdf_then_exception_raised(temp_mod
         predictor.fit(df, hyperparameters={"Naive": {}})
 
 
-@pytest.mark.parametrize(
-    "arg_1, arg_2, value",
-    [
-        ("quantile_levels", "quantiles", [0.1, 0.4]),
-        ("target", "label", "custom_target"),
-    ],
-)
-def test_when_both_argument_aliases_are_passed_to_init_then_exception_is_raised(temp_model_path, arg_1, arg_2, value):
-    init_kwargs = {arg_1: value, arg_2: value}
+def test_when_both_argument_aliases_are_passed_to_init_then_exception_is_raised(temp_model_path):
     with pytest.raises(ValueError, match="Please specify at most one of these arguments"):
-        predictor = TimeSeriesPredictor(path=temp_model_path, **init_kwargs)
+        predictor = TimeSeriesPredictor(path=temp_model_path, target="custom_target", label="custom_target")
 
 
 def test_when_invalid_argument_passed_to_init_then_exception_is_raised(temp_model_path):


### PR DESCRIPTION
*Description of changes:*
- Add deprecation warning for the `quantiles` argument to `TimeSeriesPredictor`
- Fix a potential bug that prevented users from setting `quantile_levels = []`
- Fix typo


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
