### PR TITLE
[timeseries] Bugfixes for TimeSeriesDataFrame

### DIFF
--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -323,11 +323,19 @@ class TimeSeriesDataFrame(pd.DataFrame):
 
         df = df.copy()
         if id_column is not None:
-            assert id_column in df.columns, f"Column {id_column} not found!"
+            assert id_column in df.columns, f"Column '{id_column}' not found!"
+            if id_column != ITEMID and ITEMID in df.columns:
+                raise ValueError(
+                    f"Data contains column '{ITEMID}'. This name is used internally by AutoGluon. Please rename this column"
+                )
             df.rename(columns={id_column: ITEMID}, inplace=True)
 
         if timestamp_column is not None:
-            assert timestamp_column in df.columns, f"Column {timestamp_column} not found!"
+            assert timestamp_column in df.columns, f"Column '{timestamp_column}' not found!"
+            if timestamp_column != TIMESTAMP and TIMESTAMP in df.columns:
+                raise ValueError(
+                    f"Data contains column '{TIMESTAMP}'. This name is used internally by AutoGluon. Please rename this column"
+                )
             df.rename(columns={timestamp_column: TIMESTAMP}, inplace=True)
 
         if TIMESTAMP in df.columns:

--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import itertools
+import logging
 from collections.abc import Iterable
 from typing import Any, List, Optional, Tuple, Type
 
@@ -11,6 +12,8 @@ from joblib.parallel import Parallel, delayed
 from pandas.core.internals import ArrayManager, BlockManager
 
 from autogluon.common.loaders import load_pd
+
+logger = logging.getLogger(__name__)
 
 ITEMID = "item_id"
 TIMESTAMP = "timestamp"
@@ -325,17 +328,15 @@ class TimeSeriesDataFrame(pd.DataFrame):
         if id_column is not None:
             assert id_column in df.columns, f"Column '{id_column}' not found!"
             if id_column != ITEMID and ITEMID in df.columns:
-                raise ValueError(
-                    f"Data contains column '{ITEMID}'. This name is used internally by AutoGluon. Please rename this column"
-                )
+                logger.warning(f"Renaming existing column '{ITEMID}' -> '__{ITEMID}' to avoid name collisions.")
+                df.rename(columns={ITEMID: "__" + ITEMID}, inplace=True)
             df.rename(columns={id_column: ITEMID}, inplace=True)
 
         if timestamp_column is not None:
             assert timestamp_column in df.columns, f"Column '{timestamp_column}' not found!"
             if timestamp_column != TIMESTAMP and TIMESTAMP in df.columns:
-                raise ValueError(
-                    f"Data contains column '{TIMESTAMP}'. This name is used internally by AutoGluon. Please rename this column"
-                )
+                logger.warning(f"Renaming existing column '{TIMESTAMP}' -> '__{TIMESTAMP}' to avoid name collisions.")
+                df.rename(columns={TIMESTAMP: "__" + TIMESTAMP}, inplace=True)
             df.rename(columns={timestamp_column: TIMESTAMP}, inplace=True)
 
         if TIMESTAMP in df.columns:

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -620,7 +620,8 @@ class TimeSeriesPredictor:
         if random_seed is not None:
             set_random_seed(random_seed)
         data = self._check_and_prepare_data_frame(data)
