### PR TITLE
Adding Windows platform fix for Core test failure

### DIFF
--- a/.github/workflow_scripts/test_core.sh
+++ b/.github/workflow_scripts/test_core.sh
@@ -10,9 +10,13 @@ setup_build_env
 install_local_packages "common/[tests]" "core/[all,tests]"
 
 cd core/
-if [ -n "$ADDITIONAL_TEST_ARGS" ]
+if [ "$OSTYPE" == "msys" ]
 then
-    python3 -m pytest --junitxml=results.xml --runslow "$ADDITIONAL_TEST_ARGS" tests
-else
+    # to skip certain tests on Windows platform
     python3 -m pytest --junitxml=results.xml --runslow tests
+elif [ -n "$ADDITIONAL_TEST_ARGS" ]
+then
+    python3 -m pytest --junitxml=results.xml --runslow --runplatform "$ADDITIONAL_TEST_ARGS" tests
+else
+    python3 -m pytest --junitxml=results.xml --runslow --runplatform tests
 fi

--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -13,6 +13,9 @@ on:
       pr-sha:
         description: 'The pr-sha of which the slash command was dispatched'
         required: true
+      branch_or_pr_number:
+        description: 'dummy parameter to allow benchmark workflow to run'
+        required: false
 
 jobs:
   setup:

--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -23,7 +23,6 @@ def pytest_collection_modifyitems(config, items):
     if config.getoption("--runplatform"):
         # --runplatform given in cli: do not skip platform tests
         custom_markers.pop("platform", None)
-        
     for item in items:
         if "slow" in item.keywords:
             item.add_marker(skip_slow)

--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -3,19 +3,27 @@ import pytest
 
 def pytest_addoption(parser):
     parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
+    parser.addoption("--runplatform", action="store_true", default=False, help="run all skipped platform tests")
 
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
+    config.addinivalue_line("markers", "platform: mark test as Ubuntu/Linux/Mac platform test")
     plugin = config.pluginmanager.getplugin("mypy")
     plugin.mypy_argv.append("--ignore-missing-imports")
 
 
 def pytest_collection_modifyitems(config, items):
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    skip_platform = pytest.mark.skip(reason="need --runplatform option to run")
+    custom_markers = dict(slow=skip_slow, platform=skip_platform)
     if config.getoption("--runslow"):
         # --runslow given in cli: do not skip slow tests
-        return
-    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+        custom_markers.pop("slow", None)
+    if config.getoption("--runplatform"):
+        # --runplatform given in cli: do not skip platform tests
+        custom_markers.pop("platform", None)
+        
     for item in items:
         if "slow" in item.keywords:
             item.add_marker(skip_slow)

--- a/core/tests/unittests/hpo/test_ray_hpo.py
+++ b/core/tests/unittests/hpo/test_ray_hpo.py
@@ -117,6 +117,7 @@ def test_empty_search_space():
             )
 
 
+@pytest.mark.platform
 @pytest.mark.parametrize("searcher", list(SEARCHER_PRESETS.keys()))
 @pytest.mark.parametrize("scheduler", list(SCHEDULER_PRESETS.keys()))
 def test_run(searcher, scheduler):


### PR DESCRIPTION
*Description of changes:*
Core tests fail on Windows platform after ray upgrade PR - https://github.com/autogluon/autogluon/pull/3468
Was not reproducible on Windows EC2, hence adding checks to skip it only on Windows Platforms.

Test run - https://github.com/prateekdesai04/autogluon/actions/runs/5968708969

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
