### PR TITLE
[WIP] [timeseries] Add Scaled Pinball Loss metric and use it as default in TimeSeriesPredictor

### DIFF
--- a/timeseries/src/autogluon/timeseries/evaluator.py
+++ b/timeseries/src/autogluon/timeseries/evaluator.py
@@ -92,9 +92,9 @@ class TimeSeriesEvaluator:
     target_column : str, default = "target"
         Name of the target column to be forecasting.
     eval_metric_seasonal_period : int, optional
-        Seasonal period used to compute the mean absolute scaled error (MASE) evaluation metric. This parameter is only
-        used if ``eval_metric="MASE"`. See https://en.wikipedia.org/wiki/Mean_absolute_scaled_error for more details.
-        Defaults to ``None``, in which case the seasonal period is computed based on the data frequency.
+        Seasonal period used to compute the MASE ans SPL evaluation metrics. This parameter is only used if
+        ``eval_metric`` is one of ``{"MASE", "SPL"}`. See https://en.wikipedia.org/wiki/Mean_absolute_scaled_error for
+        more details. Defaults to ``None``, in which case the seasonal period is computed based on the data frequency.
 
     Class Attributes
     ----------------

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -47,9 +47,9 @@ class AbstractTimeSeriesModel(AbstractModel):
         detailed documentation can be found in `gluonts.evaluation.Evaluator`. By default, `mean_wQuantileLoss`
         will be used.
     eval_metric_seasonal_period : int, optional
-        Seasonal period used to compute the mean absolute scaled error (MASE) evaluation metric. This parameter is only
-        used if ``eval_metric="MASE"`. See https://en.wikipedia.org/wiki/Mean_absolute_scaled_error for more details.
-        Defaults to ``None``, in which case the seasonal period is computed based on the data frequency.
+        Seasonal period used to compute the MASE ans SPL evaluation metrics. This parameter is only used if
+        ``eval_metric`` is one of ``{"MASE", "SPL"}`. See https://en.wikipedia.org/wiki/Mean_absolute_scaled_error for
+        more details. Defaults to ``None``, in which case the seasonal period is computed based on the data frequency.
     hyperparameters : dict, default = None
         Hyperparameters that will be used by the model (can be search spaces instead of fixed values).
         If None, model defaults are used. This is identical to passing an empty dictionary.

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/direct_tabular.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/direct_tabular.py
@@ -31,9 +31,9 @@ class DirectTabularModel(AbstractTimeSeriesModel):
 
     Features not known during the forecast horizon (e.g., future target values) are replaced by NaNs.
 
-    If ``eval_metric=="mean_wQuantileLoss"``, the TabularPredictor will be trained with ``"quantile"`` problem type.
-    Otherwise, TabularPredictor will be trained with ``"regression"`` problem type, and dummy quantiles will be
-    obtained by assuming that the residuals follow zero-mean normal distribution.
+    If ``eval_metric`` is either ``"SPL"`` or ``"mean_wQuantileLoss"``, the TabularPredictor will be trained with
+    ``"quantile"`` problem type. Otherwise, TabularPredictor will be trained with ``"regression"`` problem type, and
+    dummy quantiles will by obtained by assuming that the residuals follow zero-mean normal distribution.
 
 
     Other Parameters
@@ -85,7 +85,7 @@ class DirectTabularModel(AbstractTimeSeriesModel):
         self._known_covariates_lag_indices: np.array = None
         self._past_covariates_lag_indices: np.array = None
         self._time_features: List[Callable] = None
-        self.is_quantile_model = self.eval_metric == "mean_wQuantileLoss"
+        self.is_quantile_model = self.eval_metric in ["mean_wQuantileLoss", "SPL"]
         if 0.5 not in self.quantile_levels:
             self.must_drop_median = True
             self.quantile_levels = sorted(set([0.5] + self.quantile_levels))

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -86,6 +86,7 @@ class RecursiveTabularModel(AbstractTimeSeriesModel):
         "MAPE": "mean_absolute_percentage_error",
         "sMAPE": "mean_absolute_percentage_error",
         "mean_wQuantileLoss": "mean_absolute_error",
+        "SPL": "mean_absolute_error",
         "MSE": "mean_squared_error",
         "RMSE": "root_mean_squared_error",
     }

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -61,9 +61,9 @@ class TimeSeriesPredictor:
 
         For more information about these metrics, see https://docs.aws.amazon.com/forecast/latest/dg/metrics.html.
     eval_metric_seasonal_period : int, optional
