### PR TITLE
Add calibrate_decision_threshold

### DIFF
--- a/core/src/autogluon/core/calibrate/__init__.py
+++ b/core/src/autogluon/core/calibrate/__init__.py
@@ -1,0 +1,1 @@
+from ._decision_threshold import calibrate_decision_threshold

--- a/core/src/autogluon/core/calibrate/_decision_threshold.py
+++ b/core/src/autogluon/core/calibrate/_decision_threshold.py
@@ -1,0 +1,70 @@
+import logging
+from typing import List, Union
+
+import numpy as np
+
+from ..constants import BINARY
+from ..utils import get_pred_from_proba
+
+logger = logging.getLogger(__name__)
+
+
+# TODO: docstring
+# TODO: Can use a smarter search strategy than brute force for faster speed, such as bayes opt.
+def calibrate_decision_threshold(y: np.array,
+                                 y_pred_proba: np.array,
+                                 metric,
+                                 decision_thresholds: Union[int, List[float]] = 50,
+                                 verbose: bool = True) -> float:
+    problem_type = BINARY
+    assert len(y_pred_proba.shape) == 1
+    assert len(y.shape) == 1
+    assert len(y) == len(y_pred_proba)
+    if isinstance(decision_thresholds, int):
+        # Order thresholds by their proximity to 0.5
+        num_checks_half = decision_thresholds
+        num_checks = num_checks_half * 2
+        decision_thresholds = [[0.5]] + [[0.5 - (i / num_checks), 0.5 + (i / num_checks)] for i in
+                                         range(1, num_checks_half + 1)]
+        decision_thresholds = [item for sublist in decision_thresholds for item in sublist]
+    best_score_val = None
+    best_threshold = None
+
+    y_pred_val = get_pred_from_proba(
+        y_pred_proba=y_pred_proba,
+        problem_type=problem_type,
+        decision_threshold=0.5,
+    )
+    # TODO: Avoid calling like this, re-use logic that works with weights + extra args
+    score_val_baseline = metric(y_true=y, y_pred=y_pred_val)
+
+    if verbose:
+        logger.log(20, f'\nCalibrating decision threshold to optimize metric: {metric.name} '
+                       f'| Checking {len(decision_thresholds)} thresholds...')
+    for decision_threshold in decision_thresholds:
+        extra_log = ''
+        y_pred_val = get_pred_from_proba(
+            y_pred_proba=y_pred_proba,
+            problem_type=problem_type,
+            decision_threshold=decision_threshold,
+        )
+        # TODO: Avoid calling like this, re-use logic that works with weights + extra args
+        score_val = metric(y_true=y, y_pred=y_pred_val)
+
+        if best_score_val is None or score_val > best_score_val:
+            best_threshold = decision_threshold
+            best_score_val = score_val
+            extra_log = '\t| NEW BEST'
+        elif best_score_val == score_val:
+            # If the new threshold is closer to 0.5 than the previous threshold, prioritize it.
+            if abs(decision_threshold - 0.5) < abs(best_threshold - 0.5):
+                best_threshold = decision_threshold
+                best_score_val = score_val
+                extra_log = '\t| NEW BEST (Tie, using threshold that is closer to 0.5)'
+
+        if verbose:
+            logger.log(15, f'\tthreshold: {decision_threshold:.3f}\t| val: {score_val:.4f}{extra_log}')
+    if verbose:
+        logger.log(20, f'\tBase Threshold: {0.5:.3f}\t| val: {score_val_baseline:.4f}')
+        logger.log(20, f'\tBest Threshold: {best_threshold:.3f}\t| val: {best_score_val:.4f}')
+    return best_threshold

--- a/core/src/autogluon/core/calibrate/_decision_threshold.py
+++ b/core/src/autogluon/core/calibrate/_decision_threshold.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Union
+from typing import Callable, List, Union
 
 import numpy as np
 
@@ -14,19 +14,28 @@ logger = logging.getLogger(__name__)
 # TODO: Can use a smarter search strategy than brute force for faster speed, such as bayes opt.
 def calibrate_decision_threshold(y: np.array,
                                  y_pred_proba: np.array,
-                                 metric: Scorer,
+                                 metric: Union[Callable, Scorer],
+                                 metric_kwargs: dict = None,
                                  decision_thresholds: Union[int, List[float]] = 50,
+                                 metric_name: str = None,
                                  verbose: bool = True) -> float:
     problem_type = BINARY
     assert len(y_pred_proba.shape) == 1
     assert len(y.shape) == 1
     assert len(y) == len(y_pred_proba)
 
-    if not metric.needs_pred:
-        logger.warning(f'WARNING: The provided metric "{metric.name}" does not use class predictions for scoring, '
-                       f'and thus is invalid for decision threshold calibration. '
-                       f'Falling back to `decision_threshold=0.5`.')
-        return 0.5
+    if metric_kwargs is None:
+        metric_kwargs = dict()
+
+    if isinstance(metric, Scorer):
+        if metric_name is None:
+            metric_name = metric.name
+        if not metric.needs_pred:
+            logger.warning(f'WARNING: The provided metric "{metric_name}" does not use class predictions for scoring, '
+                           f'and thus is invalid for decision threshold calibration. '
+                           f'Falling back to `decision_threshold=0.5`.')
+            return 0.5
+    metric_name_log = f' {metric_name}' if metric_name is not None else ''
 
     if isinstance(decision_thresholds, int):
         # Order thresholds by their proximity to 0.5
@@ -49,10 +58,10 @@ def calibrate_decision_threshold(y: np.array,
         decision_threshold=0.5,
     )
     # TODO: Avoid calling like this, re-use logic that works with weights + extra args
-    score_val_baseline = metric(y_true=y, y_pred=y_pred_val)
+    score_val_baseline = metric(y, y_pred_val, **metric_kwargs)
 
     if verbose:
-        logger.log(20, f'\nCalibrating decision threshold to optimize metric: {metric.name} '
+        logger.log(20, f'\nCalibrating decision threshold to optimize metric{metric_name_log} '
                        f'| Checking {len(decision_thresholds)} thresholds...')
     for decision_threshold in decision_thresholds:
         extra_log = ''
@@ -62,7 +71,7 @@ def calibrate_decision_threshold(y: np.array,
             decision_threshold=decision_threshold,
         )
         # TODO: Avoid calling like this, re-use logic that works with weights + extra args
-        score_val = metric(y_true=y, y_pred=y_pred_val)
+        score_val = metric(y, y_pred_val, **metric_kwargs)
 
         if best_score_val is None or score_val > best_score_val:
             best_threshold = decision_threshold

--- a/core/src/autogluon/core/calibrate/_decision_threshold.py
+++ b/core/src/autogluon/core/calibrate/_decision_threshold.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import Callable, List, Union
 
@@ -15,9 +17,9 @@ logger = logging.getLogger(__name__)
 def calibrate_decision_threshold(y: np.array,
                                  y_pred_proba: np.array,
                                  metric: Union[Callable, Scorer],
-                                 metric_kwargs: dict = None,
+                                 metric_kwargs: dict | None = None,
                                  decision_thresholds: Union[int, List[float]] = 50,
-                                 metric_name: str = None,
+                                 metric_name: str | None = None,
                                  verbose: bool = True) -> float:
     problem_type = BINARY
     assert len(y_pred_proba.shape) == 1

--- a/core/src/autogluon/core/calibrate/_decision_threshold.py
+++ b/core/src/autogluon/core/calibrate/_decision_threshold.py
@@ -61,7 +61,7 @@ def calibrate_decision_threshold(y: np.array,
     score_val_baseline = metric(y, y_pred_val, **metric_kwargs)
 
     if verbose:
-        logger.log(20, f'\nCalibrating decision threshold to optimize metric{metric_name_log} '
+        logger.log(20, f'Calibrating decision threshold to optimize metric{metric_name_log} '
                        f'| Checking {len(decision_thresholds)} thresholds...')
     for decision_threshold in decision_thresholds:
         extra_log = ''

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -3068,12 +3068,6 @@ class AbstractTrainer:
         elif isinstance(metric, str):
             metric = get_metric(metric, self.problem_type, 'eval_metric')
 
-        if not metric.needs_pred:
-            logger.warning(f'WARNING: The provided metric "{metric.name}" does not use class predictions for scoring, '
-                           f'and thus is invalid for decision threshold calibration. '
-                           f'Falling back to `decision_threshold=0.5`.')
-            return 0.5
-
         if model == 'best':
             # FIXME: Incorrect if 'val' and model is refit_full
             model = self.get_model_best()

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -3106,7 +3106,6 @@ class AbstractTrainer:
                            f'Falling back to `decision_threshold=0.5`.')
             return 0.5
 
-        # metric_func =
         return calibrate_decision_threshold(y=y,
                                             y_pred_proba=y_pred_proba,
                                             metric=lambda y, y_pred : self._score_with_y_pred(y=y, y_pred=y_pred, weights=weights, metric=metric),

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -3091,6 +3091,8 @@ class AbstractTrainer:
                                      f'It may have been deleted due to `predictor.fit(..., keep_only_best=True)`. '
                                      f'Ensure `keep_only_best=False` to be able to calibrate refit_full models.')
             model = model_parent
+
+            # TODO: Add helpful logging when data is not available, for example post optimize for deployment
             if self.has_val:
                 # Use validation data
                 X = self.load_X_val()

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import logging
 import os
@@ -3063,12 +3065,12 @@ class AbstractTrainer:
                 model.save()
 
     def calibrate_decision_threshold(self,
-                                     X: pd.DataFrame = None,
-                                     y: np.array = None,
-                                     metric: Union[str, Scorer] = None,
+                                     X: pd.DataFrame | None = None,
+                                     y: np.array | None = None,
+                                     metric: str | Scorer | None = None,
                                      model: str = 'best',
                                      weights=None,
-                                     decision_thresholds: Union[int, List[float]] = 50,
+                                     decision_thresholds: int | List[float] = 50,
                                      verbose: bool = True) -> float:
         # TODO: Docstring
         assert self.problem_type == BINARY, f'calibrate_decision_threshold is only available for `problem_type="{BINARY}"`'
@@ -3098,14 +3100,14 @@ class AbstractTrainer:
                 X = self.load_X_val()
                 if self.weight_evaluation:
                     X, weights = extract_column(X=X, col_name=self.sample_weight)
-                y = self.load_y_val()
+                y: np.array = self.load_y_val()
                 y_pred_proba = self.predict_proba(X=X, model=model)
             else:
                 # Use out-of-fold data
                 if self.weight_evaluation:
                     X = self.load_X()
                     X, weights = extract_column(X=X, col_name=self.sample_weight)
-                y = self.load_y()
+                y: np.array = self.load_y()
                 y_pred_proba = self.get_model_oof(model=model)
         else:
             y_pred_proba = self.predict_proba(X=X, model=model)

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -24,6 +24,7 @@ from ..calibrate.conformity_score import compute_conformity_score
 from ..calibrate.temperature_scaling import tune_temperature_scaling
 from ..constants import AG_ARGS, BINARY, MULTICLASS, REGRESSION, QUANTILE, SOFTCLASS, REFIT_FULL_NAME, REFIT_FULL_SUFFIX
 from ..data.label_cleaner import LabelCleanerMulticlassToBinary
+from ..metrics import get_metric
 from ..models import AbstractModel, BaggedEnsembleModel, StackerEnsembleModel, WeightedEnsembleModel, GreedyWeightedEnsembleModel, SimpleWeightedEnsembleModel
 from ..utils import default_holdout_frac, get_pred_from_proba, generate_train_test_split, infer_eval_metric, compute_permutation_feature_importance, \
     extract_column, compute_weighted_metric, convert_pred_probas_to_df
@@ -1184,6 +1185,10 @@ class AbstractTrainer:
 
         self.save()
         return self.get_model_full_dict()
+
+    def get_refit_full_parent(self, model: str) -> str:
+        """Get refit full model's parent. If model does not have a parent, return `model`."""
+        return self.get_model_attribute(model=model, attribute='refit_full_parent', default=model)
 
     # TODO: Take best performance model with lowest inference
     def get_model_best(self, can_infer=None, allow_full=True, infer_limit=None):
@@ -3046,3 +3051,91 @@ class AbstractTrainer:
                 logger.log(15, f'Temperature term found is: {temp_scalar}')
                 model.params_aux["temperature_scalar"] = temp_scalar
                 model.save()
+
+    def calibrate_decision_threshold(self,
+                                     X=None,
+                                     y=None,
+                                     metric=None,
+                                     model: str = 'best',
+                                     decision_thresholds: Union[int, List[float]] = 50,
+                                     verbose: bool = True) -> float:
+        # TODO: Docstring
+        assert self.problem_type == BINARY, f'calibrate_decision_threshold is only available for `problem_type="{BINARY}"`'
+
+        if metric is None:
+            metric = self.eval_metric
+        elif isinstance(metric, str):
+            metric = get_metric(metric, self.problem_type, 'eval_metric')
+
+        if not metric.needs_pred:
+            logger.warning(f'WARNING: The provided metric "{metric.name}" does not use class predictions for scoring, '
+                           f'and thus is invalid for decision threshold calibration. '
+                           f'Falling back to `decision_threshold=0.5`.')
+            return 0.5
+
+        if model == 'best':
+            # FIXME: Incorrect if 'val' and model is refit_full
+            model = self.get_model_best()
+
+        if y is None:
+            # If model is refit_full, use its parent to avoid over-fitting
+            # FIXME: What if parent is deleted?
+            model = self.get_refit_full_parent(model=model)
+            if self.has_val:
+                # Use validation data
+                X = self.load_X_val()
+                y = self.load_y_val()
+                y_pred_proba_val = self.get_model_pred_proba_dict(X=X, models=[model])[model]
+            else:
+                # Use out-of-fold data
+                y = self.load_y()
+                y_pred_proba_val = self.get_model_oof(model=model)
+        else:
+            y_pred_proba_val = self.predict_proba(X=X, model=model)
+
+        if isinstance(decision_thresholds, int):
+            # Order thresholds by their proximity to 0.5
+            num_checks_half = decision_thresholds
+            num_checks = num_checks_half*2
+            decision_thresholds = [[0.5]] + [[0.5 - (i/num_checks), 0.5 + (i/num_checks)] for i in range(1, num_checks_half+1)]
+            decision_thresholds = [item for sublist in decision_thresholds for item in sublist]
+        best_score_val = None
+        best_threshold = None
+
+        y_pred_val = get_pred_from_proba(
+            y_pred_proba=y_pred_proba_val,
+            problem_type=self.problem_type,
+            decision_threshold=0.5,
+        )
+        # TODO: Avoid calling like this, re-use logic that works with weights + extra args
+        score_val_baseline = metric(y_true=y, y_pred=y_pred_val)
+
+        if verbose:
+            logger.log(20, f'\nOptimizing Metric: {metric.name}')
+        for decision_threshold in decision_thresholds:
+            extra_log = ''
+            y_pred_val = get_pred_from_proba(
+                y_pred_proba=y_pred_proba_val,
+                problem_type=self.problem_type,
+                decision_threshold=decision_threshold,
+            )
+            # TODO: Avoid calling like this, re-use logic that works with weights + extra args
+            score_val = metric(y_true=y, y_pred=y_pred_val)
+
+            if best_score_val is None or score_val > best_score_val:
+                best_threshold = decision_threshold
+                best_score_val = score_val
+                extra_log = '\t| NEW BEST'
+            elif best_score_val == score_val:
+                # If the new threshold is closer to 0.5 than the previous threshold, prioritize it.
+                if abs(decision_threshold - 0.5) < abs(best_threshold - 0.5):
+                    best_threshold = decision_threshold
+                    best_score_val = score_val
+                    extra_log = '\t| NEW BEST (Tie, using threshold that is closer to 0.5)'
+
+            if verbose:
+                logger.log(15, f'\tthreshold: {decision_threshold:.3f}\t| val: {score_val:.4f}{extra_log}')
+        if verbose:
+            logger.log(20, f'\tBase Threshold: {0.5:.3f}\t| val: {score_val_baseline:.4f}')
+            logger.log(20, f'\tBest Threshold: {best_threshold:.3f}\t| val: {best_score_val:.4f}')
+        return best_threshold

--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -4,7 +4,7 @@ import pickle
 import time
 import random
 import sys
-from typing import Callable, List, Union, Tuple
+from typing import Callable, List, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -253,12 +253,26 @@ def augment_rare_classes(X, label, threshold):
     return X
 
 
-def get_pred_from_proba_df(y_pred_proba, problem_type=BINARY):
-    """From input DataFrame of pred_proba, return Series of pred"""
+def get_pred_from_proba_df(y_pred_proba: pd.DataFrame,
+                           problem_type: str = BINARY,
+                           decision_threshold: float = None) -> pd.Series:
+    """
+    From input DataFrame of pred_proba, return Series of pred.
+    The input DataFrame's columns must be the names of the target classes.
+    """
     if problem_type == REGRESSION:
         y_pred = y_pred_proba
     elif problem_type == QUANTILE:
         y_pred = y_pred_proba
+    elif problem_type == BINARY and decision_threshold is not None:
+        cols = y_pred_proba.columns
+        negative_class = cols[0]
+        positive_class = cols[1]
+        y_pred = get_pred_from_proba(y_pred_proba=y_pred_proba.values,
+                                     problem_type=problem_type,
+                                     decision_threshold=decision_threshold)
+        y_pred = [positive_class if pred == 1 else negative_class for pred in y_pred]
+        y_pred = pd.Series(data=y_pred, index=y_pred_proba.index)
     else:
         y_pred = y_pred_proba.idxmax(axis=1)
     return y_pred

--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -264,7 +264,7 @@ def get_pred_from_proba_df(y_pred_proba, problem_type=BINARY):
     return y_pred
 
 
-def get_pred_from_proba(y_pred_proba: np.ndarray, problem_type=BINARY):
+def get_pred_from_proba(y_pred_proba: np.ndarray, problem_type=BINARY, decision_threshold=0.5):
     if problem_type == BINARY:
         # Using > instead of >= to align with Pandas `.idxmax` logic which picks the left-most column during ties.
         # If this is not done, then predictions can be inconsistent when converting in binary classification from multiclass-form pred_proba and
@@ -272,9 +272,9 @@ def get_pred_from_proba(y_pred_proba: np.ndarray, problem_type=BINARY):
         if len(y_pred_proba.shape) == 2:
             assert y_pred_proba.shape[1] == 2
             # Assume positive class is in 2nd position
-            y_pred = [1 if pred > 0.5 else 0 for pred in y_pred_proba[:, 1]]
+            y_pred = [1 if pred > decision_threshold else 0 for pred in y_pred_proba[:, 1]]
         else:
-            y_pred = [1 if pred > 0.5 else 0 for pred in y_pred_proba]
+            y_pred = [1 if pred > decision_threshold else 0 for pred in y_pred_proba]
     elif problem_type == REGRESSION:
         y_pred = y_pred_proba
     elif problem_type == QUANTILE:

--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -265,9 +265,7 @@ def get_pred_from_proba_df(y_pred_proba: pd.DataFrame,
     elif problem_type == QUANTILE:
         y_pred = y_pred_proba
     elif problem_type == BINARY and decision_threshold is not None:
-        cols = y_pred_proba.columns
-        negative_class = cols[0]
-        positive_class = cols[1]
+        negative_class, positive_class = y_pred_proba.columns
         y_pred = get_pred_from_proba(y_pred_proba=y_pred_proba.values,
                                      problem_type=problem_type,
                                      decision_threshold=decision_threshold)

--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -278,8 +278,10 @@ def get_pred_from_proba_df(y_pred_proba: pd.DataFrame,
     return y_pred
 
 
-def get_pred_from_proba(y_pred_proba: np.ndarray, problem_type=BINARY, decision_threshold=0.5):
+def get_pred_from_proba(y_pred_proba: np.ndarray, problem_type=BINARY, decision_threshold: float = None):
     if problem_type == BINARY:
+        if decision_threshold is None:
+            decision_threshold = 0.5
         # Using > instead of >= to align with Pandas `.idxmax` logic which picks the left-most column during ties.
         # If this is not done, then predictions can be inconsistent when converting in binary classification from multiclass-form pred_proba and
         # binary-form pred_proba when the pred_proba is 0.5 for positive and negative classes.

--- a/core/tests/unittests/calibrate/test_decision_threshold.py
+++ b/core/tests/unittests/calibrate/test_decision_threshold.py
@@ -1,0 +1,114 @@
+import numpy as np
+import pytest
+
+from autogluon.core.calibrate import calibrate_decision_threshold
+from autogluon.core.metrics import balanced_accuracy, f1, roc_auc
+
+
+def _get_sample_data():
+    y = np.array([
+        1,
+        0,
+        1,
+        1,
+        1,
+        0,
+    ])
+    y_pred_proba = np.array([
+        0.0,
+        0.24,
+        0.25,
+        0.25,
+        0.5,
+        1.0,
+    ])
+    return y, y_pred_proba
+
+
+def test_calibrate_decision_threshold():
+    y, y_pred_proba = _get_sample_data()
+    decision_threshold = calibrate_decision_threshold(
+        y=y,
+        y_pred_proba=y_pred_proba,
+        metric=f1,
+    )
+    assert decision_threshold == 0.24
+
+    decision_threshold = calibrate_decision_threshold(
+        y=y,
+        y_pred_proba=y_pred_proba,
+        metric=balanced_accuracy,
+    )
+    assert decision_threshold == 0.24
+
+    decision_threshold = calibrate_decision_threshold(
+        y=y,
+        y_pred_proba=y_pred_proba,
+        metric=balanced_accuracy,
+        decision_thresholds=10,
+    )
+    assert decision_threshold == 1.0
+
+    decision_threshold = calibrate_decision_threshold(
+        y=y,
+        y_pred_proba=y_pred_proba,
+        metric=balanced_accuracy,
+        decision_thresholds=[0.88],
+    )
+    assert decision_threshold == 0.88
+
+
+def test_calibrate_decision_threshold_select_closer_to_0_5():
+    """Test that calibration will choose the threshold closer to 0.5 in the case of a tie"""
+    y, y_pred_proba = _get_sample_data()
+    decision_threshold = calibrate_decision_threshold(
+        y=y,
+        y_pred_proba=y_pred_proba,
+        metric=balanced_accuracy,
+        decision_thresholds=[0.5, 0.244, 0.247],
+    )
+    assert decision_threshold == 0.247
+
+    decision_threshold = calibrate_decision_threshold(
+        y=y,
+        y_pred_proba=y_pred_proba,
+        metric=balanced_accuracy,
+        decision_thresholds=[0.5, 0.247, 0.244],
+    )
+    assert decision_threshold == 0.247
+
+
+def test_calibrate_decision_threshold_proba_metric_0_5():
+    """Test that non-pred metrics will always return 0.5"""
+    y, y_pred_proba = _get_sample_data()
+    decision_threshold = calibrate_decision_threshold(
+        y=y,
+        y_pred_proba=y_pred_proba,
+        metric=roc_auc,
+    )
+    assert decision_threshold == 0.5
+    decision_threshold = calibrate_decision_threshold(
+        y=y,
+        y_pred_proba=y_pred_proba,
+        metric=roc_auc,
+        decision_thresholds=[0.1],
+    )
+    assert decision_threshold == 0.5
+
+
+def test_calibrate_decision_threshold_out_of_bounds():
+    y, y_pred_proba = _get_sample_data()
+    with pytest.raises(ValueError):
+        calibrate_decision_threshold(
+            y=y,
+            y_pred_proba=y_pred_proba,
+            metric=balanced_accuracy,
+            decision_thresholds=[1.0, 0.5, 2.0],
+        )
+    with pytest.raises(ValueError):
+        calibrate_decision_threshold(
+            y=y,
+            y_pred_proba=y_pred_proba,
+            metric=balanced_accuracy,
+            decision_thresholds=[-0.01, 0.5],
+        )

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -147,11 +147,23 @@ class AbstractTabularLearner(AbstractLearner):
                                                         inverse_transform=inverse_transform)
         return y_pred_proba
 
-    def predict(self, X: DataFrame, model=None, as_pandas=True, inverse_transform=True, transform_features=True):
+    def predict(self,
+                X: DataFrame,
+                model=None,
+                as_pandas=True,
+                inverse_transform=True,
+                transform_features=True,
+                *,
+                decision_threshold: float = None,
+                ):
+        if decision_threshold is None:
+            decision_threshold = 0.5
         X_index = copy.deepcopy(X.index) if as_pandas else None
         y_pred_proba = self.predict_proba(X=X, model=model, as_pandas=False, as_multiclass=False, inverse_transform=False, transform_features=transform_features)
         problem_type = self.label_cleaner.problem_type_transform or self.problem_type
-        y_pred = get_pred_from_proba(y_pred_proba=y_pred_proba, problem_type=problem_type)
+        y_pred = get_pred_from_proba(y_pred_proba=y_pred_proba,
+                                     problem_type=problem_type,
+                                     decision_threshold=decision_threshold)
         y_pred = self._post_process_predict(y_pred=y_pred,
                                             as_pandas=as_pandas,
                                             index=X_index,

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -2537,8 +2537,6 @@ class TabularPredictor:
         #  add get_pred_from_proba method with decision_threshold argument
         #  unit tests (non-bag, bag, non-refit, refit)
         #  unit tests (verify predict identical to predict_proba + get_pred_from_proba with a given threshold)
-        #  move minimal logic given y_pred_proba and y to a function + unit test
-        #  move bulk of logic to learner/trainer/util function
         #  add `decision_threshold` support to predict_multi
         #  add `decision_threshold` support to get_pred_from_proba_df()
         #  precision has strange edge-cases where it flips from 1.0 to 0.0 score due to becoming undefined

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -2530,11 +2530,10 @@ class TabularPredictor:
                                      data=None,
                                      metric=None,
                                      model: str = 'best',
-                                     decision_thresholds: Union[int, List[float]] = 101,
+                                     decision_thresholds: Union[int, List[float]] = 50,
                                      verbose: bool = True) -> float:
         # TODO: v0.8
         #  add docstring
-        #  ensure 0.5 is the first threshold searched unless user specifies specific thresholds.
         #  add get_pred_from_proba method with decision_threshold argument
         #  work with refit_full & data=None & 'val'
         #  unit tests (non-bag, bag, non-refit, refit)
@@ -2589,8 +2588,11 @@ class TabularPredictor:
             y_val = self.transform_labels(labels=data[self.label])
 
         if isinstance(decision_thresholds, int):
-            num_checks = decision_thresholds
-            decision_thresholds = [i / (num_checks - 1) for i in range(num_checks)]
+            # Order thresholds by their proximity to 0.5
+            num_checks_half = decision_thresholds
+            num_checks = num_checks_half*2
+            decision_thresholds = [[0.5]] + [[0.5 - (i/num_checks), 0.5 + (i/num_checks)] for i in range(1, num_checks_half+1)]
+            decision_thresholds = [item for sublist in decision_thresholds for item in sublist]
         best_score_val = None
         best_threshold = None
 

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -278,7 +278,7 @@ class TabularPredictor:
         return self._learner.problem_type
 
     @property
-    def decision_threshold(self):
+    def decision_threshold(self) -> float:
         """
         The decision threshold used to convert prediction probabilities to predictions.
         Only relevant for binary classification, otherwise the value will be None.

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -222,6 +222,7 @@ class TabularPredictor:
             logger.log(15, f"{AUTO_WEIGHT} currently does not use any sample weights.")
         self.sample_weight = sample_weight
         self.weight_evaluation = weight_evaluation  # TODO: sample_weight and weight_evaluation can both be properties that link to self._learner.sample_weight, self._learner.weight_evaluation
+        self._decision_threshold = None  # TODO: Each model should have its own decision threshold instead of one global threshold
         if self.sample_weight in [AUTO_WEIGHT, BALANCE_WEIGHT] and self.weight_evaluation:
             logger.warning(
                 f"We do not recommend specifying weight_evaluation when sample_weight='{self.sample_weight}', instead specify appropriate eval_metric.")
@@ -276,6 +277,40 @@ class TabularPredictor:
     def problem_type(self):
         return self._learner.problem_type
 
+    @property
+    def decision_threshold(self):
+        """
+        The decision threshold used to convert prediction probabilities to predictions.
+        Only relevant for binary classification, otherwise the value will be None.
+        Valid values are in the range [0.0, 1.0]
+        You can obtain an optimized `decision_threshold` by first calling `predictor.calibrate_decision_threshold()`.
+        Useful to set for metrics such as `balanced_accuracy` and `f1` as `0.5` is often not an optimal threshold.
+        Predictions are calculated via the following logic on the positive class: `1 if pred > decision_threshold else 0`
+        """
+        if self._decision_threshold is not None:
+            return self._decision_threshold
+        elif self.problem_type == BINARY:
+            return 0.5
+        else:
+            return None
+
+    def set_decision_threshold(self, decision_threshold: float):
+        """
+        Set `predictor.decision_threshold`. Problem type must be 'binary', and the value must be between 0 and 1.
+        """
+        assert self.problem_type == BINARY
+        assert decision_threshold >= 0
+        assert decision_threshold <= 1
+        if decision_threshold != self.decision_threshold:
+            logger.log(20, f'Updating predictor.decision_threshold from {self.decision_threshold} -> {decision_threshold}\n'
+                           f'\tThis will impact how prediction probabilities are converted to predictions in binary classification.\n'
+                           f'\tPrediction probabilities of the positive class >{decision_threshold} '
+                           f'will be predicted as the positive class ({self.positive_class}). '
+                           f'This can significantly impact metric scores.\n'
+                           f'\tYou can update this value via `predictor.set_decision_threshold`.\n'
+                           f'\tYou can calculate an optimal decision threshold on the validation data via `predictor.calibrate_decision_threshold()`.')
+        self._decision_threshold = decision_threshold
+
     def features(self, feature_stage: str = 'original'):
         """
         Returns a list of feature names dependent on the value of feature_stage.
@@ -324,6 +359,7 @@ class TabularPredictor:
             infer_limit=None,
             infer_limit_batch_size=None,
             fit_weighted_ensemble=True,
+            calibrate_decision_threshold=False,
             num_cpus='auto',
             num_gpus='auto',
             **kwargs):
@@ -570,6 +606,12 @@ class TabularPredictor:
             If True, a WeightedEnsembleModel will be fit in each stack layer.
             A weighted ensemble will often be stronger than an individual model while being very fast to train.
             It is recommended to keep this value set to True to maximize predictive quality.
+        calibrate_decision_threshold : bool, default = False
+            [Experimental] This may be removed / changed without warning in a future release.
+            If True, will automatically calibrate the decision threshold at the end of fit for calls to `.predict` based on the evaluation metric.
+            By default, the decision threshold is `0.5`, however for some metrics such as `f1` and `balanced_accuracy`,
+            scores can be significantly improved by choosing a threshold other than `0.5`.
+            Only valid for `problem_type='binary'`. Ignored for all other problem types.
         num_cpus: int, default = "auto"
             The total amount of cpus you want AutoGluon predictor to use.
             Auto means AutoGluon will make the decision based on the total number of cpus available and the model requirement for best performance.
@@ -900,13 +942,14 @@ class TabularPredictor:
             set_best_to_refit_full=kwargs['set_best_to_refit_full'],
             save_space=kwargs['save_space'],
             calibrate=kwargs['calibrate'],
+            calibrate_decision_threshold=calibrate_decision_threshold,
             infer_limit=infer_limit,
         )
         self.save()
         return self
 
     def _post_fit(self, keep_only_best=False, refit_full=False, set_best_to_refit_full=False, save_space=False,
-                  calibrate=False, infer_limit=None):
+                  calibrate=False, calibrate_decision_threshold=False, infer_limit=None):
         if refit_full is True:
             if keep_only_best is True:
                 if set_best_to_refit_full is True:
