### PR TITLE
[timeseries] Fix non-deterministic bug in tests

### DIFF
--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -437,7 +437,7 @@ def test_given_model_fails_when_predictor_predicts_then_exception_is_raised(temp
         with pytest.raises(
             RuntimeError, match="Following models failed to predict: \\['ARIMA', 'WeightedEnsemble'\\]"
         ):
-            predictor.predict(DUMMY_TS_DATAFRAME)
+            predictor.predict(DUMMY_TS_DATAFRAME, model="WeightedEnsemble")
 
 
 def test_given_model_fails_when_predictor_scores_then_exception_is_raised(temp_model_path):
@@ -448,7 +448,7 @@ def test_given_model_fails_when_predictor_scores_then_exception_is_raised(temp_m
         with pytest.raises(
             RuntimeError, match="Following models failed to predict: \\['ARIMA', 'WeightedEnsemble'\\]"
         ):
-            predictor.score(DUMMY_TS_DATAFRAME)
+            predictor.score(DUMMY_TS_DATAFRAME, model="WeightedEnsemble")
 
 
 def test_given_no_searchspace_and_hyperparameter_tune_kwargs_when_predictor_fits_then_exception_is_raised(


### PR DESCRIPTION
*Description of changes:*
- This PR fixes a non-deterministic bug introduced by #3237. Tests passed successfully inside the PR, but failed after the commit got merged to `master`.
- Depending on the randomly generated data in `DUMMY_TS_DATAFRAME`, the best model could be either `WeightedEnsemble` or `ARIMA` (actually, both WeightedEnsemble and ARIMA have the same score, but we choose to predict with ARIMA in such case). In the former case, the predictor predicts with `WeightedEnsemble` (=> test passes), but in the latter case with  `ARIMA` (=> test fails).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
