### PR TITLE
[AutoMM] Unify creating tokenizers for all models

### DIFF
--- a/multimodal/src/autogluon/multimodal/data/process_document.py
+++ b/multimodal/src/autogluon/multimodal/data/process_document.py
@@ -101,6 +101,7 @@ class DocumentProcessor:
         # For document text processing.
         # Disable tokenizer parallelism
         os.environ["TOKENIZERS_PARALLELISM"] = "false"
+        self.tokenizer_name = model.tokenizer_name
         self.tokenizer = model.tokenizer
         if text_max_len is None or text_max_len <= 0:
             self.text_max_len = self.tokenizer.model_max_length

--- a/multimodal/src/autogluon/multimodal/data/process_document.py
+++ b/multimodal/src/autogluon/multimodal/data/process_document.py
@@ -12,16 +12,12 @@ from nptyping import NDArray
 from PIL import ImageFile
 from torch import nn
 from torchvision import transforms
-from transformers import AutoTokenizer
 
 from ..constants import AUTOMM, BBOX, DOCUMENT_PDF
 from .collator import PadCollator, StackCollator
 from .utils import construct_image_processor, image_mean_std
 
 logger = logging.getLogger(__name__)
-
-# Disable tokenizer parallelism
-os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 
 class DocumentProcessor:
@@ -103,6 +99,8 @@ class DocumentProcessor:
         self.sep_token_box = [1000, 1000, 1000, 1000]  # sep box token
 
         # For document text processing.
+        # Disable tokenizer parallelism
+        os.environ["TOKENIZERS_PARALLELISM"] = "false"
         self.tokenizer = model.tokenizer
         if text_max_len is None or text_max_len <= 0:
             self.text_max_len = self.tokenizer.model_max_length
@@ -115,13 +113,6 @@ class DocumentProcessor:
             self.text_max_len = min(text_max_len, self.tokenizer.model_max_length)
 
         self.tokenizer.model_max_length = self.text_max_len
-
-    @staticmethod
-    def get_pretrained_tokenizer(
-        tokenizer_name: str,
-        checkpoint_name: str,
-    ):
-        return AutoTokenizer.from_pretrained(checkpoint_name)
 
     def collate_fn(self, text_column_names: Optional[List] = None) -> Dict:
         """

--- a/multimodal/src/autogluon/multimodal/data/process_ner.py
+++ b/multimodal/src/autogluon/multimodal/data/process_ner.py
@@ -45,7 +45,7 @@ class NerProcessor:
         self.label_key = model.label_key
 
         self.tokenizer = None
-        self.tokenizer_name = model.prefix
+        self.tokenizer_name = model.tokenizer_name
         self.max_len = max_len
         self.entity_map = entity_map
 

--- a/multimodal/src/autogluon/multimodal/data/process_text.py
+++ b/multimodal/src/autogluon/multimodal/data/process_text.py
@@ -9,7 +9,6 @@ import numpy as np
 from nptyping import NDArray
 from omegaconf import DictConfig
 from torch import nn
-from transformers import AutoConfig, AutoTokenizer, BertTokenizer, CLIPTokenizer, ElectraTokenizer
 
 from ..constants import CHOICES_IDS, COLUMN, TEXT, TEXT_SEGMENT_IDS, TEXT_TOKEN_IDS, TEXT_VALID_LENGTH
 from .collator import PadCollator, StackCollator
@@ -28,14 +27,6 @@ logger = logging.getLogger(__name__)
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 
-ALL_TOKENIZERS = {
-    "bert": BertTokenizer,
-    "clip": CLIPTokenizer,
-    "electra": ElectraTokenizer,
-    "hf_auto": AutoTokenizer,
-}
-
-
 class TextProcessor:
     """
     Prepare text data for the model specified by "prefix". For multiple models requiring text data,
