### PR TITLE
Add missing colab buttons to advanced AutoMM tutorials

### DIFF
--- a/docs/tutorials/multimodal/advanced_topics/continuous_training.ipynb
+++ b/docs/tutorials/multimodal/advanced_topics/continuous_training.ipynb
@@ -4,7 +4,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Continuous Training"
+    "# Continuous Training",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/autogluon/autogluon/blob/master/docs/tutorials/multimodal/advanced_topics/continuous_training.ipynb)\n",
+    "[![Open In SageMaker Studio Lab](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/autogluon/autogluon/blob/master/docs/tutorials/multimodal/advanced_topics/continuous_training.ipynb)\n",
+    "\n",
+    "\n"
    ]
   },
   {

--- a/docs/tutorials/multimodal/advanced_topics/presets.ipynb
+++ b/docs/tutorials/multimodal/advanced_topics/presets.ipynb
@@ -7,6 +7,10 @@
    "source": [
     "# AutoMM Presets\n",
     "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/autogluon/autogluon/blob/master/docs/tutorials/multimodal/advanced_topics/presets.ipynb)\n",
+    "[![Open In SageMaker Studio Lab](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/autogluon/autogluon/blob/master/docs/tutorials/multimodal/advanced_topics/presets.ipynb)\n",
+    "\n",
+    "\n",
     "It is well-known that we usually need to set hyperparameters before the learning process begins. Deep learning models, e.g., pretrained foundation models, can have anywhere from a few hyperparameters to a few hundred. The hyperparameters can impact training speed, final model performance, and inference latency. However, choosing the proper hyperparameters may be challenging for many users with limited expertise.\n",
     "\n",
     "In this tutorial, we will introduce the easy-to-use presets in AutoMM. Our presets can condense the complex hyperparameter setups into simple strings. More specifically, AutoMM supports three presets: `medium_quality`, `high_quality`, and `best_quality`."


### PR DESCRIPTION
*Description of changes:*
The "Open in Colab" type buttons are missing in these two tutorials:
- https://auto.gluon.ai/stable/tutorials/multimodal/advanced_topics/presets.html
- https://auto.gluon.ai/stable/tutorials/multimodal/advanced_topics/continuous_training.html

These PR adds buttons to open the notebooks in Colab and Studio Lab.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
