### PR TITLE
Fix path logic

### DIFF
--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -12,6 +12,7 @@ import pandas as pd
 from tqdm import tqdm
 
 from autogluon.common.utils.log_utils import set_logger_verbosity
+from autogluon.common.utils.path_converter import PathConverter
 from autogluon.common.utils.utils import hash_pandas_df
 from autogluon.core.models import AbstractModel
 from autogluon.core.utils.exceptions import TimeLimitExceeded
@@ -38,6 +39,7 @@ class SimpleAbstractTrainer:
 
     def __init__(self, path: str, low_memory: bool, save_data: bool, *args, **kwargs):
         self.path = path
+        self.path = PathConverter.to_relative(self.path)
         self.reset_paths = False
 
         self.low_memory = low_memory
@@ -541,7 +543,6 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         excluded_model_types: Optional[List[str]] = None,
         time_limit: Optional[float] = None,
     ) -> List[str]:
-
         logger.info(f"\nStarting training. Start time is {time.strftime('%Y-%m-%d %H:%M:%S')}")
 
         time_start = time.time()
@@ -1046,7 +1047,6 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         val_data: Optional[TimeSeriesDataFrame] = None,
         models: List[str] = None,
     ) -> List[str]:
-
         train_data = train_data or self.load_train_data()
         val_data = val_data or self.load_val_data()
         refit_full_data = self._merge_refit_full_data(train_data, val_data)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* https://github.com/autogluon/autogluon/pull/3288 introduce logic for saving relative paths for models. This logic affects `timeseries` too and `Trainer` in `timeseries` is not being updated with the relative path logic. This could be an issue in some edge cases, for example:
```
`current_working_dir` is `/home/ubuntu/user/test`
`path` specified to predictor is `/home/ubuntu/timeseries`

`model_paths` after training will contain `../timeseries/model/XXX`
while the `path` being saved in trainer is `/home/ubuntu/timeseries`
Then when we try to find common prefix to reset the context, it fails as there's no common prefix
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
