### PR TITLE
[AutoMM] Support torch.compile()

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -26,7 +26,7 @@ DEPENDENT_PACKAGES = {
     "networkx": ">=3.0,<4",  # Major version cap
     "tqdm": ">=4.38,<5",  # Major version cap
     "Pillow": ">=9.3,<9.6",  # "<{N+2}" upper cap
-    "torch": ">=1.13,<2.1",  # "<{N+1}" upper cap
+    "torch": ">=2.0,<2.1",  # "<{N+1}" upper cap
     "pytorch-lightning": ">=2.0.0,<2.1",  # "<{N+1}" upper cap
 }
 if LITE_MODE:

--- a/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
@@ -14,3 +14,7 @@ env:
   strategy: "ddp_spawn_find_unused_parameters_true"
   deepspeed_allgather_size: 1e9 # DeepSpeed allgather size (number of elements gathered at a time). Limits memory required for allgather on large models.
   deepspeed_allreduce_size: 1e9 # DeepSpeed allreduce size (number of elements reduced at a time). Limits memory required for allreduce on large models.
+  compile:
+    turn_on: False
+    mode: "default"
+    dynamic: None

--- a/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
@@ -17,4 +17,5 @@ env:
   compile:
     turn_on: False
     mode: "default"
-    dynamic: None
+    dynamic: True
+    backend: "inductor"

--- a/multimodal/src/autogluon/multimodal/constants.py
+++ b/multimodal/src/autogluon/multimodal/constants.py
@@ -305,3 +305,6 @@ MULTI_IMAGE_MIX_DATASET = "multi_image_mix_dataset"
 
 # strategies
 DDP = "ddp"
+
+# torch constants
+TORCH_COMPILE_MIN_VERSION = "2.2.0.dev20230907"

--- a/multimodal/src/autogluon/multimodal/constants.py
+++ b/multimodal/src/autogluon/multimodal/constants.py
@@ -307,4 +307,4 @@ MULTI_IMAGE_MIX_DATASET = "multi_image_mix_dataset"
 DDP = "ddp"
 
 # torch constants
-TORCH_COMPILE_MIN_VERSION = "2.2.0.dev20230907"
+TORCH_COMPILE_MIN_VERSION = "2.2.0.dev20230908"

--- a/multimodal/src/autogluon/multimodal/models/utils.py
+++ b/multimodal/src/autogluon/multimodal/models/utils.py
@@ -701,7 +701,11 @@ def run_model(model: nn.Module, batch: dict, trt_model: Optional[nn.Module] = No
         TFewModel,
         OnnxModule,
     )
-    pure_model = model.module if isinstance(model, nn.DataParallel) else model
+    pure_model = model
+    if isinstance(model, torch._dynamo.eval_frame.OptimizedModule):
+        pure_model = model._orig_mod
+    if isinstance(model, nn.DataParallel):
+        pure_model = model.module
     if isinstance(pure_model, OnnxModule):
         for k in batch:
             # HACK input data types in ONNX

--- a/multimodal/src/autogluon/multimodal/models/utils.py
+++ b/multimodal/src/autogluon/multimodal/models/utils.py
@@ -4,6 +4,7 @@ import warnings
 from typing import Dict, List, Optional, Tuple
 
 import torch
+import torch._dynamo
 from torch import nn
 from torch.nn.modules.loss import _Loss
 from transformers import AutoConfig, AutoModel, AutoTokenizer, BertTokenizer, CLIPTokenizer, ElectraTokenizer

--- a/multimodal/src/autogluon/multimodal/optimization/utils.py
+++ b/multimodal/src/autogluon/multimodal/optimization/utils.py
@@ -692,6 +692,8 @@ def apply_layerwise_lr_decay(
     decay_param_names = get_weight_decay_param_names(model)
 
     for name, param in model.named_parameters():
+        if name.startswith("_orig_mod."):
+            name = "".join(name.split("_orig_mod."))
         layer_id = model.name_to_id[name]
         if layer_id == 0:  # Set top layer (e.g. head, fusion_mlp, adapter) as being trainable.
             param.requires_grad = True

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -79,6 +79,7 @@ from .constants import (
     SCORE,
     TEXT,
     TEXT_NER,
+    TORCH_COMPILE_MIN_VERSION,
     UNIFORM_SOUP,
     XYWH,
     Y_PRED,
@@ -1150,6 +1151,18 @@ class MultiModalPredictor(ExportMixin):
             )
         else:  # continuing training
             model = self._model
+
+        if OmegaConf.select(config, "env.compile.turn_on", default=False):
+            assert version.parse(torch.__version__) >= version.parse(TORCH_COMPILE_MIN_VERSION), (
+                f"torch.compile requires torch version >= {TORCH_COMPILE_MIN_VERSION}, "
+                f"but torch version {torch.__version__} is detected."
+            )
+            logger.debug("Using torch.compile() in compiling the model.")
+            model = torch.compile(
+                model,
+                mode=OmegaConf.select(config, "env.compile.mode", default="default"),
+                dynamic=OmegaConf.select(config, "env.compile.dynamic", default=None),
+            )
 
         norm_param_names = get_norm_layer_param_names(model)
 

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -1161,7 +1161,8 @@ class MultiModalPredictor(ExportMixin):
             model = torch.compile(
                 model,
                 mode=OmegaConf.select(config, "env.compile.mode", default="default"),
-                dynamic=OmegaConf.select(config, "env.compile.dynamic", default=None),
+                dynamic=OmegaConf.select(config, "env.compile.dynamic", default=True),
+                backend=OmegaConf.select(config, "env.compile.backend", default="inductor"),
             )
 
         norm_param_names = get_norm_layer_param_names(model)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Users can turn on compiling their models through `predictor.fit(hyperparameters={"env.compile.turn_on", True})`.

Limitations
- Doesn't work for multi-gpu training.
- Needs pytorch version >= `2.2.0.dev20230908`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
