### PR TITLE
[common] Fix deprecation warnings

### DIFF
--- a/common/src/autogluon/common/utils/deprecated_utils.py
+++ b/common/src/autogluon/common/utils/deprecated_utils.py
@@ -27,7 +27,7 @@ def _deprecation_warning(
         warnings.warn(
             f"Deprecation Warning: {msg}. This will raise an error in the future!",
             category=DeprecationWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
 
 


### PR DESCRIPTION
The deprecation warnings generated by the `Deprecated` decorator are currently silenced. This happens because Python silences all `DeprecationWarning`s by default, except those that occur inside the `if __name__ = "__main__:"` idiom ([PEP565](https://peps.python.org/pep-0565/)).

<details>
<summary>Minimal working example</summary>

```python
from autogluon.common.utils.deprecated_utils import Deprecated

@Deprecated(min_version_to_warn="0.8", min_version_to_error="1.0")
def f(x):
    return x

if __name__ == "__main__":
    f(1)  # this does not produce a warning
```

</details>

With the current value `stacklevel=2` the warnings are attributed to the decorator inside `common/src/autogluon/common/utils/deprecated_utils.py`, so they are silenced.

*Description of changes:*
- Set `stacklevel=3` to attribute the warnings to the the main script. This ensures that the warnings are correctly displayed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
