### PR TITLE
[timeseries] Minor bugfixes & improvements for local forecasting models

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
+++ b/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
@@ -138,7 +138,7 @@ class AbstractLocalModel(AbstractTimeSeriesModel):
             fraction_failed_models = number_failed_models / len(predictions_with_flags)
             logger.warning(
                 f"\tWarning: {self.name} failed for {number_failed_models} time series "
-                f"({fraction_failed_models:.1%}%). Fallback model SeasonalNaive was used for these time series."
+                f"({fraction_failed_models:.1%}). Fallback model SeasonalNaive was used for these time series."
             )
         predictions_df = pd.concat([pred for pred, _ in predictions_with_flags])
         predictions_df.index = get_forecast_horizon_index_ts_dataframe(data, self.prediction_length)

--- a/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
+++ b/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
@@ -138,7 +138,7 @@ class AbstractLocalModel(AbstractTimeSeriesModel):
             fraction_failed_models = number_failed_models / len(predictions_with_flags)
             logger.warning(
                 f"\tWarning: {self.name} failed for {number_failed_models} time series "
-                f"({100 * fraction_failed_models:.1f}%). Fallback model SeasonalNaive was used for these time series."
+                f"({fraction_failed_models:.1%}%). Fallback model SeasonalNaive was used for these time series."
             )
         predictions_df = pd.concat([pred for pred, _ in predictions_with_flags])
         predictions_df.index = get_forecast_horizon_index_ts_dataframe(data, self.prediction_length)

--- a/timeseries/src/autogluon/timeseries/models/local/statsforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/local/statsforecast.py
@@ -95,11 +95,14 @@ class AutoARIMAModel(AbstractStatsForecastModel):
         When set to None, seasonal_period will be inferred from the frequency of the training data. Can also be
         specified manually by providing an integer > 1.
         If seasonal_period (inferred or provided) is equal to 1, seasonality will be disabled.
-    n_jobs : int or float, default = -1
+    n_jobs : int or float, default = 0.5
         Number of CPU cores used to fit the models in parallel.
         When set to a float between 0.0 and 1.0, that fraction of available CPU cores is used.
         When set to a positive integer, that many cores are used.
         When set to -1, all CPU cores are used.
