### PR TITLE
vw version bump

### DIFF
--- a/common/src/autogluon/common/utils/try_import.py
+++ b/common/src/autogluon/common/utils/try_import.py
@@ -220,10 +220,10 @@ def try_import_vowpalwabbit():
 
         vowpalwabbit_version = parse_version(vowpalwabbit.__version__)
         assert vowpalwabbit_version >= parse_version("9.0.0") and vowpalwabbit_version < parse_version(
-            "9.5.0"
-        ), f"Currently, we only support vowpalwabbit version >=9.0 and <9.5. Found vowpalwabbit version: {vowpalwabbit_version}"
+            "9.9.0"
+        ), f"Currently, we only support vowpalwabbit version >=9.0 and <9.9. Found vowpalwabbit version: {vowpalwabbit_version}"
     except ImportError:
-        raise ImportError("`import vowpalwabbit` failed.\n" "A quick tip is to install via `pip install vowpalwabbit>=9,<9.5")
+        raise ImportError("`import vowpalwabbit` failed.\n" "A quick tip is to install via `pip install vowpalwabbit>=9,<9.9")
 
 
 def try_import_fasttext():

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -66,7 +66,7 @@ extras_require = {
     ],
     "vowpalwabbit": [
         # FIXME: 9.5+ causes VW to save an empty model which always predicts 0. Confirmed on MacOS (Intel CPU). Unknown how to fix.
-        "vowpalwabbit>=9,<9.5",
+        "vowpalwabbit>=9,<9.9",
     ],
     "skl2onnx": [
         "skl2onnx>=1.13.0,<1.14.0",


### PR DESCRIPTION
bump vw version to 9.8

*Description of changes:*
I've just increased allowed version of wovpal wabbit to 9.8 in file:
https://github.com/autogluon/autogluon/blob/master/common/src/autogluon/common/utils/try_import.py
I've tested it locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
