### PR TITLE
[timeseries] Check AG-TS version when loading TimeSeriesPredictor

### DIFF
--- a/common/src/autogluon/common/utils/utils.py
+++ b/common/src/autogluon/common/utils/utils.py
@@ -5,7 +5,7 @@ import logging
 import os
 import platform
 import sys
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 from ..version import __version__
 try:
@@ -137,3 +137,33 @@ def bytes_to_mega_bytes(memory_amount: int) -> int:
     """ Utility to convert a number of bytes (int) into a number of mega bytes (int)
     """
     return memory_amount >> 20
+
+
+def check_saved_predictor_version(
+    version_current: str,
+    version_saved: str,
+    require_version_match: bool = True,
+    logger: Optional[logging.Logger] = None,
+) -> None:
+    if logger is None:
+        logger = logging.getLogger(__name__)
+
+    if version_saved != version_current:
+        logger.warning("")
+        logger.warning("############################## WARNING ##############################")
+        logger.warning(
+            "WARNING: AutoGluon version differs from the version used to create the predictor! "
+            "This may lead to instability and it is highly recommended the predictor be loaded "
+            "with the exact AutoGluon version it was created with."
+        )
+        logger.warning(f"\tPredictor Version: {version_saved}")
+        logger.warning(f"\tCurrent Version:   {version_current}")
+        logger.warning("############################## WARNING ##############################")
+        logger.warning("")
+
+        if require_version_match:
+            raise AssertionError(
+                f"Predictor was created on version {version_saved} but is being loaded with version {version_current}. "
+                f"Please ensure the versions match to avoid instability. While it is NOT recommended, "
+                f"this error can be bypassed by specifying `require_version_match=False`."
+            )

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -1,9 +1,7 @@
 import logging
 import pprint
 import time
-import traceback
 import warnings
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Type, Union
 
 import pandas as pd
@@ -13,12 +11,12 @@ from autogluon.common.utils.utils import check_saved_predictor_version, setup_ou
 from autogluon.core.utils.decorators import apply_presets
 from autogluon.core.utils.loaders import load_pkl, load_str
 from autogluon.core.utils.savers import save_pkl, save_str
+from autogluon.timeseries import __version__ as current_ag_version
 from autogluon.timeseries.configs import TIMESERIES_PRESETS_CONFIGS
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP, TimeSeriesDataFrame
 from autogluon.timeseries.learner import AbstractLearner, TimeSeriesLearner
 from autogluon.timeseries.trainer import AbstractTimeSeriesTrainer
 from autogluon.timeseries.utils.random import set_random_seed
-from autogluon.timeseries.version import __version__ as current_ag_version
 
 logger = logging.getLogger(__name__)
 
@@ -708,7 +706,7 @@ class TimeSeriesPredictor:
         return predictor
 
     def _save_version_file(self):
-        version_file_contents = str(current_ag_version)
+        version_file_contents = current_ag_version
         version_file_path = self.path + self._predictor_version_file_name
         save_str.save(path=version_file_path, data=version_file_contents, verbose=False)
 


### PR DESCRIPTION
*Issue #, if available:* #2808

*Description of changes:*
- Move logic for checking if the current AG version matches the saved version of the predictor to `autogluon.common.utils.utils`
- Use this logic inside `TimeSeriesPredictor` to keep track of the version used to train the model.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
