### PR TITLE
Tabular: Add model failures tracking support

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -1712,6 +1712,10 @@ class AbstractModel:
             # 'disk_size': self.get_disk_size(),
             "memory_size": self.get_memory_size(),  # Memory usage of model in bytes
             "compile_time": self.compile_time if hasattr(self, "compile_time") else None,
+            "is_initialized": self.is_initialized(),
+            "is_fit": self.is_fit(),
+            "is_valid": self.is_valid(),
+            "can_infer": self.can_infer(),
         }
         return info
 

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -122,6 +122,7 @@ class AbstractModel:
         self.path = self.create_contexts(os.path.join(self.path_root, self.path_suffix))  # TODO: Make this path a function for consistency.
 
         self.num_classes = None
+        self.quantile_levels = None
         self.model = None
         self.problem_type = problem_type
 
@@ -132,6 +133,7 @@ class AbstractModel:
             self.eval_metric = metrics.get_metric(eval_metric, self.problem_type, "eval_metric")  # Note: we require higher values = better performance
         else:
             self.eval_metric = None
+        self.stopping_metric = None
         self.normalize_pred_probas = None
 
         self.features = None  # External features, do not use internally
@@ -151,6 +153,7 @@ class AbstractModel:
         self.params = {}
         self.params_aux = {}
         self.params_trained = dict()
+        self.nondefault_params = []
         self._is_initialized = False
         self._is_fit_metadata_registered = False
         self._fit_metadata = dict()
@@ -1724,7 +1727,7 @@ class AbstractModel:
             "model_type": type(self).__name__,
             "problem_type": self.problem_type,
             "eval_metric": self.eval_metric.name,
-            "stopping_metric": self.stopping_metric.name,
+            "stopping_metric": self.stopping_metric.name if self.stopping_metric is not None else None,
             "fit_time": self.fit_time,
             "num_classes": self.num_classes,
             "quantile_levels": self.quantile_levels,

--- a/core/src/autogluon/core/models/dummy/dummy_model.py
+++ b/core/src/autogluon/core/models/dummy/dummy_model.py
@@ -29,6 +29,10 @@ class DummyModel(AbstractModel):
     def _fit(self, X, y, **kwargs):
         X = self.preprocess(X)
         model_cls = self._get_model_type()
+        model_params = self._get_model_params()
+        if "raise" in model_params:
+            raise_msg = model_params.get("raise_msg", "")
+            raise model_params["raise"](raise_msg)
         if model_cls == DummyQuantileRegressor:
             self.model = model_cls(quantile_levels=self.quantile_levels)
         else:

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -883,6 +883,8 @@ class BaggedEnsembleModel(AbstractModel):
         if model_params_list is None:
             model_params_list = [self.load_child(child).get_trained_params() for child in self.models]
 
+        if len(model_params_list) == 0:
+            return dict()
         model_params_compressed = dict()
         for param in model_params_list[0].keys():
             model_param_vals = [model_params[param] for model_params in model_params_list]

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import inspect
 import logging
@@ -1112,10 +1114,10 @@ class BaggedEnsembleModel(AbstractModel):
 
         return info
 
-    def get_memory_size(self):
+    def get_memory_size(self, allow_exception: bool = False) -> int | None:
         models = self.models
         self.models = None
-        memory_size = super().get_memory_size()
+        memory_size = super().get_memory_size(allow_exception=allow_exception)
         self.models = models
         return memory_size
 

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -879,7 +879,7 @@ class BaggedEnsembleModel(AbstractModel):
     def convert_to_template_child(self):
         return self._get_model_base().convert_to_template()
 
-    def _get_compressed_params(self, model_params_list=None):
+    def _get_compressed_params(self, model_params_list=None) -> dict:
         if model_params_list is None:
             model_params_list = [self.load_child(child).get_trained_params() for child in self.models]
 

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -173,7 +173,6 @@ class AbstractTrainer:
 
         self._extra_banned_names = set()  # Names which are banned but are not used by a trained model.
 
