### PR TITLE
[timeseries] Avoid importing pytorch_lightning at top level

### DIFF
--- a/common/src/autogluon/common/utils/utils.py
+++ b/common/src/autogluon/common/utils/utils.py
@@ -184,6 +184,7 @@ def seed_everything(seed: int) -> None:
     np.random.seed(seed)
     try:
         import torch
+
         torch.manual_seed(seed)
     except ImportError:
         pass

--- a/common/src/autogluon/common/utils/utils.py
+++ b/common/src/autogluon/common/utils/utils.py
@@ -7,6 +7,7 @@ from hashlib import md5
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+import numpy as np
 import pandas as pd
 
 from ..version import __version__
@@ -176,3 +177,13 @@ def hash_pandas_df(df: Optional[pd.DataFrame]) -> str:
     else:
         hashable_object = "0".encode("utf-8")
     return md5(hashable_object).hexdigest()
+
+
+def seed_everything(seed: int) -> None:
+    """Set random seeds for numpy and PyTorch."""
+    np.random.seed(seed)
+    try:
+        import torch
+        torch.manual_seed(seed)
+    except ImportError:
+        pass

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -343,7 +343,8 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         time_limit: int = None,
         **kwargs,
     ) -> None:
-        import pytorch_lightning  # necessary to initialize the loggers
+        # necessary to initialize the loggers
+        import pytorch_lightning  # noqa
 
         verbosity = kwargs.get("verbosity", 2)
         for logger_name in logging.root.manager.loggerDict:

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -343,6 +343,8 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         time_limit: int = None,
         **kwargs,
     ) -> None:
+        import pytorch_lightning  # necessary to initialize the loggers
+
         verbosity = kwargs.get("verbosity", 2)
         for logger_name in logging.root.manager.loggerDict:
             if "pytorch_lightning" in logger_name:

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -9,14 +9,12 @@ import gluonts
 import gluonts.core.settings
 import numpy as np
 import pandas as pd
-import torch
 from gluonts.core.component import from_hyperparameters
 from gluonts.dataset.common import Dataset as GluonTSDataset
 from gluonts.dataset.field_names import FieldName
+from gluonts.model.estimator import Estimator as GluonTSEstimator
 from gluonts.model.forecast import Forecast, QuantileForecast, SampleForecast
-from gluonts.torch.model.estimator import PyTorchLightningEstimator as GluonTSPyTorchLightningEstimator
-from gluonts.torch.model.forecast import DistributionForecast
-from gluonts.torch.model.predictor import PyTorchPredictor as GluonTSPyTorchPredictor
+from gluonts.model.predictor import Predictor as GluonTSPredictor
 from pandas.tseries.frequencies import to_offset
 
 from autogluon.common.loaders import load_pkl
@@ -27,9 +25,11 @@ from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 from autogluon.timeseries.utils.forecast import get_forecast_horizon_index_ts_dataframe
 from autogluon.timeseries.utils.warning_filters import disable_root_logger, torch_warning_filter
 
+# NOTE: We avoid imports for torch and pytorch_lightning at the top level and hide them inside class methods.
+# This is done to skip these imports during multiprocessing (which may cause bugs)
+
 logger = logging.getLogger(__name__)
 gts_logger = logging.getLogger(gluonts.__name__)
-pl_loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict if "pytorch_lightning" in name]
 
 
 GLUONTS_SUPPORTED_OFFSETS = ["Y", "Q", "M", "W", "D", "B", "H", "T", "min", "S"]
