### PR TITLE
Move PyMuPDF to optional

### DIFF
--- a/docs/tutorials/multimodal/document/pdf_classification.ipynb
+++ b/docs/tutorials/multimodal/document/pdf_classification.ipynb
@@ -17,8 +17,21 @@
     "There's no worry about the receiver being unable to view the document or see an imperfect version regardless of their operating system and device models.\n",
     "\n",
     "Using AutoMM, you can handle and build machine learning models on PDF documents just like working on other modalities such as text and images, without bothering about PDFs processing. \n",
-    "In this tutorial, we will introduce how to classify PDF documents automatically with AutoMM using document foundation models. Let’s get started!"
+    "In this tutorial, we will introduce how to classify PDF documents automatically with AutoMM using document foundation models. Let’s get started!\n",
+    "\n",
+    "Install AutoGluon MultiModal with extra dependency PyMuPDF:"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "!pip install autogluon.multimodal[PyMuPDF]"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "attachments": {},

--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -75,10 +75,10 @@ extras_require = {
     ]
 }
 
-for test_package in ['PyMuPDF']:
+for test_package in ["PyMuPDF"]:
     tests_require += extras_require[test_package]
 
-extras_require['tests'] = tests_require
+extras_require["tests"] = tests_require
 
 
 if __name__ == "__main__":

--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -55,22 +55,30 @@ install_requires = [
     "jinja2>=3.0.3,<3.2",
     "tensorboard>=2.9,<3",
     "pytesseract>=0.3.9,<0.3.11",
-    "PyMuPDF<=1.21.1",
 ]
 
 install_requires = ag.get_dependency_version_ranges(install_requires)
 
+tests_require = [
+    "black>=22.3,<23.0",
+    "isort>=5.10",
+    "datasets>=2.3.2,<=2.3.2",
+    "onnx>=1.13.0,<1.14.0",
+    "onnxruntime>=1.13.0,<1.14.0;platform_system=='Darwin'",
+    "onnxruntime-gpu>=1.13.0,<1.14.0;platform_system!='Darwin'",
+    "tensorrt>=8.5.3.1,<8.5.4;platform_system=='Linux'",
+]
+
 extras_require = {
-    "tests": [
-        "black>=22.3,<23.0",
-        "isort>=5.10",
-        "datasets>=2.3.2,<=2.3.2",
-        "onnx>=1.13.0,<1.14.0",
-        "onnxruntime>=1.13.0,<1.14.0;platform_system=='Darwin'",
-        "onnxruntime-gpu>=1.13.0,<1.14.0;platform_system!='Darwin'",
-        "tensorrt>=8.5.3.1,<8.5.4;platform_system=='Linux'",
+    "PyMuPDF": [
+        "PyMuPDF<=1.21.1",
     ]
 }
+
+for test_package in ['PyMuPDF']:
+    tests_require += extras_require[test_package]
+
+extras_require['tests'] = tests_require
 
 
 if __name__ == "__main__":

--- a/multimodal/src/autogluon/multimodal/data/process_document.py
+++ b/multimodal/src/autogluon/multimodal/data/process_document.py
@@ -284,6 +284,7 @@ class DocumentProcessor:
                 # Process PDF documents.
                 if feature_modalities[per_col_name] == DOCUMENT_PDF:
                     import fitz
+
                     # Load the pdf file.
                     pdf_doc = fitz.open(per_col_image_features[0])
                     first_page = pdf_doc.load_page(0)

--- a/multimodal/src/autogluon/multimodal/data/process_document.py
+++ b/multimodal/src/autogluon/multimodal/data/process_document.py
@@ -4,7 +4,6 @@ import warnings
 from io import BytesIO
 from typing import Any, Dict, List, Optional, Union
 
-import fitz
 import numpy as np
 import PIL
 import pytesseract
@@ -284,6 +283,7 @@ class DocumentProcessor:
             try:
                 # Process PDF documents.
                 if feature_modalities[per_col_name] == DOCUMENT_PDF:
+                    import fitz
                     # Load the pdf file.
                     pdf_doc = fitz.open(per_col_image_features[0])
                     first_page = pdf_doc.load_page(0)
@@ -297,7 +297,8 @@ class DocumentProcessor:
                     with PIL.Image.open(per_col_image_features[0]) as doc_image:
                         doc_image = doc_image.convert(image_mode)
                         words, normalized_word_boxes = self.get_ocr_features(per_col_image_features[0], doc_image)
-
+            except ImportError as e:
+                raise e
             except Exception as e:
                 if self.missing_value_strategy.lower() == "zero":
                     logger.debug(f"Using a zero image due to '{e}'")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Move PyMuPDF to optional
Since PyMuPDF isn't available in Conda, better to move to an optional dependency as it is only used in a specific scenario for PDF file reading.

TODO:

- [ ] Merge into master
- [ ] Merge diff into branch 0.8.0 -> use this for conda release, don't use master

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