@@ -45,7 +36,6 @@ class TextProcessor:
     def __init__(
         self,
         model: nn.Module,
-        tokenizer_name: Optional[str] = "hf_auto",
         max_len: Optional[int] = None,
         insert_sep: Optional[bool] = True,
         text_segment_num: Optional[int] = 1,
@@ -56,15 +46,12 @@ class TextProcessor:
         train_augment_types: Optional[List[str]] = None,
         template_config: Optional[DictConfig] = None,
         normalize_text: Optional[bool] = False,
-        use_fast: Optional[bool] = True,
     ):
         """
         Parameters
         ----------
         model
             The model for which this processor would be created.
-        tokenizer_name
-            Name of the huggingface tokenizer type (default "hf_auto").
         max_len
             The maximum length of text tokens.
         insert_sep
@@ -87,24 +74,12 @@ class TextProcessor:
             Whether to normalize text to resolve encoding problems.
             Examples of normalized texts can be found at
             https://github.com/autogluon/autogluon/tree/master/examples/automm/kaggle_feedback_prize#15-a-few-examples-of-normalized-texts
-        use_fast
-            Use a fast Rust-based tokenizer if it is supported for a given model.
-            If a fast tokenizer is not available for a given model, a normal Python-based tokenizer is returned instead.
-            See: https://huggingface.co/docs/transformers/model_doc/auto#transformers.AutoTokenizer.from_pretrained.use_fast
-
         """
         self.prefix = model.prefix
-        self.tokenizer_name = tokenizer_name
         self.requires_column_info = requires_column_info
-        # Use the model's tokenizer if it exists.
-        if hasattr(model, "tokenizer"):
-            self.tokenizer = model.tokenizer
-        else:
-            self.tokenizer = self.get_pretrained_tokenizer(
-                tokenizer_name=tokenizer_name,
-                checkpoint_name=model.checkpoint_name,
-                use_fast=use_fast,
-            )
+        self.tokenizer_name = model.tokenizer_name
+        # model should have a tokenizer
+        self.tokenizer = model.tokenizer
         if hasattr(self.tokenizer, "deprecation_warnings"):
             # Disable the warning "Token indices sequence length is longer than the specified maximum sequence..."
             # See https://github.com/huggingface/transformers/blob/6ac77534bfe97c00e0127bb4fc846ae0faf1c9c5/src/transformers/tokenization_utils_base.py#L3362
@@ -373,45 +348,6 @@ class TextProcessor:
         if cls_id is None or sep_id is None or eos_id is None:
             raise ValueError(f"tokenizer class: {tokenizer.__class__.__name__} has no valid cls, sep, and eos ids.")
         return cls_id, sep_id, eos_id
