### PR TITLE
Fix platform tests

### DIFF
--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -52,6 +52,11 @@ function install_tabular {
     install_local_packages "tabular/$1"
 }
 
+function install_tabular_platforms {
+    # pygraphviz will be installed with conda in platform tests
+    install_local_packages "tabular/$1"
+}
+
 function install_multimodal_no_groundingdino {
     # groundingdino has issue when installing on Windows
     # https://github.com/IDEA-Research/GroundingDINO/issues/57

--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -5,6 +5,7 @@ function setup_build_env {
     python3 -m pip install "black>=22.3,<23.0"
     python3 -m pip install isort>=5.10
     python3 -m pip install bandit
+    python3 -m pip install packaging
 }
 
 function setup_build_contrib_env {

--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -46,9 +46,16 @@ function install_local_packages {
     done
 }
 
-function install_tabular {
-    python3 -m pip install --upgrade pygraphviz
-    install_local_packages "tabular/$1"
+function install_multimodal_no_groundingdino {
+    # groundingdino has issue when installing on Windows
+    # https://github.com/IDEA-Research/GroundingDINO/issues/57
+    source $(dirname "$0")/setup_mmcv.sh
+    
+    # launch different process for each test to make sure memory is released
+    python3 -m pip install --upgrade pytest-xdist
+    install_local_packages "multimodal/$1"
+    setup_mmcv
+    # python3 -m pip install --upgrade "mmocr<1.0"  # not compatible with mmcv 2.0
 }
 
 function install_multimodal {
@@ -66,6 +73,12 @@ function install_multimodal {
 function install_all {
     install_local_packages "common/[tests]" "core/[all]" "features/" "tabular/[all,tests]" "timeseries/[all,tests]" "eda/[tests]"
     install_multimodal "[tests]"
+    install_local_packages "autogluon/"
+}
+
+function install_all_windows {
+    install_local_packages "common/[tests]" "core/[all]" "features/" "tabular/[all,tests]" "timeseries/[all,tests]" "eda/[tests]"
+    install_multimodal_no_groundingdino "[tests]"
     install_local_packages "autogluon/"
 }
 

--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -47,6 +47,11 @@ function install_local_packages {
     done
 }
 
+function install_tabular {
+    python3 -m pip install --upgrade pygraphviz
+    install_local_packages "tabular/$1"
+}
+
 function install_multimodal_no_groundingdino {
     # groundingdino has issue when installing on Windows
     # https://github.com/IDEA-Research/GroundingDINO/issues/57

--- a/.github/workflow_scripts/test_install.sh
+++ b/.github/workflow_scripts/test_install.sh
@@ -6,6 +6,5 @@ source $(dirname "$0")/env_setup.sh
 
 setup_build_env
 setup_torch_cpu
-python3 -m pip install 'mxnet==1.9.*'
 install_all
 build_all

--- a/.github/workflow_scripts/test_install_windows.sh
+++ b/.github/workflow_scripts/test_install_windows.sh
@@ -7,4 +7,3 @@ source $(dirname "$0")/env_setup.sh
 setup_build_env
 setup_torch_cpu
 install_all_windows
-build_all

--- a/.github/workflow_scripts/test_install_windows.sh
+++ b/.github/workflow_scripts/test_install_windows.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -ex
+
+source $(dirname "$0")/env_setup.sh
+
+setup_build_env
+setup_torch_cpu
+install_all_windows
+build_all

--- a/.github/workflow_scripts/test_tabular.sh
+++ b/.github/workflow_scripts/test_tabular.sh
@@ -21,7 +21,7 @@ install_local_packages "common/[tests]" "core/[all,tests]" "features/"
 
 if [ "$IS_PLATFORM_TEST" = "true" ]
 then
-    install_tabular_platforms
+    install_tabular_platforms "[all,tests]"
 else
     install_tabular "[all,tests]"
 fi

--- a/.github/workflow_scripts/test_tabular.sh
+++ b/.github/workflow_scripts/test_tabular.sh
@@ -18,7 +18,14 @@ else
 fi
 
 install_local_packages "common/[tests]" "core/[all,tests]" "features/"
-install_tabular "[all,tests]"
+
+if [ "$IS_PLATFORM_TEST" = "true" ]
+then
+    install_tabular_platforms
+else
+    install_tabular "[all,tests]"
+fi
+
 install_multimodal "[tests]"
 
 cd tabular/

--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -232,6 +232,12 @@ jobs:
           auto-update-conda: true
           python-version: ${{ matrix.python }}
       - name: unit-test
+        if: matrix.os != 'windows-latest'
         shell: bash -l {0}
         run: |
           chmod +x ./.github/workflow_scripts/test_install.sh && ./.github/workflow_scripts/test_install.sh
+      - name: unit-test on Windows
+        if: matrix.os == 'windows-latest'
+        shell: bash -l {0}
+        run: |
+          chmod +x ./.github/workflow_scripts/test_install_windows.sh && ./.github/workflow_scripts/test_install_windows.sh

--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -234,7 +234,4 @@ jobs:
       - name: unit-test
         shell: bash -l {0}
         run: |
-          # test_install.sh script will install mxnet, which doesn't work on Windows.
-          source .github/workflow_scripts/env_setup.sh
-          setup_build_env
-          install_all
+          chmod +x ./.github/workflow_scripts/test_install.sh && ./.github/workflow_scripts/test_install.sh

--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -199,13 +199,10 @@ jobs:
           brew unlink libomp
           brew install libomp.rb
           rm libomp.rb
-      - name: Setup graphviz
-        shell: bash -l {0}
-        run: |
-          conda install --channel conda-forge pygraphviz
       - name: unit-test
         shell: bash -l {0}
         run: |
+          conda install --channel conda-forge pygraphviz
           chmod +x ./.github/workflow_scripts/test_tabular.sh && ./.github/workflow_scripts/test_tabular.sh "-m not gpu" "true"
 
   install:

--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -199,6 +199,10 @@ jobs:
           brew unlink libomp
           brew install libomp.rb
           rm libomp.rb
+      - name: Setup graphviz
+        shell: bash -l {0}
+        run: |
+          conda install --channel conda-forge pygraphviz
       - name: unit-test
         shell: bash -l {0}
         run: |

--- a/common/tests/unittests/test_hash_pandas_df.py
+++ b/common/tests/unittests/test_hash_pandas_df.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from tempfile import TemporaryFile
+import tempfile
 
 from autogluon.common.loaders import load_pkl
 from autogluon.common.savers import save_pkl
@@ -19,9 +19,10 @@ def _get_pandas_df(num_rows=20):
 
 def test_when_df_saved_and_loaded_from_disk_then_hash_is_unchanged():
     df = _get_pandas_df()
-    with TemporaryFile() as temp_file:
-        save_pkl.save(temp_file.name, df)
-        loaded_df = load_pkl.load(str(temp_file))
+    with tempfile.TemporaryDirectory() as _:
+        tem_pfile = "temp_file.pkl"
+        save_pkl.save(tem_pfile, df)
+        loaded_df = load_pkl.load(tem_pfile)
     assert hash_pandas_df(df) == hash_pandas_df(loaded_df)
 
 

--- a/common/tests/unittests/test_hash_pandas_df.py
+++ b/common/tests/unittests/test_hash_pandas_df.py
@@ -2,6 +2,8 @@ import numpy as np
 import pandas as pd
 import tempfile
 
+from pathlib import Path
+
 from autogluon.common.loaders import load_pkl
 from autogluon.common.savers import save_pkl
 from autogluon.common.utils.utils import hash_pandas_df
@@ -19,10 +21,10 @@ def _get_pandas_df(num_rows=20):
 
 def test_when_df_saved_and_loaded_from_disk_then_hash_is_unchanged():
     df = _get_pandas_df()
-    with tempfile.TemporaryDirectory() as _:
-        tem_pfile = "temp_file.pkl"
-        save_pkl.save(tem_pfile, df)
-        loaded_df = load_pkl.load(tem_pfile)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_file = str(Path(temp_dir) / "temp_file.pkl")
+        save_pkl.save(temp_file, df)
+        loaded_df = load_pkl.load(temp_file)
     assert hash_pandas_df(df) == hash_pandas_df(loaded_df)
 
 

--- a/common/tests/unittests/test_hash_pandas_df.py
+++ b/common/tests/unittests/test_hash_pandas_df.py
@@ -20,7 +20,7 @@ def _get_pandas_df(num_rows=20):
 def test_when_df_saved_and_loaded_from_disk_then_hash_is_unchanged():
     df = _get_pandas_df()
     with TemporaryFile() as temp_file:
-        save_pkl.save(str(temp_file), df)
+        save_pkl.save(temp_file.name, df)
         loaded_df = load_pkl.load(str(temp_file))
     assert hash_pandas_df(df) == hash_pandas_df(loaded_df)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* install fail because of setup_mmcv.sh not being found. Change to use install_all.sh now as we don't need mxnet anymore
* fix tempfile path. `str(tempfile)` doesn't give a string but still the object itself for some reason causing issue on Windows. Tried to use `tempfile.name` instead but the underlying issue with `TemporaryFile` is that it opens the file automatically, while our saving logic tries to open it again. This will fail on Windows. Change to create a tempdir instead

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
