### PR TITLE
[Lightning] Update lightning import

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -27,7 +27,7 @@ DEPENDENT_PACKAGES = {
     "tqdm": ">=4.38,<5",  # Major version cap
     "Pillow": ">=9.3,<9.6",  # "<{N+2}" upper cap
     "torch": ">=2.0,<2.1",  # "<{N+1}" upper cap
-    "pytorch-lightning": ">=2.0.0,<2.1",  # "<{N+1}" upper cap
+    "lightning": ">=2.0.0,<2.1",  # "<{N+1}" upper cap
 }
 if LITE_MODE:
     DEPENDENT_PACKAGES = {package: version for package, version in DEPENDENT_PACKAGES.items() if package not in ["psutil", "Pillow", "timm"]}

--- a/docs/tutorials/multimodal/advanced_topics/customization.ipynb
+++ b/docs/tutorials/multimodal/advanced_topics/customization.ipynb
@@ -692,7 +692,7 @@
     "- `\"ddp\"`: distributed data parallel (python script based).\n",
     "- `\"ddp_spawn\"`: distributed data parallel (spawn based).\n",
     "\n",
-    "See [here](https://lightning.ai/docs/pytorch/stable/extensions/strategy.html#selecting-a-built-in-strategy) for more details."
+    "See [here](https://pytorch-lightning.readthedocs.io/en/stable/accelerators/gpu.html#distributed-modes) for more details."
    ]
   },
   {
@@ -1532,14 +1532,6 @@
     "# set not to scale the soft label loss\n",
     "predictor.fit(hyperparameters={\"distiller.soft_label_weight\": 1})\n",
     "```\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "dd27e401",
-   "metadata": {},
-   "source": [
-    "Please bear with us while we analyse the content"
    ]
   }
  ],

--- a/docs/tutorials/multimodal/advanced_topics/customization.ipynb
+++ b/docs/tutorials/multimodal/advanced_topics/customization.ipynb
@@ -640,7 +640,7 @@
     "### env.num_workers\n",
     "\n",
     "The number of worker processes used by the Pytorch dataloader in training. Note that more workers don't always bring speedup especially when `env.strategy = \"ddp_spawn\"`.\n",
