### PR TITLE
[timeseries] Fix non-deterministic bug in tests (update of #3255)

### DIFF
--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -431,24 +431,20 @@ def test_given_enable_ensemble_false_when_predictor_called_then_ensemble_is_not_
 
 def test_given_model_fails_when_predictor_predicts_then_exception_is_raised(temp_model_path):
     predictor = TimeSeriesPredictor(path=temp_model_path)
-    predictor.fit(train_data=DUMMY_TS_DATAFRAME, hyperparameters={"ARIMA": {"maxiter": 1}, "Naive": {}})
+    predictor.fit(train_data=DUMMY_TS_DATAFRAME, hyperparameters={"ARIMA": {"maxiter": 1}})
     with mock.patch("autogluon.timeseries.models.local.statsmodels.ARIMAModel.predict") as arima_predict:
         arima_predict.side_effect = RuntimeError("Numerical error")
-        with pytest.raises(
-            RuntimeError, match="Following models failed to predict: \\['ARIMA', 'WeightedEnsemble'\\]"
-        ):
-            predictor.predict(DUMMY_TS_DATAFRAME, model="WeightedEnsemble")
+        with pytest.raises(RuntimeError, match="Following models failed to predict: \\['ARIMA'\\]"):
+            predictor.predict(DUMMY_TS_DATAFRAME)
 
 
 def test_given_model_fails_when_predictor_scores_then_exception_is_raised(temp_model_path):
     predictor = TimeSeriesPredictor(path=temp_model_path)
-    predictor.fit(train_data=DUMMY_TS_DATAFRAME, hyperparameters={"ARIMA": {"maxiter": 1}, "Naive": {}})
+    predictor.fit(train_data=DUMMY_TS_DATAFRAME, hyperparameters={"ARIMA": {"maxiter": 1}})
     with mock.patch("autogluon.timeseries.models.local.statsmodels.ARIMAModel.predict") as arima_predict:
         arima_predict.side_effect = RuntimeError("Numerical error")
-        with pytest.raises(
-            RuntimeError, match="Following models failed to predict: \\['ARIMA', 'WeightedEnsemble'\\]"
-        ):
-            predictor.score(DUMMY_TS_DATAFRAME, model="WeightedEnsemble")
+        with pytest.raises(RuntimeError, match="Following models failed to predict: \\['ARIMA'\\]"):
+            predictor.score(DUMMY_TS_DATAFRAME)
 
 
 def test_given_no_searchspace_and_hyperparameter_tune_kwargs_when_predictor_fits_then_exception_is_raised(


### PR DESCRIPTION
*Description of changes:*
- Catch another potential bug not handled by #3255. The old test would fail in the rare case that `Naive` had the best validation score & was the only model used by the ensemble.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
