### PR TITLE
[AutoMM] Use ddp_spawn for muti-GPU inference

### DIFF
--- a/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
@@ -11,6 +11,6 @@ env:
   fast_dev_run: False
   deterministic: False
   auto_select_gpus: True
-  strategy: "ddp_spawn"
+  strategy: "ddp_spawn_find_unused_parameters_true"
   deepspeed_allgather_size: 1e9 # DeepSpeed allgather size (number of elements gathered at a time). Limits memory required for allgather on large models.
   deepspeed_allreduce_size: 1e9 # DeepSpeed allreduce size (number of elements reduced at a time). Limits memory required for allreduce on large models.

--- a/multimodal/src/autogluon/multimodal/constants.py
+++ b/multimodal/src/autogluon/multimodal/constants.py
@@ -302,3 +302,6 @@ ALL_MODEL_QUALITIES = [HIGH_QUALITY, MEDIUM_QUALITY, BEST_QUALITY, DEFAULT]
 # datasets
 DEFAULT_DATASET = "default_dataset"
 MULTI_IMAGE_MIX_DATASET = "multi_image_mix_dataset"
+
+# strategies
+DDP = "ddp"

--- a/multimodal/src/autogluon/multimodal/data/datamodule.py
+++ b/multimodal/src/autogluon/multimodal/data/datamodule.py
@@ -226,6 +226,6 @@ class BaseDataModule(LightningDataModule):
                 data_processors=self.data_processors,
                 per_gpu_batch_size=self.per_gpu_batch_size,
             ),
-            persistent_workers=False,
+            persistent_workers=self.num_workers > 0,
         )
         return loader

--- a/multimodal/src/autogluon/multimodal/utils/__init__.py
+++ b/multimodal/src/autogluon/multimodal/utils/__init__.py
@@ -1,4 +1,4 @@
-from .cache import DDPCacheWriter
+from .cache import DDPPredictionWriter
 from .checkpoint import AutoMMModelCheckpoint, AutoMMModelCheckpointIO, average_checkpoints
 from .config import (
     apply_omegaconf_overrides,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Deprecate `dp` from the default inference since lightning no longer supports it (https://github.com/Lightning-AI/lightning/pull/16748). Now we use the same strategy for both training and inference.
- Change the default strategy from `ddp_spawn` to `ddp_spawn_find_unused_parameters_true`. According to https://github.com/Lightning-AI/lightning/pull/16611, lightning set `find_unused_parameters=False` by default. 

TODOs:
- Evaluate the benefit of greedy soup. Two options: 1) turn it off; 2) keep it and use single gpu for evaluation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
