### PR TITLE
Fix crash when `time_limit` is None and overwritten via `max_time_limit`

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -498,10 +498,12 @@ class AbstractModel:
             time_limit = max(time_limit, min_time_limit)
         kwargs["time_limit"] = time_limit
         if time_limit_og != time_limit:
+            time_limit_og_str = f"{time_limit_og:.2f}s" if time_limit_og is not None else "None"
+            time_limit_str = f"{time_limit:.2f}s" if time_limit is not None else "None"
             logger.log(
                 20,
                 f"\tTime limit adjusted due to model hyperparameters: "
-                f"{time_limit_og:.2f}s -> {time_limit:.2f}s "
+                f"{time_limit_og_str} -> {time_limit_str} "
                 f"(ag.max_time_limit={max_time_limit}, "
                 f"ag.max_time_limit_ratio={max_time_limit_ratio}, "
                 f"ag.min_time_limit={min_time_limit})",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix crash when `time_limit` is None and overwritten via `max_time_limit`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
