### PR TITLE
Add wrapper to generate deprecated decorator

### DIFF
--- a/common/src/autogluon/common/utils/deprecated_utils.py
+++ b/common/src/autogluon/common/utils/deprecated_utils.py
@@ -1,7 +1,7 @@
 import functools
 import inspect
 import warnings
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from packaging import version
 
@@ -38,7 +38,7 @@ def Deprecated(
     new: Optional[str] = None,
     custom_warning_msg: Optional[str] = None,
     version_to_remove: Optional[str] = None,
-    _mock_version: Optional[str] = None
+    _ag_version: Optional[str] = None,
 ):
     """
     Decorator to add deprecation warnings or raise an error to the decorated object.
@@ -95,8 +95,8 @@ def Deprecated(
     def _decorator(obj):
         error = False
         ag_version = __version__
-        if _mock_version is not None:
-            ag_version = _mock_version
+        if _ag_version is not None:
+            ag_version = _ag_version
         if version.parse(ag_version) < version.parse(min_version_to_warn):
             return obj
         if version.parse(ag_version) >= version.parse(min_version_to_error):
@@ -149,6 +149,7 @@ def _rename_kwargs(
                     f"{func_name} received both {old_name} and {new_name} as arguments."
                     f"{old_name} is deprecated, please use {new_name} instead."
                 )
+            print(error)
             _deprecation_warning(
                 old=old_name,
                 new=new_name,
@@ -166,7 +167,7 @@ def Deprecated_args(
     min_version_to_error: str,
     custom_warning_msg: Optional[str] = None,
     version_to_remove: Optional[str] = None,
-    _mock_version: Optional[str] = None,
+    _ag_version: Optional[str] = None,
     **kwargs_mapping,
 ):
     """
