### PR TITLE
[Multimodal] Fix seed

### DIFF
--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -692,8 +692,6 @@ class MultiModalPredictor(ExportMixin):
         if isinstance(tuning_data, str):
             tuning_data = load_pd.load(tuning_data)
 
-        pl.seed_everything(seed, workers=True)
-
         if self._presets is not None:
             # FIXME: Silently ignoring user input, there should be a warning
             presets = self._presets
@@ -809,6 +807,7 @@ class MultiModalPredictor(ExportMixin):
             ckpt_path=None if hpo_mode else self._ckpt_path,
             resume=False if hpo_mode else self._resume,
             enable_progress_bar=False if hpo_mode else self._enable_progress_bar,
+            seed=seed,
             presets=presets,
             config=config,
             hyperparameters=hyperparameters,
@@ -1069,6 +1068,7 @@ class MultiModalPredictor(ExportMixin):
         ckpt_path: str,
         resume: bool,
         enable_progress_bar: bool,
+        seed: int,
         presets: Optional[str] = None,
         config: Optional[dict] = None,
         hyperparameters: Optional[Union[str, Dict, List[str]]] = None,
@@ -1079,6 +1079,7 @@ class MultiModalPredictor(ExportMixin):
         clean_ckpts: bool = True,
         **hpo_kwargs,
     ):
+        pl.seed_everything(seed, workers=True)
         # TODO(?) We should have a separate "_pre_training_event()" for logging messages.
         logger.info(get_fit_start_message(save_path, validation_metric_name))
         config = get_config(


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/autogluon/autogluon/issues/3219

*Description of changes:*
* The issue above can be reproduced by providing a fixed HPO search space, i.e. `learning_rate = tune.choice([1])` and running multiple runs will give different results.
* The root cause should be because the current `seed_everything` call happens in `fit` while this seed setting is not affecting hpo trials. This behavior can be verified by printing torch seed inside `_fit` via `torch.random.initial_seed()`. Different runs will give different seed value.
* This PR moves the `seed_everything` call to `_fit`, which happens inside forked process created by ray and should fix the issue


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
