### PR TITLE
Fix refit crash

### DIFF
--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -3378,12 +3378,16 @@ class AbstractTrainer:
             return
 
         if model_name is None:
+            if self.has_val:
+                can_infer = True
+            else:
+                can_infer = None
             if self.model_best is not None:
-                models = self.get_model_names(can_infer=True)
+                models = self.get_model_names(can_infer=can_infer)
                 if self.model_best in models:
                     model_name = self.model_best
             if model_name is None:
-                model_name = self.get_model_best(can_infer=True)
+                model_name = self.get_model_best(can_infer=can_infer)
 
         model_full_dict = self.get_model_full_dict()
         model_name_og = model_name

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -3383,7 +3383,7 @@ class AbstractTrainer:
                 if self.model_best in models:
                     model_name = self.model_best
             if model_name is None:
-                self.get_model_best(can_infer=True)
+                model_name = self.get_model_best(can_infer=True)
 
         model_full_dict = self.get_model_full_dict()
         model_name_og = model_name

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -2605,6 +2605,8 @@ class TabularPredictor:
         self._assert_is_fit("refit_full")
         ts = time.time()
         model_best = self._get_model_best(can_infer=None)
+        if model == "best":
+            model = model_best
         logger.log(
             20,
             "Refitting models via `predictor.refit_full` using all of the data (combined train and validation)...\n"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix edge-case crash in `.refit_full('best')` when "best" differs between trainer and predictor (for example, when `WeightedEnsemble` only has 1 base model, and when predictor was fit with `_save_bag_folds=False`. Now the `"best"` model refit will be the predictor's "best" model to avoid an exception during `.predict(data)`
- Fix edge-case crash when `.fit(..., _save_bag_folds=False, calibrate=True, refit_full=False)` where no models can infer and calibration is called, resulting in an exception. Now models that can't infer can be calibrated, which after refit_full results in calibrated refit models.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
