### PR TITLE
Update namespace packages for PEP420 compatibility

### DIFF
--- a/autogluon/src/autogluon/__init__.py
+++ b/autogluon/src/autogluon/__init__.py
@@ -1,1 +1,0 @@
-__import__("pkg_resources").declare_namespace(__name__)

--- a/autogluon/src/autogluon/_internal_/__init__.py
+++ b/autogluon/src/autogluon/_internal_/__init__.py
@@ -1,0 +1,1 @@
+# Placeholder to resolve empty package

--- a/common/src/autogluon/__init__.py
+++ b/common/src/autogluon/__init__.py
@@ -1,1 +1,0 @@
-__import__("pkg_resources").declare_namespace(__name__)

--- a/core/src/autogluon/__init__.py
+++ b/core/src/autogluon/__init__.py
@@ -1,1 +1,0 @@
-__import__("pkg_resources").declare_namespace(__name__)

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -93,7 +93,7 @@ def create_version_file(*, version, submodule):
 
 
 def default_setup_args(*, version, submodule):
-    from setuptools import find_packages
+    from setuptools import find_namespace_packages
     long_description = open(os.path.join(AUTOGLUON_ROOT_PATH, 'README.md')).read()
     if submodule is None:
         name = PACKAGE_NAME
@@ -111,7 +111,7 @@ def default_setup_args(*, version, submodule):
         license_files=('../LICENSE', '../NOTICE'),
 
         # Package info
-        packages=find_packages('src'),
+        packages=find_namespace_packages('src', include=['autogluon.*']),
         package_dir={'': 'src'},
         namespace_packages=[AUTOGLUON],
         zip_safe=True,

--- a/core/src/autogluon/core/utils/version_utils.py
+++ b/core/src/autogluon/core/utils/version_utils.py
@@ -34,7 +34,7 @@ def _get_autogluon_versions():
     """Retrieve version of all autogluon subpackages and its dependencies"""
     versions = dict()
     for pkg in list(pkgutil.iter_modules(autogluon.__path__, autogluon.__name__ + '.')):
-        if pkg.name == 'autogluon.version':  # autogluon.version will be recognized as a submodule by pkgutil. We don't need it
+        if pkg.name in ['autogluon.version', 'autogluon.setup', 'autogluon._internal_']:  # autogluon.version will be recognized as a submodule by pkgutil. We don't need it
             continue
         try:
             module = importlib.import_module(pkg.name)

--- a/core/src/autogluon/core/utils/version_utils.py
+++ b/core/src/autogluon/core/utils/version_utils.py
@@ -1,68 +1,46 @@
-import autogluon
-import importlib
 import pkgutil
-import pkg_resources
 import platform
+import re
 import sys
-
 from datetime import datetime
+from importlib.metadata import version, distribution
 
+import autogluon
 from autogluon.common.utils.nvutil import cudaInit, cudaSystemGetNVMLVersion
 from autogluon.common.utils.resource_utils import ResourceManager
-
-# We don't include test dependency here
-autogluon_extras_dict = {
-    'autogluon.core': ('all',),
-    'autogluon.common': (),
-    'autogluon.features': (),
-    'autogluon.timeseries': (),
-    'autogluon.tabular': ('all',),
-}
-
-# This is needed because some module are different in its import name and pip install name
-import_name_dict = {
-    'pillow': 'PIL',
-    'pytorch-lightning': 'pytorch_lightning',
-    'scikit-image': 'skimage',
-    'scikit-learn': 'sklearn',
-    'smart-open': 'smart_open',
-    'timm-clean': 'timm',
-}
 
 
 def _get_autogluon_versions():
     """Retrieve version of all autogluon subpackages and its dependencies"""
     versions = dict()
     for pkg in list(pkgutil.iter_modules(autogluon.__path__, autogluon.__name__ + '.')):
