### PR TITLE
Update CatBoost to 1.2

### DIFF
--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -34,7 +34,10 @@ extras_require = {
         'lightgbm>=3.3,<3.4',
     ],
     'catboost': [
-        'catboost>=1.1,<1.2',
+        # CatBoost wheel build is not working correctly on darwin for CatBoost 1.2 on Python 3.8, so use old version in this case.
+        # https://github.com/autogluon/autogluon/pull/3190#issuecomment-1540599280
+        'catboost>=1.1,<1.2 ; python_version <= "3.8" and sys_platform == "darwin"',
+        'catboost>=1.1,<1.3',
     ],
     # FIXME: Debug why xgboost 1.6 has 4x+ slower inference on multiclass datasets compared to 1.4
     #  It is possibly only present on MacOS, haven't tested linux.

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -34,9 +34,9 @@ extras_require = {
         'lightgbm>=3.3,<3.4',
     ],
     'catboost': [
-        # CatBoost wheel build is not working correctly on darwin for CatBoost 1.2 on Python 3.8, so use old version in this case.
+        # CatBoost wheel build is not working correctly on darwin for CatBoost 1.2, so use old version in this case.
         # https://github.com/autogluon/autogluon/pull/3190#issuecomment-1540599280
-        'catboost>=1.1,<1.2 ; python_version <= "3.8" and sys_platform == "darwin"',
+        'catboost>=1.1,<1.2 ; sys_platform == "darwin"',
         'catboost>=1.1,<1.3',
     ],
     # FIXME: Debug why xgboost 1.6 has 4x+ slower inference on multiclass datasets compared to 1.4


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update CatBoost to 1.2

- CatBoost 1.2 has 8% faster training speed in multiclass classification with the log loss metric.
- Will plan to benchmark after merge on mainline during code freeze instead of benchmarking this PR individually, as it will be easy to isolate the root cause of regressions in case this PR is the cause.

TODO:

- [x] Run the CI on Windows/MacOS

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
