### PR TITLE
Refactor path

### DIFF
--- a/common/src/autogluon/common/utils/utils.py
+++ b/common/src/autogluon/common/utils/utils.py
@@ -33,7 +33,7 @@ def setup_outputdir(path, warn_if_exist=True, create_dir=True, path_suffix=None)
     if path is None:
         utcnow = datetime.utcnow()
         timestamp = utcnow.strftime("%Y%m%d_%H%M%S")
-        path = f"AutogluonModels{os.path.sep}ag-{timestamp}{path_suffix}{os.path.sep}"
+        path = os.path.join("AutogluonModels", f"ag-{timestamp}{path_suffix}")
         for i in range(1, 1000):
             try:
                 if create_dir:
@@ -44,7 +44,7 @@ def setup_outputdir(path, warn_if_exist=True, create_dir=True, path_suffix=None)
                         raise FileExistsError
                     break
             except FileExistsError:
-                path = f"AutogluonModels{os.path.sep}ag-{timestamp}-{i:03d}{path_suffix}{os.path.sep}"
+                path = os.path.join("AutogluonModels", f"ag-{timestamp}-{i:03d}{path_suffix}")
         else:
             raise RuntimeError("more than 1000 jobs launched in the same second")
         logger.log(25, f'No path specified. Models will be saved in: "{path}"')
@@ -57,8 +57,6 @@ def setup_outputdir(path, warn_if_exist=True, create_dir=True, path_suffix=None)
         except FileExistsError:
             logger.warning(f'Warning: path already exists! This predictor may overwrite an existing predictor! path="{path}"')
     path = os.path.expanduser(path)  # replace ~ with absolute path if it exists
-    if path[-1] != os.path.sep:
-        path = path + os.path.sep
     return path
 
 

--- a/common/tests/unittests/test_setup_outputdir.py
+++ b/common/tests/unittests/test_setup_outputdir.py
@@ -16,19 +16,16 @@ class SetupOutputDirTestCase(unittest.TestCase):
         # checks that setup_outputdir returns a path AutogluonModels/ag-* when no path is given
         path = None
         returned_path = setup_outputdir(path, warn_if_exist=True, create_dir=False, path_suffix=None)
-        print(returned_path)
-        assert f"AutogluonModels{os.path.sep}ag" in returned_path
+        assert os.path.join("AutogluonModels", "ag") in returned_path
 
         # checks that setup_outputdir returns the path given as input when given a path of type `str`
         path = tempfile.TemporaryDirectory().name
         returned_path = setup_outputdir(path, warn_if_exist=True, create_dir=False, path_suffix=None)
-        print(returned_path)
         assert str(Path(returned_path)) == path
 
         # checks that setup_outputdir returns the path given as input when given a path of type `pathlib.Path`
         path = Path(tempfile.TemporaryDirectory().name)
         returned_path = setup_outputdir(path, warn_if_exist=True, create_dir=False, path_suffix=None)
-        print(returned_path)
         assert str(Path(returned_path)) == str(path)
 
 

--- a/core/src/autogluon/core/hpo/executors.py
+++ b/core/src/autogluon/core/hpo/executors.py
@@ -443,7 +443,7 @@ class RayHpoExecutor(HpoExecutor):
             trial_id = details.get("trial_id")
             file_id = trial_id  # unique identifier to files from this trial
             trial_model_name = os.path.join(model_name, file_id)