-        self._models_failed_to_train = []  # List of models which failed to train
         self._models_failed_to_train_errors = dict()  # Dict of model name -> model failure metadata
 
         # self._exceptions_list = []  # TODO: Keep exceptions list for debugging during benchmarking.
@@ -1825,7 +1824,6 @@ class AbstractTrainer:
             total_time = crash_time - fit_start_time
             tb = traceback.format_exc()
             model_info = self.get_model_info(model=model)
-            self._models_failed_to_train.append(model.name)
             self._models_failed_to_train_errors[model.name] = dict(
                 exc_type=err.__class__.__name__,
                 exc_str=str(err),
@@ -2992,7 +2990,6 @@ class AbstractTrainer:
                 "total_time",
             ]
             valid_keys_inner = [
-                # "name",
                 "model_type",
                 "hyperparameters",
                 "hyperparameters_fit",
@@ -3026,12 +3023,10 @@ class AbstractTrainer:
             "total_time",
             "model_type",
             "child_model_type",
-            # "stack_level",
             "is_initialized",
             "is_fit",
             "is_valid",
             "can_infer",
-            # "fit_order",
             "num_features",
             "num_models",
             "memory_size",

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -2446,9 +2446,8 @@ class AbstractTrainer:
             **kwargs,
         )
         if len(self.get_model_names()) == 0:
-            # FIXME: Add toggle
+            # TODO v1.0: Add toggle to raise exception if no models trained
             logger.log(30, "Warning: AutoGluon did not successfully train any models")
-            # raise ValueError("AutoGluon did not successfully train any models")
         return model_names_fit
 
     def _predict_model(self, X, model, model_pred_proba_dict=None, cascade=False):
@@ -2780,8 +2779,19 @@ class AbstractTrainer:
         """Gets all model names which would cause model files to be overwritten if a new model was trained with the name"""
         return self.get_model_names() + list(self._extra_banned_names)
 
-    # TODO: Docstring
     def _flatten_model_info(self, model_info: dict) -> dict:
+        """
+        Flattens the model_info nested dictionary into a shallow dictionary to convert to a pandas DataFrame row.
+
+        Parameters
+        ----------
+        model_info: dict
+            A nested dictionary of model metadata information
+
+        Returns
+        -------
+        A flattened dictionary of model info.
+        """
         model_info_keys = [
             "num_features",
             "model_type",
@@ -2997,8 +3007,6 @@ class AbstractTrainer:
                 "child_hyperparameters",
                 "child_hyperparameters_fit",
             ]
-            # FIXME: Combine with others
-            # model_info_extra =
             model_info_out = {k: v for k, v in model_info.items() if k in valid_keys}
             model_info_inner_out = {k: v for k, v in model_info_inner.items() if k in valid_keys_inner}
 

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -2446,7 +2446,9 @@ class AbstractTrainer:
             **kwargs,
         )
         if len(self.get_model_names()) == 0:
-            raise ValueError("AutoGluon did not successfully train any models")
+            # FIXME: Add toggle
+            logger.log(30, "Warning: AutoGluon did not successfully train any models")
+            # raise ValueError("AutoGluon did not successfully train any models")
         return model_names_fit
 
     def _predict_model(self, X, model, model_pred_proba_dict=None, cascade=False):

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -432,10 +432,10 @@ class DefaultLearner(AbstractTabularLearner):
 
         return new_threshold, holdout_frac, num_bag_folds
 
-    def get_info(self, include_model_info=False, **kwargs):
+    def get_info(self, include_model_info=False, include_model_failures=False, **kwargs):
         learner_info = super().get_info(**kwargs)
         trainer = self.load_trainer()
