### PR TITLE
Tabular: Log hyperparameters

### DIFF
--- a/common/src/autogluon/common/model_filter/_model_filter.py
+++ b/common/src/autogluon/common/model_filter/_model_filter.py
@@ -12,7 +12,7 @@ class ModelFilter:
         models: Union[Dict[str, Any], List[str]], included_model_types: List[str]
     ) -> Union[Dict[str, Any], List[str]]:
         """
-        Only include models specifeid in `included_model_types`, other models will be removed
+        Only include models specified in `included_model_types`, other models will be removed
         If model specified in `included_model_types` doesn't present in `models`, will warn users and ignore
 
         Parameters
@@ -33,9 +33,11 @@ class ModelFilter:
         elif isinstance(models, list):
             included_models = [model for model in models if model in included_model_types]
             missing_models = set(included_model_types) - set(included_models)
+        if included_model_types is not None:
+            logger.log(20, f"Included models: {list(included_model_types)} (Specified by `included_model_types`, all other model types will be skipped)")
         if len(missing_models) > 0:
             logger.warning(
-                f"The models types {missing_models} are not present in the model list specified by the user and will be ignored:"
+                f"\tThe models types {list(missing_models)} are not present in the model list specified by the user and will be ignored:"
             )
         return included_models
 
@@ -67,7 +69,7 @@ class ModelFilter:
             models_after_exclusion = [model for model in models if model not in excluded_model_types]
             excluded_models = set(models) - set(models_after_exclusion)
         if excluded_models is not None:
-            logger.log(20, f"Excluded models: {excluded_models}")
+            logger.log(20, f"Excluded models: {list(excluded_models)} (Specified by `excluded_model_types`)")
         return models_after_exclusion
 
     @staticmethod

--- a/tabular/src/autogluon/tabular/trainer/auto_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/auto_trainer.py
@@ -95,6 +95,14 @@ class AutoTrainer(AbstractTrainer):
                                      'specify the following:\n'
                                      '\tpredictor.fit(..., tuning_data=tuning_data, use_bag_holdout=True)')
 
+        # Log the hyperparameters dictionary so it easy to edit if the user wants.
+        log_str = f'User-specified model hyperparameters to be fit:\n' \
+                  '{\n'
+        for k in hyperparameters.keys():
+            log_str += f"\t'{k}': {hyperparameters[k]},\n"
+        log_str += '}'
+        logger.log(20, log_str)
+
         self._train_multi_and_ensemble(X=X,
                                        y=y,
                                        X_val=X_val,


### PR DESCRIPTION
*Issue #, if available:*
Resolves #3057 

*Description of changes:*
- Add logging of the hyperparameter dictionary
- The logging is copy-paste-able by the user so they can edit it and pass into a new fit call.
- Also enhanced the included/excluded models logging to use list instead of set (looks cleaner), and added additional info to the logs so the user understands why the log occurred.

Example:

Mainline:
```
Data preprocessing and feature engineering runtime = 0.1s ...
AutoGluon will gauge predictive performance using evaluation metric: 'log_loss'
	This metric's sign has been flipped to adhere to being higher_is_better. The metric score can be multiplied by -1 to get the metric value.
	This metric expects predicted probabilities rather than predicted class labels, so you'll need to use predict_proba() instead of predict()
	To change this, specify the eval_metric parameter of Predictor()
Automatically generating train/validation split with holdout_frac=0.2, Train Rows: 646, Val Rows: 162
Fitting 2 L1 models ...
Fitting model: KNeighborsUnif ...
```

This PR:
```
Data preprocessing and feature engineering runtime = 0.1s ...
AutoGluon will gauge predictive performance using evaluation metric: 'log_loss'
	This metric's sign has been flipped to adhere to being higher_is_better. The metric score can be multiplied by -1 to get the metric value.
	This metric expects predicted probabilities rather than predicted class labels, so you'll need to use predict_proba() instead of predict()
	To change this, specify the eval_metric parameter of Predictor()
Automatically generating train/validation split with holdout_frac=0.2, Train Rows: 646, Val Rows: 162
User-specified model hyperparameters to be fit:
{
	'NN_TORCH': {},
	'GBM': [{'extra_trees': True, 'ag_args': {'name_suffix': 'XT'}}, {}, 'GBMLarge'],
	'CAT': {},
	'XGB': {},
	'FASTAI': {},
	'RF': [{'criterion': 'gini', 'ag_args': {'name_suffix': 'Gini', 'problem_types': ['binary', 'multiclass']}}, {'criterion': 'entropy', 'ag_args': {'name_suffix': 'Entr', 'problem_types': ['binary', 'multiclass']}}, {'criterion': 'squared_error', 'ag_args': {'name_suffix': 'MSE', 'problem_types': ['regression', 'quantile']}}],
	'XT': [{'criterion': 'gini', 'ag_args': {'name_suffix': 'Gini', 'problem_types': ['binary', 'multiclass']}}, {'criterion': 'entropy', 'ag_args': {'name_suffix': 'Entr', 'problem_types': ['binary', 'multiclass']}}, {'criterion': 'squared_error', 'ag_args': {'name_suffix': 'MSE', 'problem_types': ['regression', 'quantile']}}],
	'KNN': [{'weights': 'uniform', 'ag_args': {'name_suffix': 'Unif'}}, {'weights': 'distance', 'ag_args': {'name_suffix': 'Dist'}}],
}
Included models: ['KNN'] (Specified by `included_model_types`, all other model types will be skipped)
Fitting 2 L1 models ...
Fitting model: KNeighborsUnif ...
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
