### PR TITLE
Update GPU installation guide to use CUDA 11.7

### DIFF
--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -18,7 +18,7 @@ function setup_build_contrib_env {
 
 function setup_torch_gpu {
     # Security-patched torch.
-    python3 -m pip install torch==1.13.1+cu116 torchvision==0.14.1+cu116 torchaudio==0.13.1+cu116 --extra-index-url https://download.pytorch.org/whl/cu116
+    python3 -m pip install torch==1.13.1+cu117 torchvision==0.14.1+cu117 torchaudio==0.13.1+cu117 --extra-index-url https://download.pytorch.org/whl/cu117
 }
 
 function setup_torch_cpu {
@@ -27,7 +27,7 @@ function setup_torch_cpu {
 }
 
 function setup_torch_gpu_non_linux {
-    pip3 install torch==1.13.1+cu116 torchvision==0.14.1+cu116 --extra-index-url https://download.pytorch.org/whl/cu116
+    pip3 install torch==1.13.1+cu117 torchvision==0.14.1+cu117 --extra-index-url https://download.pytorch.org/whl/cu117
 }
 
 function setup_torch_cpu_non_linux {

--- a/CI/batch/docker/Dockerfile.gpu
+++ b/CI/batch/docker/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/autogluon-training:0.7.0-gpu-py39-cu117-ubuntu20.04
+FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/autogluon-training:0.6.2-gpu-py38-cu113-ubuntu20.04
 
 ARG AWSCLI_VER=1.22.45
 

--- a/CI/batch/docker/Dockerfile.gpu
+++ b/CI/batch/docker/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/autogluon-inference:0.7.0-gpu-py39-cu117-ubuntu20.04
+FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/autogluon-training:0.7.0-gpu-py39-cu117-ubuntu20.04
 
 ARG AWSCLI_VER=1.22.45
 

--- a/CI/batch/docker/Dockerfile.gpu
+++ b/CI/batch/docker/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/autogluon-training:0.6.2-gpu-py38-cu113-ubuntu20.04
+FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/autogluon-inference:0.7.0-gpu-py39-cu117-ubuntu20.04
 
 ARG AWSCLI_VER=1.22.45
 

--- a/docs/install-gpu-pip.md
+++ b/docs/install-gpu-pip.md
@@ -3,7 +3,7 @@ pip install -U pip
 pip install -U setuptools wheel
 
 # Install the proper version of PyTorch following https://pytorch.org/get-started/locally/
-pip install torch==1.13.1+cu116 torchvision==0.14.1+cu116 --extra-index-url https://download.pytorch.org/whl/cu116
+pip install torch==1.13.1+cu117 torchvision==0.14.1+cu117 --extra-index-url https://download.pytorch.org/whl/cu117
 
 pip install autogluon
 ```

--- a/docs/install-gpu-source.md
+++ b/docs/install-gpu-source.md
@@ -3,7 +3,7 @@ pip install -U pip
 pip install -U setuptools wheel
 
 # Install the proper version of PyTorch following https://pytorch.org/get-started/locally/
-pip install torch==1.13.1+cu116 torchvision==0.14.1+cu116 --extra-index-url https://download.pytorch.org/whl/cu116
+pip install torch==1.13.1+cu117 torchvision==0.14.1+cu117 --extra-index-url https://download.pytorch.org/whl/cu117
 
 git clone https://github.com/autogluon/autogluon
 cd autogluon && ./full_install.sh

--- a/docs/install-windows-gpu.md
+++ b/docs/install-windows-gpu.md
@@ -11,7 +11,7 @@ conda activate myenv
 4. Install the proper GPU PyTorch version by following the [PyTorch Install Documentation](https://pytorch.org/get-started/locally/) (Recommended). Alternatively, use the following command:
 
 ```bash
-pip install torch==1.13.1+cu116 torchvision==0.14.1+cu116 --extra-index-url https://download.pytorch.org/whl/cu116
+pip install torch==1.13.1+cu117 torchvision==0.14.1+cu117 --extra-index-url https://download.pytorch.org/whl/cu117
 ```
 
 5. Sanity check that your installation is valid and can detect your GPU via testing in Python:


### PR DESCRIPTION
*Issue #, if available:*

[Issue 2885](https://github.com/autogluon/autogluon/issues/2885)

*Description of changes:*
Update GPU installation guide to use CUDA 11.7

* Log (from Linux with GPU)
```
dev-dsk-tonyhu-2c-77435e3d % pip install torch==1.13.1+cu117 torchvision==0.14.1+cu117 --extra-index-url https://download.pytorch.org/whl/cu117

pip install autogluon
Looking in indexes: https://pypi.org/simple, https://pypi.ngc.nvidia.com, https://download.pytorch.org/whl/cu117
Collecting torch==1.13.1+cu117
  Downloading https://download.pytorch.org/whl/cu117/torch-1.13.1%2Bcu117-cp39-cp39-linux_x86_64.whl (1801.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.8/1.8 GB 61.5 MB/s eta 0:00:00
Collecting torchvision==0.14.1+cu117
  Downloading https://download.pytorch.org/whl/cu117/torchvision-0.14.1%2Bcu117-cp39-cp39-linux_x86_64.whl (24.3 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 24.3/24.3 MB 55.4 MB/s eta 0:00:00
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
