### PR TITLE
Cleanup diskspace for docker image build

### DIFF
--- a/.github/workflows/build_latest_image.yml
+++ b/.github/workflows/build_latest_image.yml
@@ -25,7 +25,7 @@ jobs:
         sudo swapoff -a
         sudo rm -f /swapfile
         sudo apt clean
-        docker rmi $(docker image ls -aq)
+        docker system prune -af
         df -h
     - name: Build the Docker image
       run: |
@@ -49,7 +49,7 @@ jobs:
         sudo swapoff -a
         sudo rm -f /swapfile
         sudo apt clean
-        docker rmi $(docker image ls -aq)
+        docker system prune -af
         df -h
     - name: Build the Docker image
       run: |
@@ -73,7 +73,7 @@ jobs:
         sudo swapoff -a
         sudo rm -f /swapfile
         sudo apt clean
-        docker rmi $(docker image ls -aq)
+        docker system prune -af
         df -h
     - name: Build the Docker image
       run: |
@@ -97,7 +97,7 @@ jobs:
         sudo swapoff -a
         sudo rm -f /swapfile
         sudo apt clean
-        docker rmi $(docker image ls -aq)
+        docker system prune -af
         df -h
     - name: Build the Docker image
       run: |

--- a/.github/workflows/build_latest_image.yml
+++ b/.github/workflows/build_latest_image.yml
@@ -20,6 +20,13 @@ jobs:
         role-to-assume: arn:aws:iam::369469875935:role/CloudCIECRRole
         role-duration-seconds: 3600
         aws-region: us-east-1
+    - name: free disk space
+      run: |
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        sudo apt clean
+        docker rmi $(docker image ls -aq)
+        df -h
     - name: Build the Docker image
       run: |
         cd CI/docker
@@ -37,6 +44,13 @@ jobs:
         role-to-assume: arn:aws:iam::369469875935:role/CloudCIECRRole
         role-duration-seconds: 3600
         aws-region: us-east-1
+    - name: free disk space
+      run: |
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        sudo apt clean
+        docker rmi $(docker image ls -aq)
+        df -h
     - name: Build the Docker image
       run: |
         cd CI/docker
@@ -54,6 +68,13 @@ jobs:
         role-to-assume: arn:aws:iam::369469875935:role/CloudCIECRRole
         role-duration-seconds: 3600
         aws-region: us-east-1
+    - name: free disk space
+      run: |
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        sudo apt clean
+        docker rmi $(docker image ls -aq)
+        df -h
     - name: Build the Docker image
       run: |
         cd CI/docker
@@ -71,6 +92,13 @@ jobs:
         role-to-assume: arn:aws:iam::369469875935:role/CloudCIECRRole
         role-duration-seconds: 3600
         aws-region: us-east-1
+    - name: free disk space
+      run: |
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        sudo apt clean
+        docker rmi $(docker image ls -aq)
+        df -h
     - name: Build the Docker image
       run: |
         cd CI/docker


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Nightly image building is failing recently because of the increase of the image size leading to out of disk space for github runners. Adding a step to cleanup the machine to squeeze more space.
* Has been tested [here](https://github.com/yinweisu/autogluon/actions/runs/5191861673)
* To be noticed, if our image size continue to grow, it's likely that we'll need to move away from github hosted runners...


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
