### PR TITLE
Add docstring for hyperparameter_tune_kwargs

### DIFF
--- a/docs/tutorials/tabular/tabular-indepth.ipynb
+++ b/docs/tutorials/tabular/tabular-indepth.ipynb
@@ -111,7 +111,7 @@
     "    'num_trials': num_trials,\n",
     "    'scheduler' : 'local',\n",
     "    'searcher': search_strategy,\n",
-    "}\n",
+    "}  # Refer to TabularPredictor.fit docstring for all valid values\n",
     "\n",
     "predictor = TabularPredictor(label=label, eval_metric=metric).fit(\n",
     "    train_data, tuning_data=val_data, time_limit=time_limit,\n",

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -661,7 +661,7 @@ class TabularPredictor:
                 If None, then hyperparameter tuning will not be performed.
                 You can either choose to provide a preset
                     Valid preset values:
-                        'auto': Performs HPO via bayesian optimization search on NN_TORCH and NN_FASTAI models, and random search on other models using local scheduler.
+                        'auto': Performs HPO via bayesian optimization search on NN_TORCH and FASTAI models, and random search on other models using local scheduler.
                         'random': Performs HPO via random search using local scheduler.
                 Or provide a dict to specify searchers and schedulers
                     Valid keys:
@@ -672,7 +672,7 @@ class TabularPredictor:
                         'searcher': Which searching algorithm to use
                             'local_random': Uses the 'random' searcher
                             'random': Perform random search
-                            'auto': Perform bayesian optimization search on NN_TORCH and NN_FASTAI models. Perform random search on other models.
+                            'auto': Perform bayesian optimization search on NN_TORCH and FASTAI models. Perform random search on other models.
                     The 'scheduler' and 'searcher' key are required when providing a dict.
                     An example of a valid dict:
                         hyperparameter_tune_kwargs = {

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -661,7 +661,7 @@ class TabularPredictor:
                 If None, then hyperparameter tuning will not be performed.
                 You can either choose to provide a preset
                     Valid preset values:
-                        'auto': Uses the 'random' preset.
+                        'auto': Performs HPO via bayesian optimization search on NN_TORCH and NN_FASTAI models, and random search on other models using local scheduler.
                         'random': Performs HPO via random search using local scheduler.
                 Or provide a dict to specify searchers and schedulers
                     Valid keys:

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -659,10 +659,27 @@ class TabularPredictor:
             hyperparameter_tune_kwargs : str or dict, default = None
                 Hyperparameter tuning strategy and kwargs (for example, how many HPO trials to run).
                 If None, then hyperparameter tuning will not be performed.
-                Valid preset values:
-                    'auto': Uses the 'random' preset.
-                    'random': Performs HPO via random search using local scheduler.
-                The 'searcher' key is required when providing a dict.
+                You can either choose to provide a preset
+                    Valid preset values:
+                        'auto': Uses the 'random' preset.
+                        'random': Performs HPO via random search using local scheduler.
+                Or provide a dict to specify searchers and schedulers
+                    Valid keys:
+                        'num_trials': How many HPO trials to run
+                        'scheduler': Which scheduler to use
+                            Valid values:
+                                'local': Local shceduler that schedule trials FIFO
+                        'searcher': Which searching algorithm to use
+                            'local_random': Uses the 'random' searcher
+                            'random': Perform random search
+                            'auto': Perform bayesian optimization search on NN_TORCH and NN_FASTAI models. Perform random search on other models.
+                    The 'scheduler' and 'searcher' key are required when providing a dict.
+                    An example of a valid dict:
+                        hyperparameter_tune_kwargs = {
+                            'num_trials': 5,
+                            'scheduler' : 'local',
+                            'searcher': 'auto',
+                        }
             feature_prune_kwargs: dict, default = None
                 Performs layer-wise feature pruning via recursive feature elimination with permutation feature importance.
                 This fits all models in a stack layer once, discovers a pruned set of features, fits all models in the stack layer


### PR DESCRIPTION
*Issue #, if available:*
* https://github.com/autogluon/autogluon/issues/1485

*Description of changes:*
* Added docstring for `hyperparameter_tune_kwargs`. Tutorial for search space will be added in a separate PR to speed up building process

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
