### PR TITLE
Set bf16 AMP fallback to fp16 AMP

### DIFF
--- a/multimodal/src/autogluon/multimodal/utils/environment.py
+++ b/multimodal/src/autogluon/multimodal/utils/environment.py
@@ -100,10 +100,10 @@ def infer_precision(
             warnings.warn(
                 "bf16 is not supported by the GPU device / cuda version. "
                 "Consider using GPU devices with versions after Amphere or upgrading cuda to be >=11.0. "
-                "MultiModalPredictor is switching precision from bf16 to 32.",
+                "MultiModalPredictor is switching precision from bf16 AMP to fp16 AMP.",
                 UserWarning,
             )
-            precision = 32
+            precision = 16
 
     if as_torch:
         precision_mapping = {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Hi 👋 We noticed a fallback to 32 bit floats on older T4 GPUs (g4dn family) for `presets='multilingual'`. This PR sets that fallback to fp16 AMP instead of falling back to 32.

This way, we still have fast training on the older machines. Or was there some reason to fall back to 32?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. ✅ 
