### PR TITLE
[AutoMM] Fix training in notebook

### DIFF
--- a/multimodal/src/autogluon/multimodal/utils/environment.py
+++ b/multimodal/src/autogluon/multimodal/utils/environment.py
@@ -11,7 +11,7 @@ from torch import nn
 
 from autogluon.common.utils.resource_utils import ResourceManager
 
-from ..constants import AUTOMM, OBJECT_DETECTION, OCR
+from ..constants import DDP, OBJECT_DETECTION, OCR
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +55,7 @@ def compute_num_gpus(config_num_gpus: Union[int, float, List], strategy: str):
                 UserWarning,
             )
 
-    if is_interactive() and num_gpus > 1 and strategy in ["ddp", "ddp_spawn"]:
+    if is_interactive() and num_gpus > 1 and strategy.startswith(DDP):
         warnings.warn(
             "Interactive environment is detected. Currently, MultiModalPredictor does not support multi-gpu "
             "training under an interactive environment due to the limitation of ddp / ddp_spawn strategies "


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The default strategy is `ddp_spawn_find_unused_parameters_true`. Make sure training in an interactive env with multi-gpus doesn't fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
