### PR TITLE
Add log for fit time adjustments

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -481,6 +481,7 @@ class AbstractModel:
         if sample_weight is not None and isinstance(sample_weight, str):
             raise ValueError("In model.fit(), sample_weight should be array of sample weight values, not string.")
         time_limit = kwargs.get("time_limit", None)
+        time_limit_og = time_limit
         max_time_limit_ratio = self.params_aux.get("max_time_limit_ratio", 1)
         if time_limit is not None:
             time_limit *= max_time_limit_ratio
@@ -496,6 +497,12 @@ class AbstractModel:
         elif time_limit is not None:
             time_limit = max(time_limit, min_time_limit)
         kwargs["time_limit"] = time_limit
+        if time_limit_og != time_limit:
+            logger.log(20, f"\tTime limit adjusted due to model hyperparameters: "
+                           f"{time_limit_og:.2f}s -> {time_limit:.2f}s "
+                           f"(ag.max_time_limit={max_time_limit}, "
+                           f"ag.max_time_limit_ratio={max_time_limit_ratio}, "
+                           f"ag.min_time_limit={min_time_limit})")
         kwargs = self._preprocess_fit_resources(**kwargs)
         return kwargs
 

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -498,11 +498,14 @@ class AbstractModel:
             time_limit = max(time_limit, min_time_limit)
         kwargs["time_limit"] = time_limit
         if time_limit_og != time_limit:
-            logger.log(20, f"\tTime limit adjusted due to model hyperparameters: "
-                           f"{time_limit_og:.2f}s -> {time_limit:.2f}s "
-                           f"(ag.max_time_limit={max_time_limit}, "
-                           f"ag.max_time_limit_ratio={max_time_limit_ratio}, "
-                           f"ag.min_time_limit={min_time_limit})")
+            logger.log(
+                20,
+                f"\tTime limit adjusted due to model hyperparameters: "
+                f"{time_limit_og:.2f}s -> {time_limit:.2f}s "
+                f"(ag.max_time_limit={max_time_limit}, "
+                f"ag.max_time_limit_ratio={max_time_limit_ratio}, "
+                f"ag.min_time_limit={min_time_limit})",
+            )
         kwargs = self._preprocess_fit_resources(**kwargs)
         return kwargs
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add log for fit time adjustments

Previously, if user specified per-model time limit arguments, this would not be logged and thus it was not clear why a model was stopped or trained for a certain duration.

This PR:
```
    hyperparameters = {
        'GBM': {},
        'CAT': {'ag.max_time_limit': 5},
    }
    predictor = predictor.fit(train_data, hyperparameters=hyperparameters, time_limit=120)
```

```
User-specified model hyperparameters to be fit:
{
	'GBM': {},
	'CAT': {'ag.max_time_limit': 5},
}
Fitting 2 L1 models ...
Fitting model: LightGBM ... Training model for up to 119.82s of the 119.82s of remaining time.
	0.9383	 = Validation score   (roc_auc)
	2.27s	 = Training   runtime
	0.01s	 = Validation runtime
Fitting model: CatBoost ... Training model for up to 117.53s of the 117.53s of remaining time.
	Time limit adjusted due to model hyperparameters: 117.53s -> 5.00s (ag.max_time_limit=5, ag.max_time_limit_ratio=1.0, ag.min_time_limit=0)
	Ran out of time, early stopping on iteration 359.
	0.9386	 = Validation score   (roc_auc)
	5.08s	 = Training   runtime
	0.01s	 = Validation runtime
Fitting model: WeightedEnsemble_L2 ... Training model for up to 119.82s of the 112.43s of remaining time.
	0.9401	 = Validation score   (roc_auc)
	0.08s	 = Training   runtime
	0.0s	 = Validation runtime
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
