### PR TITLE
[BUG] Cannot load TabularNeuralNetTorchModel trained on GPU on a CPU

### DIFF
--- a/eda/setup.py
+++ b/eda/setup.py
@@ -15,7 +15,7 @@ spec.loader.exec_module(ag)  # type: ignore
 ###########################
 
 version = ag.load_version_file()
-version = ag.update_version(version, use_file_if_exists=False, create_file=True)
+version = ag.update_version(version)
 
 submodule = 'eda'
 install_requires = [

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -6,7 +6,6 @@ import time
 import warnings
 import numpy as np
 import pandas as pd
-import torch
 
 from typing import Dict, Union
 
@@ -564,6 +563,7 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
         return num_cpus, num_gpus
 
     def save(self, path: str = None, verbose=True) -> str:
+        import torch
         # Save on CPU to ensure the model can be loaded on a box without GPU
         self.model = self.model.to(torch.device("cpu"))
         path = super().save(path, verbose)
@@ -573,6 +573,8 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
 
     @classmethod
     def load(cls, path: str, reset_paths=True, verbose=True):
+        import torch
+
         model: TabularNeuralNetTorchModel = super().load(path=path, reset_paths=reset_paths, verbose=verbose)
 
         original_device_type = model.device.type


### PR DESCRIPTION
*Issue #, if available:*
#2954

*Description of changes:*
Updated `save`/`load` procedures in `TabularNeuralNetTorchModel`; Unfortunately we don't have an option to control torch loading directly as recommended in [this doc](https://pytorch.org/tutorials/recipes/recipes/save_load_across_devices.html) because pickle automatically calling `torch.load` without a way to add a hook and inject additional device parameters.

### Results running on different boxes

Loading trained model on GPU box:
![image](https://github.com/autogluon/autogluon/assets/10080307/d7e25016-a7b0-4c69-a021-d83f96ca8f8e)

Loading the same model on CPU:
![image](https://github.com/autogluon/autogluon/assets/10080307/637b0541-edf2-46cf-badc-8410b0e69ba5)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