@@ -953,6 +996,13 @@ class TabularPredictor:
                 self._trainer.calibrate_model()
             else:
                 logger.log(30, 'WARNING: `calibrate=True` is only applicable to classification or quantile regression problems. Skipping calibration...')
+
+        if calibrate_decision_threshold:
+            if self.problem_type != BINARY:
+                logger.log(30, 'WARNING: `calibrate_decision_threshold=True` is only applicable to binary classification. Skipping calibration...')
+            else:
+                best_threshold = self.calibrate_decision_threshold()
+                self.set_decision_threshold(decision_threshold=best_threshold)
 
         if keep_only_best:
             self.delete_models(models_to_keep='best', dry_run=False)
@@ -1408,7 +1458,7 @@ class TabularPredictor:
         decision_threshold : float, default = None
             The decision threshold used to convert prediction probabilities to predictions.
             Only relevant for binary classification, otherwise ignored.
-            If None, defaults to `0.5`.
+            If None, defaults to `predictor.decision_threshold`.
             Valid values are in the range [0.0, 1.0]
             You can obtain an optimized `decision_threshold` by first calling `predictor.calibrate_decision_threshold()`.
             Useful to set for metrics such as `balanced_accuracy` and `f1` as `0.5` is often not an optimal threshold.
@@ -1420,6 +1470,8 @@ class TabularPredictor:
         """
         self._assert_is_fit('predict')
         data = self._get_dataset(data)
+        if decision_threshold is None:
+            decision_threshold = self.decision_threshold
         return self._learner.predict(X=data, model=model, as_pandas=as_pandas, transform_features=transform_features, decision_threshold=decision_threshold)
 
     def predict_proba(self, data, model=None, as_pandas=True, as_multiclass=True, transform_features=True):
@@ -1468,10 +1520,11 @@ class TabularPredictor:
     def get_pred_from_proba(self,
                             y_pred_proba: Union[pd.DataFrame, np.ndarray],
                             decision_threshold: float = None) -> Union[pd.Series, np.array]:
-        # FIXME: docstring
-        # FIXME: Work for external/internal, work for pandas/numpy
+        # TODO: docstring
         if not self.can_predict_proba:
             raise AssertionError(f'`predictor.get_pred_from_proba` is not supported when problem_type="{self.problem_type}".')
+        if decision_threshold is None:
+            decision_threshold = self.decision_threshold
         return self._learner.get_pred_from_proba(y_pred_proba=y_pred_proba, decision_threshold=decision_threshold)
 
     @property
@@ -1483,7 +1536,7 @@ class TabularPredictor:
         self._assert_is_fit('can_predict_proba')
         return problem_type_info.can_predict_proba(problem_type=self.problem_type)
 
-    def evaluate(self, data, model=None, silent=False, auxiliary_metrics=True, detailed_report=False) -> dict:
+    def evaluate(self, data, model=None, decision_threshold=None, silent=False, auxiliary_metrics=True, detailed_report=False) -> dict:
         """
         Report the predictive performance evaluated over a given dataset.
         This is basically a shortcut for: `pred_proba = predict_proba(data); evaluate_predictions(data[label], pred_proba)`.