-        Seasonal period used to compute the mean absolute scaled error (MASE) evaluation metric. This parameter is only
-        used if ``eval_metric="MASE"`. See https://en.wikipedia.org/wiki/Mean_absolute_scaled_error for more details.
-        Defaults to ``None``, in which case the seasonal period is computed based on the data frequency.
+        Seasonal period used to compute the MASE ans SPL evaluation metrics. This parameter is only used if
+        ``eval_metric`` is one of ``{"MASE", "SPL"}`. See https://en.wikipedia.org/wiki/Mean_absolute_scaled_error for
+        more details. Defaults to ``None``, in which case the seasonal period is computed based on the data frequency.
     known_covariates_names: List[str], optional
         Names of the covariates that are known in advance for all time steps in the forecast horizon. These are also
         known as dynamic features, exogenous variables, additional regressors or related time series. Examples of such

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -46,11 +46,12 @@ class TimeSeriesPredictor:
         The forecast horizon, i.e., How many time steps into the future the models should be trained to predict.
         For example, if time series contain daily observations, setting ``prediction_length = 3`` will train
         models that predict up to 3 days into the future from the most recent observation.
-    eval_metric : str, default = "mean_wQuantileLoss"
+    eval_metric : str, default = "SPL"
         Metric by which predictions will be ultimately evaluated on future test data. AutoGluon tunes hyperparameters
         in order to improve this metric on validation data, and ranks models (on validation data) according to this
         metric. Available options:
 
+        - ``"SPL"``: scaled pinball loss, defined as average of quantile losses for the specified ``quantile_levels`` normalized by the scale of each time series
         - ``"mean_wQuantileLoss"``: mean weighted quantile loss, defined as average of quantile losses for the specified ``quantile_levels`` scaled by the total value of the time series
         - ``"MAPE"``: mean absolute percentage error
         - ``"sMAPE"``: "symmetric" mean absolute percentage error

--- a/timeseries/src/autogluon/timeseries/trainer/auto_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/auto_trainer.py
@@ -11,7 +11,7 @@ class AutoTimeSeriesTrainer(AbstractTimeSeriesTrainer):
     def construct_model_templates(self, hyperparameters, multi_window: bool = False, **kwargs):
         path = kwargs.pop("path", self.path)
         eval_metric = kwargs.pop("eval_metric", self.eval_metric)
-        eval_metric_seasonal_period = kwargs.pop("eval_metric", self.eval_metric_seasonal_period)
+        eval_metric_seasonal_period = kwargs.pop("eval_metric_seasonal_period", self.eval_metric_seasonal_period)
         quantile_levels = kwargs.pop("quantile_levels", self.quantile_levels)
         hyperparameter_tune = kwargs.get("hyperparameter_tune", False)
         return get_preset_models(

--- a/timeseries/tests/unittests/test_evaluator.py
+++ b/timeseries/tests/unittests/test_evaluator.py
@@ -204,3 +204,17 @@ def test_when_eval_metric_seasonal_period_is_longer_than_ts_then_scale_is_set_to
         y_past=DUMMY_TS_DATAFRAME["target"], seasonal_period=seasonal_period
     )
     assert (naive_error_per_item == 1.0).all()
+
+
+@pytest.mark.parametrize("seasonal_period", [None, 1, 7])
+def test_given_only_median_quantile_predicted_then_spl_equals_mase(deepar_trained, seasonal_period):
+    model = deepar_trained
+    train, test = DUMMY_TS_DATAFRAME.train_test_split(model.prediction_length)
+    predictions = model.predict(train)[["mean", "0.5"]]
+    evaluator_spl = TimeSeriesEvaluator(
+        eval_metric="SPL", prediction_length=model.prediction_length, eval_metric_seasonal_period=seasonal_period
+    )
+    evaluator_mase = TimeSeriesEvaluator(
+        eval_metric="MASE", prediction_length=model.prediction_length, eval_metric_seasonal_period=seasonal_period
+    )
+    assert np.allclose(evaluator_spl(test, predictions), evaluator_mase(test, predictions))


### PR DESCRIPTION
*Description of changes:*
- Add Scaled Pinball Loss (SPL) metric for probabilistic forecasting, as defined in the [M5-Uncertainty competition guide](https://www.kaggle.com/competitions/m5-forecasting-uncertainty), and use it as the default in TimeSeriesPredictor.
  - The `SPL` metric is "scale-invariant", i.e., the error for each time series is normalized by its scale. For this reason, `SPL` effectively assigns "equal importance" to each time series in the dataset.
  - The currently used `mean_wQuantileLoss` metric does not normalize errors on per-time-series basis. For this reason, mean_wQuantileLoss effectively assigns higher weight to time series that have a larger scale.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
