### PR TITLE
[timeseries] Subsample time series to avoid high memory usage of the RecursiveTabular model 

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -52,7 +52,7 @@ class TabularEstimator(BaseEstimator):
 class RecursiveTabularModel(AbstractTimeSeriesModel):
     """Predict time series values one by one using TabularPredictor.
 
-    Based on the `mlforecast`<https://github.com/Nixtla/mlforecast>_ library.
+    Based on the `mlforecast <https://github.com/Nixtla/mlforecast>`_ library.
 
 
     Other Parameters

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -230,6 +230,8 @@ class RecursiveTabularModel(AbstractTimeSeriesModel):
     @staticmethod
     def _subsample_data_to_avoid_oom(data: TimeSeriesDataFrame, max_num_rows: int = 30_000_000) -> TimeSeriesDataFrame:
         """Subsample time series from the dataset to avoid out of memory errors inside MLForecast.preprocess."""
+        # TODO: Find a better way to ensure that the model does not run out of memory. E.g., by estimating the expected
+        # memory usage & comparing it to currently available RAM
         if len(data) > max_num_rows:
             item_ids = data.item_ids
             num_items_to_keep = math.ceil(len(item_ids) * max_num_rows / len(data))
@@ -257,7 +259,6 @@ class RecursiveTabularModel(AbstractTimeSeriesModel):
         mlforecast_init_args = self._get_mlforecast_init_args(train_data, model_params)
         self.mlf = MLForecast(models={}, freq=self.freq, **mlforecast_init_args)
 
-        # TODO: Find a better way to ensure that the model does not run out of memory that check available RAM
         train_data = self._subsample_data_to_avoid_oom(train_data)
 
         # Do not use external val_data as tuning_data to avoid overfitting

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -228,7 +228,7 @@ class RecursiveTabularModel(AbstractTimeSeriesModel):
         return features[self.mlf.ts.features_order_], features[self.mlf.ts.target_col]
 
     @staticmethod
-    def _subsample_data_to_avoid_oom(data: TimeSeriesDataFrame, max_num_rows: int = 30_000_000) -> TimeSeriesDataFrame:
+    def _subsample_data_to_avoid_oom(data: TimeSeriesDataFrame, max_num_rows: int = 20_000_000) -> TimeSeriesDataFrame:
         """Subsample time series from the dataset to avoid out of memory errors inside MLForecast.preprocess."""
         # TODO: Find a better way to ensure that the model does not run out of memory. E.g., by estimating the expected
         # memory usage & comparing it to currently available RAM

--- a/timeseries/tests/unittests/models/test_mlforecast.py
+++ b/timeseries/tests/unittests/models/test_mlforecast.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -15,7 +13,6 @@ TESTABLE_MODELS = [
 
 
 @pytest.mark.parametrize("known_covariates_names", [["known_1", "known_2"], []])
-# @pytest.mark.parametrize("past_covariates_names", [["past_1", "past_2", "past_3"], []])
 @pytest.mark.parametrize("static_features_names", [["cat_1"], []])
 @pytest.mark.parametrize("differences", [[2, 3], []])
 @pytest.mark.parametrize("lags", [[1, 2, 5], [4]])

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -205,8 +205,6 @@ def test_given_hyperparameters_with_lists_when_trainer_called_then_multiple_mode
     trainer = AutoTimeSeriesTrainer(path=temp_model_path, enable_ensemble=False)
     trainer.fit(train_data=DUMMY_TS_DATAFRAME, hyperparameters=hyperparameters)
     leaderboard = trainer.leaderboard()
-    print(leaderboard["model"].values)
-    print(expected_model_names)
     assert len(leaderboard) == len(expected_model_names)
     assert all(name in leaderboard["model"].values for name in expected_model_names)
 


### PR DESCRIPTION
*Description of changes:*
- An ad-hoc solution the OOM problems caused by `RecursiveTabular` model on large datasets (>50M rows). We subsample time series to ensure that there are at most ~30M rows in the dataset.
- The previously considered solution considered #3272 turned out to not generalize to different machines. We can try designing a better strategy in the future (or eliminating the root cause of the excessive memory consumption) after the v0.8 release.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