@@ -1497,6 +1550,11 @@ class TabularPredictor:
         model : str (optional)
             The name of the model to get prediction probabilities from. Defaults to None, which uses the highest scoring model on the validation set.
             Valid models are listed in this `predictor` by calling `predictor.get_model_names()`.
+        decision_threshold : float, default = None
+            The decision threshold to use when converting prediction probabilities to predictions.
+            This will impact the scores of metrics such as `f1` and `accuracy`.
+            If None, defaults to `predictor.decision_threshold`. Ignored unless `problem_type='binary'`.
+            Refer to the `predictor.decision_threshold` docstring for more information.
         silent : bool, default = False
             If False, performance results are printed.
         auxiliary_metrics: bool, default = True
@@ -1512,6 +1570,8 @@ class TabularPredictor:
         """
         self._assert_is_fit('evaluate')
         data = self._get_dataset(data)
+        if decision_threshold is None:
+            decision_threshold = self.decision_threshold
         if self.can_predict_proba:
             y_pred = self.predict_proba(data=data, model=model)
         else:
@@ -1520,10 +1580,11 @@ class TabularPredictor:
             sample_weight = data[self.sample_weight]
         else:
             sample_weight = None
-        return self.evaluate_predictions(y_true=data[self.label], y_pred=y_pred, sample_weight=sample_weight, silent=silent,
+        return self.evaluate_predictions(y_true=data[self.label], y_pred=y_pred, sample_weight=sample_weight,
+                                         decision_threshold=decision_threshold, silent=silent,
                                          auxiliary_metrics=auxiliary_metrics, detailed_report=detailed_report)
 
-    def evaluate_predictions(self, y_true, y_pred, sample_weight=None, silent=False, auxiliary_metrics=True, detailed_report=False) -> dict:
+    def evaluate_predictions(self, y_true, y_pred, sample_weight=None, decision_threshold=None, silent=False, auxiliary_metrics=True, detailed_report=False) -> dict:
         """
         Evaluate the provided prediction probabilities against ground truth labels.
         Evaluation is based on the `eval_metric` previously specified in init, or default metrics if none was specified.
