### PR TITLE
Update UA Identifier to Google Analytics 4 Measurement ID

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ myst_enable_extensions = ['colon_fence', 'deflist', 'dollarmath', 'html_image', 
 autosummary_generate = True
 numpydoc_show_class_members = False
 
-googleanalytics_id = "UA-96378503-20"
+googleanalytics_id = "G-6XDS99SP0C"
 
 nb_execution_mode = 'force'
 # nb_execution_raise_on_error=True


### PR DESCRIPTION
*Description of changes:*
AutoGluon embeds a Google Analytics JavaScript tracker into our website docs in order to measure visits to our website documentation. We have been using a "Universal Analytics property" which is being sunset and we must migrate to a "Google Analytics 4 property". This has already been set up through our Google Analytics account. To complete the migration, we need to replace our existing `UA ID` in our website docs with our new `GA4 ID`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