-        return self._learner.predict(data, known_covariates=known_covariates, model=model)
+        predictions = self._learner.predict(data, known_covariates=known_covariates, model=model)
+        return predictions.reindex(data.item_ids, level=ITEMID)  # make sure that item_id order is preserved
 
     def evaluate(self, data: Union[TimeSeriesDataFrame, pd.DataFrame], **kwargs):
         """Evaluate the performance for given dataset, computing the score determined by ``self.eval_metric``

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -208,6 +208,7 @@ class TimeSeriesPredictor:
         if not df.index.is_monotonic_increasing:
             logger.info("Provided data is not sorted by item_id & timestamp, sorting...")
             df = df.sort_index()
+            df._cached_freq = None  # in case frequency was incorrectly cached as IRREGULAR_TIME_INDEX_FREQSTR
         if df.freq is None:
             raise ValueError(
                 "Frequency not provided and cannot be inferred. This is often due to the "

--- a/timeseries/tests/smoketests/test_features_and_covariates.py
+++ b/timeseries/tests/smoketests/test_features_and_covariates.py
@@ -105,7 +105,9 @@ def test_predictor_smoke_test(
 
     known_covariates = test_data.slice_by_timestep(-prediction_length, None)[known_covariates_names]
     predictions = predictor.predict(train_data, known_covariates=known_covariates)
-    # Handle the case when ignore_time_index=True
-    future_test_data = predictor._check_and_prepare_data_frame(test_data).slice_by_timestep(-prediction_length, None)
+
+    if ignore_time_index:
+        test_data = test_data.get_reindexed_view(freq="S")
+    future_test_data = test_data.slice_by_timestep(-prediction_length, None)
 
     assert predictions.index.equals(future_test_data.index)

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -585,6 +585,16 @@ def test_given_data_cannot_be_interpreted_as_tsdf_then_exception_raised(temp_mod
         predictor.fit(df, hyperparameters={"Naive": {}})
 
 
+def test_given_data_is_not_sorted_then_predictor_can_fit_and_predict(temp_model_path):
+    shuffled_df = pd.DataFrame(DUMMY_TS_DATAFRAME).sample(frac=1.0)
+    ts_df = TimeSeriesDataFrame(shuffled_df)
+
+    predictor = TimeSeriesPredictor(path=temp_model_path, prediction_length=2)
+    predictor.fit(ts_df, hyperparameters={"Naive": {}})
+    predictions = predictor.predict(ts_df)
+    assert len(predictions) == predictor.prediction_length * ts_df.num_items
+
+
 def test_when_both_argument_aliases_are_passed_to_init_then_exception_is_raised(temp_model_path):
     with pytest.raises(ValueError, match="Please specify at most one of these arguments"):
         predictor = TimeSeriesPredictor(path=temp_model_path, target="custom_target", label="custom_target")

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -834,15 +834,15 @@ def test_when_dropna_called_then_missing_values_are_dropped():
     assert not df_dropped.isna().any().any()
 
 
-def test_when_data_contains_item_id_column_that_is_unused_then_exception_is_raised():
+def test_when_data_contains_item_id_column_that_is_unused_then_column_is_renamed():
     df = SAMPLE_DATAFRAME.copy()
     df["custom_id"] = df[ITEMID]
-    with pytest.raises(ValueError, match=f"Data contains column '{ITEMID}'"):
-        TimeSeriesDataFrame.from_data_frame(df, id_column="custom_id")
+    ts_df = TimeSeriesDataFrame.from_data_frame(df, id_column="custom_id")
+    assert f"__{ITEMID}" in ts_df.columns
 
 
-def test_when_data_contains_timestamp_column_that_is_unused_then_exception_is_raised():
+def test_when_data_contains_timestamp_column_that_is_unused_then_column_is_renamed():
     df = SAMPLE_DATAFRAME.copy()
     df["custom_timestamp"] = df[TIMESTAMP]
-    with pytest.raises(ValueError, match=f"Data contains column '{TIMESTAMP}'"):
-        TimeSeriesDataFrame.from_data_frame(df, timestamp_column="custom_timestamp")
+    ts_df = TimeSeriesDataFrame.from_data_frame(df, timestamp_column="custom_timestamp")
+    assert f"__{TIMESTAMP}" in ts_df.columns

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -832,3 +832,17 @@ def test_when_dropna_called_then_missing_values_are_dropped():
     df.iloc[[1, 5, 10, 14, 22]] = np.nan
     df_dropped = df.dropna()
     assert not df_dropped.isna().any().any()
+
+
+def test_when_data_contains_item_id_column_that_is_unused_then_exception_is_raised():
+    df = SAMPLE_DATAFRAME.copy()
+    df["custom_id"] = df[ITEMID]
+    with pytest.raises(ValueError, match=f"Data contains column '{ITEMID}'"):
+        TimeSeriesDataFrame.from_data_frame(df, id_column="custom_id")
+
+
+def test_when_data_contains_timestamp_column_that_is_unused_then_exception_is_raised():
+    df = SAMPLE_DATAFRAME.copy()
+    df["custom_timestamp"] = df[TIMESTAMP]
+    with pytest.raises(ValueError, match=f"Data contains column '{TIMESTAMP}'"):
+        TimeSeriesDataFrame.from_data_frame(df, timestamp_column="custom_timestamp")


### PR DESCRIPTION
*Issue #, if available:* #3036, #2995

*Description of changes:*
- Raise exception if provided data contains a column `item_id` that is not used as `item_id` / `timestamp` that is not used as `timestamp` - fixes #2995
- Automatically sort data by `['item_id', 'timestamp']`, if data provided by user isn't sorted - fixes #3036

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
