### PR TITLE
Tabular: Fix train_test split edge-case

### DIFF
--- a/core/tests/unittests/utils/test_utils.py
+++ b/core/tests/unittests/utils/test_utils.py
@@ -1,8 +1,8 @@
-import pytest
 import unittest
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from autogluon.core.constants import BINARY, MULTICLASS, MULTICLASS_UPPER_LIMIT, REGRESSION
 from autogluon.core.utils import infer_problem_type

--- a/core/tests/unittests/utils/test_utils.py
+++ b/core/tests/unittests/utils/test_utils.py
@@ -1,3 +1,4 @@
+import pytest
 import unittest
 
 import numpy as np
@@ -5,6 +6,7 @@ import pandas as pd
 
 from autogluon.core.constants import BINARY, MULTICLASS, MULTICLASS_UPPER_LIMIT, REGRESSION
 from autogluon.core.utils import infer_problem_type
+from autogluon.core.utils.utils import generate_train_test_split
 
 
 class TestInferProblemType(unittest.TestCase):
@@ -77,3 +79,57 @@ class TestInferProblemType(unittest.TestCase):
         small_integer_regression_series = pd.Series(np.arange(MULTICLASS_UPPER_LIMIT - 1), dtype=np.int64)
         inferred_problem_type = infer_problem_type(small_integer_regression_series)
         assert inferred_problem_type == REGRESSION
+
+
+def test_generate_train_test_split_edgecase():
+    """
+    Test rare edge-cases when data has many classes or very few samples when doing train test splits.
+    """
+    data = pd.DataFrame(index=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
+    data["label"] = [0, 1, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5]
+
+    for test_size in range(1, 12):
+        """
+        Normal Case: Regression should always work
+        """
+        X_train, X_test, y_train, y_test = generate_train_test_split(X=data, y=data["label"], problem_type="regression", test_size=test_size)
+        assert len(X_train) == len(y_train)
+        assert list(X_train.index) == list(y_train.index)
+        assert len(X_test) == len(y_test)
+        assert list(X_test.index) == list(y_test.index)
+        assert len(X_test) == test_size
+        assert len(X_train) == len(data) - test_size
+
+    for test_size in range(1, 6):
+        """
+        Edge-case: There are fewer test rows than classes
+         This only works because of special try/except logic in `generate_train_test_split`.
+        """
+        X_train, X_test, y_train, y_test = generate_train_test_split(X=data, y=data["label"], problem_type="multiclass", test_size=test_size)
+        assert len(X_train) == len(y_train)
+        assert list(X_train.index) == list(y_train.index)
+        assert len(X_test) == len(y_test)
+        assert list(X_test.index) == list(y_test.index)
+        assert len(X_test) <= test_size
+        assert len(X_train) == len(data) - len(X_test)
+
+    for test_size in range(6, 7):
+        """
+        Normal Case
+        """
+        X_train, X_test, y_train, y_test = generate_train_test_split(X=data, y=data["label"], problem_type="multiclass", test_size=test_size)
+        assert len(X_train) == len(y_train)
+        assert list(X_train.index) == list(y_train.index)
+        assert len(X_test) == len(y_test)
+        assert list(X_test.index) == list(y_test.index)
+        assert len(X_test) <= test_size
+        assert len(X_train) == len(data) - len(X_test)
+
+    for test_size in range(7, 12):
+        """
+        Edge-case: There are fewer train rows than classes
+        Error due to not enough training data to have at least one instance of every class in train.
+        Note: Ideally this shouldn't raise an exception, but writing the logic to avoid the error is tricky and the scenario should never occur in practice.
+        """
+        with pytest.raises(ValueError):
+            X_train, X_test, y_train, y_test = generate_train_test_split(X=data, y=data["label"], problem_type="multiclass", test_size=test_size)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In cases where there are an extreme number of classes compared to data samples and the data is large, AutoGluon can crash during train test split due to a bug in scikit-learn's `train_test_split` function.

Example:

```
Train Data Rows:    1528329
Train Data Class Count: 27000
```

Because the test split would be 1% of the total data based on AutoGluon's split logic, it results in the test data having fewer rows than the number of classes, triggering the error:

```
ValueError: The test_size = 14915 should be greater or equal to the number of classes = 27000
```

While scikit-learn claims that test_size must be greater than the number of classes, this isn't technically required fundamentally. This PR adds a work-around for this limitation by disabling stratification during train test split if stratification would lead to the above error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