@@ -1538,6 +1599,11 @@ class TabularPredictor:
             Caution: For certain types of `eval_metric` (such as 'roc_auc'), `y_pred` must be predicted-probabilities rather than predicted labels.
         sample_weight : :class:`pd.Series`, default = None
             Sample weight for each row of data. If None, uniform sample weights are used.
+        decision_threshold : float, default = None
+            The decision threshold to use when converting prediction probabilities to predictions.
+            This will impact the scores of metrics such as `f1` and `accuracy`.
+            If None, defaults to `predictor.decision_threshold`. Ignored unless `problem_type='binary'`.
+            Refer to the `predictor.decision_threshold` docstring for more information.
         silent : bool, default = False
             If False, performance results are printed.
         auxiliary_metrics: bool, default = True
@@ -1551,13 +1617,17 @@ class TabularPredictor:
         NOTE: Metrics scores always show in higher is better form.
         This means that metrics such as log_loss and root_mean_squared_error will have their signs FLIPPED, and values will be negative.
         """
-        return self._learner.evaluate_predictions(y_true=y_true, y_pred=y_pred, sample_weight=sample_weight, silent=silent,
+        if decision_threshold is None:
+            decision_threshold = self.decision_threshold
+        return self._learner.evaluate_predictions(y_true=y_true, y_pred=y_pred, sample_weight=sample_weight,
+                                                  decision_threshold=decision_threshold, silent=silent,
                                                   auxiliary_metrics=auxiliary_metrics, detailed_report=detailed_report)
 
     def leaderboard(self,
                     data=None,
                     extra_info: bool = False,
                     extra_metrics: list = None,
+                    decision_threshold: float = None,
                     only_pareto_frontier: bool = False,
                     skip_score: bool = False,
                     silent: bool = False) -> pd.DataFrame:
@@ -1668,6 +1738,14 @@ class TabularPredictor:
             NOTE: Metrics scores always show in higher is better form.
             This means that metrics such as log_loss and root_mean_squared_error will have their signs FLIPPED, and values will be negative.
             This is necessary to avoid the user needing to know the metric to understand if higher is better when looking at leaderboard.
+        decision_threshold : float, default = None
+            The decision threshold to use when converting prediction probabilities to predictions.
+            This will impact the scores of metrics such as `f1` and `accuracy`.
+            If None, defaults to `predictor.decision_threshold`. Ignored unless `problem_type='binary'`.
+            Refer to the `predictor.decision_threshold` docstring for more information.
+            NOTE: `score_val` will not be impacted by this value in v0.8.
+                `score_val` will always show the validation scores achieved with a decision threshold of `0.5`.
+                Only test scores will be properly updated.
         only_pareto_frontier : bool, default = False
             If `True`, only return model information of models in the Pareto frontier of the accuracy/latency trade-off (models which achieve the highest score within their end-to-end inference time).
             At minimum this will include the model with the highest score and the model with the lowest inference time.
@@ -1686,7 +1764,9 @@ class TabularPredictor:
         """
         self._assert_is_fit('leaderboard')
         data = self._get_dataset(data, allow_nan=True)
