### PR TITLE
Update setup.py - LightGBM version bump

### DIFF
--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -33,7 +33,7 @@ install_requires = [
 
 extras_require = {
     "lightgbm": [
-        "lightgbm>=3.3,<4.2",  # <{N+1} upper cap, where N is the latest released minor version
+        "lightgbm>=3.3,<4.4",  # <{N+1} upper cap, where N is the latest released minor version
     ],
     "catboost": [
         # CatBoost wheel build is not working correctly on darwin for CatBoost 1.2, so use old version in this case.


### PR DESCRIPTION
*Description of changes:*
There is a new version of LightGBM: https://github.com/microsoft/LightGBM/releases/tag/v4.0.0
I think the most important part is quantization that promises 2x speed-up in training (https://arxiv.org/pdf/2207.09682.pdf)
It could be enabled by parameter `use_quantized_grad`  (https://lightgbm.readthedocs.io/en/latest/Parameters.html)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