-            trial_model_path = model_path_root + trial_model_name + os.path.sep
+            trial_model_path = os.path.join(model_path_root, trial_model_name)
             hpo_models[trial_model_name] = dict(path=trial_model_path)
 
             hpo_models[trial_model_name] = dict(
@@ -552,7 +552,7 @@ class CustomHpoExecutor(HpoExecutor):
             # TODO: ignore models which were killed early by scheduler (eg. in Hyperband). How to ID these?
             file_id = f"T{trial+1}"  # unique identifier to files from this trial
             trial_model_name = os.path.join(model_name, file_id)
-            trial_model_path = model_path_root + trial_model_name + os.path.sep
+            trial_model_path = os.path.join(model_path_root, trial_model_name)
             trial_reward = self.scheduler.searcher.get_reward(hpo_results["config_history"][trial])
             if trial_reward is None or trial_reward == float("-inf"):
                 continue

--- a/core/src/autogluon/core/learner/abstract_learner.py
+++ b/core/src/autogluon/core/learner/abstract_learner.py
@@ -122,7 +122,7 @@ class AbstractLearner:
     # TODO: avoid re-computing paths on all models path_context -> path for v0.1
     @classmethod
     def load_info(cls, path, reset_paths=True, load_model_if_required=True):
-        load_path = path + cls.learner_info_name
+        load_path = os.path.join(path, cls.learner_info_name)
         try:
             return load_pkl.load(path=load_path)
         except Exception as e:
@@ -135,8 +135,8 @@ class AbstractLearner:
     def save_info(self, include_model_info=False):
         info = self.get_info(include_model_info=include_model_info)
 
-        save_pkl.save(path=self.path + self.learner_info_name, object=info)
-        save_json.save(path=self.path + self.learner_info_json_name, obj=info)
+        save_pkl.save(path=os.path.join(self.path, self.learner_info_name), object=info)
+        save_json.save(path=os.path.join(self.path, self.learner_info_json_name), obj=info)
         return info
 
     def get_info(self, **kwargs):

--- a/core/src/autogluon/core/learner/abstract_learner.py
+++ b/core/src/autogluon/core/learner/abstract_learner.py
@@ -49,7 +49,7 @@ class AbstractLearner:
         path_context: str
             Top-level directory where models and trainer will be saved.
         """
-        model_context = os.path.join(path_context, "models") + os.path.sep
+        model_context = os.path.join(path_context, "models")
         save_path = os.path.join(path_context, self.learner_file_name)
         return path_context, model_context, save_path
 
@@ -86,7 +86,7 @@ class AbstractLearner:
 
     @classmethod
     def load(cls, path_context, reset_paths=True):
-        load_path = path_context + cls.learner_file_name
+        load_path = os.path.join(path_context, cls.learner_file_name)
         obj = load_pkl.load(path=load_path)
         if reset_paths:
             obj.set_contexts(path_context)
@@ -113,7 +113,9 @@ class AbstractLearner:
         else:
             if self.trainer_path is None:
                 raise AssertionError("Trainer does not exist.")
-            return self.trainer_type.load(path=self.trainer_path, reset_paths=self.reset_paths)  # noqa
+            # trainer_path is used to determine if there's a trained trainer
+            # model_context contains the new trainer_path with updated context
+            return self.trainer_type.load(path=self.model_context, reset_paths=self.reset_paths)  # noqa
 
     # reset_paths=True if the learner files have changed location since fitting.
     # TODO: Potentially set reset_paths=False inside load function if it is the same path to

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -120,7 +120,7 @@ class AbstractModel:
         # v0.9 FIXME: This is a hack, change so we aren't vulnerable to self.path_root breaking things
         self.path_root = PathConverter.to_relative(self.path_root)
 
-        self.path = self.create_contexts(self.path_root + self.path_suffix)  # TODO: Make this path a function for consistency.
+        self.path = self.create_contexts(os.path.join(self.path_root, self.path_suffix))  # TODO: Make this path a function for consistency.
 
         self.num_classes = None
         self.model = None
@@ -1002,7 +1002,7 @@ class AbstractModel:
             Path to the saved model, minus the file name.
             This should generally be a directory path ending with a '/' character (or appropriate path separator value depending on OS).
             If None, self.path is used.
-            The final model file is typically saved to path + self.model_file_name.
+            The final model file is typically saved to os.path.join(path, self.model_file_name).
         verbose : bool, default True
             Whether to log the location of the saved file.
 
@@ -1037,7 +1037,7 @@ class AbstractModel:
         path : str
             Path to the saved model, minus the file name.
             This should generally be a directory path ending with a '/' character (or appropriate path separator value depending on OS).
-            The model file is typically located in path + cls.model_file_name.
+            The model file is typically located in os.path.join(path, cls.model_file_name).
         reset_paths : bool, default True
             Whether to reset the self.path value of the loaded model to be equal to path.
             It is highly recommended to keep this value as True unless accessing the original self.path value is important.
@@ -1708,7 +1708,7 @@ class AbstractModel:
 
     @classmethod
     def load_info(cls, path, load_model_if_required=True) -> dict:
-        load_path = path + cls.model_info_name
+        load_path = os.path.join(path, cls.model_info_name)
         try:
             return load_pkl.load(path=load_path)
         except:
@@ -1721,8 +1721,8 @@ class AbstractModel:
     def save_info(self) -> dict:
         info = self.get_info()
 
-        save_pkl.save(path=self.path + self.model_info_name, object=info)
-        json_path = self.path + self.model_info_json_name
+        save_pkl.save(path=os.path.join(self.path, self.model_info_name), object=info)
+        json_path = os.path.join(self.path, self.model_info_json_name)
         save_json.save(path=json_path, obj=info)
         return info
 

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -1051,6 +1051,9 @@ class AbstractModel:
             Loaded model object.
         """
         file_path = os.path.join(path, cls.model_file_name)
+        print("model load")
+        print(path)
+        print(file_path)
         model = load_pkl.load(path=file_path, verbose=verbose)
         if reset_paths:
             model.set_contexts(path)

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -70,7 +70,7 @@ class AbstractModel:
         If None, a new unique time-stamped directory is chosen.
     name : str, default = None
         Name of the subdirectory inside path where model will be saved.
-        The final model directory will be path+name+os.path.sep()
+        The final model directory will be os.path.join(path, name)
         If None, defaults to the model's class name: self.__class__.__name__
     problem_type : str, default = None
         Type of prediction problem, i.e. is this a binary/multiclass classification or regression problem (options: 'binary', 'multiclass', 'regression').
@@ -112,9 +112,6 @@ class AbstractModel:
         self.path_root = path
         if self.path_root is None:
             path_suffix = self.name
-            if len(self.name) > 0:
-                if self.name[0] != os.path.sep:
-                    path_suffix = os.path.sep + path_suffix
             # TODO: Would be ideal to not create dir, but still track that it is unique. However, this isn't possible to do without a global list of used dirs or using UUID.
             path_cur = setup_outputdir(path=None, create_dir=True, path_suffix=path_suffix)
             self.path_root = path_cur.rsplit(self.path_suffix, 1)[0]
@@ -256,7 +253,7 @@ class AbstractModel:
 
     @property
     def path_suffix(self):
-        return self.name + os.path.sep
+        return self.name
 
     def is_valid(self) -> bool:
         """
@@ -373,7 +370,10 @@ class AbstractModel:
 
     def rename(self, name: str):
         """Renames the model and updates self.path to reflect the updated name."""
-        self.path = self.path[: -len(self.name) - 1] + name + os.path.sep
+        if self.name is not None and len(self.name) > 0:
+            self.path = os.path.join(os.path.dirname(self.path), name)
+        else:
+            self.path = os.path.join(self.path, name)
         self.name = name
 
     def preprocess(self, X, preprocess_nonadaptive=True, preprocess_stateful=True, **kwargs):
@@ -1050,7 +1050,7 @@ class AbstractModel:
         model : cls
             Loaded model object.
         """
-        file_path = path + cls.model_file_name
+        file_path = os.path.join(path, cls.model_file_name)
         model = load_pkl.load(path=file_path, verbose=verbose)
         if reset_paths:
             model.set_contexts(path)

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -117,9 +117,6 @@ class AbstractModel:
             self.path_root = path_cur.rsplit(self.path_suffix, 1)[0]
             logger.log(20, f"Warning: No path was specified for model, defaulting to: {self.path_root}")
 
-        # v0.9 FIXME: This is a hack, change so we aren't vulnerable to self.path_root breaking things
-        self.path_root = PathConverter.to_relative(self.path_root)
-
         self.path = self.create_contexts(os.path.join(self.path_root, self.path_suffix))  # TODO: Make this path a function for consistency.
 
         self.num_classes = None

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -1048,9 +1048,6 @@ class AbstractModel:
             Loaded model object.
         """
         file_path = os.path.join(path, cls.model_file_name)
-        print("model load")
-        print(path)
-        print(file_path)
         model = load_pkl.load(path=file_path, verbose=verbose)
         if reset_paths:
             model.set_contexts(path)

--- a/core/src/autogluon/core/models/abstract/model_trial.py
+++ b/core/src/autogluon/core/models/abstract/model_trial.py
@@ -77,7 +77,7 @@ def init_model(args, model_cls, init_params, backend, is_bagged_model=False):
         if "hyperparameters" not in init_params:
             init_params["hyperparameters"] = {}
         init_params["hyperparameters"].update(args)
-    init_params["name"] = init_params["name"] + os.path.sep + file_prefix
+    init_params["name"] = os.path.join(init_params["name"], file_prefix)
 
     return model_cls(**init_params)
 

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -954,7 +954,7 @@ class BaggedEnsembleModel(AbstractModel):
     @classmethod
     def load_oof(cls, path, verbose=True):
         try:
-            oof = load_pkl.load(path=os.path.join(path + "utils", cls._oof_filename), verbose=verbose)
+            oof = load_pkl.load(path=os.path.join(path, "utils", cls._oof_filename), verbose=verbose)
             oof_pred_proba = oof["_oof_pred_proba"]
             oof_pred_model_repeats = oof["_oof_pred_model_repeats"]
         except FileNotFoundError:
@@ -968,7 +968,7 @@ class BaggedEnsembleModel(AbstractModel):
         if self._oof_pred_proba is not None:
             pass
         else:
-            oof = load_pkl.load(path=os.path.join(self.path + "utils", self._oof_filename))
+            oof = load_pkl.load(path=os.path.join(self.path, "utils", self._oof_filename))
             self._oof_pred_proba = oof["_oof_pred_proba"]
             self._oof_pred_model_repeats = oof["_oof_pred_model_repeats"]
 
@@ -992,10 +992,10 @@ class BaggedEnsembleModel(AbstractModel):
         return model_names
 
     def load_model_base(self):
-        return load_pkl.load(path=os.path.join(self.path + "utils", "model_template.pkl"))
+        return load_pkl.load(path=os.path.join(self.path, "utils", "model_template.pkl"))
 
     def save_model_base(self, model_base):
-        save_pkl.save(path=os.path.join(self.path + "utils", "model_template.pkl"), object=model_base)
+        save_pkl.save(path=os.path.join(self.path, "utils", "model_template.pkl"), object=model_base)
 
     def save(self, path=None, verbose=True, save_oof=True, save_children=False) -> str:
         if path is None:
@@ -1007,7 +1007,7 @@ class BaggedEnsembleModel(AbstractModel):
 
         if save_oof and self._oof_pred_proba is not None:
             save_pkl.save(
-                path=os.path.join(path + "utils", self._oof_filename),
+                path=os.path.join(path, "utils", self._oof_filename),
                 object={
                     "_oof_pred_proba": self._oof_pred_proba,
                     "_oof_pred_model_repeats": self._oof_pred_model_repeats,
@@ -1029,20 +1029,20 @@ class BaggedEnsembleModel(AbstractModel):
         super().reduce_memory_size(remove_fit=remove_fit, remove_info=remove_info, requires_save=requires_save, **kwargs)
         if remove_fit_stack:
             try:
-                os.remove(os.path.join(self.path + "utils", self._oof_filename))
+                os.remove(os.path.join(self.path, "utils", self._oof_filename))
             except FileNotFoundError:
                 pass
             if requires_save:
                 self._oof_pred_proba = None
                 self._oof_pred_model_repeats = None
             try:
-                os.remove(os.path.join(self.path + "utils", "model_template.pkl"))
+                os.remove(os.path.join(self.path, "utils", "model_template.pkl"))
             except FileNotFoundError:
                 pass
             if requires_save:
                 self.model_base = None
             try:
-                os.rmdir(self.path + "utils")
+                os.rmdir(self.path, "utils")
             except OSError:
                 pass
         if reduce_children:

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -1042,7 +1042,7 @@ class BaggedEnsembleModel(AbstractModel):
             if requires_save:
                 self.model_base = None
             try:
-                os.rmdir(self.path, "utils")
+                os.rmdir(os.path.join(self.path, "utils"))
             except OSError:
                 pass
         if reduce_children:

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -374,7 +374,7 @@ class BaggedEnsembleModel(AbstractModel):
         if self._n_repeats != 0:
             raise ValueError(f"n_repeats must equal 0 when fitting a single model with k_fold == 1, value: {self._n_repeats}")
         model_base.name = f"{model_base.name}S1F1"
-        model_base.set_contexts(path_context=self.path + model_base.name + os.path.sep)
+        model_base.set_contexts(path_context=os.path.join(self.path, model_base.name))
         time_start_fit = time.time()
         model_base.fit(X=X, y=y, time_limit=time_limit, **kwargs)
         model_base.fit_time = time.time() - time_start_fit
@@ -748,7 +748,7 @@ class BaggedEnsembleModel(AbstractModel):
 
     def load_child(self, model: Union[AbstractModel, str], verbose=False) -> AbstractModel:
         if isinstance(model, str):
-            child_path = self.create_contexts(self.path + model + os.path.sep)
+            child_path = self.create_contexts(os.path.join(self.path, model))
             return self._child_type.load(path=child_path, verbose=verbose)
         else:
             return model
@@ -788,7 +788,7 @@ class BaggedEnsembleModel(AbstractModel):
         if path is None:
             path = self.path
         child = self.load_child(model)
-        child.set_contexts(path + child.name + os.path.sep)
+        child.set_contexts(os.path.join(path, child.name))
         child.save(verbose=verbose)
 
     def can_compile(self, compiler_configs=None):
@@ -975,7 +975,7 @@ class BaggedEnsembleModel(AbstractModel):
     def persist_child_models(self, reset_paths=True):
         for i, model_name in enumerate(self.models):
             if isinstance(model_name, str):
-                child_path = self.create_contexts(self.path + model_name + os.path.sep)
+                child_path = self.create_contexts(os.path.join(self.path, model_name))
                 child_model = self._child_type.load(path=child_path, reset_paths=reset_paths, verbose=True)
                 self.models[i] = child_model
 
@@ -1136,7 +1136,7 @@ class BaggedEnsembleModel(AbstractModel):
         child_info_dict = dict()
         for model in self.models:
             if isinstance(model, str):
-                child_path = self.create_contexts(self.path + model + os.path.sep)
+                child_path = self.create_contexts(os.path.join(self.path, model))
                 child_info_dict[model] = self._child_type.load_info(child_path)
             else:
                 child_info_dict[model.name] = model.get_info()

--- a/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
+++ b/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
@@ -322,7 +322,7 @@ class SequentialLocalFoldFittingStrategy(FoldFittingStrategy):
         y_fold, y_val_fold = self.y.iloc[train_index], self.y.iloc[val_index]
         fold_model = copy.deepcopy(model_base)
         fold_model.name = f"{fold_model.name}{model_name_suffix}"
-        fold_model.set_contexts(self.bagged_ensemble_model.path + fold_model.name + os.path.sep)
+        fold_model.set_contexts(os.path.join(self.bagged_ensemble_model.path, fold_model.name))
         kwargs_fold = kwargs.copy()
         is_pseudo = self.X_pseudo is not None and self.y_pseudo is not None
         if self.sample_weight is not None:
@@ -379,7 +379,7 @@ def _ray_fit(
     train_index, val_index = fold
     fold_model = copy.deepcopy(model_base)
     fold_model.name = f"{fold_model.name}{model_name_suffix}"
-    fold_model_local_save_path = bagged_ensemble_model_path + fold_model.name + os.path.sep
+    fold_model_local_save_path = os.path.join(bagged_ensemble_model_path, fold_model.name)
     fold_model.set_contexts(fold_model_local_save_path)
     if type(X) == str and type(y) == str:
         with open(X, "rb") as X_f, open(y, "rb") as y_f:

--- a/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
+++ b/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
@@ -555,7 +555,7 @@ class ParallelFoldFittingStrategy(FoldFittingStrategy):
                     model_sync_path: str = self.model_sync_path + fold_model
                     if not model_sync_path.endswith("/"):
                         model_sync_path += "/"
-                self.sync_model_artifact(local_path=os.path.join(self.bagged_ensemble_model.path + fold_model), model_sync_path=model_sync_path)
+                self.sync_model_artifact(local_path=os.path.join(self.bagged_ensemble_model.path, fold_model), model_sync_path=model_sync_path)
             except TimeLimitExceeded:
                 # Terminate all ray tasks because a fold failed
                 self.terminate_all_unfinished_tasks(unfinished)

--- a/core/src/autogluon/core/models/ensemble/stacker_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/stacker_ensemble_model.py
@@ -55,11 +55,6 @@ class StackerEnsembleModel(BaggedEnsembleModel):
         self.base_model_names = base_model_names
         self.base_models_dict: Dict[str, AbstractModel] = base_models_dict  # String name -> Model objects
         self.base_model_paths_dict = {key: os.path.relpath(val, self.path) for key, val in base_model_paths_dict.items()}
-        print(self.base_model_paths_dict)
-
-        # FIXME: DO NOT DO THIS, FIX ASAP
-        self.base_model_paths_dict = {k: PathConverter.to_relative(v) for k, v in self.base_model_paths_dict.items()}
-
         self.base_model_types_dict = base_model_types_dict
 
         # TODO: Consider deleting these variables after initialization

--- a/core/src/autogluon/core/models/ensemble/stacker_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/stacker_ensemble_model.py
@@ -172,11 +172,11 @@ class StackerEnsembleModel(BaggedEnsembleModel):
         path_root_orig = self.path_root
         path_root_orig = PathConverter.to_current(path_root_orig)
         self.path_root = path_root_orig
-        abs_path_root_orig = os.path.abspath(path_root_orig) + os.path.sep
+        abs_path_root_orig = os.path.abspath(path_root_orig)
         self.base_model_paths_dict = {model: PathConverter.to_current(model_path) for model, model_path in self.base_model_paths_dict.items()}
         super().set_contexts(path_context=path_context)
         for model, model_path in self.base_model_paths_dict.items():
-            model_path = os.path.abspath(model_path) + os.path.sep
+            model_path = os.path.abspath(model_path)
             model_local_path = model_path.split(abs_path_root_orig, 1)[1]
             self.base_model_paths_dict[model] = self.path_root + model_local_path
 

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -1116,7 +1116,7 @@ class AbstractTrainer:
         model_type = self.get_model_attribute(model=model, attribute="type")
         if issubclass(model_type, BaggedEnsembleModel):
             model_path = self.get_model_attribute(model=model, attribute="path")
-            return model_type.load_oof(path=model_path)
+            return model_type.load_oof(path=os.path.join(self.path, model_path))
         else:
             raise AssertionError(f"Model {model} must be a BaggedEnsembleModel to return oof_pred_proba")
 
@@ -1561,7 +1561,7 @@ class AbstractTrainer:
             return self.models[model_name]
         else:
             if path is None:
-                path = self.get_model_attribute(model=model_name, attribute="path")
+                path = self.get_model_attribute(model=model_name, attribute="path")  # get relative location of the model to the trainer
             if model_type is None:
                 model_type = self.get_model_attribute(model=model_name, attribute="type")
             return model_type.load(path=os.path.join(self.path, path), reset_paths=self.reset_paths)
@@ -2033,7 +2033,7 @@ class AbstractTrainer:
                 model_names_trained = []
                 self._extra_banned_names.add(model.name)
                 for model_hpo_name, model_info in hpo_models.items():
-                    model_hpo = self.load_model(model_hpo_name, path=model_info["path"], model_type=type(model))
+                    model_hpo = self.load_model(model_hpo_name, path=os.path.relpath(model_info["path"], self.path), model_type=type(model))
                     logger.log(20, f"Fitted model: {model_hpo.name} ...")
                     if self._add_model(model=model_hpo, stack_name=stack_name, level=level):
                         model_names_trained.append(model_hpo.name)

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -1842,7 +1842,9 @@ class AbstractTrainer:
             # Cache y_pred_proba_val for later reuse to avoid redundant predict calls
             self._save_model_y_pred_proba_val(model=model.name, y_pred_proba_val=y_pred_proba_val)
             extra_attributes["cached_y_pred_proba_val"] = True
-
+        
+        print(model.path)
+        print(self.path)
         self.model_graph.add_node(
             model.name,
             fit_time=model.fit_time,

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -178,7 +178,7 @@ class AbstractTrainer:
     # path_root is the directory containing learner.pkl
     @property
     def path_root(self) -> str:
-        return self.path.rsplit(os.path.sep, maxsplit=2)[0]
+        return os.path.dirname(self.path)
 
     @property
     def path_utils(self) -> str:
@@ -1559,9 +1559,6 @@ class AbstractTrainer:
                 path = self.get_model_attribute(model=model_name, attribute="path")  # get relative location of the model to the trainer
             if model_type is None:
                 model_type = self.get_model_attribute(model=model_name, attribute="type")
-            print("trainer load_model")
-            print(path)
-            print(self.path)
             return model_type.load(path=os.path.join(self.path, path), reset_paths=self.reset_paths)
 
     def unpersist_models(self, model_names="all") -> list:
@@ -1843,11 +1840,6 @@ class AbstractTrainer:
             self._save_model_y_pred_proba_val(model=model.name, y_pred_proba_val=y_pred_proba_val)
             extra_attributes["cached_y_pred_proba_val"] = True
 
-        print("_add_model")
-        print(model.path)
-        print(self.path)
-        print(os.path.relpath(model.path, self.path))
-        print("exit _add_model")
         self.model_graph.add_node(
             model.name,
             fit_time=model.fit_time,

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -183,16 +183,16 @@ class AbstractTrainer:
 
     @property
     def path_utils(self) -> str:
-        return self.path_root + "utils" + os.path.sep
+        return str(Path(self.path_root) / "utils")
 
     @property
     def _path_attr(self) -> str:
         """Path to cached model graph attributes"""
-        return f"{self.path_utils}attr{os.path.sep}"
+        return str(Path(self.path_utils) / "attr")
 
     @property
     def path_data(self) -> str:
-        return self.path_utils + "data" + os.path.sep
+        return str(Path(self.path_utils) / "data")
 
     @property
     def has_val(self) -> bool:
@@ -201,25 +201,25 @@ class AbstractTrainer:
 
     def load_X(self):
         if self._X_saved:
-            path = self.path_data + "X.pkl"
+            path = str(Path(self.path_data) / "X.pkl")
             return load_pkl.load(path=path)
         return None
 
     def load_X_val(self):
         if self._X_val_saved:
-            path = self.path_data + "X_val.pkl"
+            path = str(Path(self.path_data) / "X_val.pkl")
             return load_pkl.load(path=path)
         return None
 
     def load_y(self):
         if self._y_saved:
-            path = self.path_data + "y.pkl"
+            path = str(Path(self.path_data) / "y.pkl")
             return load_pkl.load(path=path)
         return None
 
     def load_y_val(self):
         if self._y_val_saved:
-            path = self.path_data + "y_val.pkl"
+            path = str(Path(self.path_data) / "y_val.pkl")
             return load_pkl.load(path=path)
         return None
 
@@ -232,22 +232,22 @@ class AbstractTrainer:
         return X, y, X_val, y_val
 
     def save_X(self, X, verbose=True):
-        path = self.path_data + "X.pkl"
+        path = str(Path(self.path_data) / "X.pkl")
         save_pkl.save(path=path, object=X, verbose=verbose)
         self._X_saved = True
 
     def save_X_val(self, X, verbose=True):
-        path = self.path_data + "X_val.pkl"
+        path = str(Path(self.path_data) / "X_val.pkl")
         save_pkl.save(path=path, object=X, verbose=verbose)
         self._X_val_saved = True
 
     def save_y(self, y, verbose=True):
-        path = self.path_data + "y.pkl"
+        path = str(Path(self.path_data) / "y.pkl")
         save_pkl.save(path=path, object=y, verbose=verbose)
         self._y_saved = True
 
     def save_y_val(self, y, verbose=True):
-        path = self.path_data + "y_val.pkl"
+        path = str(Path(self.path_data) / "y_val.pkl")
         save_pkl.save(path=path, object=y, verbose=verbose)
         self._y_val_saved = True
 
@@ -1892,11 +1892,11 @@ class AbstractTrainer:
 
     def _path_attr_model(self, model: str):
         """Returns directory where attributes are cached"""
-        return f"{self._path_attr}{model}{os.path.sep}"
+        return str(Path(self._path_attr) / model)
 
     def _path_to_model_attr(self, model: str, attribute: str):
         """Returns pkl file path for a cached model attribute"""
-        return f"{self._path_attr_model(model)}{attribute}.pkl"
+        return str(Path(self._path_attr_model(model)) / f"{attribute}.pkl")
 
     def _save_model_y_pred_proba_val(self, model: str, y_pred_proba_val):
         """Cache y_pred_proba_val for later reuse to avoid redundant predict calls"""
@@ -2926,10 +2926,10 @@ class AbstractTrainer:
     ):
         if remove_data and self.is_data_saved:
             data_files = [
-                self.path_data + "X.pkl",
-                self.path_data + "X_val.pkl",
-                self.path_data + "y.pkl",
-                self.path_data + "y_val.pkl",
+                str(Path(self.path_data) / "X.pkl"),
+                str(Path(self.path_data) / "X_val.pkl"),
+                str(Path(self.path_data) / "y.pkl"),
+                str(Path(self.path_data) / "y_val.pkl"),
             ]
             for data_file in data_files:
                 try:

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -183,16 +183,16 @@ class AbstractTrainer:
 
     @property
     def path_utils(self) -> str:
-        return str(Path(self.path_root) / "utils")
+        return os.path.join(self.path_root, "utils")
 
     @property
     def _path_attr(self) -> str:
         """Path to cached model graph attributes"""
-        return str(Path(self.path_utils) / "attr")
+        return os.path.join(self.path_utils, "attr")
 
     @property
     def path_data(self) -> str:
-        return str(Path(self.path_utils) / "data")
+        return os.path.join(self.path_utils, "data")
 
     @property
     def has_val(self) -> bool:
@@ -201,25 +201,25 @@ class AbstractTrainer:
 
     def load_X(self):
         if self._X_saved:
-            path = str(Path(self.path_data) / "X.pkl")
+            path = os.path.join(self.path_data, "X.pkl")
             return load_pkl.load(path=path)
         return None
 
     def load_X_val(self):
         if self._X_val_saved:
-            path = str(Path(self.path_data) / "X_val.pkl")
+            path = os.path.join(self.path_data, "X_val.pkl")
             return load_pkl.load(path=path)
         return None
 
     def load_y(self):
         if self._y_saved:
-            path = str(Path(self.path_data) / "y.pkl")
+            path = os.path.join(self.path_data, "y.pkl")
             return load_pkl.load(path=path)
         return None
 
     def load_y_val(self):
         if self._y_val_saved:
-            path = str(Path(self.path_data) / "y_val.pkl")
+            path = os.path.join(self.path_data, "y_val.pkl")
             return load_pkl.load(path=path)
         return None
 
@@ -232,22 +232,22 @@ class AbstractTrainer:
         return X, y, X_val, y_val
 
     def save_X(self, X, verbose=True):
-        path = str(Path(self.path_data) / "X.pkl")
+        path = os.path.join(self.path_data, "X.pkl")
         save_pkl.save(path=path, object=X, verbose=verbose)
         self._X_saved = True
 
     def save_X_val(self, X, verbose=True):
-        path = str(Path(self.path_data) / "X_val.pkl")
+        path = os.path.join(self.path_data, "X_val.pkl")
         save_pkl.save(path=path, object=X, verbose=verbose)
         self._X_val_saved = True
 
     def save_y(self, y, verbose=True):
-        path = str(Path(self.path_data) / "y.pkl")
+        path = os.path.join(self.path_data, "y.pkl")
         save_pkl.save(path=path, object=y, verbose=verbose)
         self._y_saved = True
 
     def save_y_val(self, y, verbose=True):
-        path = str(Path(self.path_data) / "y_val.pkl")
+        path = os.path.join(self.path_data, "y_val.pkl")
         save_pkl.save(path=path, object=y, verbose=verbose)
         self._y_val_saved = True
 
@@ -1891,11 +1891,11 @@ class AbstractTrainer:
 
     def _path_attr_model(self, model: str):
         """Returns directory where attributes are cached"""
-        return str(Path(self._path_attr) / model)
+        return os.path.join(self._path_attr, model)
 
     def _path_to_model_attr(self, model: str, attribute: str):
         """Returns pkl file path for a cached model attribute"""
-        return str(Path(self._path_attr_model(model)) / f"{attribute}.pkl")
+        return os.path.join(self._path_attr_model(model), f"{attribute}.pkl")
 
     def _save_model_y_pred_proba_val(self, model: str, y_pred_proba_val):
         """Cache y_pred_proba_val for later reuse to avoid redundant predict calls"""
@@ -2925,10 +2925,10 @@ class AbstractTrainer:
     ):
         if remove_data and self.is_data_saved:
             data_files = [
-                str(Path(self.path_data) / "X.pkl"),
-                str(Path(self.path_data) / "X_val.pkl"),
-                str(Path(self.path_data) / "y.pkl"),
-                str(Path(self.path_data) / "y_val.pkl"),
+                os.path.join(self.path_data, "X.pkl"),
+                os.path.join(self.path_data, "X_val.pkl"),
+                os.path.join(self.path_data, "y.pkl"),
+                os.path.join(self.path_data, "y_val.pkl"),
             ]
             for data_file in data_files:
                 try:

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -1842,7 +1842,7 @@ class AbstractTrainer:
             # Cache y_pred_proba_val for later reuse to avoid redundant predict calls
             self._save_model_y_pred_proba_val(model=model.name, y_pred_proba_val=y_pred_proba_val)
             extra_attributes["cached_y_pred_proba_val"] = True
-        
+
         print(model.path)
         print(self.path)
         print(os.path.relpath(model.path, self.path))

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -1564,7 +1564,7 @@ class AbstractTrainer:
                 path = self.get_model_attribute(model=model_name, attribute="path")
             if model_type is None:
                 model_type = self.get_model_attribute(model=model_name, attribute="type")
-            return model_type.load(path=path, reset_paths=self.reset_paths)
+            return model_type.load(path=os.path.join(self.path, path), reset_paths=self.reset_paths)
 
     def unpersist_models(self, model_names="all") -> list:
         if model_names == "all":
@@ -1845,6 +1845,7 @@ class AbstractTrainer:
         
         print(model.path)
         print(self.path)
+        print(os.path.relpath(model.path, self.path))
         self.model_graph.add_node(
             model.name,
             fit_time=model.fit_time,

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -101,7 +101,6 @@ class AbstractTrainer:
         verbosity=2,
     ):
         self.path = path
-        self.path = PathConverter.to_relative(self.path)
         self.problem_type = problem_type
         self.feature_metadata = feature_metadata
         self.save_data = save_data

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -2629,7 +2629,10 @@ class AbstractTrainer:
                 if not isinstance(model, str):
                     model = model.name
                 model_names.append(model)
-            models_attribute_dict = {key: val for key, val in models_attribute_dict.items() if key in model_names}
+            if attribute == "path":
+                models_attribute_dict = {key: os.path.join(*val) for key, val in models_attribute_dict.items() if key in model_names}
+            else:
+                models_attribute_dict = {key: val for key, val in models_attribute_dict.items() if key in model_names}
         return models_attribute_dict
 
     def get_model_attribute(self, model, attribute: str, **kwargs):

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -1849,7 +1849,7 @@ class AbstractTrainer:
             predict_child_time=predict_child_time,
             predict_1_child_time=predict_1_child_time,
             val_score=model.val_score,
-            path=os.path.relpath(model.path, self.path),  # model's relative path to trainer
+            path=os.path.relpath(model.path, self.path).split(os.sep),  # model's relative path to trainer
             type=type(model),  # Outer type, can be BaggedEnsemble, StackEnsemble (Type that is able to load the model)
             type_inner=type_inner,  # Inner type, if Ensemble then it is the type of the inner model (May not be able to load with this type)
             can_infer=model.can_infer(),
@@ -2647,6 +2647,8 @@ class AbstractTrainer:
                 return kwargs["default"]
             else:
                 raise ValueError(f"Model does not contain attribute: (model={model}, attribute={attribute})")
+        if attribute == "path":
+            return os.path.join(*self.model_graph.nodes[model][attribute])
         return self.model_graph.nodes[model][attribute]
 
     def set_model_attribute(self, model, attribute: str, val):

--- a/multimodal/tests/unittests/others/test_save_path.py
+++ b/multimodal/tests/unittests/others/test_save_path.py
@@ -130,9 +130,9 @@ def test_continuous_training_save_path():
 
     # continue training
     predictor.fit(train_data=dataset.train_df, time_limit=10)
-    assert predictor.path != abs_path and f"AutogluonModels{os.path.sep}ag-" in predictor.path
+    assert predictor.path != abs_path and os.path.join("AutogluonModels", "ag-") in predictor.path
 
     # load a saved predictor and continue training
     predictor_loaded = MultiModalPredictor.load(save_path)
     predictor_loaded.fit(train_data=dataset.train_df, time_limit=10)
-    assert predictor_loaded.path != abs_path and f"AutogluonModels{os.path.sep}ag-" in predictor.path
+    assert predictor_loaded.path != abs_path and os.path.join("AutogluonModels", "ag-") in predictor.path

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -115,7 +115,7 @@ class CatBoostModel(AbstractModel):
                 except:
                     pass
                 else:
-                    params["train_dir"] = self.path + "catboost_info"
+                    params["train_dir"] = os.path.join(self.path, "catboost_info")
 
         # TODO: Add more control over these params (specifically early_stopping_rounds)
         verbosity = kwargs.get("verbosity", 2)

--- a/tabular/src/autogluon/tabular/models/fasttext/fasttext_model.py
+++ b/tabular/src/autogluon/tabular/models/fasttext/fasttext_model.py
@@ -143,7 +143,7 @@ class FastTextModel(AbstractModel):
         # save fasttext model: fasttext model cannot be pickled; saved it separately
         # TODO: s3 support
         if self._load_model:
-            fasttext_model_file_name = path + self.model_bin_file_name
+            fasttext_model_file_name = os.path.join(path, self.model_bin_file_name)
             self.model.save_model(fasttext_model_file_name)
         self._load_model = None
         return path
@@ -157,7 +157,7 @@ class FastTextModel(AbstractModel):
             try_import_fasttext()
             import fasttext
 
-            fasttext_model_file_name = model.path + cls.model_bin_file_name
+            fasttext_model_file_name = os.path.join(model.path, cls.model_bin_file_name)
             # TODO: hack to subpress a deprecation warning from fasttext
             # remove it once official fasttext is updated beyond 0.9.2
             # https://github.com/facebookresearch/fastText/issues/1067

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -298,14 +298,14 @@ class LGBModel(AbstractModel):
                 y_val = None
 
         # X, W_train = self.convert_to_weight(X=X)
-        dataset_train = construct_dataset(x=X, y=y, location=f"{self.path}datasets{os.path.sep}train", params=data_params, save=save, weight=sample_weight)
+        dataset_train = construct_dataset(x=X, y=y, location=os.path.join("self.path", "datasets", "train"), params=data_params, save=save, weight=sample_weight)
         # dataset_train = construct_dataset_lowest_memory(X=X, y=y, location=self.path + 'datasets/train', params=data_params)
         if X_val is not None:
             # X_val, W_val = self.convert_to_weight(X=X_val)
             dataset_val = construct_dataset(
                 x=X_val,
                 y=y_val,
-                location=f"{self.path}datasets{os.path.sep}val",
+                location=os.path.join(self.path, "datasets", "val"),
                 reference=dataset_train,
                 params=data_params,
                 save=save,

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -298,7 +298,9 @@ class LGBModel(AbstractModel):
                 y_val = None
 
         # X, W_train = self.convert_to_weight(X=X)
-        dataset_train = construct_dataset(x=X, y=y, location=os.path.join("self.path", "datasets", "train"), params=data_params, save=save, weight=sample_weight)
+        dataset_train = construct_dataset(
+            x=X, y=y, location=os.path.join("self.path", "datasets", "train"), params=data_params, save=save, weight=sample_weight
+        )
         # dataset_train = construct_dataset_lowest_memory(X=X, y=y, location=self.path + 'datasets/train', params=data_params)
         if X_val is not None:
             # X_val, W_val = self.convert_to_weight(X=X_val)

--- a/tabular/src/autogluon/tabular/models/rf/compilers/native.py
+++ b/tabular/src/autogluon/tabular/models/rf/compilers/native.py
@@ -32,12 +32,12 @@ class AbstractNativeCompiler:
     @staticmethod
     def save(model, path: str):
         os.makedirs(os.path.dirname(path), exist_ok=True)
-        with open(path + "model_native.pkl", "wb") as fp:
+        with open(os.path.join(path, "model_native.pkl"), "wb") as fp:
             fp.write(pickle.dumps(model))
 
     @staticmethod
     def load(path: str):
-        with open(path + "model_native.pkl", "rb") as fp:
+        with open(os.path.join(path, "model_native.pkl"), "rb") as fp:
             pkl = fp.read()
         return pickle.loads(pkl)
 

--- a/tabular/src/autogluon/tabular/models/rf/compilers/onnx.py
+++ b/tabular/src/autogluon/tabular/models/rf/compilers/onnx.py
@@ -110,14 +110,14 @@ class RFOnnxCompiler:
     def save(model, path: str) -> str:
         """Save the compiled model into onnx file format."""
         os.makedirs(os.path.dirname(path), exist_ok=True)
-        with open(path + "model.onnx", "wb") as f:
+        with open(os.path.join(path, "model.onnx"), "wb") as f:
             f.write(model.SerializeToString())
-        return path + "model.onnx"
+        return os.path.join(path, "model.onnx")
 
     @staticmethod
     def load(path: str) -> RFOnnxPredictor:
         """Load from the path that contains an onnx file."""
         import onnx
 
-        onnx_bytes = onnx.load(path + "model.onnx")
+        onnx_bytes = onnx.load(os.path.join(path, "model.onnx"))
         return RFOnnxPredictor(model=onnx_bytes)

--- a/tabular/src/autogluon/tabular/models/tab_transformer/tab_transformer_model.py
+++ b/tabular/src/autogluon/tabular/models/tab_transformer/tab_transformer_model.py
@@ -340,7 +340,7 @@ class TabTransformerModel(AbstractNeuralNetworkModel):
 
                     best_val_epoch = e
                     os.makedirs(os.path.dirname(self.path), exist_ok=True)
-                    torch.save(self.model, self.path + self._temp_file_name)
+                    torch.save(self.model, os.path.join(self.path, self._temp_file_name))
 
             # If time limit has exceeded or we haven't improved in some number of epochs, stop early.
             if e - best_val_epoch > epochs_wo_improve:
@@ -354,8 +354,8 @@ class TabTransformerModel(AbstractNeuralNetworkModel):
 
         if loader_val is not None:
             try:
-                self.model = torch.load(self.path + self._temp_file_name)
-                os.remove(self.path + self._temp_file_name)
+                self.model = torch.load(os.path.join(self.path, self._temp_file_name))
+                os.remove(os.path.join(self.path, self._temp_file_name))
             except:
                 pass
             logger.log(15, "Best model found in epoch %d" % best_val_epoch)
@@ -489,7 +489,7 @@ class TabTransformerModel(AbstractNeuralNetworkModel):
         if path is None:
             path = self.path
 
-        params_filepath = path + self.params_file_name
+        params_filepath = os.path.join(path, self.params_file_name)
 
         os.makedirs(os.path.dirname(path), exist_ok=True)
 
@@ -508,11 +508,11 @@ class TabTransformerModel(AbstractNeuralNetworkModel):
     def load(cls, path: str, reset_paths=False, verbose=True):
         import torch
 
-        obj: TabTransformerModel = load_pkl.load(path=path + cls.model_file_name, verbose=verbose)
+        obj: TabTransformerModel = load_pkl.load(path=os.path.join(path, cls.model_file_name), verbose=verbose)
         if reset_paths:
             obj.set_contexts(path)
 
-        obj.model = torch.load(path + cls.params_file_name)
+        obj.model = torch.load(os.path.join(path, cls.params_file_name))
 
         return obj
 

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -597,7 +597,7 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
         path : str
             Path to the saved model, minus the file name.
             This should generally be a directory path ending with a '/' character (or appropriate path separator value depending on OS).
-            The model file is typically located in path + cls.model_file_name.
+            The model file is typically located in os.path.join(path, cls.model_file_name).
         reset_paths : bool, default True
             Whether to reset the self.path value of the loaded model to be equal to path.
             It is highly recommended to keep this value as True unless accessing the original self.path value is important.

--- a/tabular/src/autogluon/tabular/models/vowpalwabbit/vowpalwabbit_model.py
+++ b/tabular/src/autogluon/tabular/models/vowpalwabbit/vowpalwabbit_model.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 
 import numpy as np

--- a/tabular/src/autogluon/tabular/models/vowpalwabbit/vowpalwabbit_model.py
+++ b/tabular/src/autogluon/tabular/models/vowpalwabbit/vowpalwabbit_model.py
@@ -183,7 +183,7 @@ class VowpalWabbitModel(AbstractModel):
         self.model = __model
         # Export model
         if self._load_model:
-            file_path = path + self.model_internals_file_name
+            file_path = os.path.join(path, self.model_internals_file_name)
             self.model.save(file_path)
         self._load_model = None
         return path
@@ -203,7 +203,7 @@ class VowpalWabbitModel(AbstractModel):
         params = model._get_model_params()
         # Load the internal model file
         if model._load_model:
-            file_path = path + cls.model_internals_file_name
+            file_path = os.path.join(path, cls.model_internals_file_name)
 
             model_load_params = f" -i {file_path} --quiet"
             if model.problem_type in PROBLEM_TYPES_CLASSIFICATION:

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 
 from autogluon.common.features.types import R_BOOL, R_CATEGORY, R_FLOAT, R_INT
@@ -206,7 +207,7 @@ class XGBoostModel(AbstractModel):
         path = super().save(path=path, verbose=verbose)
         if _model is not None:
             # Halves disk usage compared to .json / .pkl
-            _model.save_model(path + "xgb.ubj")
+            _model.save_model(os.path.join(path, "xgb.ubj"))
         self.model = _model
         return path
 
@@ -216,7 +217,7 @@ class XGBoostModel(AbstractModel):
         if model._xgb_model_type is not None:
             model.model = model._xgb_model_type()
             # Much faster to load using .ubj than .json (10x+ speedup)
-            model.model.load_model(path + "xgb.ubj")
+            model.model.load_model(os.path.join(path, "xgb.ubj"))
             model._xgb_model_type = None
         return model
 

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -3593,7 +3593,7 @@ class TabularPredictor:
         """
         Inner load method, called in `load`.
         """
-        predictor: TabularPredictor = load_pkl.load(path=path + cls.predictor_file_name)
+        predictor: TabularPredictor = load_pkl.load(path=os.path.join(path + cls.predictor_file_name))
         learner = predictor._learner_type.load(path)
         predictor._set_post_fit_vars(learner=learner)
         return predictor

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -3531,20 +3531,20 @@ class TabularPredictor:
 
     @classmethod
     def _load_version_file(cls, path) -> str:
-        version_file_path = path + cls._predictor_version_file_name
+        version_file_path = os.path.join(path, cls._predictor_version_file_name)
         version = load_str.load(path=version_file_path)
         return version
 
     @classmethod
     def _load_metadata_file(cls, path: str, silent=True):
-        metadata_file_path = path + cls._predictor_metadata_file_name
+        metadata_file_path = os.path.join(path, cls._predictor_metadata_file_name)
         return load_json.load(path=metadata_file_path, verbose=not silent)
 
     def _save_version_file(self, silent=False):
         from ..version import __version__
 
         version_file_contents = f"{__version__}"
-        version_file_path = self.path + self._predictor_version_file_name
+        version_file_path = os.path.join(self.path, self._predictor_version_file_name)
         save_str.save(path=version_file_path, data=version_file_contents, verbose=not silent)
 
     def _save_metadata_file(self, silent=False):
@@ -3552,7 +3552,7 @@ class TabularPredictor:
         Save metadata json file to disk containing information such as
         python version, autogluon version, installed packages, operating system, etc.
         """
-        metadata_file_path = self.path + self._predictor_metadata_file_name
+        metadata_file_path = os.path.join(self.path, self._predictor_metadata_file_name)
 
         metadata = get_autogluon_metadata()
 
@@ -3577,7 +3577,7 @@ class TabularPredictor:
         self._learner.save()
         self._learner = None
         self._trainer = None
-        save_pkl.save(path=path + self.predictor_file_name, object=self)
+        save_pkl.save(path=os.path.join(path, self.predictor_file_name), object=self)
         self._learner = tmp_learner
         self._trainer = tmp_trainer
         self._save_version_file(silent=silent)
@@ -3593,7 +3593,7 @@ class TabularPredictor:
         """
         Inner load method, called in `load`.
         """
-        predictor: TabularPredictor = load_pkl.load(path=os.path.join(path + cls.predictor_file_name))
+        predictor: TabularPredictor = load_pkl.load(path=os.path.join(path, cls.predictor_file_name))
         learner = predictor._learner_type.load(path)
         predictor._set_post_fit_vars(learner=learner)
         return predictor
@@ -3641,7 +3641,7 @@ class TabularPredictor:
             version_saved = cls._load_version_file(path=path)
         except:
             logger.warning(
-                f'WARNING: Could not find version file at "{path + cls._predictor_version_file_name}".\n'
+                f'WARNING: Could not find version file at "{os.path.join(path, cls._predictor_version_file_name)}".\n'
                 f"This means that the predictor was fit in a version `<=0.3.1`."
             )
             version_saved = None
@@ -3668,7 +3668,7 @@ class TabularPredictor:
             metadata_init = cls._load_metadata_file(path=path)
         except:
             logger.warning(
-                f'WARNING: Could not find metadata file at "{path + cls._predictor_metadata_file_name}".\n'
+                f'WARNING: Could not find metadata file at "{os.path.join(path, cls._predictor_metadata_file_name)}".\n'
                 f"This could mean that the predictor was fit in a version `<=0.5.2`."
             )
             metadata_init = None

--- a/tabular/tests/unittests/models/test_dummy.py
+++ b/tabular/tests/unittests/models/test_dummy.py
@@ -72,7 +72,7 @@ def test_dummy_binary_absolute_path(fit_helper):
         hyperparameters={DummyModel: {}},
     )
     path = Path(".") / "AG_test"