-        return self._learner.leaderboard(X=data, extra_info=extra_info, extra_metrics=extra_metrics,
+        if decision_threshold is None:
+            decision_threshold = self.decision_threshold
+        return self._learner.leaderboard(X=data, extra_info=extra_info, extra_metrics=extra_metrics, decision_threshold=decision_threshold,
                                          only_pareto_frontier=only_pareto_frontier, skip_score=skip_score, silent=silent)
 
     def predict_proba_multi(self,
@@ -1812,6 +1892,8 @@ class TabularPredictor:
         Dictionary with model names as keys and model predictions as values.
         """
         self._assert_is_fit('predict_multi')
+        if decision_threshold is None:
+            decision_threshold = self.decision_threshold
         data = self._get_dataset(data, allow_nan=True)
         return self._learner.predict_multi(X=data,
                                            models=models,
@@ -2532,32 +2614,63 @@ class TabularPredictor:
         return models
 
     def calibrate_decision_threshold(self,
-                                     data=None,
+                                     data: Union[str, pd.DataFrame] = None,
                                      metric=None,
                                      model: str = 'best',
                                      decision_thresholds: Union[int, List[float]] = 50,
                                      verbose: bool = True) -> float:
+        """
+        Calibrate the decision threshold in binary classification to optimize a given metric.
+        You can pass the output of this method as input to `predictor.set_decision_threshold` to update the predictor.
+        Will raise an AssertionError if `predictor.problem_type != 'binary'`.
+
+        Note that while calibrating the decision threshold can help to improve a given metric,
+        other metrics may end up having worse scores.
+        For example, calibrating on `balanced_accuracy` will often harm `accuracy`.
+        Users should keep this in mind while leveraging decision threshold calibration.
+
+        Parameters
+        ----------
+        data : Union[str, pd.DataFrame], default = None
+            The data to use for calibration. Must contain the label column.
+            We recommend to keep this value as None unless you are an advanced user and understand the implications.
+            If None, will use internal data such as the holdout validation data or out-of-fold predictions.
+        metric : autogluon.core.metrics.Scorer or str, default = None
+            The metric to optimize during calibration.
+            If None, uses `predictor.eval_metric`.
+        model : str, default = 'best'
+            The model to use prediction probabilities of when calibrating the threshold.
+            If 'best', will use `predictor.get_model_best()`.
+        decision_thresholds : Union[int, List[float]], default = 50
+            The number of decision thresholds on either side of `0.5` to search.
+            The default of 50 will result in 101 searched thresholds: [0.00, 0.01, 0.02, ..., 0.49, 0.50, 0.51, ..., 0.98, 0.99, 1.00]
+            Alternatively, a list of decision thresholds can be passed and only the thresholds in the list will be searched.
+        verbose : bool, default = True
+            If True, will log information about the calibration process.
+
+        Returns
+        -------
+        Decision Threshold: A float between 0 and 1 defining the decision boundary for predictions that
+        maximizes the `metric` score on the `data` for the `model`.
+        """
         # TODO: v0.8
-        #  add docstring
-        #  unit tests (non-bag, bag, non-refit, refit)
-        #  precision has strange edge-cases where it flips from 1.0 to 0.0 score due to becoming undefined
-        #    consider warning users who pass this metric,
-        #    or edit this metric so they do not flip value when undefined.
-        #      UndefinedMetricWarning: Precision is ill-defined and being set to 0.0 due to no predicted samples.
-        #      Use `zero_division` parameter to control this behavior.
         #  add tutorial section
         #
         # TODO: v0.9
         #  Calculate optimal threshold for each model separately when deciding best model
         #  sampling/time limit
-        #  add .fit flag to automatically calibrate decision threshold
-        #  make decision threshold work in predictor.leaderboard
         #  update validation scores of models based on threshold
         #  speed up the logic / search for optimal threshold more efficiently
         #  make threshold calibration part of internal optimization, such as during fit_weighted_ensemble.
+        #  precision has strange edge-cases where it flips from 1.0 to 0.0 score due to becoming undefined
+        #    consider warning users who pass this metric,
+        #    or edit this metric so they do not flip value when undefined.
+        #      UndefinedMetricWarning: Precision is ill-defined and being set to 0.0 due to no predicted samples.
+        #      Use `zero_division` parameter to control this behavior.
 
         self._assert_is_fit('calibrate_decision_threshold')
         assert self.problem_type == BINARY, f'calibrate_decision_threshold is only available for `problem_type="{BINARY}"`'
+        data = self._get_dataset(data, allow_nan=True)
 
         if metric is None:
             metric = self.eval_metric
@@ -2570,7 +2683,7 @@ class TabularPredictor:
                                                           decision_thresholds=decision_thresholds,
                                                           verbose=verbose)
 
-    def get_oof_pred(self, model: str = None, transformed=False, train_data=None, internal_oof=False, can_infer=None) -> pd.Series:
+    def get_oof_pred(self, model: str = None, transformed=False, train_data=None, internal_oof=False, decision_threshold=None, can_infer=None) -> pd.Series:
         """
         Note: This is advanced functionality not intended for normal usage.
 
@@ -2588,6 +2701,8 @@ class TabularPredictor:
             Refer to `get_oof_pred_proba()` documentation.
         internal_oof : bool, default = False
             Refer to `get_oof_pred_proba()` documentation.
+        decision_threshold : float, default = None
+            Refer to `predict_multi` documentation.
         can_infer : bool, default = None
             Refer to `get_oof_pred_proba()` documentation.
 
@@ -2596,13 +2711,17 @@ class TabularPredictor:
         :class:`pd.Series` object of the out-of-fold training predictions of the model.
         """
         self._assert_is_fit('get_oof_pred')
+        if decision_threshold is None:
+            decision_threshold = self.decision_threshold
         y_pred_proba_oof = self.get_oof_pred_proba(model=model,
                                                    transformed=transformed,
                                                    as_multiclass=True,
                                                    train_data=train_data,
                                                    internal_oof=internal_oof,
                                                    can_infer=can_infer)
-        y_pred_oof = get_pred_from_proba_df(y_pred_proba_oof, problem_type=self.problem_type)
+        y_pred_oof = get_pred_from_proba_df(y_pred_proba_oof,
+                                            problem_type=self.problem_type,
+                                            decision_threshold=decision_threshold)
         if transformed:
             return self._learner.label_cleaner.to_transformed_dtype(y_pred_oof)
         return y_pred_oof

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import inspect
 import logging
@@ -22,6 +24,7 @@ from autogluon.common.utils.utils import setup_outputdir, get_autogluon_metadata
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION, QUANTILE, AUTO_WEIGHT, BALANCE_WEIGHT, PSEUDO_MODEL_SUFFIX, PROBLEM_TYPES_CLASSIFICATION
 from autogluon.core.data.label_cleaner import LabelCleanerMulticlassToBinary
 from autogluon.core.dataset import TabularDataset
+from autogluon.core.metrics import Scorer
 from autogluon.core.problem_type import problem_type_info
 from autogluon.core.pseudolabeling.pseudolabeling import filter_pseudo, filter_ensemble_pseudo
 from autogluon.core.scheduler.scheduler_factory import scheduler_factory
@@ -1431,12 +1434,12 @@ class TabularPredictor:
                                             **fit_extra_kwargs)
 
     def predict(self,
-                data,
-                model=None,
-                as_pandas=True,
-                transform_features=True,
+                data: str | TabularDataset | pd.DataFrame,
+                model: str | None = None,
+                as_pandas: bool = True,
+                transform_features: bool = True,
                 *,
-                decision_threshold: float = None):
+                decision_threshold: float | None = None):
         """
         Use trained models to produce predictions of `label` column values for new data.
 
@@ -1474,7 +1477,12 @@ class TabularPredictor:
             decision_threshold = self.decision_threshold
         return self._learner.predict(X=data, model=model, as_pandas=as_pandas, transform_features=transform_features, decision_threshold=decision_threshold)
 
-    def predict_proba(self, data, model=None, as_pandas=True, as_multiclass=True, transform_features=True):
+    def predict_proba(self,
+                      data: str | TabularDataset | pd.DataFrame,
+                      model: str | None = None,
+                      as_pandas: bool = True,
+                      as_multiclass: bool = True,
+                      transform_features: bool = True):
         """
         Use trained models to produce predicted class probabilities rather than class-labels (if task is classification).
         If `predictor.problem_type` is regression or quantile, this will raise an AssertionError.
@@ -1518,8 +1526,8 @@ class TabularPredictor:
         return self._learner.predict_proba(X=data, model=model, as_pandas=as_pandas, as_multiclass=as_multiclass, transform_features=transform_features)
 
     def get_pred_from_proba(self,
-                            y_pred_proba: Union[pd.DataFrame, np.ndarray],
-                            decision_threshold: float = None) -> Union[pd.Series, np.array]:
+                            y_pred_proba: pd.DataFrame | np.ndarray,
+                            decision_threshold: float | None = None) -> pd.Series | np.array:
         """
         Given prediction probabilities, convert to predictions.
 
@@ -1654,10 +1662,10 @@ class TabularPredictor:
                                                   auxiliary_metrics=auxiliary_metrics, detailed_report=detailed_report)
 
     def leaderboard(self,
-                    data=None,
+                    data: str | TabularDataset | pd.DataFrame | None = None,
                     extra_info: bool = False,
-                    extra_metrics: list = None,
-                    decision_threshold: float = None,
+                    extra_metrics: list | None = None,
+                    decision_threshold: float | None = None,
                     only_pareto_frontier: bool = False,
                     skip_score: bool = False,
                     silent: bool = False) -> pd.DataFrame:
@@ -2644,10 +2652,10 @@ class TabularPredictor:
         return models
 
     def calibrate_decision_threshold(self,
-                                     data: Union[str, pd.DataFrame] = None,
-                                     metric=None,
+                                     data: str | TabularDataset | pd.DataFrame | None = None,
+                                     metric: str | Scorer | None = None,
                                      model: str = 'best',
-                                     decision_thresholds: Union[int, List[float]] = 50,
+                                     decision_thresholds: int | List[float] = 50,
                                      verbose: bool = True) -> float:
         """
         Calibrate the decision threshold in binary classification to optimize a given metric.

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1520,7 +1520,37 @@ class TabularPredictor:
     def get_pred_from_proba(self,
                             y_pred_proba: Union[pd.DataFrame, np.ndarray],
                             decision_threshold: float = None) -> Union[pd.Series, np.array]:
-        # TODO: docstring
+        """
+        Given prediction probabilities, convert to predictions.
+
+        Parameters
+        ----------
+        y_pred_proba : :class:`pd.DataFrame` or :class:`np.ndarray`
+            The prediction probabilities to convert to predictions.
+            Obtainable via the output of `predictor.predict_proba`.
+        decision_threshold : float, default = None
+            The decision threshold used to convert prediction probabilities to predictions.
+            Only relevant for binary classification, otherwise ignored.
+            If None, defaults to `predictor.decision_threshold`.
+            Valid values are in the range [0.0, 1.0]
+            You can obtain an optimized `decision_threshold` by first calling `predictor.calibrate_decision_threshold()`.
+            Useful to set for metrics such as `balanced_accuracy` and `f1` as `0.5` is often not an optimal threshold.
+            Predictions are calculated via the following logic on the positive class: `1 if pred > decision_threshold else 0`
+
+        Returns
+        -------
+        Array of predictions, one corresponding to each row in given dataset. Either :class:`np.ndarray` or :class:`pd.Series` depending on `y_pred_proba` dtype.
+
+        Examples
+        --------
+        >>> from autogluon.tabular import TabularPredictor
+        >>> predictor = TabularPredictor(label='class').fit('train.csv', label='class')
+        >>> y_pred_proba = predictor.predict_proba('test.csv')
+        >>>
+        >>> # y_pred and y_pred_from_proba are identical
+        >>> y_pred = predictor.predict('test.csv')
+        >>> y_pred_from_proba = predictor.get_pred_from_proba(y_pred_proba=y_pred_proba)
+        """
         if not self.can_predict_proba:
             raise AssertionError(f'`predictor.get_pred_from_proba` is not supported when problem_type="{self.problem_type}".')
         if decision_threshold is None:

--- a/tabular/tests/unittests/models/test_lightgbm.py
+++ b/tabular/tests/unittests/models/test_lightgbm.py
@@ -62,3 +62,41 @@ def test_lightgbm_quantile(fit_helper):
     dataset_name = 'ames'
     init_args = dict(problem_type='quantile', quantile_levels=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, init_args=init_args)
+
+
+def test_lightgbm_binary_with_calibrate_decision_threshold(fit_helper):
+    """Tests that calibrate_decision_threshold works and does not make the validation score worse on the given metric"""
+    fit_args = dict(
+        hyperparameters={LGBModel: {}},
+    )
+    dataset_name = 'adult'
+
+    predictor = fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, delete_directory=False, refit_full=False)
+
+    for metric in [None, 'f1', 'balanced_accuracy', 'mcc', 'recall', 'precision']:
+        decision_threshold = predictor.calibrate_decision_threshold(metric=metric)
+        if metric is None:
+            metric = predictor.eval_metric.name
+        assert decision_threshold >= 0
+        assert decision_threshold <= 1
+
+        X_val, y_val = predictor.load_data_internal(data='val', return_X=True, return_y=True)
+        y_val = predictor.transform_labels(labels=y_val, inverse=True)
+
+        y_pred_val = predictor.predict(data=X_val, transform_features=False)
+        y_pred_val_w_decision_threshold = predictor.predict(data=X_val, decision_threshold=decision_threshold, transform_features=False)
+
+        result = predictor.evaluate_predictions(y_true=y_val, y_pred=y_pred_val)
+        result_calibrated = predictor.evaluate_predictions(y_true=y_val, y_pred=y_pred_val_w_decision_threshold)
+
+        # Ensure validation score never becomes worse on the calibrated metric
+        assert result[metric] <= result_calibrated[metric]
+        if metric in ['recall', 'precision']:
+            # recall and precision should always be able to achieve a perfect validation score
+            assert result_calibrated[metric] == 1.0
+
+    for decision_threshold in [0.0, 0.01, 0.02, 0.03, 0.1, 0.2, 0.4999, 0.5, 0.5001, 0.8, 0.9, 0.97, 0.98, 0.99, 1.0]:
+        # TODO: Verify that predict_proba + get_pred_from_proba w/ threshold is equivalent to predict w/ threshold
+        pass
+
+    assert predictor.calibrate_decision_threshold(metric='roc_auc') == 0.5

--- a/tabular/tests/unittests/models/test_lightgbm.py
+++ b/tabular/tests/unittests/models/test_lightgbm.py
@@ -105,3 +105,57 @@ def test_lightgbm_binary_with_calibrate_decision_threshold(fit_helper):
             assert result_calibrated[metric] == 1.0
 
     assert predictor.calibrate_decision_threshold(metric='roc_auc') == 0.5
+
+
+def test_lightgbm_binary_with_calibrate_decision_threshold_bagged_refit(fit_helper, dataset_loader_helper):
+    """Tests that calibrate_decision_threshold works and does not make the validation score worse on the given metric"""
+    fit_args = dict(
+        hyperparameters={LGBModel: {}},
+        num_bag_folds=2,
+        calibrate_decision_threshold=True,
+    )
+    init_args = dict(
+        eval_metric='f1'
+    )
+    dataset_name = 'adult'
+
+    directory_prefix = './datasets/'
+    train_data, test_data, dataset_info = dataset_loader_helper.load_dataset(name=dataset_name,
+                                                                             directory_prefix=directory_prefix)
+    label = dataset_info['label']
+    predictor = fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, init_args=init_args, fit_args=fit_args,
+                                                    delete_directory=False, refit_full=True)
+
+    assert predictor._decision_threshold is not None
+    assert predictor.decision_threshold == predictor._decision_threshold
+    optimal_decision_threshold = predictor.calibrate_decision_threshold()
+    assert optimal_decision_threshold == predictor.decision_threshold
+    og_threshold = predictor.decision_threshold
+
+    y_pred_test = predictor.predict(test_data)
+
+    scores_predictions = predictor.evaluate_predictions(y_true=test_data[label], y_pred=y_pred_test)
+    scores = predictor.evaluate(test_data)
+    scores_05 = predictor.evaluate(test_data, decision_threshold=0.5)
+
+    for k in scores_predictions:
+        assert scores[k] == scores_predictions[k]
+    assert scores['f1'] > scores_05['f1']  # Calibration should help f1
+    assert scores['accuracy'] < scores_05['accuracy']  # Calibration should harm accuracy
+
+    predictor.set_decision_threshold(0.5)
+    assert predictor.decision_threshold == 0.5
+    assert predictor._decision_threshold == 0.5
+    scores_05_native = predictor.evaluate(test_data)
+
+    for k in scores_05:
+        assert scores_05[k] == scores_05_native[k]
+
+    leaderboard_05 = predictor.leaderboard(test_data)
+    lb_score_05 = leaderboard_05[leaderboard_05['model'] == predictor.get_model_best()].iloc[0]['score_test']
+    assert lb_score_05 == scores_05['f1']
+
+    predictor.set_decision_threshold(og_threshold)
+    leaderboard = predictor.leaderboard(test_data)
+    lb_score = leaderboard[leaderboard['model'] == predictor.get_model_best()].iloc[0]['score_test']
+    assert lb_score == scores['f1']

--- a/tabular/tests/unittests/models/test_lightgbm.py
+++ b/tabular/tests/unittests/models/test_lightgbm.py
@@ -104,8 +104,4 @@ def test_lightgbm_binary_with_calibrate_decision_threshold(fit_helper):
             # recall should always be able to achieve a perfect validation score
             assert result_calibrated[metric] == 1.0
 
-    for decision_threshold in [0.0, 0.01, 0.02, 0.03, 0.1, 0.2, 0.4999, 0.5, 0.5001, 0.8, 0.9, 0.97, 0.98, 0.99, 1.0]:
-        # TODO: Verify that predict_proba + get_pred_from_proba w/ threshold is equivalent to predict w/ threshold
-        pass
-
     assert predictor.calibrate_decision_threshold(metric='roc_auc') == 0.5


### PR DESCRIPTION
*Issue #, if available:*
resolves #1038, #1515 
pre-req for #3112 

*Description of changes:*
Add `TabularPredictor.calibrate_decision_threshold` which allows to optimize a given metric's decision threshold for predictions to strongly enhance the metric score.

The below code and output showcase how this logic can reliably improve metric scores on a variety of metrics, particularly `f1` and `balanced_accuracy`.

<details>
  <summary>Example Code</summary>

```python
from autogluon.tabular import TabularPredictor, TabularDataset


if __name__ == '__main__':
    path_prefix = 'https://autogluon.s3.amazonaws.com/datasets/Inc/'
    label = 'class'

    path_train = path_prefix + 'train.csv'
    path_test = path_prefix + 'test.csv'

    train_data = TabularDataset(path_train)
    train_data = train_data.sample(25000, random_state=0)
    test_data = TabularDataset(path_test)

    predictor: TabularPredictor = TabularPredictor(
        label=label,
        verbosity=3,
    ).fit(
        train_data=train_data,
        hyperparameters={'GBM': {}},
        # fit_weighted_ensemble=False,
        num_bag_folds=2,
        num_bag_sets=1,
    )
    predictor.leaderboard(test_data)

    from autogluon.core.metrics import accuracy, balanced_accuracy, f1, mcc, precision, recall
    y_pred = predictor.predict(data=test_data)
    result = predictor.evaluate_predictions(y_true=test_data[label], y_pred=y_pred)
    decision_threshold_dict = dict()
    for eval_metric in [accuracy, balanced_accuracy, f1, mcc, precision, recall]:
        decision_threshold = predictor.calibrate_decision_threshold(metric=eval_metric)
        decision_threshold_dict[eval_metric.name] = decision_threshold

        y_pred_w_decision_threshold = predictor.predict(data=test_data, decision_threshold=decision_threshold)
        result_calibrated = predictor.evaluate_predictions(y_true=test_data[label], y_pred=y_pred_w_decision_threshold)

        metric_score = result[eval_metric.name]
        metric_score_calibrated = result_calibrated[eval_metric.name]

        decision_threshold_dict[eval_metric.name] = dict(
            decision_threshold=decision_threshold,
            metric_score=metric_score,
            metric_score_calibrated=metric_score_calibrated,
        )

    for name, result_dict in decision_threshold_dict.items():
        decision_threshold = result_dict['decision_threshold']
        metric_score = result_dict['metric_score']
        metric_score_calibrated = result_dict['metric_score_calibrated']
        print(f'decision_threshold={decision_threshold:.3f}\t| metric="{name}"'
              f'\n\ttest_score uncalibrated: {metric_score:.4f}'
              f'\n\ttest_score   calibrated: {metric_score_calibrated:.4f}'
              f'\n\ttest_score        delta: {metric_score_calibrated-metric_score:.4f}')

```
</details>

<details>
  <summary>Example Output</summary>

```
decision_threshold=0.500	| metric="accuracy"
	test_score uncalibrated: 0.8703
	test_score   calibrated: 0.8703
	test_score        delta: 0.0000
decision_threshold=0.220	| metric="balanced_accuracy"
	test_score uncalibrated: 0.7925
	test_score   calibrated: 0.8476
	test_score        delta: 0.0551
decision_threshold=0.380	| metric="f1"
	test_score uncalibrated: 0.7022
	test_score   calibrated: 0.7245
	test_score        delta: 0.0222
decision_threshold=0.380	| metric="mcc"
	test_score uncalibrated: 0.6243
	test_score   calibrated: 0.6347
	test_score        delta: 0.0105
decision_threshold=0.990	| metric="precision"
	test_score uncalibrated: 0.7713
	test_score   calibrated: 1.0000
	test_score        delta: 0.2287
decision_threshold=0.000	| metric="recall"
	test_score uncalibrated: 0.6445
	test_score   calibrated: 1.0000
	test_score        delta: 0.3555
```
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
