### PR TITLE
[timeseries] Add excluded_model_types and simplify preset generation logic

### DIFF
--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -124,6 +124,7 @@ class TimeSeriesLearner(AbstractLearner):
             val_data=val_data,
             hyperparameters=hyperparameters,
             hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
+            excluded_model_types=kwargs.get("excluded_model_types"),
             time_limit=time_limit,
         )
         self.save_trainer(trainer=self.trainer)

--- a/timeseries/src/autogluon/timeseries/models/abstract/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/__init__.py
@@ -1,3 +1,3 @@
-from .abstract_timeseries_model import AbstractTimeSeriesModel, AbstractTimeSeriesModelFactory
+from .abstract_timeseries_model import AbstractTimeSeriesModel
 
-__all__ = ["AbstractTimeSeriesModel", "AbstractTimeSeriesModelFactory"]
+__all__ = ["AbstractTimeSeriesModel"]

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -462,10 +462,3 @@ class AbstractTimeSeriesModel(AbstractModel):
             return {}
         else:
             return self._user_params.copy()
-
-
-class AbstractTimeSeriesModelFactory:
-    """Factory class interface for callable objects that produce timeseries models"""
-
-    def __call__(self, *args, **kwargs) -> AbstractTimeSeriesModel:
-        raise NotImplementedError

--- a/timeseries/src/autogluon/timeseries/models/gluonts/mx/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/mx/models.py
@@ -7,7 +7,6 @@ import mxnet as mx
 
 from autogluon.core.utils import warning_filter
 from autogluon.timeseries.dataset.ts_dataframe import TimeSeriesDataFrame
-from autogluon.timeseries.models.abstract.abstract_timeseries_model import AbstractTimeSeriesModelFactory
 from autogluon.timeseries.models.gluonts.abstract_gluonts import AbstractGluonTSModel
 
 with warning_filter():
@@ -475,19 +474,3 @@ class GenericGluonTSMXNetModel(AbstractGluonTSMXNetModel):
         if get_mxnet_context() != mx.context.cpu():
             init_kwargs["hybridize"] = False
         return init_kwargs
-
-
-class GenericGluonTSMXNetModelFactory(AbstractTimeSeriesModelFactory):
-    """Factory class for GenericGluonTSModel for convenience of use"""
-
-    def __init__(self, gluonts_estimator_class: Type[GluonTSEstimator], **kwargs):
-        self.gluonts_estimator_class = gluonts_estimator_class
-        self.init_kwargs = kwargs
-
-    def __call__(self, **kwargs):
-        model_init_kwargs = self.init_kwargs.copy()
-        model_init_kwargs.update(kwargs)
-        return GenericGluonTSMXNetModel(
-            gluonts_estimator_class=self.gluonts_estimator_class,
-            **model_init_kwargs,
-        )

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -379,9 +379,9 @@ class TimeSeriesPredictor:
             If str is passed, will use a preset hyperparameter configuration defined in`
             `autogluon/timeseries/trainer/models/presets.py``.
 
-            If dict is provided, the keys are strings that indicate which models to train. Each value is itself a dict
-            containing hyperparameters for each of the trained models, or a list of such dicts. Any omitted
-            hyperparameters not specified here will be set to default. For example::
+            If dict is provided, the keys are strings or types that indicate which models to train. Each value is
+            itself a dict containing hyperparameters for each of the trained models, or a list of such dicts. Any
+            omitted hyperparameters not specified here will be set to default. For example::
 
                 predictor.fit(
                     ...

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -291,6 +291,7 @@ class TimeSeriesPredictor:
         presets: Optional[str] = None,
         hyperparameters: Dict[Union[str, Type], Any] = None,
         hyperparameter_tune_kwargs: Optional[Union[str, Dict]] = None,
+        excluded_model_types: Optional[List[str]] = None,
         num_val_windows: int = 1,
         refit_full: bool = False,
         enable_ensemble: bool = True,
@@ -378,9 +379,9 @@ class TimeSeriesPredictor:
             If str is passed, will use a preset hyperparameter configuration defined in`
             `autogluon/timeseries/trainer/models/presets.py``.
 
-            If dict is provided, the keys are strings or Types that indicate which models to train. Each value is
-            itself a dict containing hyperparameters for each of the trained models, or a list of such dicts. Any
-            omitted hyperparameters not specified here will be set to default. For example::
+            If dict is provided, the keys are strings that indicate which models to train. Each value is itself a dict
+            containing hyperparameters for each of the trained models, or a list of such dicts. Any omitted
+            hyperparameters not specified here will be set to default. For example::
 
                 predictor.fit(
                     ...
@@ -448,6 +449,8 @@ class TimeSeriesPredictor:
                         "num_trials": 5,
                     }
                 )
