### PR TITLE
[timeseries] Fix high memory usage of the RecursiveTabular model

### DIFF
--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -49,6 +49,7 @@ extras_require = {
         "pytest-timeout>=2.1,<3",
         "isort>=5.10",
         "black>=22.3,<23.0",
+        "memory_profiler",
     ],
 }
 

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -135,7 +135,7 @@ class RecursiveTabularModel(AbstractTimeSeriesModel):
 
         lags = model_params.get("lags")
         if lags is None:
-            lags = get_lags_for_frequency(self.freq, lag_ub=200)
+            lags = get_lags_for_frequency(self.freq)
 
         date_features = model_params.get("date_features")
         if date_features is None:

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -1,13 +1,12 @@
 import logging
 import math
 import warnings
-from typing import Any, Callable, Dict, List, Optional, Tuple
 from dataclasses import dataclass
-import math
-import psutil
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
+import psutil
 from scipy.stats import norm
 from sklearn.base import BaseEstimator
 

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -342,9 +342,9 @@ class MLFMemoryUsage:
     peak_mem_usage = a * num_rows * num_features + b * num_rows * c
     """
 
-    a = 3.16e-5
-    b = 1.4e-4
-    c = 661
+    a = 3.33e-05
+    b = 1.18e-04
+    c = 703.4
 
     def _estimate_memory_usage(self, num_rows: int, num_features: int) -> float:
         return self.a * num_rows * num_features + self.b * num_rows + self.c
@@ -355,12 +355,10 @@ class MLFMemoryUsage:
         """Randomly select a subset of time series to ensure that peak memory usage stays below threshold."""
         memory_available = psutil.virtual_memory().available / 1e6
         max_memory_util = memory_available * max_mem_util_frac
-        if self._estimate_memory_usage(num_rows=len(data), num_features=num_features) > max_memory_util:
+        estimated_mem_usage = self._estimate_memory_usage(num_rows=len(data), num_features=num_features)
+        if estimated_mem_usage > max_memory_util:
             item_ids = data.item_ids
-            avg_ts_length = len(data) / len(item_ids)
-            num_items_to_keep = math.ceil(
-                (max_memory_util - self.c) / avg_ts_length / (self.a * num_features + self.b)
-            )
+            num_items_to_keep = math.ceil(max_memory_util / estimated_mem_usage)
             items_to_keep = np.random.choice(item_ids, num_items_to_keep, replace=False)
             logger.debug(
                 f"Randomly selected {num_items_to_keep} ({num_items_to_keep / len(item_ids):.1%}) time series "

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import os
 import re
 import warnings
@@ -197,7 +198,6 @@ class RecursiveTabularModel(AbstractTimeSeriesModel):
         self,
         data: TimeSeriesDataFrame,
         last_k_values: Optional[int] = None,
-        max_num_samples: Optional[int] = None,
     ) -> Tuple[pd.DataFrame, pd.Series]:
         """Construct feature matrix containing lags, covariates, and target time series values.
 
@@ -209,8 +209,6 @@ class RecursiveTabularModel(AbstractTimeSeriesModel):
             Time series data that needs to be converted.
         last_k_values : int, optional
             If given, only last `last_k_values` rows will be kept for each time series.
-        max_num_samples : int, optional
-            If given, the output will contain at most this many rows.
         """
         item_ids_to_exclude = data.item_ids[data.num_timesteps_per_item() < self.required_ts_length]
         if len(item_ids_to_exclude) > 0:
@@ -222,12 +220,10 @@ class RecursiveTabularModel(AbstractTimeSeriesModel):
             dropna=False,
             static_features=None,  # we handle static features in `_to_mlforecast_df`, without relying on MLForecast
         )
+        del self.mlf.ts.features_
         if last_k_values is not None:
             features = features.groupby("unique_id", sort=False).tail(last_k_values)
         features.dropna(subset=self.mlf.ts.target_col, inplace=True)
-        if max_num_samples is not None and len(features) > max_num_samples:
-            rows_per_item = int(max_num_samples / data.num_items) + 1
-            features = features.groupby("unique_id", sort=False).tail(rows_per_item)
         features = features.reset_index(drop=True)
         return features[self.mlf.ts.features_order_], features[self.mlf.ts.target_col]
 
@@ -248,11 +244,12 @@ class RecursiveTabularModel(AbstractTimeSeriesModel):
         self.mlf = MLForecast(models={}, freq=self.freq, **mlforecast_init_args)
 
         # Do not use external val_data as tuning_data to avoid overfitting
-        max_num_samples = model_params.get("max_num_samples", 1_000_000)
         train_subset, val_subset = train_data.train_test_split(self.prediction_length)
-        X_train, y_train = self._get_features_dataframe(train_subset, max_num_samples=max_num_samples)
+        max_num_samples = model_params.get("max_num_samples", 1_000_000)
+        max_rows_per_item = math.ceil(max_num_samples / train_data.num_items)
+        X_train, y_train = self._get_features_dataframe(train_subset, last_k_values=max_rows_per_item)
         X_val, y_val = self._get_features_dataframe(
-            val_subset, last_k_values=self.prediction_length, max_num_samples=max_num_samples
+            val_subset, last_k_values=min(self.prediction_length, max_rows_per_item)
         )
 
         estimator = TabularEstimator(

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -1,5 +1,6 @@
 import logging
 import math
+import os
 import warnings
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Tuple

--- a/timeseries/tests/unittests/models/test_mlforecast.py
+++ b/timeseries/tests/unittests/models/test_mlforecast.py
@@ -1,10 +1,9 @@
 import numpy as np
 import pandas as pd
 import pytest
-
 from memory_profiler import memory_usage
 
-from autogluon.timeseries.models.autogluon_tabular.mlforecast import RecursiveTabularModel, MLFMemoryUsage
+from autogluon.timeseries.models.autogluon_tabular.mlforecast import MLFMemoryUsage, RecursiveTabularModel
 from autogluon.timeseries.utils.features import TimeSeriesFeatureGenerator
 
 from ..common import get_data_frame_with_variable_lengths

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -205,8 +205,6 @@ def test_given_hyperparameters_with_lists_when_trainer_called_then_multiple_mode
     trainer = AutoTimeSeriesTrainer(path=temp_model_path, enable_ensemble=False)
     trainer.fit(train_data=DUMMY_TS_DATAFRAME, hyperparameters=hyperparameters)
     leaderboard = trainer.leaderboard()
-    print(leaderboard["model"].values)
-    print(expected_model_names)
     assert len(leaderboard) == len(expected_model_names)
     assert all(name in leaderboard["model"].values for name in expected_model_names)
 


### PR DESCRIPTION
*Description of changes:*
- Currently, the `RecursiveTabular` model based on the `mlforecast` library can result in extremely high memory usage for large datasets (e.g., model crashes with OOM for datasets with >50M rows like `M5`, `Corporacion Favorita`, `London Smart Meters` on `m5.4xlarge` instances with 64 GB of RAM). This PR fixes this problem by selecting a subset of the time series to ensure that the peak memory usage does not exceed 80% of the available memory.
- The approach is based on fitting a linear model of the form `a * num_rows * num_features + b * num_rows + c` to predict the peak memory usage. I fit the model using memory usage statistics for 6 datasets with 10K-10M rows & different choices for `num_features`. The model was validated on on the M5 dataset with >50M rows:
  - Predicted peak memory utilization: `81354.0 MB`
  - Actual peak memory utilization: `79258.9 MB`
  - When setting the max allowed memory utilization to `48029.7 MB` & selecting items based on the heuristic, the resulting peak memory usage was `48122.7 MB`.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
