### PR TITLE
Tabular: Fix crash when save path is absolute

### DIFF
--- a/common/src/autogluon/common/utils/path_converter.py
+++ b/common/src/autogluon/common/utils/path_converter.py
@@ -1,5 +1,6 @@
+import os
 import platform
-from pathlib import PurePosixPath, PureWindowsPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 
 class PathConverter:
@@ -20,13 +21,53 @@ class PathConverter:
     @staticmethod
     def to_windows(path: str) -> str:
         PathConverter._validate_path(path)
-        return str(PureWindowsPath(PurePosixPath(path)))
+        return str(PathConverter._to_windows(path))
+
+    @staticmethod
+    def _to_windows(path: str) -> PureWindowsPath:
+        return PureWindowsPath(PurePosixPath(path))
 
     @staticmethod
     def to_posix(path: str) -> str:
         PathConverter._validate_path(path)
-        return str(PurePosixPath(PureWindowsPath(path)))
+        return str(PathConverter._to_posix(path))
+
+    @staticmethod
+    def _to_posix(path: str) -> PurePosixPath:
+        return PurePosixPath(PureWindowsPath(path))
 
     @staticmethod
     def to_current(path: str) -> str:
         return PathConverter.to_windows(path) if PathConverter._is_windows() else PathConverter.to_posix(path)
+
+    @staticmethod
+    def os_path_sep() -> str:
+        return os.path.sep
+
+    # v0.9 FIXME: Avoid calling this as much as possible
+    #  Refactor code so that calling this is not necessary
+    @staticmethod
+    def to_relative(path: str) -> str:
+        if path == '':
+            return path
+        if not PathConverter._is_absolute(path=path):
+            return path
+        os_path_sep = PathConverter.os_path_sep()
+        path_relative = os.path.relpath(path)
+        if path.endswith(os_path_sep):
+            if not path_relative.endswith(os_path_sep):
+                path_relative += os_path_sep
+        return path_relative
+
+    @staticmethod
+    def to_absolute(path: str) -> str:
+        if path == '':
+            return path
+        if PathConverter._is_absolute(path=path):
+            return path
+        path_absolute = str(Path(path).resolve())
+        os_path_sep = PathConverter.os_path_sep()
+        if path.endswith(os_path_sep):
+            if not path_absolute.endswith(os_path_sep):
+                path_absolute += os_path_sep
+        return path_absolute

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -17,6 +17,7 @@ from autogluon.common.utils.distribute_utils import DistributedContext
 from autogluon.common.features.feature_metadata import FeatureMetadata
 from autogluon.common.utils.try_import import try_import_ray
 from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
+from autogluon.common.utils.path_converter import PathConverter
 from autogluon.common.utils.utils import setup_outputdir
 from autogluon.common.utils.lite import disable_if_lite_mode
 from autogluon.common.utils.log_utils import DuplicateFilter
@@ -112,10 +113,9 @@ class AbstractModel:
             path_cur = setup_outputdir(path=None, create_dir=True, path_suffix=path_suffix)
             self.path_root = path_cur.rsplit(self.path_suffix, 1)[0]
             logger.log(20, f'Warning: No path was specified for model, defaulting to: {self.path_root}')
-        if self.path_root != '':
-            # v0.9 FIXME: This is a hack, change so we aren't vulnerable to self.path_root breaking things
-            self.path_root = os.path.relpath(self.path_root)  # FIXME: DO NOT DO THIS, FIX ASAP
-            self.path_root += os.path.sep
+
+        # v0.9 FIXME: This is a hack, change so we aren't vulnerable to self.path_root breaking things
+        self.path_root = PathConverter.to_relative(self.path_root)
 
         self.path = self.create_contexts(self.path_root + self.path_suffix)  # TODO: Make this path a function for consistency.
 

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -112,7 +112,11 @@ class AbstractModel:
             path_cur = setup_outputdir(path=None, create_dir=True, path_suffix=path_suffix)
             self.path_root = path_cur.rsplit(self.path_suffix, 1)[0]
             logger.log(20, f'Warning: No path was specified for model, defaulting to: {self.path_root}')
-        self.path_root = os.path.relpath(self.path_root)  # FIXME: DO NOT DO THIS, FIX ASAP
+        if self.path_root != '':
+            # v0.9 FIXME: This is a hack, change so we aren't vulnerable to self.path_root breaking things
+            self.path_root = os.path.relpath(self.path_root)  # FIXME: DO NOT DO THIS, FIX ASAP
+            self.path_root += os.path.sep
+
         self.path = self.create_contexts(self.path_root + self.path_suffix)  # TODO: Make this path a function for consistency.
 
         self.num_classes = None

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -112,6 +112,7 @@ class AbstractModel:
             path_cur = setup_outputdir(path=None, create_dir=True, path_suffix=path_suffix)
             self.path_root = path_cur.rsplit(self.path_suffix, 1)[0]
             logger.log(20, f'Warning: No path was specified for model, defaulting to: {self.path_root}')
+        self.path_root = os.path.relpath(self.path_root)  # FIXME: DO NOT DO THIS, FIX ASAP
         self.path = self.create_contexts(self.path_root + self.path_suffix)  # TODO: Make this path a function for consistency.
 
         self.num_classes = None

--- a/core/src/autogluon/core/models/ensemble/stacker_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/stacker_ensemble_model.py
@@ -53,6 +53,12 @@ class StackerEnsembleModel(BaggedEnsembleModel):
         self.base_model_names = base_model_names
         self.base_models_dict: Dict[str, AbstractModel] = base_models_dict  # String name -> Model objects
         self.base_model_paths_dict = base_model_paths_dict
