### PR TITLE
[WIP] Allow pandas <=2.1

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -30,11 +30,7 @@ DEPENDENT_PACKAGES = {
     "pytorch-lightning": ">=2.0.0,<2.1",  # "<{N+1}" upper cap
 }
 if LITE_MODE:
-    DEPENDENT_PACKAGES = {
-        package: version
-        for package, version in DEPENDENT_PACKAGES.items()
-        if package not in ["psutil", "Pillow", "timm"]
-    }
+    DEPENDENT_PACKAGES = {package: version for package, version in DEPENDENT_PACKAGES.items() if package not in ["psutil", "Pillow", "timm"]}
 
 DEPENDENT_PACKAGES = {package: package + version for package, version in DEPENDENT_PACKAGES.items()}
 # TODO: Use DOCS_PACKAGES and TEST_PACKAGES

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -19,7 +19,7 @@ DEPENDENT_PACKAGES = {
     # note: if python 3.7 is used, the open CVEs are present: CVE-2021-41496 | CVE-2021-34141; fixes are available in 1.22.x, but python 3.8 only
     "boto3": ">=1.10,<2",  # <2 because unlikely to introduce breaking changes in minor releases. >=1.10 because 1.10 is 3 years old, no need to support older
     "numpy": ">=1.21,<1.27",  # "<{N+3}" upper cap, where N is the latest released minor version, assuming no warnings using N
-    "pandas": ">=1.4.1,<1.6",  # "<{N+1}" upper cap
+    "pandas": ">=1.4.1,<2.2",  # Latest release cap
     "scikit-learn": ">=1.0,<1.3",  # "<{N+1}" upper cap
     "scipy": ">=1.5.4,<1.12",  # "<{N+2}" upper cap
     "psutil": ">=5.7.3,<6",  # Major version cap
@@ -30,7 +30,11 @@ DEPENDENT_PACKAGES = {
     "pytorch-lightning": ">=2.0.0,<2.1",  # "<{N+1}" upper cap
 }
 if LITE_MODE:
-    DEPENDENT_PACKAGES = {package: version for package, version in DEPENDENT_PACKAGES.items() if package not in ["psutil", "Pillow", "timm"]}
+    DEPENDENT_PACKAGES = {
+        package: version
+        for package, version in DEPENDENT_PACKAGES.items()
+        if package not in ["psutil", "Pillow", "timm"]
+    }
 
 DEPENDENT_PACKAGES = {package: package + version for package, version in DEPENDENT_PACKAGES.items()}
 # TODO: Use DOCS_PACKAGES and TEST_PACKAGES

--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -293,13 +293,13 @@ class TimeSeriesDataFrame(pd.DataFrame):
         ----------
         iterable_dataset: Iterable
             An iterator over dictionaries, each with a ``target`` field specifying the value of the
-            (univariate) time series, and a ``start`` field that features a pandas Timestamp with features.
+            (univariate) time series, and a ``start`` field with the starting time as a pandas Period .
             Example::
 
                 iterable_dataset = [
-                    {"target": [0, 1, 2], "start": pd.Timestamp("01-01-2019", freq='D')},
-                    {"target": [3, 4, 5], "start": pd.Timestamp("01-01-2019", freq='D')},
-                    {"target": [6, 7, 8], "start": pd.Timestamp("01-01-2019", freq='D')}
+                    {"target": [0, 1, 2], "start": pd.Period("01-01-2019", freq='D')},
+                    {"target": [3, 4, 5], "start": pd.Period("01-01-2019", freq='D')},
+                    {"target": [6, 7, 8], "start": pd.Period("01-01-2019", freq='D')}
                 ]
         num_cpus : int, default = -1
             Number of CPU cores used to process the iterable dataset in parallel. Set to -1 to use all cores.

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -20,11 +20,11 @@ from autogluon.timeseries.dataset.ts_dataframe import (
 
 from .common import get_data_frame_with_variable_lengths
 
-START_TIMESTAMP = pd.Timestamp("01-01-2019", freq="D")  # type: ignore
-END_TIMESTAMP = pd.Timestamp("01-02-2019", freq="D")  # type: ignore
+START_TIMESTAMP = pd.Timestamp("01-01-2019")  # type: ignore
+END_TIMESTAMP = pd.Timestamp("01-02-2019")  # type: ignore
 ITEM_IDS = (0, 1, 2)
 TARGETS = np.arange(9)
-DATETIME_INDEX = tuple(pd.date_range(START_TIMESTAMP, periods=3))
+DATETIME_INDEX = tuple(pd.date_range(START_TIMESTAMP, periods=3, freq="D"))
 EMPTY_ITEM_IDS = np.array([], dtype=np.int64)
 EMPTY_DATETIME_INDEX = np.array([], dtype=np.dtype("datetime64[ns]"))  # type: ignore
 EMPTY_TARGETS = np.array([], dtype=np.int64)
@@ -56,9 +56,9 @@ SAMPLE_DATAFRAME = pd.DataFrame(SAMPLE_TS_DATAFRAME).reset_index()
 
 
 SAMPLE_ITERABLE = [
-    {"target": [0, 1, 2], "start": pd.Timestamp("01-01-2019", freq="D")},  # type: ignore
-    {"target": [3, 4, 5], "start": pd.Timestamp("01-01-2019", freq="D")},  # type: ignore
-    {"target": [6, 7, 8], "start": pd.Timestamp("01-01-2019", freq="D")},  # type: ignore
+    {"target": [0, 1, 2], "start": pd.Period("01-01-2019", freq="D")},  # type: ignore
+    {"target": [3, 4, 5], "start": pd.Period("01-01-2019", freq="D")},  # type: ignore
+    {"target": [6, 7, 8], "start": pd.Period("01-01-2019", freq="D")},  # type: ignore
 ]
 
 
@@ -70,10 +70,6 @@ def test_from_iterable():
         TimeSeriesDataFrame([])
 
     sample_iter = [{"target": [0, 1, 2]}]
-    with pytest.raises(ValueError):
-        TimeSeriesDataFrame(sample_iter)
-
-    sample_iter = [{"target": [0, 1, 2], "start": pd.Timestamp("01-01-2019")}]  # type: ignore
     with pytest.raises(ValueError):
         TimeSeriesDataFrame(sample_iter)
 
@@ -111,7 +107,7 @@ def test_from_gluonts_list_dataset():
     prediction_length = 24
     freq = "D"
     custom_dataset = np.random.normal(size=(number_of_ts, ts_length))
-    start = pd.Timestamp("01-01-2019", freq=freq)  # type: ignore
+    start = pd.Period("01-01-2019", freq=freq)  # type: ignore
 
     gluonts_list_dataset = ListDataset(
         [{"target": x, "start": start} for x in custom_dataset[:, :-prediction_length]],
@@ -267,7 +263,7 @@ def test_when_dataset_constructed_from_iterable_with_freq_then_freq_is_inferred(
 @pytest.mark.parametrize("start_time, freq", FREQ_TEST_CASES)
 def test_when_dataset_constructed_via_constructor_with_freq_then_freq_is_inferred(start_time, freq):
     item_list = ListDataset(
-        [{"target": [1, 2, 3], "start": pd.Timestamp(start_time, freq=freq)} for _ in range(3)],  # type: ignore
+        [{"target": [1, 2, 3], "start": pd.Period(start_time, freq=freq)} for _ in range(3)],  # type: ignore
         freq=freq,
     )
 
@@ -281,7 +277,7 @@ def test_when_dataset_constructed_via_constructor_with_freq_and_persisted_then_c
     start_time, freq
 ):
     item_list = ListDataset(
-        [{"target": [1, 2, 3], "start": pd.Timestamp(start_time, freq=freq)} for _ in range(3)],  # type: ignore
+        [{"target": [1, 2, 3], "start": pd.Period(start_time, freq=freq)} for _ in range(3)],  # type: ignore
         freq=freq,
     )
 
@@ -350,9 +346,9 @@ def test_when_dataset_constructed_with_irregular_timestamps_then_freq_call_cache
 
 
 SAMPLE_ITERABLE_2 = [
-    {"target": [0, 1, 2, 3], "start": pd.Timestamp("2019-01-01", freq="D")},  # type: ignore
-    {"target": [3, 4, 5, 4], "start": pd.Timestamp("2019-01-02", freq="D")},  # type: ignore
-    {"target": [6, 7, 8, 5], "start": pd.Timestamp("2019-01-03", freq="D")},  # type: ignore
+    {"target": [0, 1, 2, 3], "start": pd.Period("2019-01-01", freq="D")},  # type: ignore
+    {"target": [3, 4, 5, 4], "start": pd.Period("2019-01-02", freq="D")},  # type: ignore
+    {"target": [6, 7, 8, 5], "start": pd.Period("2019-01-03", freq="D")},  # type: ignore
 ]
 
 


### PR DESCRIPTION
*Issue #, if available:* #3251

*Description of changes:*
- Increase pandas version range to `>=1.4.1,<2.2`
- Fix time series documentation & tests in light of the deprecations in pandas 2.0

*To do:*
- [ ] pandas >=2.1 does not support Python 3.8 - need to update the AG version range for Python first?
- [ ] Check for regressions / required changes to other modules for pandas 2.0 support

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