-        trainer_info = trainer.get_info(include_model_info=include_model_info)
+        trainer_info = trainer.get_info(include_model_info=include_model_info, include_model_failures=include_model_failures)
         learner_info.update(
             {
                 "time_fit_preprocessing": self._time_fit_preprocessing,

--- a/tabular/src/autogluon/tabular/models/automm/automm_model.py
+++ b/tabular/src/autogluon/tabular/models/automm/automm_model.py
@@ -251,7 +251,7 @@ class MultiModalPredictorModel(AbstractModel):
         model._load_model = None
         return model
 
-    def get_memory_size(self) -> int:
+    def _get_memory_size(self) -> int:
         """Return the memory size by calculating the total number of parameters.
 
         Returns

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -79,8 +79,8 @@ class CatBoostModel(AbstractModel):
         data_mem_usage_bytes = data_mem_usage * 5 + data_mem_usage / 4 * num_classes  # TODO: Extremely crude approximation, can be vastly improved
 
         params = self._get_model_params()
-        border_count = params.get('border_count', 254)
-        depth = params.get('depth', 6)
+        border_count = params.get("border_count", 254)
+        depth = params.get("depth", 6)
         # Formula based on manual testing, aligns with LightGBM histogram sizes
         histogram_mem_usage_bytes = 20 * math.pow(2, depth) * len(X.columns) * border_count
 

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -1,8 +1,10 @@
 import logging
+import math
 import os
 import time
 
 import numpy as np
+import pandas as pd
 
 from autogluon.common.features.types import R_BOOL, R_CATEGORY, R_FLOAT, R_INT
 from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
@@ -61,10 +63,28 @@ class CatBoostModel(AbstractModel):
                     X[category] = X[category].cat.add_categories("__NaN__").fillna("__NaN__")
         return X
 
-    def _estimate_memory_usage(self, X, **kwargs):
+    def _estimate_memory_usage(self, X: pd.DataFrame, **kwargs) -> float:
+        """
+        Returns the expected peak memory usage in bytes of the CatBoost model during fit.
+
+        The memory usage of CatBoost is primarily made up of two sources:
+
+        1. The size of the data
+        2. The size of the histogram cache
+            Scales roughly by 5080*num_features*2^depth bytes
+            For 10000 features and 6 depth, the histogram would be 3.2 GB.
+        """
         num_classes = self.num_classes if self.num_classes else 1  # self.num_classes could be None after initialization if it's a regression problem
         data_mem_usage = get_approximate_df_mem_usage(X).sum()
-        approx_mem_size_req = data_mem_usage * 7 + data_mem_usage / 4 * num_classes  # TODO: Extremely crude approximation, can be vastly improved
+        data_mem_usage_bytes = data_mem_usage * 5 + data_mem_usage / 4 * num_classes  # TODO: Extremely crude approximation, can be vastly improved
+
+        params = self._get_model_params()
+        border_count = params.get('border_count', 254)
+        depth = params.get('depth', 6)
+        # Formula based on manual testing, aligns with LightGBM histogram sizes
+        histogram_mem_usage_bytes = 20 * math.pow(2, depth) * len(X.columns) * border_count
+
+        approx_mem_size_req = data_mem_usage_bytes + histogram_mem_usage_bytes
         return approx_mem_size_req
 
     # TODO: Use Pool in preprocess, optimize bagging to do Pool.split() to avoid re-computing pool for each fold! Requires stateful + y

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -83,6 +83,7 @@ class CatBoostModel(AbstractModel):
         depth = params.get("depth", 6)
         # Formula based on manual testing, aligns with LightGBM histogram sizes
         histogram_mem_usage_bytes = 20 * math.pow(2, depth) * len(X.columns) * border_count
+        histogram_mem_usage_bytes *= 1.2  # Add a 20% buffer
 
         approx_mem_size_req = data_mem_usage_bytes + histogram_mem_usage_bytes
         return approx_mem_size_req

--- a/tabular/src/autogluon/tabular/models/fasttext/fasttext_model.py
+++ b/tabular/src/autogluon/tabular/models/fasttext/fasttext_model.py
@@ -166,7 +166,7 @@ class FastTextModel(AbstractModel):
         model._load_model = None
         return model
 
-    def get_memory_size(self) -> int:
+    def _get_memory_size(self) -> int:
         return self._model_size_estimate
 
     def _more_tags(self):

--- a/tabular/src/autogluon/tabular/models/lgb/callbacks.py
+++ b/tabular/src/autogluon/tabular/models/lgb/callbacks.py
@@ -135,8 +135,8 @@ def early_stopping_custom(
 
         model_size_memory_ratio = estimated_model_size_mb / available_mb
         if verbose or (model_size_memory_ratio > 0.25):
-            logging.debug("Available Memory: " + str(available_mb) + " MB")
-            logging.debug("Estimated Model Size: " + str(estimated_model_size_mb) + " MB")
+            logger.debug("Available Memory: " + str(available_mb) + " MB")
+            logger.debug("Estimated Model Size: " + str(estimated_model_size_mb) + " MB")
 
         early_stop = False
         if model_size_memory_ratio > 1.0:

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -80,11 +80,11 @@ class LGBModel(AbstractModel):
         data_mem_usage_bytes = data_mem_usage * 5 + data_mem_usage / 4 * num_classes  # TODO: Extremely crude approximation, can be vastly improved
 
         params = self._get_model_params()
-        max_bins = params.get('max_bins', 255)
-        num_leaves = params.get('num_leaves', 31)
+        max_bins = params.get("max_bins", 255)
+        num_leaves = params.get("num_leaves", 31)
         # Memory usage of histogram based on https://github.com/microsoft/LightGBM/issues/562#issuecomment-304524592
         histogram_mem_usage_bytes = 20 * max_bins * len(X.columns) * num_leaves
-        histogram_mem_usage_bytes_max = params.get('histogram_pool_size', None)
+        histogram_mem_usage_bytes_max = params.get("histogram_pool_size", None)
         if histogram_mem_usage_bytes_max is not None:
             histogram_mem_usage_bytes_max *= 1e6  # Convert megabytes to bytes, `histogram_pool_size` is in MB.
             if histogram_mem_usage_bytes > histogram_mem_usage_bytes_max:

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -77,7 +77,7 @@ class LGBModel(AbstractModel):
         """
         num_classes = self.num_classes if self.num_classes else 1  # self.num_classes could be None after initialization if it's a regression problem
         data_mem_usage = get_approximate_df_mem_usage(X).sum()
-        data_mem_usage_bytes = data_mem_usage * 6 + data_mem_usage / 4 * num_classes  # TODO: Extremely crude approximation, can be vastly improved
+        data_mem_usage_bytes = data_mem_usage * 5 + data_mem_usage / 4 * num_classes  # TODO: Extremely crude approximation, can be vastly improved
 
         params = self._get_model_params()
         max_bins = params.get('max_bins', 255)

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -64,10 +64,33 @@ class LGBModel(AbstractModel):
             stopping_metric_name = stopping_metric
         return stopping_metric, stopping_metric_name
 
-    def _estimate_memory_usage(self, X, **kwargs):
+    def _estimate_memory_usage(self, X: DataFrame, **kwargs) -> float:
+        """
+        Returns the expected peak memory usage in bytes of the LightGBM model during fit.
+
+        The memory usage of LightGBM is primarily made up of two sources:
+
+        1. The size of the data
+        2. The size of the histogram cache
+            Scales roughly by 5100*num_features*num_leaves bytes
+            For 10000 features and 128 num_leaves, the histogram would be 6.5 GB.
+        """
         num_classes = self.num_classes if self.num_classes else 1  # self.num_classes could be None after initialization if it's a regression problem
         data_mem_usage = get_approximate_df_mem_usage(X).sum()
-        approx_mem_size_req = data_mem_usage * 7 + data_mem_usage / 4 * num_classes  # TODO: Extremely crude approximation, can be vastly improved
+        data_mem_usage_bytes = data_mem_usage * 6 + data_mem_usage / 4 * num_classes  # TODO: Extremely crude approximation, can be vastly improved
+
+        params = self._get_model_params()
+        max_bins = params.get('max_bins', 255)
+        num_leaves = params.get('num_leaves', 31)
+        # Memory usage of histogram based on https://github.com/microsoft/LightGBM/issues/562#issuecomment-304524592
+        histogram_mem_usage_bytes = 20 * max_bins * len(X.columns) * num_leaves
+        histogram_mem_usage_bytes_max = params.get('histogram_pool_size', None)
+        if histogram_mem_usage_bytes_max is not None:
+            histogram_mem_usage_bytes_max *= 1e6  # Convert megabytes to bytes, `histogram_pool_size` is in MB.
+            if histogram_mem_usage_bytes > histogram_mem_usage_bytes_max:
+                histogram_mem_usage_bytes = histogram_mem_usage_bytes_max
+
+        approx_mem_size_req = data_mem_usage_bytes + histogram_mem_usage_bytes
         return approx_mem_size_req
 
     def _fit(self, X, y, X_val=None, y_val=None, time_limit=None, num_gpus=0, num_cpus=0, sample_weight=None, sample_weight_val=None, verbosity=2, **kwargs):

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -89,6 +89,7 @@ class LGBModel(AbstractModel):
             histogram_mem_usage_bytes_max *= 1e6  # Convert megabytes to bytes, `histogram_pool_size` is in MB.
             if histogram_mem_usage_bytes > histogram_mem_usage_bytes_max:
                 histogram_mem_usage_bytes = histogram_mem_usage_bytes_max
+        histogram_mem_usage_bytes *= 1.2  # Add a 20% buffer
 
         approx_mem_size_req = data_mem_usage_bytes + histogram_mem_usage_bytes
         return approx_mem_size_req

--- a/tabular/src/autogluon/tabular/models/vowpalwabbit/vowpalwabbit_model.py
+++ b/tabular/src/autogluon/tabular/models/vowpalwabbit/vowpalwabbit_model.py
@@ -223,7 +223,7 @@ class VowpalWabbitModel(AbstractModel):
         y_pred_proba = np.array([self.model.predict(row) for row in X])
         return self._convert_proba_to_unified_form(y_pred_proba)
 
-    def get_memory_size(self) -> int:
+    def _get_memory_size(self) -> int:
         # TODO: Can be improved further to make it more accurate
         # Returning 5MB as the value
         return int(5e6)

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -195,11 +195,14 @@ class XGBoostModel(AbstractModel):
         # Formula based on manual testing, aligns with LightGBM histogram sizes
         #  This approximation is less accurate than it is for LightGBM and CatBoost.
         #  Note that max_depth didn't appear to reduce memory usage below 6, and it was unclear if it increased memory usage above 6.
-        if max_depth < 10:
+        if max_depth < 7:
             depth_modifier = math.pow(2, 6)
+        elif max_depth < 9:
+            depth_modifier = math.pow(2, max_depth)
         else:
-            depth_modifier = math.pow(2, max_depth - 3)
+            depth_modifier = math.pow(2, max_depth - 1)
         histogram_mem_usage_bytes = 20 * depth_modifier * len(X.columns) * max_bin
+        histogram_mem_usage_bytes *= 1.2  # Add a 20% buffer
 
         approx_mem_size_req = data_mem_usage_bytes + histogram_mem_usage_bytes
         return approx_mem_size_req

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import os
 import time
 
@@ -174,9 +175,33 @@ class XGBoostModel(AbstractModel):
         return {"early_stop"}
 
     def _estimate_memory_usage(self, X, **kwargs):
+        """
+        Returns the expected peak memory usage in bytes of the XGBoost model during fit.
+
+        The memory usage of XGBoost is primarily made up of two sources:
+
+        1. The size of the data
+        2. The size of the histogram cache
+            Scales roughly by 5120*num_features*2^max_depth bytes
+            For 10000 features and 6 max_depth, the histogram would be 3.2 GB.
+        """
         num_classes = self.num_classes if self.num_classes else 1  # self.num_classes could be None after initialization if it's a regression problem
         data_mem_usage = get_approximate_df_mem_usage(X).sum()
-        approx_mem_size_req = data_mem_usage * 7 + data_mem_usage / 4 * num_classes  # TODO: Extremely crude approximation, can be vastly improved
+        data_mem_usage_bytes = data_mem_usage * 7 + data_mem_usage / 4 * num_classes  # TODO: Extremely crude approximation, can be vastly improved
+
+        params = self._get_model_params()
+        max_bin = params.get('max_bin', 256)
+        max_depth = params.get('max_depth', 6)
+        # Formula based on manual testing, aligns with LightGBM histogram sizes
+        #  This approximation is less accurate than it is for LightGBM and CatBoost.
+        #  Note that max_depth didn't appear to reduce memory usage below 6, and it was unclear if it increased memory usage above 6.
+        if max_depth < 10:
+            depth_modifier = math.pow(2, 6)
+        else:
+            depth_modifier = math.pow(2, max_depth-3)
+        histogram_mem_usage_bytes = 20 * depth_modifier * len(X.columns) * max_bin
+
+        approx_mem_size_req = data_mem_usage_bytes + histogram_mem_usage_bytes
         return approx_mem_size_req
 
     def _validate_fit_memory_usage(self, mem_error_threshold: float = 1.0, mem_warning_threshold: float = 0.75, mem_size_threshold: int = 1e9, **kwargs):

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -190,15 +190,15 @@ class XGBoostModel(AbstractModel):
         data_mem_usage_bytes = data_mem_usage * 7 + data_mem_usage / 4 * num_classes  # TODO: Extremely crude approximation, can be vastly improved
 
         params = self._get_model_params()
-        max_bin = params.get('max_bin', 256)
-        max_depth = params.get('max_depth', 6)
+        max_bin = params.get("max_bin", 256)
+        max_depth = params.get("max_depth", 6)
         # Formula based on manual testing, aligns with LightGBM histogram sizes
         #  This approximation is less accurate than it is for LightGBM and CatBoost.
         #  Note that max_depth didn't appear to reduce memory usage below 6, and it was unclear if it increased memory usage above 6.
         if max_depth < 10:
             depth_modifier = math.pow(2, 6)
         else:
-            depth_modifier = math.pow(2, max_depth-3)
+            depth_modifier = math.pow(2, max_depth - 3)
         histogram_mem_usage_bytes = 20 * depth_modifier * len(X.columns) * max_bin
 
         approx_mem_size_req = data_mem_usage_bytes + histogram_mem_usage_bytes

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1024,6 +1024,10 @@ class TabularPredictor:
         calibrate_decision_threshold=False,
         infer_limit=None,
     ):
+        if not self.get_model_names():
+            logger.log(30, "Warning: No models found, skipping post_fit logic...")
+            return
+
         if refit_full is True:
             if keep_only_best is True:
                 if set_best_to_refit_full is True:

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1926,6 +1926,52 @@ class TabularPredictor:
             silent=silent,
         )
 
