### PR TITLE
Update persist_models max_memory 0.1 -> 0.4

### DIFF
--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -2380,7 +2380,7 @@ class TabularPredictor:
                 raise ValueError(f'Unknown compiler_configs preset: "{compiler_configs}"')
         self._trainer.compile_models(model_names=models, with_ancestors=with_ancestors, compiler_configs=compiler_configs)
 
-    def persist_models(self, models='best', with_ancestors=True, max_memory=0.1) -> list:
+    def persist_models(self, models='best', with_ancestors=True, max_memory=0.4) -> list:
         """
         Persist models in memory for reduced inference latency. This is particularly important if the models are being used for online-inference where low latency is critical.
         If models are not persisted in memory, they are loaded from disk every time they are asked to make predictions.
@@ -2396,7 +2396,7 @@ class TabularPredictor:
             If True, all ancestor models of the provided models will also be persisted.
             If False, stacker models will not have the models they depend on persisted unless those models were specified in `models`. This will slow down inference as the ancestor models will still need to be loaded from disk for each predict call.
             Only relevant for stacker models.
-        max_memory : float, default = 0.1
+        max_memory : float, default = 0.4
             Proportion of total available memory to allow for the persisted models to use.
             If the models' summed memory usage requires a larger proportion of memory than max_memory, they are not persisted. In this case, the output will be an empty list.
             If None, then models are persisted regardless of estimated memory usage. This can cause out-of-memory errors.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update persist_models max_memory 0.1 -> 0.4

0.4 is a safe memory amount to persist with, as confirmed on AMLB.
This results in an average 2x batch_size=1 inference speedup for best_quality preset with no drawbacks.

```
(06_11is with `max_memory=0.1` , 06_19 is with `max_memory=0.4`)

AutoGluon_bq_1h8c_2023_06_11 | rows_per_s_mean=0.22 | rows_per_s_median=0.39
AutoGluon_bq_1h8c_2023_06_19 | rows_per_s_mean=0.35 | rows_per_s_median=0.65

AutoGluon_hq_1h8c_2023_06_11 | rows_per_s_mean=3.56 | rows_per_s_median=10.08
AutoGluon_hq_1h8c_2023_06_19 | rows_per_s_mean=5.61 | rows_per_s_median=9.84

AutoGluon_hq_il001_1h8c_2023_06_11 | rows_per_s_mean=6.9 | rows_per_s_median=37.52
AutoGluon_hq_il001_1h8c_2023_06_19 | rows_per_s_mean=12.13 | rows_per_s_median=38.26

AutoGluon_mq_1h8c_2023_06_11 | rows_per_s_mean=9.51 | rows_per_s_median=23.11
AutoGluon_mq_1h8c_2023_06_19 | rows_per_s_mean=9.94 | rows_per_s_median=21.58
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