@@ -133,7 +133,6 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         possible values.
     """
 
-    gluonts_estimator_class: Type[GluonTSPyTorchLightningEstimator]
     gluonts_model_path = "gluon_ts"
     # datatype of floating point and integers passed internally to GluonTS
     float_dtype: Type = np.float32
@@ -162,7 +161,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
             hyperparameters=hyperparameters,
             **kwargs,
         )
-        self.gts_predictor: Optional[GluonTSPyTorchPredictor] = None
+        self.gts_predictor: Optional[GluonTSPredictor] = None
         self.callbacks = []
         self.num_feat_static_cat = 0
         self.num_feat_static_real = 0
@@ -189,11 +188,13 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
 
     @classmethod
     def load(cls, path: str, reset_paths: bool = True, verbose: bool = True) -> "AbstractGluonTSModel":
+        from gluonts.torch.model.predictor import PyTorchPredictor
+
         with torch_warning_filter():
             model = load_pkl.load(path=os.path.join(path, cls.model_file_name), verbose=verbose)
             if reset_paths:
                 model.set_contexts(path)
-            model.gts_predictor = GluonTSPyTorchPredictor.deserialize(Path(path) / cls.gluonts_model_path)
+            model.gts_predictor = PyTorchPredictor.deserialize(Path(path) / cls.gluonts_model_path)
         return model
 
     def _deferred_init_params_aux(self, **kwargs) -> None:
@@ -255,11 +256,15 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         init_kwargs.setdefault("max_epochs", init_kwargs.get("epochs"))
         return init_kwargs
 
-    def _get_estimator(self) -> GluonTSPyTorchLightningEstimator:
+    def _get_estimator_class(self) -> Type[GluonTSEstimator]:
+        raise NotImplementedError
+
+    def _get_estimator(self) -> GluonTSEstimator:
         """Return the GluonTS Estimator object for the model"""
         # As GluonTSPyTorchLightningEstimator objects do not implement `from_hyperparameters` convenience
         # constructors, we re-implement the logic here.
         # we translate the "epochs" parameter to "max_epochs" for consistency in the AbstractGluonTSModel interface
+        import torch
 
         init_args = self._get_estimator_init_args()
 
@@ -278,7 +283,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
             trainer_kwargs["devices"] = 1
 
         return from_hyperparameters(
-            self.gluonts_estimator_class,
+            self._get_estimator_class(),
             trainer_kwargs=trainer_kwargs,
             **init_args,
         )
@@ -339,8 +344,10 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         **kwargs,
     ) -> None:
         verbosity = kwargs.get("verbosity", 2)
-        for pl_logger in pl_loggers:
-            pl_logger.setLevel(logging.ERROR if verbosity <= 3 else logging.INFO)
+        for logger_name in logging.root.manager.loggerDict:
+            if "pytorch_lightning" in logger_name:
+                pl_logger = logging.getLogger(logger_name)
+                pl_logger.setLevel(logging.ERROR if verbosity <= 3 else logging.INFO)
         set_logger_verbosity(verbosity, logger=logger)
         gts_logger.setLevel(logging.ERROR if verbosity <= 3 else logging.INFO)
 
@@ -432,9 +439,9 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         return QuantileForecast(**forecast_init_args)
 
     @staticmethod
-    def _distribution_to_quantile_forecast(
-        forecast: DistributionForecast, quantile_levels: List[float]
-    ) -> QuantileForecast:
+    def _distribution_to_quantile_forecast(forecast: Forecast, quantile_levels: List[float]) -> QuantileForecast:
+        import torch
+
         # Compute all quantiles in parallel instead of a for-loop
         quantiles = torch.tensor(quantile_levels, device=forecast.distribution.mean.device).reshape(-1, 1)
         quantile_predictions = forecast.distribution.icdf(quantiles).cpu().detach().numpy()
@@ -455,6 +462,8 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         quantile_levels: List[float],
         forecast_index: pd.MultiIndex,
     ) -> TimeSeriesDataFrame:
+        from gluonts.torch.model.forecast import DistributionForecast
+
         # TODO: Concatenate all forecasts into a single tensor/object before converting?
         # Especially for DistributionForecast this could result in massive speedups
         if isinstance(forecasts[0], SampleForecast):

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -4,14 +4,12 @@ Module including wrappers for PyTorch implementations of models in GluonTS
 import logging
 from typing import Any, Dict, Type
 
-from gluonts.torch.model.d_linear import DLinearEstimator
-from gluonts.torch.model.deepar import DeepAREstimator
-from gluonts.torch.model.estimator import PyTorchLightningEstimator as GluonTSPyTorchLightningEstimator
-from gluonts.torch.model.patch_tst import PatchTSTEstimator
-from gluonts.torch.model.simple_feedforward import SimpleFeedForwardEstimator
-from gluonts.torch.model.tft import TemporalFusionTransformerEstimator
+from gluonts.model.estimator import Estimator as GluonTSEstimator
 
 from autogluon.timeseries.models.gluonts.abstract_gluonts import AbstractGluonTSModel
+
+# NOTE: We avoid imports for torch and pytorch_lightning at the top level and hide them inside class methods.
+# This is done to skip these imports during multiprocessing (which may cause bugs)
 
 # FIXME: introduces cpflows dependency. We exclude this model until a future release.
 # from gluonts.torch.model.mqf2 import MQF2MultiHorizonEstimator
@@ -71,9 +69,13 @@ class DeepARModel(AbstractGluonTSModel):
         Learning rate used during training
     """
 