-
-    @staticmethod
-    def get_pretrained_tokenizer(
-        tokenizer_name: str,
-        checkpoint_name: str,
-        use_fast: Optional[bool] = True,
-    ):
-        """
-        Load the tokenizer for a pre-trained huggingface checkpoint.
-
-        Parameters
-        ----------
-        tokenizer_name
-            The tokenizer type, e.g., "bert", "clip", "electra", and "hf_auto".
-        checkpoint_name
-            Name of a pre-trained checkpoint.
-        use_fast
-            Use a fast Rust-based tokenizer if it is supported for a given model.
-            If a fast tokenizer is not available for a given model, a normal Python-based tokenizer is returned instead.
-            See: https://huggingface.co/docs/transformers/model_doc/auto#transformers.AutoTokenizer.from_pretrained.use_fast
-
-        Returns
-        -------
-        A tokenizer instance.
-        """
-        try:
-            tokenizer_class = ALL_TOKENIZERS[tokenizer_name]
-            return tokenizer_class.from_pretrained(checkpoint_name, use_fast=use_fast)
-        except TypeError as e:
-            try:
-                tokenizer_class = ALL_TOKENIZERS["bert"]
-                tokenizer = tokenizer_class.from_pretrained(checkpoint_name)
-                logger.warning(
-                    f"Current checkpoint {checkpoint_name} does not support AutoTokenizer. "
-                    "Switch to BertTokenizer instead."
-                )
-                return tokenizer
-            except:
-                raise e
 
     @staticmethod
     def get_trimmed_lengths(

--- a/multimodal/src/autogluon/multimodal/models/clip.py
+++ b/multimodal/src/autogluon/multimodal/models/clip.py
@@ -18,7 +18,13 @@ from ..constants import (
     TEXT_TOKEN_IDS,
     TEXT_VALID_LENGTH,
 )
-from .utils import assign_layer_ids, get_column_features, get_hf_config_and_model, init_weights
+from .utils import (
+    assign_layer_ids,
+    get_column_features,
+    get_hf_config_and_model,
+    get_pretrained_tokenizer,
+    init_weights,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +41,7 @@ class CLIPForImageText(nn.Module):
         checkpoint_name: str,
         num_classes: Optional[int] = None,
         pretrained: Optional[bool] = True,
+        tokenizer_name: Optional[str] = "clip",
     ):
         """
         Load the pretrained CLIP from huggingface transformers.
@@ -49,6 +56,8 @@ class CLIPForImageText(nn.Module):
             The number of classes. 1 for a regression task.
         pretrained
             Whether using the pretrained weights. If pretrained=True, download the pretrained model.
+        tokenizer_name
+            Name of the huggingface tokenizer type.
         """
         super().__init__()
         logger.debug(f"initializing {checkpoint_name}")
@@ -56,6 +65,11 @@ class CLIPForImageText(nn.Module):
         self.num_classes = num_classes
 
         self.config, self.model = get_hf_config_and_model(checkpoint_name=checkpoint_name, pretrained=pretrained)
+        self.tokenizer_name = tokenizer_name
+        self.tokenizer = get_pretrained_tokenizer(
+            tokenizer_name=self.tokenizer_name,
+            checkpoint_name=self.checkpoint_name,
+        )
 
         self.out_features = self.model.config.projection_dim
 

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -2594,6 +2594,7 @@ class MultiModalPredictor(ExportMixin):
                 TEXT,
                 TEXT_NER,
                 NER,
+                DOCUMENT,
             ]:  # NER is included for backward compatibility
                 if modality in data_processors:
                     data_processors[modality] = load_text_tokenizers(

--- a/multimodal/src/autogluon/multimodal/utils/data.py
+++ b/multimodal/src/autogluon/multimodal/utils/data.py
@@ -147,7 +147,6 @@ def create_data_processor(
     elif data_type == TEXT:
         data_processor = TextProcessor(
             model=model,
-            tokenizer_name=model_config.tokenizer_name,
             max_len=model_config.max_text_len,
             insert_sep=model_config.insert_sep,
             text_segment_num=model_config.text_segment_num,
@@ -157,7 +156,6 @@ def create_data_processor(
             train_augment_types=OmegaConf.select(model_config, "text_train_augment_types"),
             template_config=getattr(config.data, "templates", OmegaConf.create({"turn_on": False})),
             normalize_text=getattr(config.data.text, "normalize_text", False),
-            use_fast=OmegaConf.select(model_config, "use_fast", default=True),
         )
     elif data_type == CATEGORICAL:
         data_processor = CategoricalProcessor(
@@ -174,7 +172,7 @@ def create_data_processor(
         data_processor = NerProcessor(
             model=model,
             max_len=model_config.max_text_len,
-            config=config,
+            entity_map=config.entity_map,
         )
     elif data_type == ROIS:
         data_processor = MMDetProcessor(

--- a/multimodal/src/autogluon/multimodal/utils/export.py
+++ b/multimodal/src/autogluon/multimodal/utils/export.py
@@ -29,7 +29,7 @@ class ExportMixin:
 
         Parameters
         ----------
-        path : str
+        save_path : str
             Path to directory where models and configs should be saved.
         """
 
@@ -61,17 +61,11 @@ class ExportMixin:
                 f"No models available for dump. Current supported models are: {supported_models.keys()}"
             )
 
-        # get tokenizers for hf_text
-        text_processors = self._data_processors.get(TEXT, {})
-        tokenizers = {}
-        for per_processor in text_processors:
-            tokenizers[per_processor.prefix] = per_processor.tokenizer
-
         for model_key in models:
             for per_model in models[model_key]:
                 subdir = os.path.join(save_path, per_model.prefix)
                 os.makedirs(subdir, exist_ok=True)
-                per_model.save(save_path=subdir, tokenizers=tokenizers)
+                per_model.save(save_path=subdir)
 
         return save_path
 

--- a/multimodal/src/autogluon/multimodal/utils/load.py
+++ b/multimodal/src/autogluon/multimodal/utils/load.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Optional, Tuple, Union
 
 from ..constants import LAST_CHECKPOINT, MODEL_CHECKPOINT
 from ..data import DocumentProcessor, NerProcessor, TextProcessor
+from ..models.utils import get_pretrained_tokenizer
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +32,7 @@ def load_text_tokenizers(
     for per_text_processor in text_processors:
         if isinstance(per_text_processor.tokenizer, str):
             per_path = os.path.join(path, per_text_processor.tokenizer)
-            per_text_processor.tokenizer = per_text_processor.get_pretrained_tokenizer(
+            per_text_processor.tokenizer = get_pretrained_tokenizer(
                 tokenizer_name=per_text_processor.tokenizer_name,
                 checkpoint_name=per_path,
             )

--- a/multimodal/src/autogluon/multimodal/utils/model.py
+++ b/multimodal/src/autogluon/multimodal/utils/model.py
@@ -196,6 +196,7 @@ def create_model(
             checkpoint_name=model_config.checkpoint_name,
             num_classes=num_classes,
             pretrained=pretrained,
+            tokenizer_name=model_config.tokenizer_name,
         )
     elif model_name.lower().startswith(TIMM_IMAGE):
         model = TimmAutoModelForImagePrediction(
@@ -214,6 +215,8 @@ def create_model(
             gradient_checkpointing=OmegaConf.select(model_config, "gradient_checkpointing"),
             low_cpu_mem_usage=OmegaConf.select(model_config, "low_cpu_mem_usage", default=False),
             pretrained=pretrained,
+            tokenizer_name=model_config.tokenizer_name,
+            use_fast=OmegaConf.select(model_config, "use_fast", default=True),
         )
     elif model_name.lower().startswith(T_FEW):
         model = TFewModel(
@@ -226,6 +229,7 @@ def create_model(
             gradient_checkpointing=OmegaConf.select(model_config, "gradient_checkpointing"),
             low_cpu_mem_usage=OmegaConf.select(model_config, "low_cpu_mem_usage", default=False),
             pretrained=pretrained,
+            tokenizer_name=model_config.tokenizer_name,
         )
     elif model_name.lower().startswith(NUMERICAL_MLP):
         model = NumericalMLP(
@@ -306,6 +310,7 @@ def create_model(
             gradient_checkpointing=OmegaConf.select(model_config, "gradient_checkpointing"),
             low_cpu_mem_usage=OmegaConf.select(model_config, "low_cpu_mem_usage", default=False),
             pretrained=pretrained,
+            tokenizer_name=model_config.tokenizer_name,
         )
     elif model_name.lower().startswith(MMDET_IMAGE):
         model = MMDetAutoModelForObjectDetection(
@@ -341,6 +346,7 @@ def create_model(
             gradient_checkpointing=OmegaConf.select(model_config, "gradient_checkpointing"),
             low_cpu_mem_usage=OmegaConf.select(model_config, "low_cpu_mem_usage", default=False),
             pretrained=pretrained,
+            tokenizer_name=model_config.tokenizer_name,
         )
     elif model_name.lower().startswith(FUSION_MLP):
         model = functools.partial(

--- a/multimodal/tests/unittests/others/test_ner.py
+++ b/multimodal/tests/unittests/others/test_ner.py
@@ -2,7 +2,6 @@ import pandas as pd
 import pytest
 from ray import tune
 
-from autogluon.core.hpo.ray_tune_constants import SCHEDULER_PRESETS, SEARCHER_PRESETS
 from autogluon.multimodal import MultiModalPredictor
 
 
@@ -28,7 +27,10 @@ def get_data():
 
 @pytest.mark.parametrize(
     "checkpoint_name,searcher,scheduler",
-    [("google/electra-small-discriminator", "bayes", "FIFO")],
+    [
+        ("google/electra-small-discriminator", None, None),
+        ("google/electra-small-discriminator", "bayes", "FIFO"),
+    ],
 )
 def test_ner(checkpoint_name, searcher, scheduler):
     train_data = get_data()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Previously, tokenizers were created in both model and data processor, which is difficult to maintain. This PR is to unify creating tokenizers for all models. Now tokenizers are created in the model initializations and then passed to data processors.
- Fixed the slow loading issue of M5 tokenizer. `use_fast` is only needed in one place.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