-    path = str(path.resolve()) + os.path.sep
+    path = str(path.resolve())
     init_args = dict(path=path)
 
     dataset_name = "adult"
@@ -98,7 +98,7 @@ def test_dummy_binary_model_absolute_path(model_fit_helper):
     """Test that absolute path works"""
     fit_args = dict()
     path = Path(".") / "AG_test"
-    path = str(path.resolve()) + os.path.sep
+    path = str(path.resolve())
     model = DummyModel(path=path)
     dataset_name = "adult"
     model_fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, model=model, fit_args=fit_args)

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -214,7 +214,7 @@ def test_advanced_functionality():
     with pytest.raises(AssertionError):
         # Ensure don't overwrite existing predictor
         predictor.clone(path=predictor.path)
-    path_clone = predictor.clone(path=predictor.path[:-1] + "_clone" + os.path.sep)
+    path_clone = predictor.clone(path=predictor.path + "_clone")
     predictor_clone = TabularPredictor.load(path_clone)
     assert predictor.path != predictor_clone.path
     if predictor_clone.can_predict_proba:
@@ -226,7 +226,7 @@ def test_advanced_functionality():
     assert len(leaderboard) == len(leaderboard_clone)
 
     # Test cloning for deployment logic
-    path_clone_for_deployment_og = predictor.path[:-1] + "_clone_for_deployment" + os.path.sep
+    path_clone_for_deployment_og = predictor.path + "_clone_for_deployment"
     with pytest.raises(FileNotFoundError):
         # Assert that predictor does not exist originally
         TabularPredictor.load(path_clone_for_deployment_og)

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -118,7 +118,7 @@ class AbstractTimeSeriesModel(AbstractModel):
         # Save self._oof_predictions as a separate file, not model attribute
         if self._oof_predictions is not None:
             save_pkl.save(
-                path=os.path.join(self.path + "utils", self._oof_filename),
+                path=os.path.join(self.path, "utils", self._oof_filename),
                 object=self._oof_predictions,
                 verbose=verbose,
             )