-        if pkg.name in ['autogluon.version', 'autogluon.setup', 'autogluon._internal_']:  # autogluon.version will be recognized as a submodule by pkgutil. We don't need it
+        # The following packages will be recognized as a submodule by pkgutil -exclude them.
+        if pkg.name in ['autogluon.version', 'autogluon.setup', 'autogluon._internal_']:
             continue
         try:
-            module = importlib.import_module(pkg.name)
-            versions[pkg.name] = module.__version__
-            versions.update(_get_dependency_versions(pkg.name, autogluon_extras_dict.get(pkg.name, ())))
+            versions[pkg.name] = version(pkg.name)
+            versions.update(_get_dependency_versions(pkg.name))
         except ImportError:
             versions[pkg.name] = None
     return versions
 
 
-def _get_dependency_versions(package, extras=()):
+def _get_dependency_versions(package):
     """Retrieve direct dependency of the given package
 
     Args:
         package (str): name of the package
-        extras (tuple, optional): extras in package dependency. Defaults to ().
     """
-    package = pkg_resources.working_set.by_key[package]
-    dependencies = [str(r.key) for r in package.requires(extras=extras)]
+    # Get all requires for the package
+    dependencies = distribution(package).requires
+    # Filter-out test dependencies
+    dependencies = [req for req in dependencies if not bool(re.search('extra.*test', req))]
+    # keep only package name
+    dependencies = [re.findall('[a-zA-Z0-9_\\-]+', req)[0].strip() for req in dependencies]
     versions = dict()
     for dependency in dependencies:
-        dependency = import_name_dict.get(dependency, dependency)
         try:
-            module = importlib.import_module(dependency)
-            version = getattr(module, "__version__", None)
-            if version is None:
-                version = getattr(module, "__VERSION__", None)
-            versions[dependency] = version
+            versions[dependency] = version(dependency)
         except ImportError:
             versions[dependency] = None
     return versions
@@ -106,7 +84,7 @@ def show_versions():
     versions = _get_autogluon_versions()
     sorted_keys = sorted(versions.keys(), key=lambda x: x.lower())
 
-    maxlen = max(len(x) for x in versions)
+    maxlen = 0 if len(versions) == 0 else max(len(x) for x in versions)
     print("\nINSTALLED VERSIONS")
     print("------------------")
     for k, v in sys_info.items():

--- a/eda/src/autogluon/__init__.py
+++ b/eda/src/autogluon/__init__.py
@@ -1,1 +1,0 @@
-__import__("pkg_resources").declare_namespace(__name__)

--- a/features/src/autogluon/__init__.py
+++ b/features/src/autogluon/__init__.py
@@ -1,1 +1,0 @@
-__import__("pkg_resources").declare_namespace(__name__)

--- a/multimodal/src/autogluon/__init__.py
+++ b/multimodal/src/autogluon/__init__.py
@@ -1,1 +1,0 @@
-__import__("pkg_resources").declare_namespace(__name__)

--- a/tabular/src/autogluon/__init__.py
+++ b/tabular/src/autogluon/__init__.py
@@ -1,1 +1,0 @@
-__import__("pkg_resources").declare_namespace(__name__)

--- a/timeseries/src/autogluon/__init__.py
+++ b/timeseries/src/autogluon/__init__.py
@@ -1,1 +1,0 @@
-__import__("pkg_resources").declare_namespace(__name__)


### PR DESCRIPTION
*Description of changes:*
Building the project generates deprecation warnings and suggests transitioning to the use of implicit namespace packages (refer to [native namespace packages](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/#native-namespace-packages) and [PEP420](https://peps.python.org/pep-0420/)):

```
../../venv-ag-310/lib/python3.10/site-packages/pkg_resources/__init__.py:2870
  /Users/user/Projects/venv-ag-310/lib/python3.10/site-packages/pkg_resources/__init__.py:2870: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('autogluon')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)
```

The action requires removing `__init__.py` from the root of the namespace package and switching to using `find_namespace_packages` instead of `find_packages`.

Pre-merge checklist:
- [x] builds passing
- [x] discussed with the team
- [ ] verify nightly builds are working properly; rollback if any issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