-    gluonts_estimator_class: Type[GluonTSPyTorchLightningEstimator] = DeepAREstimator
     default_num_samples: int = 250
     supports_known_covariates = True
+
+    def _get_estimator_class(self) -> Type[GluonTSEstimator]:
+        from gluonts.torch.model.deepar import DeepAREstimator
+
+        return DeepAREstimator
 
     def _get_estimator_init_args(self) -> Dict[str, Any]:
         init_kwargs = super()._get_estimator_init_args()
@@ -113,7 +115,10 @@ class SimpleFeedForwardModel(AbstractGluonTSModel):
         Learning rate used during training
     """
 
-    gluonts_estimator_class: Type[GluonTSPyTorchLightningEstimator] = SimpleFeedForwardEstimator
+    def _get_estimator_class(self) -> Type[GluonTSEstimator]:
+        from gluonts.torch.model.simple_feedforward import SimpleFeedForwardEstimator
+
+        return SimpleFeedForwardEstimator
 
 
 class TemporalFusionTransformerModel(AbstractGluonTSModel):
@@ -161,13 +166,17 @@ class TemporalFusionTransformerModel(AbstractGluonTSModel):
         Learning rate used during training
     """
 
-    gluonts_estimator_class: Type[GluonTSPyTorchLightningEstimator] = TemporalFusionTransformerEstimator
     supports_known_covariates = True
     supports_past_covariates = True
 
     @property
     def default_context_length(self) -> int:
         return max(64, 2 * self.prediction_length)
+
+    def _get_estimator_class(self) -> Type[GluonTSEstimator]:
+        from gluonts.torch.model.tft import TemporalFusionTransformerEstimator
+
+        return TemporalFusionTransformerEstimator
 
     def _get_estimator_init_args(self) -> Dict[str, Any]:
         init_kwargs = super()._get_estimator_init_args()
@@ -216,11 +225,14 @@ class DLinearModel(AbstractGluonTSModel):
         Weight decay regularization parameter.
     """
 
-    gluonts_estimator_class: Type[GluonTSPyTorchLightningEstimator] = DLinearEstimator
-
     @property
     def default_context_length(self) -> int:
         return 96
+
+    def _get_estimator_class(self) -> Type[GluonTSEstimator]:
+        from gluonts.torch.model.d_linear import DLinearEstimator
+
+        return DLinearEstimator
 
 
 class PatchTSTModel(AbstractGluonTSModel):
@@ -265,11 +277,14 @@ class PatchTSTModel(AbstractGluonTSModel):
         Weight decay regularization parameter.
     """
 
-    gluonts_estimator_class: Type[GluonTSPyTorchLightningEstimator] = PatchTSTEstimator
-
     @property
     def default_context_length(self) -> int:
         return 96
+
+    def _get_estimator_class(self) -> Type[GluonTSEstimator]:
+        from gluonts.torch.model.patch_tst import PatchTSTEstimator
+
+        return PatchTSTEstimator
 
     def _get_estimator_init_args(self) -> Dict[str, Any]:
         init_kwargs = super()._get_estimator_init_args()

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -5,11 +5,10 @@ import time
 from typing import Any, Dict, List, Optional, Type, Union
 
 import pandas as pd