+        excluded_model_types: List[str], optional
+            Banned subset of model types to avoid training during ``fit()``, even if present in ``hyperparameters``.
         num_val_windows : int, default = 1
             Number of backtests done on ``train_data`` for each trained model to estimate the validation performance.
             A separate copy of each model is trained for each validation window.
@@ -488,6 +491,7 @@ class TimeSeriesPredictor:
             evaluation_metric=self.eval_metric,
             hyperparameters=hyperparameters,
             hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
+            excluded_model_types=excluded_model_types,
             num_val_windows=num_val_windows,
             enable_ensemble=enable_ensemble,
             random_seed=random_seed,
@@ -525,6 +529,7 @@ class TimeSeriesPredictor:
             val_data=tuning_data,
             hyperparameters=hyperparameters,
             hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
+            excluded_model_types=excluded_model_types,
             time_limit=time_left,
             verbosity=verbosity,
             num_val_windows=num_val_windows,

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -1,9 +1,7 @@
 import logging
 import pprint
 import time
-import traceback
 import warnings
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Type, Union
 
 import pandas as pd
@@ -447,10 +445,17 @@ class TimeSeriesPredictor:
                         "scheduler": "local",
                         "searcher": "auto",
                         "num_trials": 5,
-                    }
+                    },
                 )
         excluded_model_types: List[str], optional
             Banned subset of model types to avoid training during ``fit()``, even if present in ``hyperparameters``.
+            For example, the following code will train all models included in the ``high_quality`` presets except ``DeepAR``::
+
+                predictor.fit(
+                    ...,
+                    presets="high_quality",
+                    excluded_model_types=["DeepAR"],
+                )
         num_val_windows : int, default = 1
             Number of backtests done on ``train_data`` for each trained model to estimate the validation performance.
             A separate copy of each model is trained for each validation window.

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -549,6 +549,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         models: Optional[List[AbstractTimeSeriesModel]] = None,
         val_data: Optional[TimeSeriesDataFrame] = None,
         hyperparameter_tune_kwargs: Optional[Union[str, dict]] = None,
+        excluded_model_types: Optional[List[str]] = None,
         time_limit: Optional[float] = None,
     ) -> List[str]:
 
@@ -578,6 +579,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
                 hyperparameter_tune=hyperparameter_tune_kwargs is not None,  # TODO: remove hyperparameter_tune
                 freq=train_data.freq,
                 multi_window=self.num_val_windows > 0,
+                excluded_model_types=excluded_model_types,
             )
 
         logger.info(f"Models that will be trained: {list(m.name for m in models)}")

--- a/timeseries/src/autogluon/timeseries/trainer/auto_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/auto_trainer.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from ..models.presets import get_preset_models
 from .abstract_trainer import AbstractTimeSeriesTrainer, TimeSeriesDataFrame
@@ -23,9 +23,10 @@ class AutoTimeSeriesTrainer(AbstractTimeSeriesTrainer):
             hyperparameters=hyperparameters,
             hyperparameter_tune=hyperparameter_tune,
             quantiles=quantile_levels,
