### PR TITLE
Fix log to file Windows tests

### DIFF
--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -3315,6 +3315,7 @@ class TabularPredictor:
             assert predictor_path is not None, "Please either provide `predictor_path` or `log_file_path` to load the log file"
             file_path = os.path.join(predictor_path, "logs", cls._predictor_log_file_name)
         assert os.path.isfile(file_path), f"Log file does not exist at {file_path}"
+        lines = []
         with open(file_path, "r") as f:
             lines = f.readlines()
         return lines

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -1104,20 +1104,20 @@ def test_tabular_log_to_file():
     log = TabularPredictor.load_log(predictor_path=predictor.path)
     assert "TabularPredictor saved." in log[-1]
     
-    with tempfile.TemporaryDirectory() as tempdir:
-        log_file = os.path.join(tempdir, "temp.log")
-        predictor = TabularPredictor(
-            label='class',
-            log_to_file=True,
-            log_file_path=log_file
-        ).fit(
-            train_data=train_data,
-            hyperparameters={
-                "DUMMY": {}
-            }
-        )
-        log = TabularPredictor.load_log(log_file_path=log_file)
-        assert "TabularPredictor saved." in log[-1]
+    log_file = os.path.join(".", "temp.log")
+    predictor = TabularPredictor(
+        label='class',
+        log_to_file=True,
+        log_file_path=log_file
+    ).fit(
+        train_data=train_data,
+        hyperparameters={
+            "DUMMY": {}
+        }
+    )
+    log = TabularPredictor.load_log(log_file_path=log_file)
+    assert "TabularPredictor saved." in log[-1]
+    os.remove(log_file)
     
     with pytest.raises(AssertionError):
         TabularPredictor.load_log()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* tempfile behaves weird on Windows: if you create a file within the TemporaryDirectory, the directory will fail to clean up itself. Minimal reproducible example
```python
def test_foo():
    with tempfile.TemporaryDirectory() as tempdir:
        temp = os.path.join(tempdir, "abc")
        with open(temp, "r") as f:
            pass
```
pytest running test above will fail^^^
* Removed usage of tempfile


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