-import pytorch_lightning as pl
 
 from autogluon.common.utils.deprecated_utils import Deprecated_args
 from autogluon.common.utils.log_utils import set_logger_verbosity
-from autogluon.common.utils.utils import check_saved_predictor_version, setup_outputdir
+from autogluon.common.utils.utils import check_saved_predictor_version, seed_everything, setup_outputdir
 from autogluon.core.utils.decorators import apply_presets
 from autogluon.core.utils.loaders import load_pkl, load_str
 from autogluon.core.utils.savers import save_pkl, save_str
@@ -584,7 +583,7 @@ class TimeSeriesPredictor:
         logger.info("=====================================================")
 
         if random_seed is not None:
-            pl.seed_everything(random_seed)
+            seed_everything(random_seed)
 
         time_left = None if time_limit is None else time_limit - (time.time() - time_start)
         self._learner.fit(
@@ -682,7 +681,7 @@ class TimeSeriesPredictor:
                 2020-03-05     8.3
         """
         if random_seed is not None:
-            pl.seed_everything(random_seed)
+            seed_everything(random_seed)
         # Don't use data.item_ids in case data is not a TimeSeriesDataFrame
         original_item_id_order = data.reset_index()[ITEMID].unique()
         data = self._check_and_prepare_data_frame(data)

--- a/timeseries/tests/smoketests/test_features_and_covariates.py
+++ b/timeseries/tests/smoketests/test_features_and_covariates.py
@@ -10,7 +10,7 @@ from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP, TimeSer
 
 TARGET_COLUMN = "custom_target"
 ITEM_IDS = ["Z", "A", "1", "C"]
-DUMMY_MODEL_HPARAMS = {"maxiter": 1, "epochs": 1, "num_batches_per_epoch": 1}
+DUMMY_MODEL_HPARAMS = {"maxiter": 1, "epochs": 1, "num_batches_per_epoch": 1, "use_fallback_model": False}
 
 
 def generate_train_and_test_data(
@@ -94,9 +94,6 @@ def test_predictor_smoke_test(
     known_covariates_names = [col for col in train_data if col.startswith("known_")]
 
     with warnings.catch_warnings():
-        # Ensure that no warnings are raised
-        warnings.simplefilter("error")
-
         predictor = TimeSeriesPredictor(
             target=TARGET_COLUMN,
             prediction_length=prediction_length,

--- a/timeseries/tests/unittests/models/gluonts/test_gluonts.py
+++ b/timeseries/tests/unittests/models/gluonts/test_gluonts.py
@@ -81,7 +81,7 @@ def test_when_models_saved_then_gluonts_predictors_can_be_loaded(model_class, te
 
     loaded_model = model.__class__.load(path=model.path)
 
-    assert model.gluonts_estimator_class is loaded_model.gluonts_estimator_class
+    assert model._get_estimator_class() is loaded_model._get_estimator_class()
     assert loaded_model.gts_predictor.to(model.gts_predictor.device) == model.gts_predictor
 
 


### PR DESCRIPTION
A recent update to `pytorch_lightning` has potential to introduce a massive performance regression to forecasting models in AutoGluon that rely on multiprocessing / joblib. As of `v2.0.8` of `pytorch_lightning`, a multiprocessing lock is created whenever the module is imported. This increased the process initialization time significantly.

For example, total runtime of the above code snippet
```python
import pytorch_lightning as pl
from autogluon.timeseries import TimeSeriesPredictor, TimeSeriesDataFrame

data = TimeSeriesDataFrame('https://autogluon.s3.amazonaws.com/datasets/timeseries/m4_hourly/train.csv')
predictor = TimeSeriesPredictor()
predictor.fit(data, hyperparameters={"Naive": {}})
```

- current `master` branch: 1m 42s
- with this PR: 36s.


*Description of changes:*
- Hide all imports of `pytorch_lightning` and `torch` inside class methods. This ensures that they are not imported by the processes spawned by joblib.
- Create a separate method for setting the random seed that does not rely on `pytorch_lightning`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