-    "For more details, see the guideline [here](https://pytorch-lightning.readthedocs.io/en/stable/accelerators/gpu.html#distributed-data-parallel)."
+    "For more details, see the guideline [here](https://lightning.ai/docs/pytorch/stable/accelerators/gpu_intermediate.html#distributed-data-parallel)."
    ]
   },
   {
@@ -653,30 +653,6 @@
     "predictor.fit(hyperparameters={\"env.num_workers\": 2})\n",
     "# use 4 workers in the training dataloader\n",
     "predictor.fit(hyperparameters={\"env.num_workers\": 4})\n",
-    "```\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6d9d307f",
-   "metadata": {},
-   "source": [
-    "### env.auto_select_gpus\n",
-    "\n",
-    "If enabled and devices is an integer, pick available GPUs automatically. This is especially useful when GPUs are configured to be in “exclusive mode”, such that only one process at a time can access them.\n",
-    "For more details, see the guideline [here](https://pytorch-lightning.readthedocs.io/en/stable/common/trainer.html)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7fb0f2b9",
-   "metadata": {},
-   "source": [
-    "```\n",
-    "# default used by AutoMM\n",
-    "predictor.fit(hyperparameters={\"env.auto_select_gpus\": True})\n",
-    "# disable auto select gpus\n",
-    "predictor.fit(hyperparameters={\"env.auto_select_gpus\": False})\n",
     "```\n"
    ]
   },
@@ -716,7 +692,7 @@
     "- `\"ddp\"`: distributed data parallel (python script based).\n",
     "- `\"ddp_spawn\"`: distributed data parallel (spawn based).\n",
     "\n",
-    "See [here](https://pytorch-lightning.readthedocs.io/en/stable/accelerators/gpu.html#distributed-modes) for more details."
+    "See [here](https://lightning.ai/docs/pytorch/stable/extensions/strategy.html#selecting-a-built-in-strategy) for more details."
    ]
   },
   {

--- a/docs/tutorials/multimodal/advanced_topics/customization.ipynb
+++ b/docs/tutorials/multimodal/advanced_topics/customization.ipynb
@@ -692,7 +692,7 @@
     "- `\"ddp\"`: distributed data parallel (python script based).\n",
     "- `\"ddp_spawn\"`: distributed data parallel (spawn based).\n",
     "\n",
-    "See [here](https://pytorch-lightning.readthedocs.io/en/stable/accelerators/gpu.html#distributed-modes) for more details."
+    "See [here](https://lightning.ai/docs/pytorch/stable/extensions/strategy.html#selecting-a-built-in-strategy) for more details."
    ]
   },
   {

--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -28,7 +28,7 @@ install_requires = [
     "tqdm",  # version range defined in `core/_setup_utils.py`
     "boto3",  # version range defined in `core/_setup_utils.py`
     "torch",  # version range defined in `core/_setup_utils.py`
-    "pytorch-lightning",  # version range defined in `core/_setup_utils.py`
+    "lightning",  # version range defined in `core/_setup_utils.py`
     "requests>=2.21,<3",
     "jsonschema>=4.14,<4.18",
     "seqeval>=1.2.2,<1.3.0",

--- a/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
@@ -5,7 +5,7 @@ env:
   per_gpu_batch_size: 8  # training per gpu batch size
   eval_batch_size_ratio: 4  # per_gpu_batch_size_evaluation = per_gpu_batch_size * eval_batch_size_ratio
   per_gpu_batch_size_evaluation:  # This is deprecated. Use eval_batch_size_ratio instead.
-  precision: 16  # training precision. Refer to https://pytorch-lightning.readthedocs.io/en/latest/advanced/mixed_precision.html
+  precision: 16  # training precision. Refer to https://lightning.ai/docs/pytorch/1.5.7/advanced/mixed_precision.html#fp16-mixed-precision
   num_workers: 2  # pytorch training dataloader workers.
   num_workers_evaluation: 2  # pytorch prediction/test dataloader workers.
   fast_dev_run: False

--- a/multimodal/src/autogluon/multimodal/data/datamodule.py
+++ b/multimodal/src/autogluon/multimodal/data/datamodule.py
@@ -16,7 +16,7 @@ class BaseDataModule(LightningDataModule):
     validation, testing, and prediction. We organize the multimodal data using pd.DataFrame.
     For some modalities, e.g, image, that cost much memory, we only store their disk path to do lazy loading.
     This class inherits from the Pytorch Lightning's LightningDataModule:
-    https://pytorch-lightning.readthedocs.io/en/latest/extensions/datamodules.html
+    https://lightning.ai/docs/pytorch/stable/data/datamodule.html
     """
 
     def __init__(
@@ -111,7 +111,7 @@ class BaseDataModule(LightningDataModule):
         """
         Set up datasets for different stages: "fit" (training and validation), "test", and "predict".
         This method is registered by Pytorch Lightning's LightningDataModule.
-        Refer to: https://pytorch-lightning.readthedocs.io/en/latest/extensions/datamodules.html#setup
+        Refer to: https://lightning.ai/docs/pytorch/stable/data/datamodule.html#setup
 
         Parameters
         ----------
@@ -137,7 +137,7 @@ class BaseDataModule(LightningDataModule):
         """
         Create the dataloader for training.
         This method is registered by Pytorch Lightning's LightningDataModule.
-        Refer to: https://pytorch-lightning.readthedocs.io/en/latest/extensions/datamodules.html#train-dataloader
+        Refer to: https://lightning.ai/docs/pytorch/stable/data/datamodule.html#train-dataloader
 
         Returns
         -------
@@ -162,7 +162,7 @@ class BaseDataModule(LightningDataModule):
         """
         Create the dataloader for validation.
         This method is registered by Pytorch Lightning's LightningDataModule.
-        Refer to: https://pytorch-lightning.readthedocs.io/en/latest/extensions/datamodules.html#val-dataloader
+        Refer to: https://lightning.ai/docs/pytorch/stable/data/datamodule.html#val-dataloader
 
         Returns
         -------
@@ -186,7 +186,7 @@ class BaseDataModule(LightningDataModule):
         """
         Create the dataloader for test.
         This method is registered by Pytorch Lightning's LightningDataModule.
-        Refer to: https://pytorch-lightning.readthedocs.io/en/latest/extensions/datamodules.html#test-dataloader
+        Refer to: https://lightning.ai/docs/pytorch/stable/data/datamodule.html#test-dataloader
 
         Returns
         -------
@@ -210,7 +210,7 @@ class BaseDataModule(LightningDataModule):
         """
         Create the dataloader for prediction.
         This method is registered by Pytorch Lightning's LightningDataModule.
-        Refer to: https://pytorch-lightning.readthedocs.io/en/latest/extensions/datamodules.html#predict-dataloader
+        Refer to: https://lightning.ai/docs/pytorch/stable/data/datamodule.html#predict-dataloader
 
         Returns
         -------

--- a/multimodal/src/autogluon/multimodal/data/datamodule.py
+++ b/multimodal/src/autogluon/multimodal/data/datamodule.py
@@ -1,10 +1,10 @@
 from typing import Dict, List, Optional, Union
 
 import pandas as pd
-from pytorch_lightning import LightningDataModule
+from lightning.pytorch import LightningDataModule
 from torch.utils.data import DataLoader, Dataset
 
-from ..constants import DEFAULT_DATASET, PREDICT, TEST, TRAIN, VALIDATE
+from ..constants import PREDICT, TEST, TRAIN, VALIDATE
 from .dataset import BaseDataset
 from .preprocess_dataframe import MultiModalFeaturePreprocessor
 from .utils import get_collate_fn

--- a/multimodal/src/autogluon/multimodal/matcher.py
+++ b/multimodal/src/autogluon/multimodal/matcher.py
@@ -892,9 +892,10 @@ class MultiModalMatcher:
         ]
 
         if hpo_mode:
-            from .utils.hpo import _TuneReportCheckpointCallback
+            from .utils.hpo import get_ray_tune_ckpt_callback
 
-            tune_report_callback = _TuneReportCheckpointCallback(
+            TuneReportCheckpointCallback = get_ray_tune_ckpt_callback()
+            tune_report_callback = TuneReportCheckpointCallback(
                 {f"{task.validation_metric_name}": f"{task.validation_metric_name}"},
                 filename=RAY_TUNE_CHECKPOINT,
             )

--- a/multimodal/src/autogluon/multimodal/optimization/deepspeed.py
+++ b/multimodal/src/autogluon/multimodal/optimization/deepspeed.py
@@ -1,4 +1,4 @@
-# Slightly adapted file of lightning.pytorch.strategies.deepspeed to not init deepspeed using pytorch-lightning's deepspeed inference workaround as this has higher memory requirements and can result in OOM during inference. Instead fallback to initialization using `deepspeed.initialize`.
+# Slightly adapted file of lightning.pytorch.strategies.deepspeed to not init deepspeed using lightning's deepspeed inference workaround as this has higher memory requirements and can result in OOM during inference. Instead fallback to initialization using `deepspeed.initialize`.
 # TODO: Support deepspeed_inference, custom kernels, and quantization for fast inference.
 
 # Copyright The PyTorch Lightning team.

--- a/multimodal/src/autogluon/multimodal/optimization/deepspeed.py
+++ b/multimodal/src/autogluon/multimodal/optimization/deepspeed.py
@@ -17,8 +17,8 @@
 import logging
 from typing import Any, Dict, Generator, List, Mapping, Optional, Tuple, Union, cast
 
+import lightning.pytorch as pl
 import torch
-from lightning.pytorch import LightningModule, accelerators
 from lightning.pytorch.accelerators.cuda import CUDAAccelerator
 from lightning.pytorch.overrides.base import _LightningModuleWrapperBase, _LightningPrecisionModuleWrapperBase
 from lightning.pytorch.plugins.environments.cluster_environment import ClusterEnvironment
@@ -46,7 +46,7 @@ class CustomDeepSpeedStrategy(DeepSpeedStrategy):
 
     def __init__(
         self,
-        accelerator: Optional["accelerators.accelerator.Accelerator"] = None,
+        accelerator: Optional["pl.accelerators.accelerator.Accelerator"] = None,
         zero_optimization: bool = True,
         stage: int = 2,
         remote_device: str = "cpu",
@@ -296,7 +296,7 @@ class CustomDeepSpeedStrategy(DeepSpeedStrategy):
     def init_deepspeed(self) -> None:
         assert self.lightning_module is not None
         # deepspeed handles gradient clipping internally
-        if is_overridden("configure_gradient_clipping", self.lightning_module, LightningModule):
+        if is_overridden("configure_gradient_clipping", self.lightning_module, pl.LightningModule):
             rank_zero_warn(
                 "Since DeepSpeed handles gradient clipping internally, the default"
                 " `LightningModule.configure_gradient_clipping` implementation will not actually clip gradients."
@@ -320,7 +320,7 @@ class CustomDeepSpeedStrategy(DeepSpeedStrategy):
                 "DeepSpeed currently does not support different `accumulate_grad_batches` at different epochs."
             )
 
-        assert isinstance(self.model, (LightningModule, _LightningPrecisionModuleWrapperBase))
+        assert isinstance(self.model, (pl.LightningModule, _LightningPrecisionModuleWrapperBase))
         model = _LightningModuleWrapperBase(pl_module=self.model)
 
         self._initialize_deepspeed_train(model)

--- a/multimodal/src/autogluon/multimodal/optimization/deepspeed.py
+++ b/multimodal/src/autogluon/multimodal/optimization/deepspeed.py
@@ -1,4 +1,4 @@
-# Slightly adapted file of pytorch_lightning.strategies.deepspeed to not init deepspeed using pytorch-lightning's deepspeed inference workaround as this has higher memory requirements and can result in OOM during inference. Instead fallback to initialization using `deepspeed.initialize`.
+# Slightly adapted file of lightning.pytorch.strategies.deepspeed to not init deepspeed using pytorch-lightning's deepspeed inference workaround as this has higher memory requirements and can result in OOM during inference. Instead fallback to initialization using `deepspeed.initialize`.
 # TODO: Support deepspeed_inference, custom kernels, and quantization for fast inference.
 
 # Copyright The PyTorch Lightning team.
@@ -17,18 +17,18 @@
 import logging
 from typing import Any, Dict, Generator, List, Mapping, Optional, Tuple, Union, cast
 
-import pytorch_lightning as pl
 import torch
-from pytorch_lightning.accelerators.cuda import CUDAAccelerator
-from pytorch_lightning.overrides.base import _LightningModuleWrapperBase, _LightningPrecisionModuleWrapperBase
-from pytorch_lightning.plugins.environments.cluster_environment import ClusterEnvironment
-from pytorch_lightning.plugins.precision import PrecisionPlugin
-from pytorch_lightning.strategies import DeepSpeedStrategy
-from pytorch_lightning.utilities import GradClipAlgorithmType
-from pytorch_lightning.utilities.exceptions import MisconfigurationException
-from pytorch_lightning.utilities.model_helpers import is_overridden
-from pytorch_lightning.utilities.rank_zero import rank_zero_warn
-from pytorch_lightning.utilities.types import _PATH
+from lightning.pytorch import LightningModule, accelerators
+from lightning.pytorch.accelerators.cuda import CUDAAccelerator
+from lightning.pytorch.overrides.base import _LightningModuleWrapperBase, _LightningPrecisionModuleWrapperBase
+from lightning.pytorch.plugins.environments.cluster_environment import ClusterEnvironment
+from lightning.pytorch.plugins.precision import PrecisionPlugin
+from lightning.pytorch.strategies import DeepSpeedStrategy
+from lightning.pytorch.utilities import GradClipAlgorithmType
+from lightning.pytorch.utilities.exceptions import MisconfigurationException
+from lightning.pytorch.utilities.model_helpers import is_overridden
+from lightning.pytorch.utilities.rank_zero import rank_zero_warn
+from lightning.pytorch.utilities.types import _PATH
 
 
 class CustomDeepSpeedStrategy(DeepSpeedStrategy):
@@ -46,7 +46,7 @@ class CustomDeepSpeedStrategy(DeepSpeedStrategy):
 
     def __init__(
         self,
-        accelerator: Optional["pl.accelerators.accelerator.Accelerator"] = None,
+        accelerator: Optional["accelerators.accelerator.Accelerator"] = None,
         zero_optimization: bool = True,
         stage: int = 2,
         remote_device: str = "cpu",
@@ -296,7 +296,7 @@ class CustomDeepSpeedStrategy(DeepSpeedStrategy):
     def init_deepspeed(self) -> None:
         assert self.lightning_module is not None
         # deepspeed handles gradient clipping internally
-        if is_overridden("configure_gradient_clipping", self.lightning_module, pl.LightningModule):
+        if is_overridden("configure_gradient_clipping", self.lightning_module, LightningModule):
             rank_zero_warn(
                 "Since DeepSpeed handles gradient clipping internally, the default"
                 " `LightningModule.configure_gradient_clipping` implementation will not actually clip gradients."
@@ -320,7 +320,7 @@ class CustomDeepSpeedStrategy(DeepSpeedStrategy):
                 "DeepSpeed currently does not support different `accumulate_grad_batches` at different epochs."
             )
 
-        assert isinstance(self.model, (pl.LightningModule, _LightningPrecisionModuleWrapperBase))
+        assert isinstance(self.model, (LightningModule, _LightningPrecisionModuleWrapperBase))
         model = _LightningModuleWrapperBase(pl_module=self.model)
 
         self._initialize_deepspeed_train(model)

--- a/multimodal/src/autogluon/multimodal/optimization/lit_distiller.py
+++ b/multimodal/src/autogluon/multimodal/optimization/lit_distiller.py
@@ -1,10 +1,10 @@
 import logging
 from typing import Callable, List, Optional, Union
 
+import lightning.pytorch as pl
 import torch
 import torch.nn.functional as F
 import torchmetrics
-from lightning.pytorch import LightningModule
 from lightning.pytorch.utilities import grad_norm
 from omegaconf import DictConfig
 from torch import nn
@@ -18,7 +18,7 @@ from .utils import apply_layerwise_lr_decay, apply_single_lr, apply_two_stages_l
 logger = logging.getLogger(__name__)
 
 
-class DistillerLitModule(LightningModule):
+class DistillerLitModule(pl.LightningModule):
     """
     Knowledge distillation loops for training and evaluation. This module is independent of
     the model definition. This class inherits from the Pytorch Lightning's LightningModule:

--- a/multimodal/src/autogluon/multimodal/optimization/lit_distiller.py
+++ b/multimodal/src/autogluon/multimodal/optimization/lit_distiller.py
@@ -1,24 +1,24 @@
 import logging
 from typing import Callable, List, Optional, Union
 
-import pytorch_lightning as pl
 import torch
 import torch.nn.functional as F
 import torchmetrics
+from lightning.pytorch import LightningModule
+from lightning.pytorch.utilities import grad_norm
 from omegaconf import DictConfig
-from pytorch_lightning.utilities import grad_norm
 from torch import nn
 from torch.nn.modules.loss import _Loss
 from torchmetrics.aggregation import BaseAggregator
 
-from ..constants import AUTOMM, FEATURES, LOGITS, WEIGHT
+from ..constants import FEATURES, LOGITS, WEIGHT
 from ..models.utils import run_model
 from .utils import apply_layerwise_lr_decay, apply_single_lr, apply_two_stages_lr, get_lr_scheduler, get_optimizer
 
 logger = logging.getLogger(__name__)
 
 
-class DistillerLitModule(pl.LightningModule):
+class DistillerLitModule(LightningModule):
     """
     Knowledge distillation loops for training and evaluation. This module is independent of
     the model definition. This class inherits from the Pytorch Lightning's LightningModule:
@@ -363,7 +363,7 @@ class DistillerLitModule(pl.LightningModule):
 
     def training_step(self, batch, batch_idx):
         """
-        Per training step. This function is registered by pl.LightningModule.
+        Per training step. This function is registered by LightningModule.
         Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#training-loop
 
         Parameters
@@ -386,7 +386,7 @@ class DistillerLitModule(pl.LightningModule):
 
     def validation_step(self, batch, batch_idx):
         """
-        Per validation step. This function is registered by pl.LightningModule.
+        Per validation step. This function is registered by LightningModule.
         Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#validation
 
         Parameters
@@ -418,7 +418,7 @@ class DistillerLitModule(pl.LightningModule):
 
     def configure_optimizers(self):
         """
-        Configure optimizer. This function is registered by pl.LightningModule.
+        Configure optimizer. This function is registered by LightningModule.
         Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#configure-optimizers
         Returns
         -------

--- a/multimodal/src/autogluon/multimodal/optimization/lit_distiller.py
+++ b/multimodal/src/autogluon/multimodal/optimization/lit_distiller.py
@@ -22,7 +22,7 @@ class DistillerLitModule(LightningModule):
     """
     Knowledge distillation loops for training and evaluation. This module is independent of
     the model definition. This class inherits from the Pytorch Lightning's LightningModule:
-    https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html
+    https://lightning.ai/docs/pytorch/stable/common/lightning_module.html
     """
 
     def __init__(
@@ -364,7 +364,7 @@ class DistillerLitModule(LightningModule):
     def training_step(self, batch, batch_idx):
         """
         Per training step. This function is registered by LightningModule.
-        Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#training-loop
+        Refer to https://lightning.ai/docs/pytorch/stable/common/lightning_module.html#training-loop
 
         Parameters
         ----------
@@ -387,7 +387,7 @@ class DistillerLitModule(LightningModule):
     def validation_step(self, batch, batch_idx):
         """
         Per validation step. This function is registered by LightningModule.
-        Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#validation
+        Refer to https://lightning.ai/docs/pytorch/stable/common/lightning_module.html#validation-loop
 
         Parameters
         ----------
@@ -419,7 +419,7 @@ class DistillerLitModule(LightningModule):
     def configure_optimizers(self):
         """
         Configure optimizer. This function is registered by LightningModule.
-        Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#configure-optimizers
+        Refer to https://lightning.ai/docs/pytorch/stable/common/lightning_module.html#configure-optimizers
         Returns
         -------
         [optimizer]

--- a/multimodal/src/autogluon/multimodal/optimization/lit_matcher.py
+++ b/multimodal/src/autogluon/multimodal/optimization/lit_matcher.py
@@ -1,9 +1,9 @@
 import logging
 from typing import Callable, Dict, List, Optional, Union
 
+import lightning.pytorch as pl
 import torch
 import torchmetrics
-from lightning.pytorch import LightningModule
 from lightning.pytorch.utilities import grad_norm
 from omegaconf import DictConfig
 from torch import nn
@@ -27,7 +27,7 @@ from .utils import (
 logger = logging.getLogger(__name__)
 
 
-class MatcherLitModule(LightningModule):
+class MatcherLitModule(pl.LightningModule):
     """
     Control the loops for training, evaluation, and prediction. This module is independent of
     the model definition. This class inherits from the Pytorch Lightning's LightningModule:

--- a/multimodal/src/autogluon/multimodal/optimization/lit_matcher.py
+++ b/multimodal/src/autogluon/multimodal/optimization/lit_matcher.py
@@ -1,16 +1,16 @@
 import logging
 from typing import Callable, Dict, List, Optional, Union
 
-import pytorch_lightning as pl
 import torch
 import torchmetrics
+from lightning.pytorch import LightningModule
+from lightning.pytorch.utilities import grad_norm
 from omegaconf import DictConfig
-from pytorch_lightning.utilities import grad_norm
 from torch import nn
 from torch.nn.modules.loss import _Loss
 from torchmetrics.aggregation import BaseAggregator
 
-from ..constants import AUTOMM, FEATURES, LOGIT_SCALE, PROBABILITY, QUERY, RESPONSE
+from ..constants import FEATURES, LOGIT_SCALE, PROBABILITY, QUERY, RESPONSE
 from ..models.utils import run_model
 from ..utils.matcher import compute_matching_probability
 from .losses import MultiNegativesSoftmaxLoss
@@ -27,7 +27,7 @@ from .utils import (
 logger = logging.getLogger(__name__)
 
 
-class MatcherLitModule(pl.LightningModule):
+class MatcherLitModule(LightningModule):
     """
     Control the loops for training, evaluation, and prediction. This module is independent of
     the model definition. This class inherits from the Pytorch Lightning's LightningModule:
@@ -258,7 +258,7 @@ class MatcherLitModule(pl.LightningModule):
 
     def training_step(self, batch, batch_idx):
         """
-        Per training step. This function is registered by pl.LightningModule.
+        Per training step. This function is registered by LightningModule.
         Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#training-loop
 
         Parameters
@@ -281,7 +281,7 @@ class MatcherLitModule(pl.LightningModule):
 
     def validation_step(self, batch, batch_idx):
         """
-        Per validation step. This function is registered by pl.LightningModule.
+        Per validation step. This function is registered by LightningModule.
         Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#validation
 
         Parameters
@@ -318,7 +318,7 @@ class MatcherLitModule(pl.LightningModule):
 
     def predict_step(self, batch, batch_idx, dataloader_idx=0):
         """
-        Per prediction step. This function is registered by pl.LightningModule.
+        Per prediction step. This function is registered by LightningModule.
         Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#prediction-loop
 
         Parameters
@@ -359,7 +359,7 @@ class MatcherLitModule(pl.LightningModule):
 
     def configure_optimizers(self):
         """
-        Configure optimizer. This function is registered by pl.LightningModule.
+        Configure optimizer. This function is registered by LightningModule.
         Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#configure-optimizers
         Returns
         -------

--- a/multimodal/src/autogluon/multimodal/optimization/lit_matcher.py
+++ b/multimodal/src/autogluon/multimodal/optimization/lit_matcher.py
@@ -31,7 +31,7 @@ class MatcherLitModule(LightningModule):
     """
     Control the loops for training, evaluation, and prediction. This module is independent of
     the model definition. This class inherits from the Pytorch Lightning's LightningModule:
-    https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html
+    https://lightning.ai/docs/pytorch/stable/common/lightning_module.html
     """
 
     def __init__(
@@ -259,7 +259,7 @@ class MatcherLitModule(LightningModule):
     def training_step(self, batch, batch_idx):
         """
         Per training step. This function is registered by LightningModule.
-        Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#training-loop
+        Refer to https://lightning.ai/docs/pytorch/stable/common/lightning_module.html#training-loop
 
         Parameters
         ----------
@@ -282,7 +282,7 @@ class MatcherLitModule(LightningModule):
     def validation_step(self, batch, batch_idx):
         """
         Per validation step. This function is registered by LightningModule.
-        Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#validation
+        Refer to https://lightning.ai/docs/pytorch/stable/common/lightning_module.html#validation-loop
 
         Parameters
         ----------
@@ -319,7 +319,7 @@ class MatcherLitModule(LightningModule):
     def predict_step(self, batch, batch_idx, dataloader_idx=0):
         """
         Per prediction step. This function is registered by LightningModule.
-        Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#prediction-loop
+        Refer to https://lightning.ai/docs/pytorch/stable/common/lightning_module.html#prediction-loop
 
         Parameters
         ----------
@@ -360,7 +360,7 @@ class MatcherLitModule(LightningModule):
     def configure_optimizers(self):
         """
         Configure optimizer. This function is registered by LightningModule.
-        Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#configure-optimizers
+        Refer to https://lightning.ai/docs/pytorch/stable/common/lightning_module.html#configure-optimizers
         Returns
         -------
         [optimizer]

--- a/multimodal/src/autogluon/multimodal/optimization/lit_mmdet.py
+++ b/multimodal/src/autogluon/multimodal/optimization/lit_mmdet.py
@@ -1,9 +1,9 @@
 import logging
 from typing import Callable, Optional, Union
 
-import pytorch_lightning as pl
 import torchmetrics
-from pytorch_lightning.utilities import grad_norm
+from lightning.pytorch import LightningModule
+from lightning.pytorch.utilities import grad_norm
 from torch.nn.modules.loss import _Loss
 from torchmetrics.aggregation import BaseAggregator
 
@@ -27,7 +27,7 @@ except ImportError as e:
 logger = logging.getLogger(__name__)
 
 
-class MMDetLitModule(pl.LightningModule):
+class MMDetLitModule(LightningModule):
     def __init__(
         self,
         model,
@@ -179,7 +179,7 @@ class MMDetLitModule(pl.LightningModule):
 
     def configure_optimizers(self):
         """
-        Configure optimizer. This function is registered by pl.LightningModule.
+        Configure optimizer. This function is registered by LightningModule.
         Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#configure-optimizers
         Returns
         -------

--- a/multimodal/src/autogluon/multimodal/optimization/lit_mmdet.py
+++ b/multimodal/src/autogluon/multimodal/optimization/lit_mmdet.py
@@ -180,7 +180,7 @@ class MMDetLitModule(LightningModule):
     def configure_optimizers(self):
         """
         Configure optimizer. This function is registered by LightningModule.
-        Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#configure-optimizers
+        Refer to https://lightning.ai/docs/pytorch/stable/common/lightning_module.html#configure-optimizers
         Returns
         -------
         [optimizer]

--- a/multimodal/src/autogluon/multimodal/optimization/lit_mmdet.py
+++ b/multimodal/src/autogluon/multimodal/optimization/lit_mmdet.py
@@ -1,8 +1,8 @@
 import logging
 from typing import Callable, Optional, Union
 
+import lightning.pytorch as pl
 import torchmetrics
-from lightning.pytorch import LightningModule
 from lightning.pytorch.utilities import grad_norm
 from torch.nn.modules.loss import _Loss
 from torchmetrics.aggregation import BaseAggregator
@@ -27,7 +27,7 @@ except ImportError as e:
 logger = logging.getLogger(__name__)
 
 
-class MMDetLitModule(LightningModule):
+class MMDetLitModule(pl.LightningModule):
     def __init__(
         self,
         model,

--- a/multimodal/src/autogluon/multimodal/optimization/lit_module.py
+++ b/multimodal/src/autogluon/multimodal/optimization/lit_module.py
@@ -1,17 +1,17 @@
 import logging
 from typing import Callable, Dict, List, Optional, Union
 
-import pytorch_lightning as pl
 import torch
 import torch.nn.functional as F
 import torchmetrics
-from pytorch_lightning.strategies import DeepSpeedStrategy
-from pytorch_lightning.utilities import grad_norm
+from lightning.pytorch import LightningModule
+from lightning.pytorch.strategies import DeepSpeedStrategy
+from lightning.pytorch.utilities import grad_norm
 from torch import nn
 from torch.nn.modules.loss import _Loss
 from torchmetrics.aggregation import BaseAggregator
 
-from ..constants import AUTOMM, LM_TARGET, LOGITS, T_FEW, TEMPLATE_LOGITS, WEIGHT
+from ..constants import LM_TARGET, LOGITS, T_FEW, TEMPLATE_LOGITS, WEIGHT
 from ..data.mixup import MixupModule, multimodel_mixup
 from ..models.utils import run_model
 from .utils import apply_layerwise_lr_decay, apply_single_lr, apply_two_stages_lr, get_lr_scheduler, get_optimizer
@@ -19,7 +19,7 @@ from .utils import apply_layerwise_lr_decay, apply_single_lr, apply_two_stages_l
 logger = logging.getLogger(__name__)
 
 
-class LitModule(pl.LightningModule):
+class LitModule(LightningModule):
     """
     Control the loops for training, evaluation, and prediction. This module is independent of
     the model definition. This class inherits from the Pytorch Lightning's LightningModule:
@@ -223,7 +223,7 @@ class LitModule(pl.LightningModule):
 
     def training_step(self, batch, batch_idx):
         """
-        Per training step. This function is registered by pl.LightningModule.
+        Per training step. This function is registered by LightningModule.
         Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#training-loop
 
         Parameters
@@ -258,7 +258,7 @@ class LitModule(pl.LightningModule):
 
     def validation_step(self, batch, batch_idx):
         """
-        Per validation step. This function is registered by pl.LightningModule.
+        Per validation step. This function is registered by LightningModule.
         Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#validation
 
         Parameters
@@ -292,7 +292,7 @@ class LitModule(pl.LightningModule):
 
     def predict_step(self, batch, batch_idx, dataloader_idx=0):
         """
-        Per prediction step. This function is registered by pl.LightningModule.
+        Per prediction step. This function is registered by LightningModule.
         Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#prediction-loop
 
         Parameters
@@ -318,7 +318,7 @@ class LitModule(pl.LightningModule):
 
     def configure_optimizers(self):
         """
-        Configure optimizer. This function is registered by pl.LightningModule.
+        Configure optimizer. This function is registered by LightningModule.
         Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#configure-optimizers
         Returns
         -------

--- a/multimodal/src/autogluon/multimodal/optimization/lit_module.py
+++ b/multimodal/src/autogluon/multimodal/optimization/lit_module.py
@@ -23,7 +23,7 @@ class LitModule(LightningModule):
     """
     Control the loops for training, evaluation, and prediction. This module is independent of
     the model definition. This class inherits from the Pytorch Lightning's LightningModule:
-    https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html
+    https://lightning.ai/docs/pytorch/stable/common/lightning_module.html
     """
 
     def __init__(
@@ -224,7 +224,7 @@ class LitModule(LightningModule):
     def training_step(self, batch, batch_idx):
         """
         Per training step. This function is registered by LightningModule.
-        Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#training-loop
+        Refer to https://lightning.ai/docs/pytorch/stable/common/lightning_module.html#training-loop
 
         Parameters
         ----------
@@ -259,7 +259,7 @@ class LitModule(LightningModule):
     def validation_step(self, batch, batch_idx):
         """
         Per validation step. This function is registered by LightningModule.
-        Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#validation
+        Refer to https://lightning.ai/docs/pytorch/stable/common/lightning_module.html#validation-loop
 
         Parameters
         ----------
@@ -293,7 +293,7 @@ class LitModule(LightningModule):
     def predict_step(self, batch, batch_idx, dataloader_idx=0):
         """
         Per prediction step. This function is registered by LightningModule.
-        Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#prediction-loop
+        Refer to https://lightning.ai/docs/pytorch/stable/common/lightning_module.html#prediction-loop
 
         Parameters
         ----------
@@ -319,7 +319,7 @@ class LitModule(LightningModule):
     def configure_optimizers(self):
         """
         Configure optimizer. This function is registered by LightningModule.
-        Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#configure-optimizers
+        Refer to https://lightning.ai/docs/pytorch/stable/common/lightning_module.html#configure-optimizers
         Returns
         -------
         [optimizer]

--- a/multimodal/src/autogluon/multimodal/optimization/lit_module.py
+++ b/multimodal/src/autogluon/multimodal/optimization/lit_module.py
@@ -1,10 +1,10 @@
 import logging
 from typing import Callable, Dict, List, Optional, Union
 
+import lightning.pytorch as pl
 import torch
 import torch.nn.functional as F
 import torchmetrics
-from lightning.pytorch import LightningModule
 from lightning.pytorch.strategies import DeepSpeedStrategy
 from lightning.pytorch.utilities import grad_norm
 from torch import nn
@@ -19,7 +19,7 @@ from .utils import apply_layerwise_lr_decay, apply_single_lr, apply_two_stages_l
 logger = logging.getLogger(__name__)
 
 
-class LitModule(LightningModule):
+class LitModule(pl.LightningModule):
     """
     Control the loops for training, evaluation, and prediction. This module is independent of
     the model definition. This class inherits from the Pytorch Lightning's LightningModule:

--- a/multimodal/src/autogluon/multimodal/optimization/lit_ner.py
+++ b/multimodal/src/autogluon/multimodal/optimization/lit_ner.py
@@ -1,18 +1,14 @@
 import logging
 from typing import Callable, Dict, List, Optional, Union
 
-import pytorch_lightning as pl
 import torch
-import torch.nn.functional as F
 import torchmetrics
 from torch import nn
 from torch.nn.modules.loss import _Loss
-from torchmetrics.aggregation import BaseAggregator
 
-from ..constants import AUTOMM, FUSION_NER, LM_TARGET, LOGITS, NER_TEXT, T_FEW, TEMPLATE_LOGITS, WEIGHT
-from ..data.mixup import MixupModule, multimodel_mixup
+from ..constants import FUSION_NER, LOGITS, NER_TEXT, WEIGHT
+from ..data.mixup import MixupModule
 from .lit_module import LitModule
-from .utils import apply_layerwise_lr_decay, apply_single_lr, apply_two_stages_lr, get_lr_scheduler, get_optimizer
 
 logger = logging.getLogger(__name__)
 
@@ -161,7 +157,7 @@ class NerLitModule(LitModule):
 
     def validation_step(self, batch, batch_idx):
         """
-        Per validation step. This function is registered by pl.LightningModule.
+        Per validation step. This function is registered by LightningModule.
         Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#validation
 
         Parameters

--- a/multimodal/src/autogluon/multimodal/optimization/lit_ner.py
+++ b/multimodal/src/autogluon/multimodal/optimization/lit_ner.py
@@ -16,8 +16,8 @@ logger = logging.getLogger(__name__)
 class NerLitModule(LitModule):
     """
     Control the loops for training, evaluation, and prediction of Named Entity Recognition. This module is independent of
-    the model definition. This class inherits from the Pytorch Lightning's LightningModule:
-    https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html
+    the model definition. This class inherits from Lightning's LightningModule:
+    https://lightning.ai/docs/pytorch/stable/common/lightning_module.html
     """
 
     def __init__(
@@ -158,7 +158,7 @@ class NerLitModule(LitModule):
     def validation_step(self, batch, batch_idx):
         """
         Per validation step. This function is registered by LightningModule.
-        Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#validation
+        Refer to https://lightning.ai/docs/pytorch/stable/common/lightning_module.html#validation
 
         Parameters
         ----------

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -174,6 +174,8 @@ from .utils import (
     upgrade_config,
 )
 
+pl_logger = logging.getLogger("lightning")
+pl_logger.propagate = False  # https://github.com/Lightning-AI/lightning/issues/4621
 logger = logging.getLogger(__name__)
 
 

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -15,16 +15,12 @@ import warnings
 from datetime import timedelta
 from typing import Dict, List, Optional, Union
 
+import lightning.pytorch as pl
 import numpy as np
 import pandas as pd
 import torch
 import transformers
 import yaml
-from lightning.pytorch import Trainer
-from lightning.pytorch import __version__ as lightning_version
-from lightning.pytorch import callbacks
-from lightning.pytorch import loggers as lightning_loggers
-from lightning.pytorch import seed_everything
 from lightning.pytorch.strategies import DeepSpeedStrategy
 from omegaconf import OmegaConf
 from packaging import version
@@ -1105,7 +1101,7 @@ class MultiModalPredictor(ExportMixin):
         clean_ckpts: bool = True,
         **hpo_kwargs,
     ):
-        seed_everything(seed, workers=True)
+        pl.seed_everything(seed, workers=True)
         # TODO(?) We should have a separate "_pre_training_event()" for logging messages.
         logger.info(get_fit_start_message(save_path, validation_metric_name))
         config = get_config(
@@ -1402,15 +1398,15 @@ class MultiModalPredictor(ExportMixin):
             mode=minmax_mode,
             save_last=True,
         )
-        early_stopping_callback = callbacks.EarlyStopping(
+        early_stopping_callback = pl.callbacks.EarlyStopping(
             monitor=task.validation_metric_name,
             patience=config.optimization.patience,
             mode=minmax_mode,
             stopping_threshold=get_stopping_threshold(validation_metric_name),
         )
-        lr_callback = callbacks.LearningRateMonitor(logging_interval="step")
-        model_summary = callbacks.ModelSummary(max_depth=1)
-        callbacks_obj = [
+        lr_callback = pl.callbacks.LearningRateMonitor(logging_interval="step")
+        model_summary = pl.callbacks.ModelSummary(max_depth=1)
+        callbacks = [
             checkpoint_callback,
             early_stopping_callback,
             lr_callback,
@@ -1418,13 +1414,13 @@ class MultiModalPredictor(ExportMixin):
         ]
 
         if hpo_mode:
-            from ray.tune.integration.pytorch_lightning import TuneReportCheckpointCallback
+            from .utils.hpo import _TuneReportCheckpointCallback
 
-            tune_report_callback = TuneReportCheckpointCallback(
+            tune_report_callback = _TuneReportCheckpointCallback(
                 {f"{task.validation_metric_name}": f"{task.validation_metric_name}"},
                 filename=RAY_TUNE_CHECKPOINT,
             )
-            callbacks_obj = [
+            callbacks = [
                 tune_report_callback,
                 early_stopping_callback,
                 lr_callback,
@@ -1436,7 +1432,7 @@ class MultiModalPredictor(ExportMixin):
             model_name_to_id=model.name_to_id,
         )
 
-        tb_logger = lightning_loggers.TensorBoardLogger(
+        tb_logger = pl.loggers.TensorBoardLogger(
             save_dir=save_path,
             name="",
             version="",
@@ -1467,9 +1463,9 @@ class MultiModalPredictor(ExportMixin):
         if not hpo_mode:
             if num_gpus <= 1:
                 if config.env.strategy == DEEPSPEED_OFFLOADING:  # Offloading currently only tested for single GPU
-                    assert version.parse(lightning_version) >= version.parse(
+                    assert version.parse(pl.__version__) >= version.parse(
                         DEEPSPEED_MIN_PL_VERSION
-                    ), f"For DeepSpeed Offloading to work reliably you need at least lightning version {DEEPSPEED_MIN_PL_VERSION}, however, found {lightning_version}. Please update your lightning version."
+                    ), f"For DeepSpeed Offloading to work reliably you need at least lightning version {DEEPSPEED_MIN_PL_VERSION}, however, found {pl.__version__}. Please update your lightning version."
                     from .optimization.deepspeed import CustomDeepSpeedStrategy
 
                     strategy = CustomDeepSpeedStrategy(
@@ -1497,7 +1493,7 @@ class MultiModalPredictor(ExportMixin):
         blacklist_msgs = ["already configured with model summary"]
         log_filter = LogFilter(blacklist_msgs)
         with apply_log_filter(log_filter):
-            trainer = Trainer(
+            trainer = pl.Trainer(
                 accelerator="gpu" if num_gpus > 0 else "auto",
                 devices=num_gpus if num_gpus > 0 else "auto",
                 num_nodes=config.env.num_nodes,
@@ -1508,7 +1504,7 @@ class MultiModalPredictor(ExportMixin):
                 max_epochs=config.optimization.max_epochs,
                 max_steps=config.optimization.max_steps,
                 max_time=max_time,
-                callbacks=callbacks_obj,
+                callbacks=callbacks,
                 logger=tb_logger,
                 gradient_clip_val=OmegaConf.select(config, "optimization.gradient_clip_val", default=1),
                 gradient_clip_algorithm=OmegaConf.select(
@@ -1803,7 +1799,7 @@ class MultiModalPredictor(ExportMixin):
         log_filter = LogFilter(blacklist_msgs)
 
         with apply_log_filter(log_filter):
-            evaluator = Trainer(
+            evaluator = pl.Trainer(
                 accelerator="gpu" if num_gpus > 0 else "auto",
                 devices=num_gpus if num_gpus > 0 else "auto",
                 num_nodes=self._config.env.num_nodes,

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -1722,8 +1722,8 @@ class MultiModalPredictor(ExportMixin):
         barebones: Optional[bool] = False,
     ) -> List[Dict]:
         if self._config.env.strategy == DEEPSPEED_OFFLOADING and DEEPSPEED_MODULE not in sys.modules:
-            # Need to initialize DeepSpeed and optimizer as currently required in Pytorch-Lighting integration of deepspeed.
-            # TODO: Using optimiation_kwargs for inference is confusing and bad design. Remove as soon as fixed in pytorch-lighting.
+            # Need to initialize DeepSpeed and optimizer as currently required in lightning's integration of deepspeed.
+            # TODO: Using optimiation_kwargs for inference is confusing and bad design. Remove as soon as fixed in lightning.
             from .optimization.deepspeed import CustomDeepSpeedStrategy
 
             strategy = CustomDeepSpeedStrategy(

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -1414,9 +1414,10 @@ class MultiModalPredictor(ExportMixin):
         ]
 
         if hpo_mode:
-            from .utils.hpo import _TuneReportCheckpointCallback
+            from .utils.hpo import get_ray_tune_ckpt_callback
 
-            tune_report_callback = _TuneReportCheckpointCallback(
+            TuneReportCheckpointCallback = get_ray_tune_ckpt_callback()
+            tune_report_callback = TuneReportCheckpointCallback(
                 {f"{task.validation_metric_name}": f"{task.validation_metric_name}"},
                 filename=RAY_TUNE_CHECKPOINT,
             )

--- a/multimodal/src/autogluon/multimodal/utils/cache.py
+++ b/multimodal/src/autogluon/multimodal/utils/cache.py
@@ -6,8 +6,8 @@ import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
 
+import lightning.pytorch as pl
 import torch
-from lightning.pytorch import LightningModule, Trainer
 from lightning.pytorch.callbacks import BasePredictionWriter
 
 from ..constants import WEIGHT
@@ -63,8 +63,8 @@ class DDPPredictionWriter(BasePredictionWriter):
 
     def write_on_epoch_end(
         self,
-        trainer: Trainer,
-        pl_module: LightningModule,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
         predictions: Sequence[Any],
         batch_indices: Sequence[Any],
     ):

--- a/multimodal/src/autogluon/multimodal/utils/cache.py
+++ b/multimodal/src/autogluon/multimodal/utils/cache.py
@@ -6,9 +6,9 @@ import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
 
-import pytorch_lightning as pl
 import torch
-from pytorch_lightning.callbacks import BasePredictionWriter
+from lightning.pytorch import LightningModule, Trainer
+from lightning.pytorch.callbacks import BasePredictionWriter
 
 from ..constants import WEIGHT
 
@@ -25,7 +25,7 @@ class DDPPredictionWriter(BasePredictionWriter):
         write_interval
             When to write. Could be "batch" or "epoch".
             See Lightning's source code at
-            https://pytorch-lightning.readthedocs.io/en/stable/_modules/pytorch_lightning/callbacks/prediction_writer.html#BasePredictionWriter
+            https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.BasePredictionWriter.html
         sleep_time
             If other process does not finish writing, sleep for a few seconds and recheck.
         """
@@ -63,8 +63,8 @@ class DDPPredictionWriter(BasePredictionWriter):
 
     def write_on_epoch_end(
         self,
-        trainer: pl.Trainer,
-        pl_module: pl.LightningModule,
+        trainer: Trainer,
+        pl_module: LightningModule,
         predictions: Sequence[Any],
         batch_indices: Sequence[Any],
     ):

--- a/multimodal/src/autogluon/multimodal/utils/checkpoint.py
+++ b/multimodal/src/autogluon/multimodal/utils/checkpoint.py
@@ -4,8 +4,8 @@ import re
 import shutil
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+import lightning.pytorch as pl
 import torch
-from lightning.pytorch import LightningModule, Trainer, callbacks, plugins
 from lightning.pytorch.strategies import DeepSpeedStrategy
 from lightning.pytorch.utilities.rank_zero import rank_zero_warn
 
@@ -66,7 +66,7 @@ def average_checkpoints(
     return avg_state_dict
 
 
-class AutoMMModelCheckpointIO(plugins.CheckpointIO):
+class AutoMMModelCheckpointIO(pl.plugins.CheckpointIO):
     """
     Class that customizes how checkpoints are saved. Saves either the entire model or only parameters that have been explicitly updated during training. The latter reduces memory footprint substantially when training very large models with parameter-efficient finetuning methods.
     Class is based on plugins.TorchCheckpointIO.
@@ -129,7 +129,7 @@ class AutoMMModelCheckpointIO(plugins.CheckpointIO):
         except AttributeError as err:
             # todo (sean): is this try catch necessary still?
             # https://github.com/Lightning-AI/lightning/pull/431
-            key = LightningModule.CHECKPOINT_HYPER_PARAMS_KEY
+            key = pl.LightningModule.CHECKPOINT_HYPER_PARAMS_KEY
             checkpoint.pop(key, None)
             rank_zero_warn(f"Warning, `{key}` dropped from checkpoint. An attribute is not picklable: {err}")
             _atomic_save(checkpoint, path)
@@ -167,7 +167,7 @@ class AutoMMModelCheckpointIO(plugins.CheckpointIO):
             logger.debug(f"Removed checkpoint: {path}")
 
 
-class AutoMMModelCheckpoint(callbacks.ModelCheckpoint):
+class AutoMMModelCheckpoint(pl.callbacks.ModelCheckpoint):
     """
     Class that inherits callbacks.ModelCheckpoint. The purpose is to resolve the potential issues in lightning.
 
@@ -192,7 +192,7 @@ class AutoMMModelCheckpoint(callbacks.ModelCheckpoint):
     def _update_best_and_save(
         self,
         current: torch.Tensor,
-        trainer: "Trainer",
+        trainer: "pl.Trainer",
         monitor_candidates: Dict[str, torch.Tensor],
     ) -> None:
 

--- a/multimodal/src/autogluon/multimodal/utils/checkpoint.py
+++ b/multimodal/src/autogluon/multimodal/utils/checkpoint.py
@@ -173,7 +173,7 @@ class AutoMMModelCheckpoint(callbacks.ModelCheckpoint):
 
     - Issue1:
 
-    It solves the issue described in https://github.com/PyTorchLightning/pytorch-lightning/issues/5582.
+    It solves the issue described in https://github.com/Lightning-AI/lightning/issues/5582.
     For ddp_spawn, the checkpoint_callback.best_k_models will be empty.
     Here, we resolve it by storing the best_models to "SAVE_DIR/best_k_models.yaml".
 

--- a/multimodal/src/autogluon/multimodal/utils/cloud_io.py
+++ b/multimodal/src/autogluon/multimodal/utils/cloud_io.py
@@ -16,7 +16,7 @@
 Copied from
 https://github.com/Lightning-AI/lightning/blob/master/src/lightning/fabric/utilities/cloud_io.py
 to address warnings:
-LightningDeprecationWarning: pytorch_lightning.utilities.cloud_io.atomic_save has been 
+LightningDeprecationWarning: lightning.pytorch.utilities.cloud_io.atomic_save has been 
 deprecated in v1.8.0 and will be removed in v1.10.0. This function is internal but you 
 can copy over its implementation.
 """

--- a/multimodal/src/autogluon/multimodal/utils/environment.py
+++ b/multimodal/src/autogluon/multimodal/utils/environment.py
@@ -6,7 +6,7 @@ import warnings
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch
-from pytorch_lightning.accelerators import find_usable_cuda_devices
+from lightning.pytorch.accelerators import find_usable_cuda_devices
 from torch import nn
 
 from autogluon.common.utils.resource_utils import ResourceManager

--- a/multimodal/src/autogluon/multimodal/utils/hpo.py
+++ b/multimodal/src/autogluon/multimodal/utils/hpo.py
@@ -2,15 +2,26 @@ import logging
 import os
 import shutil
 
+import lightning.pytorch as pl
 import yaml
 
 from autogluon.common.utils.context import set_torch_num_threads
 
-from ..constants import AUTOMM, BEST_K_MODELS_FILE, RAY_TUNE_CHECKPOINT
+from ..constants import BEST_K_MODELS_FILE, RAY_TUNE_CHECKPOINT
 from .matcher import create_siamese_model
 from .model import create_fusion_model
 
+try:
+    from ray.tune.integration.pytorch_lightning import TuneReportCheckpointCallback
+except:
+    TuneReportCheckpointCallback = None
+
 logger = logging.getLogger(__name__)
+
+
+class _TuneReportCheckpointCallback(TuneReportCheckpointCallback, pl.Callback):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 def hpo_trial(sampled_hyperparameters, predictor, checkpoint_dir=None, **_fit_args):

--- a/multimodal/src/autogluon/multimodal/utils/hpo.py
+++ b/multimodal/src/autogluon/multimodal/utils/hpo.py
@@ -11,17 +11,22 @@ from ..constants import BEST_K_MODELS_FILE, RAY_TUNE_CHECKPOINT
 from .matcher import create_siamese_model
 from .model import create_fusion_model
 
-try:
-    from ray.tune.integration.pytorch_lightning import TuneReportCheckpointCallback
-except:
-    TuneReportCheckpointCallback = None
-
 logger = logging.getLogger(__name__)
 
 
-class _TuneReportCheckpointCallback(TuneReportCheckpointCallback, pl.Callback):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+def get_ray_tune_ckpt_callback():
+    """
+    This is a workaround for the issue caused by the mixed use of old and new lightning's import style.
+    https://github.com/optuna/optuna/issues/4689
+    We can remove this function after ray adopts the new lightning import style.
+    """
+    from ray.tune.integration.pytorch_lightning import TuneReportCheckpointCallback
+
+    class _TuneReportCheckpointCallback(TuneReportCheckpointCallback, pl.Callback):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+    return _TuneReportCheckpointCallback
 
 
 def hpo_trial(sampled_hyperparameters, predictor, checkpoint_dir=None, **_fit_args):

--- a/multimodal/src/autogluon/multimodal/utils/log.py
+++ b/multimodal/src/autogluon/multimodal/utils/log.py
@@ -132,11 +132,13 @@ def apply_log_filter(log_filter):
     """
     try:
         add_log_filter(logging.getLogger(), log_filter)
+        add_log_filter(logging.getLogger("lightning"), log_filter)
         add_log_filter(logging.getLogger("lightning.pytorch"), log_filter)
         yield
 
     finally:
         remove_log_filter(logging.getLogger(), log_filter)
+        remove_log_filter(logging.getLogger("lightning"), log_filter)
         remove_log_filter(logging.getLogger("lightning.pytorch"), log_filter)
 
 

--- a/multimodal/src/autogluon/multimodal/utils/log.py
+++ b/multimodal/src/autogluon/multimodal/utils/log.py
@@ -122,7 +122,7 @@ def remove_log_filter(target_logger, log_filter):
 def apply_log_filter(log_filter):
     """
     User contextmanager to control the scope of applying one log filter.
-    Currently, it is to filter some pytorch lightning's log messages.
+    Currently, it is to filter some lightning's log messages.
     But we can easily extend it to cover more loggers.
 
     Parameters
@@ -132,12 +132,12 @@ def apply_log_filter(log_filter):
     """
     try:
         add_log_filter(logging.getLogger(), log_filter)
-        add_log_filter(logging.getLogger("pytorch_lightning"), log_filter)
+        add_log_filter(logging.getLogger("lightning.pytorch"), log_filter)
         yield
 
     finally:
         remove_log_filter(logging.getLogger(), log_filter)
-        remove_log_filter(logging.getLogger("pytorch_lightning"), log_filter)
+        remove_log_filter(logging.getLogger("lightning.pytorch"), log_filter)
 
 
 def get_fit_start_message(save_path, validation_metric_name):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ known_third_party = [
     "fairscale",
     "scikit-image",
     "smart_open",
-    "pytorch_lightning",
+    "lightning",
     "torchmetrics",
     "transformers",
     "nptyping",

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -26,7 +26,7 @@ install_requires = [
     "scipy",  # version range defined in `core/_setup_utils.py`
     "pandas",  # version range defined in `core/_setup_utils.py`
     "torch",  # version range defined in `core/_setup_utils.py`
-    "pytorch-lightning",  # version range defined in `core/_setup_utils.py`
+    "lightning",  # version range defined in `core/_setup_utils.py`
     "statsmodels>=0.13.0,<0.15",
     "gluonts>=0.13.1,<0.14",
     "networkx",  # version range defined in `core/_setup_utils.py`

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -29,7 +29,7 @@ from autogluon.timeseries.utils.warning_filters import disable_root_logger, torc
 
 logger = logging.getLogger(__name__)
 gts_logger = logging.getLogger(gluonts.__name__)
-pl_loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict if "pytorch_lightning" in name]
+pl_loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict if "lightning.pytorch" in name]
 
 
 GLUONTS_SUPPORTED_OFFSETS = ["Y", "Q", "M", "W", "D", "B", "H", "T", "min", "S"]
@@ -371,7 +371,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
 
     def _get_callbacks(self, time_limit: int, *args, **kwargs) -> List[Callable]:
         """Retrieve a list of callback objects for the GluonTS trainer"""
-        from pytorch_lightning.callbacks import Timer
+        from lightning.pytorch.callbacks import Timer
 
         return [Timer(timedelta(seconds=time_limit))] if time_limit is not None else []
 

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -29,7 +29,7 @@ from autogluon.timeseries.utils.warning_filters import disable_root_logger, torc
 
 logger = logging.getLogger(__name__)
 gts_logger = logging.getLogger(gluonts.__name__)
-pl_loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict if "lightning.pytorch" in name]
+pl_loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict if "pytorch_lightning" in name]
 
 
 GLUONTS_SUPPORTED_OFFSETS = ["Y", "Q", "M", "W", "D", "B", "H", "T", "min", "S"]
@@ -371,7 +371,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
 
     def _get_callbacks(self, time_limit: int, *args, **kwargs) -> List[Callable]:
         """Retrieve a list of callback objects for the GluonTS trainer"""
-        from lightning.pytorch.callbacks import Timer
+        from pytorch_lightning.callbacks import Timer
 
         return [Timer(timedelta(seconds=time_limit))] if time_limit is not None else []
 

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -5,7 +5,7 @@ import time
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import pandas as pd
-import pytorch_lightning as pl
+from lightning.pytorch import seed_everything
 
 from autogluon.common.utils.deprecated_utils import Deprecated_args
 from autogluon.common.utils.log_utils import set_logger_verbosity
@@ -600,7 +600,7 @@ class TimeSeriesPredictor:
         logger.info("=====================================================\n")
 
         if random_seed is not None:
-            pl.seed_everything(random_seed)
+            seed_everything(random_seed)
 
         time_left = None if time_limit is None else time_limit - (time.time() - time_start)
         self._learner.fit(
@@ -698,7 +698,7 @@ class TimeSeriesPredictor:
                 2020-03-05     8.3
         """
         if random_seed is not None:
-            pl.seed_everything(random_seed)
+            seed_everything(random_seed)
         # Don't use data.item_ids in case data is not a TimeSeriesDataFrame
         original_item_id_order = data.reset_index()[ITEMID].unique()
         data = self._check_and_prepare_data_frame(data)

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -5,7 +5,7 @@ import time
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import pandas as pd
-from lightning.pytorch import seed_everything
+import lightning.pytorch as pl
 
 from autogluon.common.utils.deprecated_utils import Deprecated_args
 from autogluon.common.utils.log_utils import set_logger_verbosity
@@ -600,7 +600,7 @@ class TimeSeriesPredictor:
         logger.info("=====================================================\n")
 
         if random_seed is not None:
-            seed_everything(random_seed)
+            pl.seed_everything(random_seed)
 
         time_left = None if time_limit is None else time_limit - (time.time() - time_start)
         self._learner.fit(
@@ -698,7 +698,7 @@ class TimeSeriesPredictor:
                 2020-03-05     8.3
         """
         if random_seed is not None:
-            seed_everything(random_seed)
+            pl.seed_everything(random_seed)
         # Don't use data.item_ids in case data is not a TimeSeriesDataFrame
         original_item_id_order = data.reset_index()[ITEMID].unique()
         data = self._check_and_prepare_data_frame(data)

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -4,8 +4,8 @@ import pprint
 import time
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
-import lightning.pytorch as pl
 import pandas as pd
+import pytorch_lightning as pl
 
 from autogluon.common.utils.deprecated_utils import Deprecated_args
 from autogluon.common.utils.log_utils import set_logger_verbosity

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -4,8 +4,8 @@ import pprint
 import time
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
-import pandas as pd
 import lightning.pytorch as pl
+import pandas as pd
 
 from autogluon.common.utils.deprecated_utils import Deprecated_args
 from autogluon.common.utils.log_utils import set_logger_verbosity


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Install the new `lightning` package and use the new import style. See the discussion: https://lightning.ai/forums/t/using-pytorch-lightning-from-lightning-import/2182/2
- Update lightning doc links
- Remove `env.auto_select_gpus` from the doc since it's no longer used.
- Resolve one issue of using ray tune with new `lightning` (https://github.com/optuna/optuna/issues/4689 and https://github.com/ray-project/ray/issues/33426)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