-            invalid_model_names=self._get_banned_model_names(),
+            all_assigned_names=self._get_banned_model_names(),
             target=self.target,
             metadata=self.metadata,
+            excluded_model_types=kwargs.get("excluded_model_types"),
             multi_window=multi_window,
         )
 
@@ -35,6 +36,7 @@ class AutoTimeSeriesTrainer(AbstractTimeSeriesTrainer):
         hyperparameters: Union[str, Dict[Any, Dict]],
         val_data: Optional[TimeSeriesDataFrame] = None,
         hyperparameter_tune_kwargs: Optional[Union[str, Dict]] = None,
+        excluded_model_types: Optional[List[str]] = None,
         time_limit: float = None,
     ):
         """
@@ -53,6 +55,8 @@ class AutoTimeSeriesTrainer(AbstractTimeSeriesTrainer):
             Optional validation data set to report validation scores on.
         hyperparameter_tune_kwargs
             Args for hyperparameter tuning
+        excluded_model_types
+            Names of models that should not be trained, even if listed in `hyperparameters`.
         time_limit
             Time limit for training
         """
@@ -61,5 +65,6 @@ class AutoTimeSeriesTrainer(AbstractTimeSeriesTrainer):
             val_data=val_data,
             hyperparameters=hyperparameters,
             hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
+            excluded_model_types=excluded_model_types,
             time_limit=time_limit,
         )

--- a/timeseries/tests/unittests/models/gluonts/mx/test_mx.py
+++ b/timeseries/tests/unittests/models/gluonts/mx/test_mx.py
@@ -7,7 +7,6 @@ from autogluon.timeseries import MXNET_INSTALLED
 if not MXNET_INSTALLED:
     pytest.skip(allow_module_level=True)
 from gluonts.mx.model.seq2seq import MQRNNEstimator
