### PR TITLE
[Tabular] Fix infer_limit being incorrectly calculated when bagging

### DIFF
--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -1979,11 +1979,16 @@ class AbstractTrainer:
             if not _is_refit:
                 predict_1_time_child = self.get_model_attribute(model=model.name, attribute="predict_1_child_time")
                 predict_1_time_child_log, time_unit = convert_time_in_s_to_log_friendly(time_in_sec=predict_1_time_child)
-                logger.log(20, f"\t{round(predict_1_time_child_log, 3)}{time_unit}\t = Validation runtime (1 row | {predict_1_batch_size} batch size | REFIT | MARGINAL)")
+                logger.log(
+                    20,
+                    f"\t{round(predict_1_time_child_log, 3)}{time_unit}\t = Validation runtime (1 row | {predict_1_batch_size} batch size | REFIT | MARGINAL)",
+                )
 
                 predict_1_time_full_child = self.get_model_attribute_full(model=model.name, attribute="predict_1_child_time")
                 predict_1_time_full_child_log, time_unit = convert_time_in_s_to_log_friendly(time_in_sec=predict_1_time_full_child)
-                logger.log(20, f"\t{round(predict_1_time_full_child_log, 3)}{time_unit}\t = Validation runtime (1 row | {predict_1_batch_size} batch size | REFIT)")
+                logger.log(
+                    20, f"\t{round(predict_1_time_full_child_log, 3)}{time_unit}\t = Validation runtime (1 row | {predict_1_batch_size} batch size | REFIT)"
+                )
 
     # TODO: Split this to avoid confusion, HPO should go elsewhere?
     def _train_single_full(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- [x] TODO: Benchmark

Fixes infer_limit being incorrectly calculated when bagging

The fix involves using the post-refit (expected) infer time of models in all scenarios involving refit full and selecting the best model when `infer_limit` is specified.

With this fix, infer_limit should work as intended in all scenarios. For users who were already using `infer_limit` combined with bagging, it is recommended to lower the `infer_limit` value by a factor of 10 to maintain similar inference speed.

Specifically, the inference time values used were incorrect when 1. choosing the best model, and 2. choosing the best model during refit full with bagging enabled.

If a bagged model had 8 folds, it would use the infer time of all 8 fold models, rather than the expected _FULL refit model.
This led to scenarios where the models would satisfy the infer limit when refit, but were filtered out of consideration due to their non-refit infer times being used at the time of filtering.

This problem got worse with repeated bagging, leading to an up to 160x difference in infer time compared to expectation.

When this problem occurs, it can lead to an exception in two ways:

Exception 1: Occurs when the `model_best` changes when considering the `infer_limit`, and that changed model does not exist in refit because it was not the model that was refit.
```
Traceback (most recent call last):
  File "/bench/frameworks/shared/callee.py", line 75, in call_run
    result = run_fn(ds, config)
  File "/bench/frameworks/AutoGluon/exec.py", line 73, in run
    predictor = TabularPredictor(
  File "/bench/frameworks/AutoGluon/venv/lib/python3.9/site-packages/autogluon/core/utils/decorators.py", line 30, in _call
    return f(*gargs, **gkwargs)
  File "/bench/frameworks/AutoGluon/venv/lib/python3.9/site-packages/autogluon/tabular/predictor/predictor.py", line 959, in fit
    self._post_fit(
  File "/bench/frameworks/AutoGluon/venv/lib/python3.9/site-packages/autogluon/tabular/predictor/predictor.py", line 1014, in _post_fit
    self._trainer.calibrate_model()
  File "/bench/frameworks/AutoGluon/venv/lib/python3.9/site-packages/autogluon/core/trainer/abstract_trainer.py", line 3041, in calibrate_model
    y_val_probs = self.get_model_oof(model_name_og)
  File "/bench/frameworks/AutoGluon/venv/lib/python3.9/site-packages/autogluon/core/trainer/abstract_trainer.py", line 967, in get_model_oof
    model_type = self.get_model_attribute(model=model, attribute='type')
  File "/bench/frameworks/AutoGluon/venv/lib/python3.9/site-packages/autogluon/core/trainer/abstract_trainer.py", line 2347, in get_model_attribute
    model = model.name
AttributeError: 'NoneType' object has no attribute 'name'
```

Exception 2: Occurs when the incorrect larger infer time values lead to 0 models satisfying the infer limit.
```
AssertionError: Trainer has no fit models that can infer while satisfying the constraints: (infer_limit=9.992981433868409e-05, allow_full=True).
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
