### PR TITLE
[eda] improve stability of flaky platform tests

### DIFF
--- a/eda/tests/unittests/analysis/test_anomaly.py
+++ b/eda/tests/unittests/analysis/test_anomaly.py
@@ -150,7 +150,8 @@ def test_AnomalyDetectorAnalysis__explain_rows_fn(dataset):
 
     result = a.explain_rows_fn(args, detector=detector, dataset=dataset, dataset_row_ids=[1, 3])
 
-    assert_frame_equal(result["rows"], pd.DataFrame({dataset: [1, 3]}, index=[1, 3]))
+    # np.int64 is required for running tests on Windows
+    assert_frame_equal(result["rows"].astype(np.int64), pd.DataFrame({dataset: [1, 3]}, index=[1, 3]).astype(np.int64))
     result.pop("rows")
 
     assert result["train_data"] is train_data

--- a/eda/tests/unittests/analysis/test_explain.py
+++ b/eda/tests/unittests/analysis/test_explain.py
@@ -28,6 +28,7 @@ def test_ShapAnalysis(label, expected_task_type, monkeypatch):
             label=label,
             return_state=True,
             render_analysis=False,
+            hyperparameters={"RF": {}},
         )
         assert state.model.problem_type == expected_task_type
 

--- a/eda/tests/unittests/auto/test_simple.py
+++ b/eda/tests/unittests/auto/test_simple.py
@@ -578,7 +578,12 @@ def test_partial_dependence_plots(monkeypatch):
 
         with tempfile.TemporaryDirectory() as path:
             state = partial_dependence_plots(
-                train_data, label="class", features=["education", "native-country"], return_state=True, path=path
+                train_data,
+                label="class",
+                features=["education", "native-country"],
+                return_state=True,
+                path=path,
+                hyperparameters={"RF": {}},
             )
 
             assert state == {

--- a/eda/tests/unittests/auto/test_simple.py
+++ b/eda/tests/unittests/auto/test_simple.py
@@ -612,8 +612,9 @@ def test_partial_dependence_plots(monkeypatch):
     ],
 )
 def test_detect_anomalies(monkeypatch, add_explainability):
-    df_train = pd.DataFrame({"A": np.arange(4), "B": np.arange(4)})
-    df_test = pd.DataFrame({"A": np.arange(5), "B": np.arange(5)})
+    # np.int64 is required for running tests on Windows
+    df_train = pd.DataFrame({"A": np.arange(4), "B": np.arange(4)}).astype(np.int64)
+    df_test = pd.DataFrame({"A": np.arange(5), "B": np.arange(5)}).astype(np.int64)
 
     train_data_scores = pd.Series([0.13, 0.01, 0.08, 0.76], name="score")
     test_data_scores = pd.Series([0.60, 0.20, 0.91, 0.60, 0.23], name="score")
@@ -667,11 +668,12 @@ def test_detect_anomalies(monkeypatch, add_explainability):
     state.anomaly_detection.pop("scores")
 
     assert list(state.anomaly_detection.anomalies.keys()) == ["train_data", "test_data"]
+    # np.int64 is required for running tests on Windows
     assert state.anomaly_detection.anomalies.train_data.equals(
-        pd.DataFrame({"A": [3], "B": [3], "score": 0.76}, index=[3])
+        pd.DataFrame({"A": [3], "B": [3], "score": 0.76}, index=[3]).astype({"A": np.int64, "B": np.int64})
     )
     assert state.anomaly_detection.anomalies.test_data.equals(
-        pd.DataFrame({"A": [2], "B": [2], "score": 0.91}, index=[2])
+        pd.DataFrame({"A": [2], "B": [2], "score": 0.91}, index=[2]).astype({"A": np.int64, "B": np.int64})
     )
     state.anomaly_detection.pop("anomalies")
 


### PR DESCRIPTION
*Description of changes:*
- [mac] mypy and coverage have conflicts with lightgbm when running coverage stage during the build process; switching to use Random Forest for SHAP tests.
- [win] np.int64 conversion is required for test on Windows box (Windows unlike Linux is frequently using int32 even on 64-bit machines).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
