### PR TITLE
Update mac cpu install instructions

### DIFF
--- a/docs/install-mac-cpu-source.md
+++ b/docs/install-mac-cpu-source.md
@@ -1,0 +1,7 @@
+```console
+pip install -U pip
+pip install -U setuptools wheel
+
+git clone https://github.com/autogluon/autogluon
+cd autogluon && ./full_install.sh
+```

--- a/docs/install-mac-cpu.md
+++ b/docs/install-mac-cpu.md
@@ -1,0 +1,9 @@
+```console
+pip install -U pip
+pip install -U setuptools wheel
+
+# pytorch documentation - https://pytorch.org/get-started/locally/
+pip install torch==1.13.1 torchvision==0.14.1 -f https://download.pytorch.org/whl/cpu/torch_stable.html
+
+pip install autogluon
+```

--- a/docs/install-mac-cpu.md
+++ b/docs/install-mac-cpu.md
@@ -2,8 +2,5 @@
 pip install -U pip
 pip install -U setuptools wheel
 
-# pytorch documentation - https://pytorch.org/get-started/locally/
-pip install torch==1.13.1 torchvision==0.14.1 -f https://download.pytorch.org/whl/cpu/torch_stable.html
-
 pip install autogluon
 ```

--- a/docs/install-mac-libomp.md
+++ b/docs/install-mac-libomp.md
@@ -1,4 +1,4 @@
-:::{note} LightGBM support on MacOS (LibOMP)
+:::{admonition} LightGBM support on MacOS (LibOMP)
 AutoGluon dependency LightGBM uses `libomp` for multi-threading. If you install `libomp` via `brew install libomp`, you may get segmentation faults due to incompatible library versions. Install a compatible version using the following commands:
 
 ```bash

--- a/docs/install.md
+++ b/docs/install.md
@@ -60,7 +60,7 @@ AutoGluon requires Python version 3.8, 3.9, or 3.10 and is available on Linux, M
     ```{include} install-mac-libomp.md
     ```
 
-    ```{include} install-cpu-pip.md 
+    ```{include} install-mac-cpu.md 
     ``` 
     ::::
   

--- a/docs/install.md
+++ b/docs/install.md
@@ -60,7 +60,7 @@ AutoGluon requires Python version 3.8, 3.9, or 3.10 and is available on Linux, M
     ```{include} install-mac-libomp.md
     ```
 
-    ```{include} install-mac-cpu.md 
+    ```{include} install-mac-cpu.md
     ``` 
     ::::
   
@@ -90,7 +90,7 @@ AutoGluon requires Python version 3.8, 3.9, or 3.10 and is available on Linux, M
     ```{include} install-mac-libomp.md
     ```
 
-    ```{include} install-cpu-source.md
+    ```{include} install-mac-cpu-source.md
     ```
     ::::
     


### PR DESCRIPTION
*Description of changes:*
A user in the autogluon-interest slack channel pointed out `there is no wheel for the 1.13.1+cpu for OSx` for `torch`. It also appears there is no `1.14.1+cpu` for `torch-vision` on macOS. We need to use the non-CPU versions .

Reference to existing issue: https://auto.gluon.ai/stable/install.html -> Mac/Pip/CPU
Install options: https://download.pytorch.org/whl/cpu/torch_stable.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
