### PR TITLE
[fix][eda] Anomaly Detection - disable bps_flag for SUOD

### DIFF
--- a/eda/src/autogluon/eda/analysis/anomaly.py
+++ b/eda/src/autogluon/eda/analysis/anomaly.py
@@ -112,7 +112,10 @@ class AnomalyDetector:
         # Can't go beyond 4 - SUOD is throwing errors
         num_cpus = min(ResourceManager.get_cpu_count(), 4)
 
-        suod_defaults = dict(base_estimators=self.detector_list, n_jobs=num_cpus, combination="average", verbose=False)
+        # Don't use `bps_flag=True` - it's using pre-trained models which aren't loading in newer versions of sklearn
+        suod_defaults = dict(
+            base_estimators=self.detector_list, n_jobs=num_cpus, combination="average", bps_flag=False, verbose=False
+        )
         self._suod_kwargs = {**suod_defaults, **detector_kwargs}
         self._detectors: Optional[List[BaseDetector]] = None
         self._train_index_to_detector: Optional[Dict[int, Any]] = None

--- a/eda/tests/unittests/analysis/test_anomaly.py
+++ b/eda/tests/unittests/analysis/test_anomaly.py
@@ -39,6 +39,7 @@ def test_AnomalyDetector__defaults_init():
     assert ad._suod_kwargs["n_jobs"] > 0
     ad._suod_kwargs.pop("n_jobs")
     assert ad._suod_kwargs == {
+        "bps_flag": False,
         "combination": "average",
         "some_kwarg": "value",
         "verbose": False,


### PR DESCRIPTION
*Description of changes:*

Don't use `bps_flag=True` - it's using pre-trained models which aren't loading in newer versions of sklearn

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
