### PR TITLE
Add enable_categorical=True support to XGBoost

### DIFF
--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -57,11 +57,10 @@ class XGBoostModel(AbstractModel):
 
         if is_train:
             if self._ohe:
-                if self._ohe_generator is None:
-                    self._ohe_generator = xgboost_utils.OheFeatureGenerator(max_levels=max_category_levels)
+                self._ohe_generator = xgboost_utils.OheFeatureGenerator(max_levels=max_category_levels)
                 self._ohe_generator.fit(X)
 
-        if self._ohe_generator is not None:
+        if self._ohe:
             X = self._ohe_generator.transform(X)
 
         return X

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -25,6 +25,7 @@ class XGBoostModel(AbstractModel):
     """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self._ohe: bool = True
         self._ohe_generator = None
         self._xgb_model_type = None
 
@@ -54,13 +55,14 @@ class XGBoostModel(AbstractModel):
     def _preprocess(self, X, is_train=False, max_category_levels=None, **kwargs):
         X = super()._preprocess(X=X, **kwargs)
 
-        if self._ohe_generator is None:
-            self._ohe_generator = xgboost_utils.OheFeatureGenerator(max_levels=max_category_levels)
-
         if is_train:
-            self._ohe_generator.fit(X)
+            if self._ohe:
+                if self._ohe_generator is None:
+                    self._ohe_generator = xgboost_utils.OheFeatureGenerator(max_levels=max_category_levels)
+                self._ohe_generator.fit(X)
 
-        X = self._ohe_generator.transform(X)
+        if self._ohe_generator is not None:
+            X = self._ohe_generator.transform(X)
 
         return X
 
@@ -83,6 +85,13 @@ class XGBoostModel(AbstractModel):
         if num_cpus:
             params['n_jobs'] = num_cpus
         max_category_levels = params.pop('proc.max_category_levels', 100)
+        enable_categorical = params.get('enable_categorical', False)
+        if enable_categorical:
+            """Skip one-hot-encoding and pass categoricals directly to XGBoost"""
+            self._ohe = False
+        else:
+            """One-hot-encode categorical features"""
+            self._ohe = True
 
         if verbosity <= 2:
             verbose = False

--- a/tabular/tests/unittests/models/test_xgboost.py
+++ b/tabular/tests/unittests/models/test_xgboost.py
@@ -24,3 +24,11 @@ def test_xgboost_regression(fit_helper):
     )
     dataset_name = 'ames'
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
+
+
+def test_xgboost_binary_enable_categorical(fit_helper):
+    fit_args = dict(
+        hyperparameters={XGBoostModel: {'enable_categorical': True}},
+    )
+    dataset_name = 'adult'
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)


### PR DESCRIPTION
*Issue #, if available:*
Resolves #2429 

*Description of changes:*
- Added support for XGBoost's new (as of XGBoost 1.6) support for categorical features via `enable_categorical=True`.
- Currently not enabled by default, will benchmark to consider enabling by default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