@@ -140,7 +140,7 @@ class AbstractTimeSeriesModel(AbstractModel):
     @classmethod
     def load_oof_predictions(cls, path: str, verbose: bool = True) -> TimeSeriesDataFrame:
         """Load the cached OOF predictions from disk."""
-        return load_pkl.load(path=os.path.join(path + "utils", cls._oof_filename), verbose=verbose)
+        return load_pkl.load(path=os.path.join(path, "utils", cls._oof_filename), verbose=verbose)
 
     def get_oof_predictions(self):
         if self._oof_predictions is None:

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -35,7 +35,7 @@ class AbstractTimeSeriesModel(AbstractModel):
         is fit to forecast.
     name : str, default = None
         Name of the subdirectory inside path where model will be saved.
-        The final model directory will be path+name+os.path.sep()
+        The final model directory will be os.path.join(path, name)
         If None, defaults to the model's class name: self.__class__.__name__
     metadata: CovariateMetadata
         A mapping of different covariate types known to autogluon.timeseries to column names
@@ -401,7 +401,7 @@ class AbstractTimeSeriesModel(AbstractModel):
         except EmptySearchSpace:
             return skip_hpo(self, train_data, val_data, time_limit=hpo_executor.time_limit)
 
-        self.set_contexts(os.path.abspath(self.path) + os.path.sep)
+        self.set_contexts(os.path.abspath(self.path))
         directory = self.path
         dataset_train_filename = "dataset_train.pkl"
         train_path = os.path.join(self.path, dataset_train_filename)

