### PR TITLE
[timeseries] Fix timeseries tutorial on Colab

### DIFF
--- a/docs/tutorials/timeseries/forecasting-indepth.ipynb
+++ b/docs/tutorials/timeseries/forecasting-indepth.ipynb
@@ -84,7 +84,8 @@
    },
    "outputs": [],
    "source": [
-    "!pip install autogluon.timeseries\n"
+    "!pip install autogluon.timeseries\n",
+    "!pip uninstall torchaudio -y  # fix incompatible torchaudio version on Colab"
    ]
   },
   {

--- a/docs/tutorials/timeseries/forecasting-quick-start.ipynb
+++ b/docs/tutorials/timeseries/forecasting-quick-start.ipynb
@@ -39,7 +39,8 @@
    },
    "outputs": [],
    "source": [
-    "!pip install autogluon.timeseries\n"
+    "!pip install autogluon.timeseries\n",
+    "!pip uninstall torchaudio -y  # fix incompatible torchaudio version on Colab"
    ]
   },
   {


### PR DESCRIPTION
*Description of changes:*
- Currently time series tutorials fail on Colab because of an incompatible version of `torchaudio` pre-installed in the Colab Python environment (Colab expects torch 2.0 while autogluon v0.8.2 installs torch 1.13, which breaks torchaudio). This PR uninstalls torchaudio to fix this problem.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