-from gluonts.mx.model.transformer import TransformerEstimator
 
 from autogluon.timeseries.models.gluonts.mx import (
     DeepARMXNetModel,
@@ -16,7 +15,6 @@ from autogluon.timeseries.models.gluonts.mx import (
     SimpleFeedForwardMXNetModel,
     TemporalFusionTransformerMXNetModel,
 )
-from autogluon.timeseries.models.gluonts.mx.models import GenericGluonTSMXNetModelFactory
 
 from ....common import DUMMY_TS_DATAFRAME
 
@@ -27,7 +25,6 @@ TESTABLE_MX_MODELS = [
     SimpleFeedForwardMXNetModel,
     # TransformerModel,
     partial(GenericGluonTSMXNetModel, gluonts_estimator_class=MQRNNEstimator),  # partial constructor for generic model
-    GenericGluonTSMXNetModelFactory(TransformerEstimator),
     TemporalFusionTransformerMXNetModel,
 ]
 TESTABLE_MX_MODELS_WITH_STATIC_FEATURES = [

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -634,3 +634,17 @@ def test_when_refit_full_is_passed_to_fit_then_refit_full_is_skipped(temp_model_
             refit_method.assert_called()
         else:
             refit_method.assert_not_called()
+
+
+def test_when_excluded_model_names_provided_then_excluded_models_are_not_trained(temp_model_path):
+    predictor = TimeSeriesPredictor(path=temp_model_path)
+    predictor.fit(
+        DUMMY_TS_DATAFRAME,
+        hyperparameters={
+            "DeepAR": {"epochs": 1, "num_batches_per_epoch": 1},
+            "SimpleFeedForward": {"epochs": 1, "num_batches_per_epoch": 1},
+        },
+        excluded_model_types=["DeepAR"],
+    )
+    leaderboard = predictor.leaderboard()
+    assert leaderboard["model"].values == ["SimpleFeedForward"]

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -477,18 +477,20 @@ def test_when_refit_full_called_with_model_name_then_single_model_is_updated(tem
     assert list(model_full_dict.values()) == ["DeepAR_FULL"]
 
 
-def test_when_some_models_have_incorrect_suffix_then_correct_model_are_trained(temp_model_path):
-    hyperparameters = {
-        "DeepAR": {"epochs": 1, "num_batches_per_epoch": 1},
-        "SimpleFeedForwardModel": {"epochs": 1, "num_batches_per_epoch": 1},
-    }
+@pytest.mark.parametrize(
+    "hyperparameters, expected_model_names",
+    [
+        ({"Naive": {}, "SeasonalNaiveModel": {}}, ["Naive", "SeasonalNaive"]),
+        ({"Naive": {}, "NaiveModel": {}}, ["Naive", "Naive_2"]),
+    ],
+)
+def test_when_some_models_have_incorrect_suffix_then_correct_model_are_trained(
+    temp_model_path, hyperparameters, expected_model_names
+):
     trainer = AutoTimeSeriesTrainer(path=temp_model_path, enable_ensemble=False)
-    trainer.fit(
-        DUMMY_TS_DATAFRAME,
-        hyperparameters=hyperparameters,
-    )
+    trainer.fit(DUMMY_TS_DATAFRAME, hyperparameters=hyperparameters)
     leaderboard = trainer.leaderboard()
-    assert sorted(leaderboard["model"].values) == ["DeepAR", "SimpleFeedForward"]
+    assert sorted(leaderboard["model"].values) == expected_model_names
 
 
 @pytest.mark.parametrize("excluded_model_types", [["DeepAR"], ["DeepARModel"]])

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -475,3 +475,34 @@ def test_when_refit_full_called_with_model_name_then_single_model_is_updated(tem
     )
     model_full_dict = trainer.refit_full("DeepAR")
     assert list(model_full_dict.values()) == ["DeepAR_FULL"]
+
+
+def test_when_some_models_have_incorrect_suffix_then_correct_model_are_trained(temp_model_path):
+    hyperparameters = {
+        "DeepAR": {"epochs": 1, "num_batches_per_epoch": 1},
+        "SimpleFeedForwardModel": {"epochs": 1, "num_batches_per_epoch": 1},
+    }
+    trainer = AutoTimeSeriesTrainer(path=temp_model_path, enable_ensemble=False)
+    trainer.fit(
+        DUMMY_TS_DATAFRAME,
+        hyperparameters=hyperparameters,
+    )
+    leaderboard = trainer.leaderboard()
+    assert sorted(leaderboard["model"].values) == ["DeepAR", "SimpleFeedForward"]
+
+
+@pytest.mark.parametrize("excluded_model_types", [["DeepAR"], ["DeepARModel"]])
+def test_when_excluded_model_names_provided_then_excluded_models_are_not_trained(
+    temp_model_path, excluded_model_types
+):
+    trainer = AutoTimeSeriesTrainer(path=temp_model_path)
+    trainer.fit(
+        DUMMY_TS_DATAFRAME,
+        hyperparameters={
+            "DeepAR": {"epochs": 1, "num_batches_per_epoch": 1},
+            "SimpleFeedForward": {"epochs": 1, "num_batches_per_epoch": 1},
+        },
+        excluded_model_types=excluded_model_types,
+    )
+    leaderboard = trainer.leaderboard()
+    assert leaderboard["model"].values == ["SimpleFeedForward"]


### PR DESCRIPTION
*Issue number*: #2600

*Description of changes:*
- Gracefully handle the case when users incorrectly add the `Model` suffix to the model name (e.g., specify `DeepARModel` instead of `DeepAR`). This is a common pain point for users since models are listed with the `Model` suffix in the [documentation](https://auto.gluon.ai/stable/tutorials/timeseries/forecasting-model-zoo.html) because of Sphinx.
- New argument `excluded_model_types` for `TimeSeriesPredictor.fit` that allows users to exclude certain models from the presets, replicating the API of `TabularPredictor`.
- Remove some untested/undocumented/probably unsupported functionality for `AbstractTimeSeriesModelFactory` & `GenericGluonTSMXNetModelFactory`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