+
+        # FIXME: DO NOT DO THIS, FIX ASAP
+        self.base_model_paths_dict = {
+            k: os.path.relpath(v) for k, v in self.base_model_paths_dict.items()
+        }
+
         self.base_model_types_dict = base_model_types_dict
 
         # TODO: Consider deleting these variables after initialization

--- a/core/src/autogluon/core/models/ensemble/stacker_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/stacker_ensemble_model.py
@@ -56,7 +56,7 @@ class StackerEnsembleModel(BaggedEnsembleModel):
 
         # FIXME: DO NOT DO THIS, FIX ASAP
         self.base_model_paths_dict = {
-            k: os.path.relpath(v) for k, v in self.base_model_paths_dict.items()
+            k: PathConverter.to_relative(v) for k, v in self.base_model_paths_dict.items()
         }
 
         self.base_model_types_dict = base_model_types_dict

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -53,6 +53,7 @@ class AbstractTrainer:
                  num_classes=None, quantile_levels=None, low_memory=False, feature_metadata=None, k_fold=0, n_repeats=1,
                  sample_weight=None, weight_evaluation=False, save_data=False, random_state=0, verbosity=2):
         self.path = path
+        self.path = PathConverter.to_relative(self.path)
         self.problem_type = problem_type
         self.feature_metadata = feature_metadata
         self.save_data = save_data

--- a/tabular/tests/unittests/models/test_dummy.py
+++ b/tabular/tests/unittests/models/test_dummy.py
@@ -1,3 +1,5 @@
+import os
+from pathlib import Path
 
 from autogluon.core.models.dummy.dummy_model import DummyModel
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION
@@ -62,3 +64,41 @@ def test_dummy_regression_model(model_fit_helper):
     fit_args = dict()
     dataset_name = 'ames'
     model_fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, model=DummyModel(), fit_args=fit_args)
+
+
+def test_dummy_binary_absolute_path(fit_helper):
+    """Test that absolute path works"""
+    fit_args = dict(
+        hyperparameters={DummyModel: {}},
+    )
+    path = Path('.') / 'AG_test'
+    path = str(path.resolve()) + os.path.sep
+    init_args = dict(path=path)
+
+    dataset_name = 'adult'
+
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, init_args=init_args, fit_args=fit_args)
+
+
+def test_dummy_binary_absolute_path_stack(fit_helper):
+    """Test that absolute path works"""
+    fit_args = dict(
+        hyperparameters={DummyModel: {}},
+        num_bag_folds=2,
+        num_bag_sets=2,
+        num_stack_levels=1,
+    )
+
+    dataset_name = 'adult'
+
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=4, path_as_absolute=True)
+
+
+def test_dummy_binary_model_absolute_path(model_fit_helper):
+    """Test that absolute path works"""
+    fit_args = dict()
+    path = Path('.') / 'AG_test'
+    path = str(path.resolve()) + os.path.sep
+    model = DummyModel(path=path)
+    dataset_name = 'adult'
+    model_fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, model=model, fit_args=fit_args)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- If using an absolute path in predictor init, will crash upon load.

This PR fixes the obvious error so that the below script works, however the current fix is not a good idea long-term, as I have no idea if there will be edge-cases where it fails. I also don't know if it will work when using multiple disk drives in a single process.

The root of the issue is that `StackerEnsembleModel` does something it shouldn't: It has the absolute paths of both itself and its base models stored as variables. Therefore, in order to figure out where the base models are upon loading in a new location, it isn't sufficient to look at the old absolute paths, instead they need to be regenerated based on 1. the old absolute path, 2. the new path.

For example:

```
Model 1: `/abc/def/`
Model 2: `./foo/bar/`


# Model 1 where model 2 is a base model:
self.path_root = `/abc/def/`
self.base_model_paths_dict = {
    'model_2': './foo/bar/'
}
```

When loaded from a new location, this can cause issues. It worked in the past except for cross-os loading.

```
new_path = './new/location/'
new_model_2_path = ?????  # <------- This is the problem, hard to figure out the correct path
```

The solution is to either

1. Delete StackerEnsembleModel and have `trainer` deal with this (Ideal, but significant work)
2. Convert absolute paths to relative paths, or otherwise hack things to avoid the breaking situation (What I've done in this PR, but I don't like it. It **probably** fixes things, but hard to know for sure in all cases).
3. Bandaid solution by try/except on the path conversion: If can't convert because absolute, assume same machine and continue (will crash if cross-OS and absolute path was used during fit).

Reproducible Example:
```python3
from autogluon.tabular import TabularPredictor, TabularDataset


if __name__ == '__main__':
    data_root = 'https://autogluon.s3.amazonaws.com/datasets/Inc/'
    train_data = TabularDataset(data_root + 'train.csv')
    train_data = train_data.sample(500)
    test_data = TabularDataset(data_root + 'test.csv')

    predictor = TabularPredictor(
        label='class',
        path='/tmp/tmpfe_o0p7g/',
    ).fit(
        train_data=train_data,
        hyperparameters={'DUMMY': {}},
        fit_weighted_ensemble=False,
        num_bag_folds=2,
        num_bag_sets=1,
    )
    predictor.persist_models('best')
    predictor.leaderboard(test_data)
```

Exception:
```
    assert not PathConverter._is_absolute(path), "It is ambiguous on how to convert an absolute path. Please provide a relative path instead"
AssertionError: It is ambiguous on how to convert an absolute path. Please provide a relative path instead
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