+    def get_model_failures(self, verbose: bool = False) -> pd.DataFrame:
+        """
+        [Advanced] Get the model failures that occurred during the fitting of this model, in the form of a pandas DataFrame.
+
+        This is useful for in-depth debugging of model failures and identifying bugs.
+
+        For more information on model failures, refer to `predictor.info()['model_info_failures']`
+
+        Parameters
+        ----------
+        verbose: bool, default = False
+            If True, the output DataFrame is printed to stdout.
+
+        Returns
+        -------
+        model_failures_df: pd.DataFrame
+            A DataFrame of model failures. Each row corresponds to a model failure, and columns correspond to meta information about that model.
+
+            Included Columns:
+                "model": The name of the model that failed
+                "exc_type": The class name of the exception raised
+                "total_time": The total time in seconds taken by the model prior to the exception (lost time due to the failure)
+                "model_type": The class name of the model
+                "child_model_type": The child class name of the model
+                "is_initialized"
+                "is_fit"
+                "is_valid"
+                "can_infer"
+                "num_features"
+                "num_models"
+                "memory_size"
+                "hyperparameters"
+                "hyperparameters_fit"
+                "child_hyperparameters"
+                "child_hyperparameters_fit"
+                "exc_str": The string message contained in the raised exception
+                "exc_traceback": The full traceback message of the exception as a string
+                "exc_order": The order of the model failure (starting from 1)
+        """
+        self._assert_is_fit("get_model_failures")
+        model_failures_df = self._trainer.get_model_failures()
+        if verbose:
+            with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
+                print(model_failures_df)
+        return model_failures_df
+
     def predict_proba_multi(
         self,
         data=None,
@@ -2722,7 +2768,7 @@ class TabularPredictor:
         Dictionary of `predictor` metadata.
         """
         self._assert_is_fit("info")
-        return self._learner.get_info(include_model_info=True)
+        return self._learner.get_info(include_model_info=True, include_model_failures=True)
 
     # TODO: Add data argument
     # TODO: Add option to disable OOF generation of newly fitted models

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -388,7 +388,7 @@ def run_tabular_benchmark_toy(fit_args):
     savedir = directory + "AutogluonOutput/"
     shutil.rmtree(savedir, ignore_errors=True)  # Delete AutoGluon output directory to ensure previous runs' information has been removed.
     predictor = TabularPredictor(label=dataset["label"], path=savedir).fit(train_data, **fit_args)
-    assert len(predictor._trainer._models_failed_to_train) == 0
+    assert len(predictor._trainer._models_failed_to_train_errors.keys()) == 0
     print(predictor.feature_metadata)
     print(predictor.feature_metadata.type_map_raw)
     print(predictor.feature_metadata.type_group_map_special)
@@ -485,7 +485,7 @@ def run_tabular_benchmarks(fast_benchmark, subsample_size, perf_threshold, seed_
                     # .sample instead of .head to increase diversity and test cases where data index is not monotonically increasing.
                     train_data = train_data.sample(n=subsample_size, random_state=seed_val)  # subsample for fast_benchmark
             predictor = TabularPredictor(label=label, path=savedir).fit(train_data, **fit_args)
-            assert len(predictor._trainer._models_failed_to_train) == 0
+            assert len(predictor._trainer._models_failed_to_train_errors.keys()) == 0
             results = predictor.fit_summary(verbosity=4)
             original_features = list(train_data)
             original_features.remove(label)

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -926,7 +926,7 @@ def test_quantile():
     directory = directory_prefix + dataset["name"] + "/"
     savedir = directory + "AutogluonOutput/"
     shutil.rmtree(savedir, ignore_errors=True)  # Delete AutoGluon output directory to ensure previous runs' information has been removed.
-    fit_args = {"time_limit": 20}
+    fit_args = {"time_limit": 40}
     predictor = TabularPredictor(label=dataset["label"], path=savedir, problem_type=dataset["problem_type"], quantile_levels=quantile_levels).fit(
         train_data, **fit_args
     )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add model failures tracking support via `predictor.get_model_failures()`
- Improve LightGBM, CatBoost, and XGBoost memory estimate by estimating the histogram memory usage.
- Improve stability of refit full when memory usage is high by increasing the memory usage cap by 25% for refit models to avoid fitting the original model successfully and then having the refit model cause a NotEnoughMemoryError exception due to requiring slightly more memory.
- PR has been tested extensively across 244 datasets with 1416 model configs. It works well, eliminating all cases of OOM due to incorrect memory estimates for GBM models, and the model failures logic works in all cases.

TODO:
- [x] Add unit tests
- [x] Add ability to not raise error when no models were trained
- [x] Polish docstrings


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