+    max_ts_length : int, default = 2500
+        If not None, only the last ``max_ts_length`` time steps of each time series will be used to train the model.
+        This significantly speeds up fitting and usually leads to no change in accuracy.
     """
 
     allowed_local_model_args = [
@@ -122,7 +125,6 @@ class AutoARIMAModel(AbstractStatsForecastModel):
         "allowmean",
         "seasonal_period",
     ]
-    MAX_TS_LENGTH = 3000
 
     def _update_local_model_args(self, local_model_args: dict) -> dict:
         local_model_args = super()._update_local_model_args(local_model_args)
@@ -155,11 +157,14 @@ class AutoETSModel(AbstractStatsForecastModel):
         When set to None, seasonal_period will be inferred from the frequency of the training data. Can also be
         specified manually by providing an integer > 1.
         If seasonal_period (inferred or provided) is equal to 1, seasonality will be disabled.
-    n_jobs : int or float, default = -1
+    n_jobs : int or float, default = 0.5
         Number of CPU cores used to fit the models in parallel.
         When set to a float between 0.0 and 1.0, that fraction of available CPU cores is used.
         When set to a positive integer, that many cores are used.
         When set to -1, all CPU cores are used.
+    max_ts_length : int, default = 2500
+        If not None, only the last ``max_ts_length`` time steps of each time series will be used to train the model.
+        This significantly speeds up fitting and usually leads to no change in accuracy.
     """
 
     allowed_local_model_args = [
@@ -196,11 +201,14 @@ class DynamicOptimizedThetaModel(AbstractStatsForecastModel):
         When set to None, seasonal_period will be inferred from the frequency of the training data. Can also be
         specified manually by providing an integer > 1.
         If seasonal_period (inferred or provided) is equal to 1, seasonality will be disabled.
-    n_jobs : int or float, default = -1
+    n_jobs : int or float, default = 0.5
         Number of CPU cores used to fit the models in parallel.
         When set to a float between 0.0 and 1.0, that fraction of available CPU cores is used.
         When set to a positive integer, that many cores are used.
         When set to -1, all CPU cores are used.
+    max_ts_length : int, default = 2500
+        If not None, only the last ``max_ts_length`` time steps of each time series will be used to train the model.
+        This significantly speeds up fitting and usually leads to no change in accuracy.
     """
 
     allowed_local_model_args = [
@@ -237,11 +245,14 @@ class ThetaModel(AbstractStatsForecastModel):
         When set to None, seasonal_period will be inferred from the frequency of the training data. Can also be
         specified manually by providing an integer > 1.
         If seasonal_period (inferred or provided) is equal to 1, seasonality will be disabled.
-    n_jobs : int or float, default = -1
+    n_jobs : int or float, default = 0.5
         Number of CPU cores used to fit the models in parallel.
         When set to a float between 0.0 and 1.0, that fraction of available CPU cores is used.
         When set to a positive integer, that many cores are used.
         When set to -1, all CPU cores are used.
+    max_ts_length : int, default = 2500
+        If not None, only the last ``max_ts_length`` time steps of each time series will be used to train the model.
+        This significantly speeds up fitting and usually leads to no change in accuracy.
     """
 
     allowed_local_model_args = [

--- a/timeseries/src/autogluon/timeseries/models/local/statsmodels.py
+++ b/timeseries/src/autogluon/timeseries/models/local/statsmodels.py
@@ -87,6 +87,9 @@ class ETSModel(AbstractLocalModel):
         When set to a float between 0.0 and 1.0, that fraction of available CPU cores is used.
         When set to a positive integer, that many cores are used.
         When set to -1, all CPU cores are used.
+    max_ts_length : int, default = 2500
+        If not None, only the last ``max_ts_length`` time steps of each time series will be used to train the model.
+        This significantly speeds up fitting and usually leads to no change in accuracy.
     """
 
     allowed_local_model_args = [
@@ -143,7 +146,7 @@ class ETSModel(AbstractLocalModel):
 
         results = [predictions.predicted_mean.rename("mean")]
         coverage_fn = lambda alpha: predictions.pred_int(alpha=alpha)
-        results += get_quantiles_from_statsmodels(coverage_fn=coverage_fn, quantile_levels=quantile_levels)
+        results += get_quantiles_from_statsmodels(coverage_fn=coverage_fn, quantile_levels=self.quantile_levels)
         return pd.concat(results, axis=1)
 
 
@@ -184,6 +187,9 @@ class ARIMAModel(AbstractLocalModel):
         When set to a float between 0.0 and 1.0, that fraction of available CPU cores is used.
         When set to a positive integer, that many cores are used.
         When set to -1, all CPU cores are used.
+    max_ts_length : int, default = 2500
+        If not None, only the last ``max_ts_length`` time steps of each time series will be used to train the model.
+        This significantly speeds up fitting and usually leads to no change in accuracy.
     """
 
     allowed_local_model_args = [
@@ -195,7 +201,6 @@ class ARIMAModel(AbstractLocalModel):
         "enforce_invertibility",
         "maxiter",
     ]
-    MAX_TS_LENGTH = 3000
 
     def _update_local_model_args(self, local_model_args: Dict[str, Any]) -> Dict[str, Any]:
         local_model_args.setdefault("trend", "c")
@@ -288,6 +293,9 @@ class ThetaStatsmodelsModel(AbstractLocalModel):
         When set to a float between 0.0 and 1.0, that fraction of available CPU cores is used.
         When set to a positive integer, that many cores are used.
         When set to -1, all CPU cores are used.
+    max_ts_length : int, default = 2500
+        If not None, only the last ``max_ts_length`` time steps of each time series will be used to train the model.
+        This significantly speeds up fitting and usually leads to no change in accuracy.
     """
 
     allowed_local_model_args = [

--- a/timeseries/tests/unittests/models/test_local.py
+++ b/timeseries/tests/unittests/models/test_local.py
@@ -42,7 +42,7 @@ DEFAULT_HYPERPARAMETERS = {"n_jobs": 1, "use_fallback_model": False}
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
 def test_when_local_model_is_saved_and_loaded_then_model_can_predict(model_class, temp_model_path):
-    model = model_class(path=temp_model_path, hyperparameters=DEFAULT_HYPERPARAMETERS)
+    model = model_class(path=temp_model_path, hyperparameters=DEFAULT_HYPERPARAMETERS, freq=DUMMY_TS_DATAFRAME.freq)
     model.fit(train_data=DUMMY_TS_DATAFRAME)
     model.save()
     loaded_model = model.__class__.load(path=model.path)
@@ -67,7 +67,10 @@ def test_when_local_model_saved_then_local_model_args_are_saved(model_class, hyp
 def test_when_local_model_predicts_then_time_index_is_correct(model_class, prediction_length, temp_model_path):
     data = DUMMY_VARIABLE_LENGTH_TS_DATAFRAME
     model = model_class(
-        path=temp_model_path, prediction_length=prediction_length, hyperparameters=DEFAULT_HYPERPARAMETERS
+        path=temp_model_path,
+        prediction_length=prediction_length,
+        hyperparameters=DEFAULT_HYPERPARAMETERS,
+        freq=data.freq,
     )
     model.fit(train_data=data)
     predictions = model.predict(data=data)

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -33,9 +33,15 @@ TESTABLE_MODELS = (
     + [get_multi_window_deepar]
 )
 
-DUMMY_HYPERPARAMETERS = {"epochs": 1, "num_batches_per_epoch": 1, "maxiter": 1, "n_jobs": 1}
+DUMMY_HYPERPARAMETERS = {
+    "epochs": 1,
+    "num_batches_per_epoch": 1,
+    "maxiter": 1,
+    "n_jobs": 1,
+    "use_fallback_model": False,
+}
 TESTABLE_PREDICTION_LENGTHS = [1, 5]
-MODELS_WITHOUT_HPO = ["DirectTabular", "AutoETS", "AutoARIMA", "DynamicOptimizedTheta"]
+MODELS_WITHOUT_HPO = ["DirectTabular"]
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
*Description of changes:*
- Expose `use_fallback_model` as an optional hyperparameter for all local models (default `True`). When set to `False`, fallback model will be disabled, and any exception in the underlying model will propagate. This is important for testing - currently, we had one model that always failed because of a bug, but this wasn't caught by the CI because of the fallback model. 
- Fix typos in docstrings
- All local models are now trained using at most the last 2500 entries of each time series. This allows to significantly reduce the training time without degrading the accuracy:
![image](https://github.com/autogluon/autogluon/assets/6944857/73d3d90b-ee9f-4729-9477-0b1c02ba1c23)
![image](https://github.com/autogluon/autogluon/assets/6944857/ef370847-189a-440d-9788-17ade3280de2)




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