@@ -214,8 +215,8 @@ def Deprecated_args(
     def _decorator(obj):
         error = False
         ag_version = __version__
-        if _mock_version is not None:
-            ag_version = _mock_version
+        if _ag_version is not None:
+            ag_version = _ag_version
         if version.parse(ag_version) < version.parse(min_version_to_warn):
             return obj
         if version.parse(ag_version) >= version.parse(min_version_to_error):
@@ -234,5 +235,21 @@ def Deprecated_args(
             return obj(*args, **kwargs)
 
         return patched_obj_with_warning_msg
+
+    return _decorator
+
+
+def construct_deprecated_wrapper(ag_version) -> Callable:
+    """Return Deprecated decorator with ag_version as the local AG version for checking"""
+    def _decorator(*args, **kwargs):
+        return Deprecated(*args, _ag_version=ag_version, **kwargs)
+
+    return _decorator
+
+
+def construct_deprecated_args_wrapper(ag_version) -> Callable:
+    """Return Deprecated_args decorator with ag_version as the local AG version for checking"""
+    def _decorator(*args, **kwargs):
+        return Deprecated_args(*args, _ag_version=ag_version, **kwargs)
 
     return _decorator

--- a/common/tests/unittests/test_deprecated_utils.py
+++ b/common/tests/unittests/test_deprecated_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from autogluon.common.utils.deprecated import Deprecated, Deprecated_args
+from autogluon.common.utils.deprecated_utils import Deprecated, Deprecated_args, construct_deprecated_wrapper, construct_deprecated_args_wrapper
 
 
 @pytest.mark.parametrize(
@@ -8,26 +8,28 @@ from autogluon.common.utils.deprecated import Deprecated, Deprecated_args
 )
 def test_should_deprecate_warning(mock_version):
     with pytest.deprecated_call():
+        Deprecated = construct_deprecated_wrapper(mock_version)
+        Deprecated_args = construct_deprecated_args_wrapper(mock_version)
         # class and function definition needs to go inside the context manager because the decorator code runs at function definition time
-        @Deprecated(min_version_to_warn="0.0", min_version_to_error="9999.0", _mock_version=mock_version)
+        @Deprecated(min_version_to_warn="0.0", min_version_to_error="9999.0")
         class ShouldDeprecateButNoErrorClass:
             pass
 
-        @Deprecated(min_version_to_warn="9999.0", min_version_to_error="9999.0", _mock_version=mock_version)
+        @Deprecated(min_version_to_warn="9999.0", min_version_to_error="9999.0")
         class NotDeprecatedClass:
-            @Deprecated(min_version_to_warn="0.0", min_version_to_error="9999.0", _mock_version=mock_version)
+            @Deprecated(min_version_to_warn="0.0", min_version_to_error="9999.0")
             def should_deprecate_but_no_error_func(self):
                 pass
 
-        @Deprecated(min_version_to_warn="0.0", min_version_to_error="9999.0", _mock_version=mock_version)
+        @Deprecated(min_version_to_warn="0.0", min_version_to_error="9999.0")
         def should_deprecate_but_no_error_func():
             pass
 
-        @Deprecated_args(min_version_to_warn="0.0", min_version_to_error="9999.0", deprecated_arg="new_arg", _mock_version=mock_version)
+        @Deprecated_args(min_version_to_warn="0.0", min_version_to_error="9999.0", deprecated_arg="new_arg")
         def func_with_deprecated_args_no_error(new_arg=None):
             return new_arg
 
-        @Deprecated_args(min_version_to_warn="0.0", min_version_to_error="9999.0", deprecated_arg=None, _mock_version=mock_version)
+        @Deprecated_args(min_version_to_warn="0.0", min_version_to_error="9999.0", deprecated_arg=None)
         def func_with_deprecated_args_no_replacement(deprecated_arg=None):
             return deprecated_arg
 
@@ -43,21 +45,23 @@ def test_should_deprecate_warning(mock_version):
 @pytest.mark.parametrize("mock_version", [("1.0"), ("0.1"), ("0.0.1"), ("0.0.1b20230508")])  # random dev version
 def test_should_raise_deprecate_error(mock_version):
     with pytest.raises(ValueError):
-        @Deprecated(min_version_to_warn="0.0", min_version_to_error="0.0", _mock_version=mock_version)
+        Deprecated = construct_deprecated_wrapper(mock_version)
+        Deprecated_args = construct_deprecated_args_wrapper(mock_version)
+        @Deprecated(min_version_to_warn="0.0", min_version_to_error="0.0")
         class ShouldDeprecateErrorClass:
             pass
 
-        @Deprecated(min_version_to_warn="9999.0", min_version_to_error="9999.0", _mock_version=mock_version)
+        @Deprecated(min_version_to_warn="9999.0", min_version_to_error="9999.0")
         class NotDeprecatedClass:
-            @Deprecated(min_version_to_warn="0.0", min_version_to_error="0.0", _mock_version=mock_version)
+            @Deprecated(min_version_to_warn="0.0", min_version_to_error="0.0")
             def should_deprecate_error_func(self):
                 pass
 
-        @Deprecated(min_version_to_warn="0.0", min_version_to_error="0.0", _mock_version=mock_version)
+        @Deprecated(min_version_to_warn="0.0", min_version_to_error="0.0")
         def should_deprecate_error_func():
             pass
 
-        @Deprecated_args(min_version_to_warn="0.0", min_version_to_error="0.0", deprecated_arg="new_arg", _mock_version=mock_version)
+        @Deprecated_args(min_version_to_warn="0.0", min_version_to_error="0.0", deprecated_arg="new_arg")
         def func_with_deprecated_args_error(new_arg=None):
             pass
 
@@ -71,17 +75,19 @@ def test_should_raise_deprecate_error(mock_version):
     "mock_version", [("1.0"), ("0.1"), ("0.0.1"), ("0.0.1b20230508"), ("9999b20230508")]  # random dev version
 )
 def test_should_not_deprecate(mock_version):
-    @Deprecated(min_version_to_warn="9999.0", min_version_to_error="9999.0", _mock_version=mock_version)
+    Deprecated = construct_deprecated_wrapper(mock_version)
+    Deprecated_args = construct_deprecated_args_wrapper(mock_version)
+    @Deprecated(min_version_to_warn="9999.0", min_version_to_error="9999.0")
     class NotDeprecatedClass:
-        @Deprecated(min_version_to_warn="9999.0", min_version_to_error="9999.0", _mock_version=mock_version)
+        @Deprecated(min_version_to_warn="9999.0", min_version_to_error="9999.0")
         def not_deprecated_func(self):
             pass
 
-    @Deprecated(min_version_to_warn="9999.0", min_version_to_error="9999.0", _mock_version=mock_version)
+    @Deprecated(min_version_to_warn="9999.0", min_version_to_error="9999.0")
     def not_deprecated_func():
         pass
 
-    @Deprecated_args(min_version_to_warn="9999.0", min_version_to_error="9999.0", deprecated_arg="new_arg", _mock_version=mock_version)
+    @Deprecated_args(min_version_to_warn="9999.0", min_version_to_error="9999.0", deprecated_arg="new_arg")
     def func_with_no_deprecated_args(new_arg=None):
         pass
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Add wrapper to generate deprecated decorator so the util can be used by modules like cloud

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
