### PR TITLE
Add Experimental Zeroshot HPO

### DIFF
--- a/tabular/src/autogluon/tabular/configs/hyperparameter_configs.py
+++ b/tabular/src/autogluon/tabular/configs/hyperparameter_configs.py
@@ -93,7 +93,33 @@ hyperparameter_config_dict = dict(
         # 'IM_GREEDYTREE': [{'max_leaf_nodes': 7, 'max_leaf_nodes': 18}],
         # 'IM_BOOSTEDRULES': [{'n_estimators': 5}, {'n_estimators': 10}],
         # 'IM_HSTREE': [{'max_rules': 6}, {'max_rules': 12}, {'max_rules': 18}],
-    }
+    },
+    zeroshot_hpo= {
+        'XT': [{'min_samples_leaf': 1, 'max_leaf_nodes': 15000, 'max_features': 0.5, 'ag_args': {'name_suffix': '_r19', 'priority': 20}}],
+        'RF': [{'min_samples_leaf': 5, 'max_leaf_nodes': 50000, 'max_features': 0.5, 'ag_args': {'name_suffix': '_r5', 'priority': 19}}],
+        'GBM': [
+            {'extra_trees': False, 'feature_fraction': 0.7248284762542815, 'learning_rate': 0.07947286942946127, 'min_data_in_leaf': 50, 'num_leaves': 89, 'ag_args': {'name_suffix': '_r158', 'priority': 18}},
+            {'extra_trees': True, 'feature_fraction': 0.7832570544199176, 'learning_rate': 0.021720607471727896, 'min_data_in_leaf': 3, 'num_leaves': 21, 'ag_args': {'name_suffix': '_r118', 'priority': 17}},
+            {'extra_trees': True, 'feature_fraction': 0.7113010892989156, 'learning_rate': 0.012535427424259274, 'min_data_in_leaf': 16, 'num_leaves': 48, 'ag_args': {'name_suffix': '_r97', 'priority': 16}},
+            {'extra_trees': True, 'feature_fraction': 0.45555769907110816, 'learning_rate': 0.009591347321206594, 'min_data_in_leaf': 50, 'num_leaves': 110, 'ag_args': {'name_suffix': '_r71', 'priority': 15}},
+            {'extra_trees': False, 'feature_fraction': 0.40979710161022476, 'learning_rate': 0.008708890211023034, 'min_data_in_leaf': 3, 'num_leaves': 80, 'ag_args': {'name_suffix': '_r111', 'priority': 14}}
+        ],
+        'FASTAI': [
+            {'bs': 1024, 'emb_drop': 0.6167722379778131, 'epochs': 44, 'layers': [200, 100, 50], 'lr': 0.053440377855629266, 'ps': 0.48477211305443607, 'ag_args': {'name_suffix': '_r25', 'priority': 13}},
+            {'bs': 1024, 'emb_drop': 0.6046989241462619, 'epochs': 48, 'layers': [200, 100, 50], 'lr': 0.00775309042164966, 'ps': 0.09244767444160731, 'ag_args': {'name_suffix': '_r51', 'priority': 12}},
+            {'bs': 512, 'emb_drop': 0.6557225316526186, 'epochs': 49, 'layers': [200, 100], 'lr': 0.023627682025564638, 'ps': 0.519566584552178, 'ag_args': {'name_suffix': '_r82', 'priority': 11}},
+            {'bs': 2048, 'emb_drop': 0.4066210919034579, 'epochs': 43, 'layers': [400, 200], 'lr': 0.0029598312717673434, 'ps': 0.4378695797438974, 'ag_args': {'name_suffix': '_r121', 'priority': 10}},
+            {'bs': 128, 'emb_drop': 0.44339037504795686, 'epochs': 31, 'layers': [400, 200, 100], 'lr': 0.008615195908919904, 'ps': 0.19220253419114286, 'ag_args': {'name_suffix': '_r145', 'priority': 9}},
+            {'bs': 128, 'emb_drop': 0.12106594798980945, 'epochs': 38, 'layers': [200, 100, 50], 'lr': 0.037991970245029975, 'ps': 0.33120008492595093, 'ag_args': {'name_suffix': '_r173', 'priority': 8}},
+            {'bs': 128, 'emb_drop': 0.4599138419358, 'epochs': 47, 'layers': [200, 100], 'lr': 0.03888383281136287, 'ps': 0.28193673177122863, 'ag_args': {'name_suffix': '_r128', 'priority': 7}}
+        ],
+        'CAT': [
+            {'depth': 5, 'l2_leaf_reg': 4.774992314058497, 'learning_rate': 0.038551267822920274, 'ag_args': {'name_suffix': '_r16', 'priority': 6}},
+            {'depth': 4, 'l2_leaf_reg': 1.9950125740798321, 'learning_rate': 0.028091050379971633, 'ag_args': {'name_suffix': '_r42', 'priority': 5}},
+            {'depth': 6, 'l2_leaf_reg': 1.8298803017644376, 'learning_rate': 0.017844259810823604, 'ag_args': {'name_suffix': '_r93', 'priority': 4}},
+            {'depth': 7, 'l2_leaf_reg': 4.81099604606794, 'learning_rate': 0.019085060180573103, 'ag_args': {'name_suffix': '_r44', 'priority': 3}}
+        ],
+    },
 )
 
 # default_FTT is experimental

--- a/tabular/src/autogluon/tabular/configs/presets_configs.py
+++ b/tabular/src/autogluon/tabular/configs/presets_configs.py
@@ -55,6 +55,11 @@ tabular_presets_dict = dict(
     #  May have **extremely** slow inference speed, to a potentially unusable degree.
     experimental_extreme_quality={'auto_stack': True, 'hyperparameters': 'extreme'},
 
+    # Experimental simulated model portfolio.
+    # Shown to achieve superior results compared to best_quality on OpenML datasets <5000 rows.
+    # Note that runtimes might be much longer than usual with this config.
+    experimental_zeroshot_hpo={'auto_stack': True, 'hyperparameters': 'zeroshot_hpo'},
+
     # ------------------------------------------
     # ------------------------------------------
     # ------------------------------------------


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add Experimental Zeroshot HPO

Shown to perform well on small datasets <5000 rows, but currently struggles to outperform best quality when facing larger datasets, due to the limitations of the current benchmark suite that the simulations are generated from that will be resolved in a future update.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
