### PR TITLE
Stable GA4 update

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ myst_enable_extensions = ['colon_fence', 'deflist', 'dollarmath', 'html_image', 
 autosummary_generate = True
 numpydoc_show_class_members = False
 
-googleanalytics_id = "UA-96378503-20"
+googleanalytics_id = "G-6XDS99SP0C"
 
 nb_execution_mode = 'force'
 # nb_execution_raise_on_error=True


### PR DESCRIPTION
*Description of changes:*
This change updates the Google Analytics identifier for the stable branch docs as described [here](https://github.com/autogluon/autogluon/pull/3330). We already did this to `master` in [this commit](https://github.com/autogluon/autogluon/commit/8af509a6a1f1249fb8d63d8c033fd5370c91143b) and verified that analytics are still working for the `/dev` web docs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