--- a/timeseries/src/autogluon/timeseries/models/abstract/model_trial.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/model_trial.py
@@ -30,7 +30,7 @@ def model_trial(
         model = init_model(
             args, model_cls, init_params, backend=hpo_executor.executor_type, is_bagged_model=is_bagged_model
         )
-        model.set_contexts(path_context=model.path_root + model.name + os.path.sep)
+        model.set_contexts(path_context=os.path.join(model.path_root, model.name))
 
         train_data = load_pkl.load(train_path)
         val_data = load_pkl.load(val_path)

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -290,7 +290,7 @@ class RecursiveTabularModel(AbstractTimeSeriesModel):
 
         estimator = TabularEstimator(
             predictor_init_kwargs={
-                "path": self.path + os.sep + "point_predictor",
+                "path": os.path.join(self.path, "point_predictor"),
                 "problem_type": ag.constants.REGRESSION,
                 "eval_metric": self.TIMESERIES_METRIC_TO_TABULAR_METRIC[self.eval_metric],
                 "verbosity": verbosity - 2,

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Type
 
 import gluonts
+import os
 import numpy as np
 import torch
 from gluonts.core.component import from_hyperparameters
@@ -115,7 +116,7 @@ class AbstractGluonTSPyTorchModel(AbstractGluonTSModel):
     @classmethod
     def load(cls, path: str, reset_paths: bool = True, verbose: bool = True) -> "AbstractGluonTSModel":
         with torch_warning_filter():
-            model = load_pkl.load(path=path + cls.model_file_name, verbose=verbose)
+            model = load_pkl.load(path=os.path.join(path, cls.model_file_name), verbose=verbose)
             if reset_paths:
                 model.set_contexts(path)
             model.gts_predictor = GluonTSPyTorchPredictor.deserialize(Path(path) / cls.gluonts_model_path)

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -2,13 +2,13 @@
 Module including wrappers for PyTorch implementations of models in GluonTS
 """
 import logging
+import os
 import shutil
 from datetime import timedelta
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Type
 
 import gluonts
-import os
 import numpy as np
 import torch
 from gluonts.core.component import from_hyperparameters

--- a/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
+++ b/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
@@ -190,7 +190,7 @@ class MultiWindowBacktestingModel(AbstractTimeSeriesModel):
         cls, path: str, reset_paths: bool = True, load_oof: bool = False, verbose: bool = True
     ) -> AbstractTimeSeriesModel:
         model = super().load(path=path, reset_paths=reset_paths, load_oof=load_oof, verbose=verbose)
-        most_recent_model_path = model.path + os.sep + cls._most_recent_model_folder + os.sep
+        most_recent_model_path = os.path.join(model.path, cls._most_recent_model_folder)
         model.most_recent_model = model.model_base_type.load(
             most_recent_model_path,
             reset_paths=reset_paths,

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import pprint
 import time
 import warnings
@@ -675,7 +676,7 @@ class TimeSeriesPredictor:
 
     @classmethod
     def _load_version_file(cls, path: str) -> str:
-        version_file_path = path + cls._predictor_version_file_name
+        version_file_path = os.path.join(path, cls._predictor_version_file_name)
         version = load_str.load(path=version_file_path)
         return version
 
@@ -705,7 +706,7 @@ class TimeSeriesPredictor:
             version_saved = cls._load_version_file(path=path)
         except:
             logger.warning(
-                f'WARNING: Could not find version file at "{path + cls._predictor_version_file_name}".\n'
+                f'WARNING: Could not find version file at "{os.path.join(path, cls._predictor_version_file_name)}".\n'
                 f"This means that the predictor was fit in a version `<=0.7.0`."
             )
             version_saved = "Unknown (Likely <=0.7.0)"
@@ -719,14 +720,14 @@ class TimeSeriesPredictor:
 
         logger.info(f"Loading predictor from path {path}")
         learner = AbstractLearner.load(path)
-        predictor = load_pkl.load(path=learner.path + cls.predictor_file_name)
+        predictor = load_pkl.load(path=os.path.join(learner.path, cls.predictor_file_name))
         predictor._learner = learner
         predictor.path = learner.path
         return predictor
 
     def _save_version_file(self):
         version_file_contents = current_ag_version
-        version_file_path = self.path + self._predictor_version_file_name
+        version_file_path = os.path.join(self.path, self._predictor_version_file_name)
         save_str.save(path=version_file_path, data=version_file_contents, verbose=False)
 
     def save(self) -> None:
@@ -737,7 +738,7 @@ class TimeSeriesPredictor:
         """
         tmp_learner = self._learner
         self._learner = None
-        save_pkl.save(path=tmp_learner.path + self.predictor_file_name, object=self)
+        save_pkl.save(path=os.path.join(tmp_learner.path, self.predictor_file_name), object=self)
         self._learner = tmp_learner
         self._save_version_file()
 

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -189,7 +189,7 @@ class SimpleAbstractTrainer:
                     model = self.models[model]
             if isinstance(model, str):
                 model_type = self.get_model_attribute(model=model, attribute="type")
-                model_path = self.get_model_attribute(model=model, attribute="path")
+                model_path = os.path.join(self.path, self.get_model_attribute(model=model, attribute="path"))
                 model_info_dict[model] = model_type.load_info(path=model_path)
             else:
                 model_info_dict[model.name] = model.get_info()
@@ -320,7 +320,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         self.models = models
 
     def _get_model_oof_predictions(self, model_name: str) -> TimeSeriesDataFrame:
-        model_path = self.get_model_attribute(model=model_name, attribute="path")
+        model_path = os.path.join(self.path, self.get_model_attribute(model=model_name, attribute="path"))
         model_type = self.get_model_attribute(model=model_name, attribute="type")
         return model_type.load_oof_predictions(path=model_path)
 
@@ -434,7 +434,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         model_names_trained = []
         # add each of the trained HPO configurations to the trained models
         for model_hpo_name, model_info in hpo_models.items():
-            model_path = model_info["path"]
+            model_path = os.path.join(self.path, model_info["path"])
             # Only load model configurations that didn't fail
             if Path(model_path).exists():
                 model_hpo = self.load_model(model_hpo_name, path=model_path, model_type=type(model))
@@ -727,7 +727,6 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
             fit_time=ensemble.fit_time,
             predict_time=ensemble.predict_time,
         )
-
         self._add_model(model=ensemble, base_models=ensemble.model_names)
         self.save_model(model=ensemble)
         return ensemble.name

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -39,7 +39,6 @@ class SimpleAbstractTrainer:
 
     def __init__(self, path: str, low_memory: bool, save_data: bool, *args, **kwargs):
         self.path = path
-        self.path = PathConverter.to_relative(self.path)
         self.reset_paths = False
 
         self.low_memory = low_memory
@@ -287,19 +286,19 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         self.hpo_results = {}
 
     def save_train_data(self, data: TimeSeriesDataFrame, verbose: bool = True) -> None:
-        path = self.path_data + "train.pkl"
+        path = os.path.join(self.path_data, "train.pkl")
         save_pkl.save(path=path, object=data, verbose=verbose)
 
     def save_val_data(self, data: TimeSeriesDataFrame, verbose: bool = True) -> None:
-        path = self.path_data + "val.pkl"
+        path = os.path.join(self.path_data, "val.pkl")
         save_pkl.save(path=path, object=data, verbose=verbose)
 
     def load_train_data(self) -> TimeSeriesDataFrame:
-        path = self.path_data + "train.pkl"
+        path = os.path.join(self.path_data, "train.pkl")
         return load_pkl.load(path=path)
 
     def load_val_data(self) -> Optional[TimeSeriesDataFrame]:
-        path = self.path_data + "val.pkl"
+        path = os.path.join(self.path_data, "val.pkl")
         if os.path.exists(path):
             return load_pkl.load(path=path)
         else:

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -39,6 +39,7 @@ class SimpleAbstractTrainer:
 
     def __init__(self, path: str, low_memory: bool, save_data: bool, *args, **kwargs):
         self.path = path
+        print(f"TRAINER INIT self.path {self.path}")
         self.reset_paths = False
 
         self.low_memory = low_memory
@@ -97,7 +98,9 @@ class SimpleAbstractTrainer:
 
     @property
     def path_root(self) -> str:
-        return self.path.rsplit(os.path.sep, maxsplit=2)[0]
+        print(f"path root: {os.path.dirname(self.path)}")
+        print(f"self.path: {self.path}")
+        return os.path.dirname(self.path)
 
     @property
     def path_utils(self) -> str:
@@ -298,7 +301,9 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         return load_pkl.load(path=path)
 
     def load_val_data(self) -> Optional[TimeSeriesDataFrame]:
+        print("load_val_data")
         path = os.path.join(self.path_data, "val.pkl")
+        print(f"path: {path}")
         if os.path.exists(path):
             return load_pkl.load(path=path)
         else:

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -98,15 +98,15 @@ class SimpleAbstractTrainer:
 
     @property
     def path_root(self) -> str:
-        return self.path.rsplit(os.path.sep, maxsplit=2)[0] + os.path.sep
+        return self.path.rsplit(os.path.sep, maxsplit=2)[0]
 
     @property
     def path_utils(self) -> str:
-        return self.path_root + "utils" + os.path.sep
+        return os.path.join(self.path_root, "utils")
 
     @property
     def path_data(self) -> str:
-        return self.path_utils + "data" + os.path.sep
+        return os.path.join(self.path_utils, "data")
 
     @property
     def path_pkl(self) -> str:

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -110,7 +110,7 @@ class SimpleAbstractTrainer:
 
     @property
     def path_pkl(self) -> str:
-        return self.path + self.trainer_file_name
+        return os.path.join(self.path, self.trainer_file_name)
 
     def set_contexts(self, path_context: str) -> None:
         self.path, model_paths = self.create_contexts(path_context)
@@ -124,7 +124,7 @@ class SimpleAbstractTrainer:
         model_paths = self.get_models_attribute_dict(attribute="path")
         for model, prev_path in model_paths.items():
             model_local_path = prev_path.split(self.path, 1)[1]
-            new_path = path + model_local_path
+            new_path = os.path.join(path, model_local_path)
             model_paths[model] = new_path
 
         return path, model_paths
@@ -144,7 +144,7 @@ class SimpleAbstractTrainer:
 
     @classmethod
     def load(cls, path: str, reset_paths: bool = False) -> "SimpleAbstractTrainer":
-        load_path = path + cls.trainer_file_name
+        load_path = os.path.join(path, cls.trainer_file_name)
         if not reset_paths:
             return load_pkl.load(path=load_path)
         else:
@@ -207,7 +207,7 @@ class SimpleAbstractTrainer:
 
     @classmethod
     def load_info(cls, path, reset_paths=False, load_model_if_required=True) -> Dict[str, Any]:
-        load_path = path + cls.trainer_info_name
+        load_path = os.path.join(path, cls.trainer_info_name)
         try:
             return load_pkl.load(path=load_path)
         except:  # noqa
@@ -220,8 +220,8 @@ class SimpleAbstractTrainer:
     def save_info(self, include_model_info: bool = False):
         info = self.get_info(include_model_info=include_model_info)
 
-        save_pkl.save(path=self.path + self.trainer_info_name, object=info)
-        save_json.save(path=self.path + self.trainer_info_json_name, obj=info)
+        save_pkl.save(path=os.path.join(self.path, self.trainer_info_name), object=info)
+        save_json.save(path=os.path.join(self.path, self.trainer_info_json_name), obj=info)
         return info
 
     def get_info(self, include_model_info: bool = False) -> Dict[str, Any]:

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -39,7 +39,6 @@ class SimpleAbstractTrainer:
 
     def __init__(self, path: str, low_memory: bool, save_data: bool, *args, **kwargs):
         self.path = path
-        print(f"TRAINER INIT self.path {self.path}")
         self.reset_paths = False
 
         self.low_memory = low_memory
@@ -88,6 +87,8 @@ class SimpleAbstractTrainer:
         """Get a member attribute for given model from the `model_graph`."""
         if not isinstance(model, str):
             model = model.name
+        if attribute == "path":
+            return os.path.join(*self.model_graph.nodes[model][attribute])
         return self.model_graph.nodes[model][attribute]
 
     def set_model_attribute(self, model: Union[str, AbstractModel], attribute: str, val):
@@ -98,8 +99,6 @@ class SimpleAbstractTrainer:
 
     @property
     def path_root(self) -> str:
-        print(f"path root: {os.path.dirname(self.path)}")
-        print(f"self.path: {self.path}")
         return os.path.dirname(self.path)
 
     @property
@@ -301,9 +300,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         return load_pkl.load(path=path)
 
     def load_val_data(self) -> Optional[TimeSeriesDataFrame]:
-        print("load_val_data")
         path = os.path.join(self.path_data, "val.pkl")
-        print(f"path: {path}")
         if os.path.exists(path):
             return load_pkl.load(path=path)
         else:
@@ -351,7 +348,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
             If ``base_models`` are provided and ``model`` is not a ``AbstractTimeSeriesEnsembleModel``.
         """
         node_attrs = dict(
-            path=os.path.relpath(model.path, self.path),
+            path=os.path.relpath(model.path, self.path).split(os.sep),
             type=type(model),
             fit_time=model.fit_time,
             predict_time=model.predict_time,

--- a/timeseries/tests/conftest.py
+++ b/timeseries/tests/conftest.py
@@ -38,5 +38,5 @@ def pytest_collection_modifyitems(config, items):
 def temp_model_path():
     """Pytest fixture to save as model paths that clean up after themselves"""
     td = tempfile.mkdtemp()
-    yield td + os.path.sep
+    yield td
     shutil.rmtree(td)

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -51,7 +51,7 @@ def trained_models():
     for model_class, prediction_length in itertools.product(TESTABLE_MODELS, TESTABLE_PREDICTION_LENGTHS):
         temp_model_path = tempfile.mkdtemp()
         model = model_class(
-            path=temp_model_path + os.path.sep,
+            path=temp_model_path,
             freq="H",
             prediction_length=prediction_length,
             hyperparameters=DUMMY_HYPERPARAMETERS,

--- a/timeseries/tests/unittests/test_learner.py
+++ b/timeseries/tests/unittests/test_learner.py
@@ -31,7 +31,7 @@ def trained_learners():
     for hp in TEST_HYPERPARAMETER_SETTINGS:
         temp_model_path = tempfile.mkdtemp()
         learner = TimeSeriesLearner(
-            path_context=temp_model_path + os.path.sep,
+            path_context=temp_model_path,
             eval_metric="MASE",
             prediction_length=3,
         )

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -33,7 +33,7 @@ def trained_trainers():
     for hp in TEST_HYPERPARAMETER_SETTINGS:
         temp_model_path = tempfile.mkdtemp()
         trainer = AutoTimeSeriesTrainer(
-            path=temp_model_path + os.path.sep,
+            path=temp_model_path,
             eval_metric="MAPE",
             prediction_length=3,
         )
@@ -390,7 +390,7 @@ def trained_and_refit_trainers():
     def fit_trainer():
         temp_model_path = tempfile.mkdtemp()
         trainer = AutoTimeSeriesTrainer(
-            path=temp_model_path + os.path.sep,
+            path=temp_model_path,
             prediction_length=3,
         )
         trainer.fit(


### PR DESCRIPTION
Issue #, if available:
* https://github.com/autogluon/autogluon/issues/3260

Description of changes:
* Refactor path logic in Tabular/TimeSeries, so that parent only will track relative paths to its children and passing correct path to its children when init/load
* Trainer now stores model's relative path as a list, and dynamically construct them to a path.
* Replaced usage os `os.path.sep` + str concatenation in path with `os.path.join` to avoid bugs

- [x] Cross OS check for tabular
- [x] Cross OS check for timeseries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
