### PR TITLE
Remove TIMM in core setup

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -28,7 +28,6 @@ DEPENDENT_PACKAGES = {
     'networkx': '>=3.0,<4',  # Major version cap
     'tqdm': '>=4.38,<5',  # Major version cap
     'Pillow': '>=9.3,<9.6',  # "<{N+2}" upper cap
-    'timm': '>=0.5.4,<0.7',  # "<{N+1}" upper cap
 }
 if LITE_MODE:
     DEPENDENT_PACKAGES = {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Remove TIMM in core setup, the versions did not align with multimodal, and multimodal is the only module that uses TIMM.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
