### PR TITLE
[timeseries] Rename mean_wQuantileLoss metric to WQL

### DIFF
--- a/docs/tutorials/timeseries/forecasting-indepth.ipynb
+++ b/docs/tutorials/timeseries/forecasting-indepth.ipynb
@@ -1133,7 +1133,7 @@
     "Different evaluation metrics capture different properties of the forecast, and therefore depend on the application that the user has in mind.\n",
     "Here is a very rough guide outlining some scenarios when you can prefer different metrics:\n",
     "\n",
-    "- `mean_wQuantileLoss` - if you care about the quantile forecasts (all other metrics ignore the quantile forecasts)\n",
+    "- `WQL` - if you care about the quantile forecasts (all other metrics ignore the quantile forecasts)\n",
     "- `MASE` or `sMAPE` - if you care about an accurate forecast for each time series, regardless of its scale\n",
     "- `MAE` - if you care about accurately predicting time series with larger scale (e.g., accurately predicting demand for popular items)\n",
     "- `RMSE` - similar to `MAE`, but penalizes large mispredictions more strongly\n",

--- a/timeseries/src/autogluon/timeseries/evaluator.py
+++ b/timeseries/src/autogluon/timeseries/evaluator.py
@@ -84,7 +84,7 @@ class TimeSeriesEvaluator:
         * ``MASE``: mean absolute scaled error. See https://en.wikipedia.org/wiki/Mean_absolute_scaled_error
         * ``MAPE``: mean absolute percentage error. See https://en.wikipedia.org/wiki/Mean_absolute_percentage_error
         * ``sMAPE``: "symmetric" mean absolute percentage error. See https://en.wikipedia.org/wiki/Symmetric_mean_absolute_percentage_error
-        * ``mean_wQuantileLoss``: mean weighted quantile loss, i.e., average quantile loss scaled
+        * ``WQL``: mean weighted quantile loss, i.e., average quantile loss scaled
          by the total absolute values of the time series. See https://docs.aws.amazon.com/forecast/latest/dg/metrics.html#metrics-wQL
         * ``MSE``: mean squared error
         * ``RMSE``: root mean squared error
@@ -112,18 +112,18 @@ class TimeSeriesEvaluator:
         :meth:``~autogluon.timeseries.TimeSeriesEvaluator.check_get_evaluation_metric``.
     """
 
-    AVAILABLE_METRICS = ["MASE", "MAPE", "sMAPE", "mean_wQuantileLoss", "MSE", "RMSE", "WAPE", "RMSSE"]
+    AVAILABLE_METRICS = ["MASE", "MAPE", "sMAPE", "WQL", "MSE", "RMSE", "WAPE", "RMSSE"]
     METRIC_COEFFICIENTS = {
         "MASE": -1,
         "MAPE": -1,
         "sMAPE": -1,
-        "mean_wQuantileLoss": -1,
+        "WQL": -1,
         "MSE": -1,
         "RMSE": -1,
         "WAPE": -1,
         "RMSSE": -1,
     }
-    DEFAULT_METRIC = "mean_wQuantileLoss"
+    DEFAULT_METRIC = "WQL"
 
     def __init__(
         self,
@@ -174,7 +174,7 @@ class TimeSeriesEvaluator:
         y_pred = self._get_median_forecast(predictions)
         return self._safemean(symmetric_mape_per_item(y_true=y_true, y_pred=y_pred))
 
-    def _mean_wquantileloss(self, y_true: pd.Series, predictions: TimeSeriesDataFrame) -> float:
+    def _wql(self, y_true: pd.Series, predictions: TimeSeriesDataFrame) -> float:
         values_true = y_true.values[:, None]  # shape [N, 1]
         quantile_pred_columns = [col for col in predictions.columns if col != "mean"]
         values_pred = predictions[quantile_pred_columns].values  # shape [N, len(quantile_levels)]

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -44,7 +44,7 @@ class AbstractTimeSeriesModel(AbstractModel):
         Metric by which predictions will be ultimately evaluated on test data.
         This only impacts `model.score()`, as eval_metric is not used during training.
         Available metrics can be found in `autogluon.timeseries.utils.metric_utils.AVAILABLE_METRICS`, and
-        detailed documentation can be found in `gluonts.evaluation.Evaluator`. By default, `mean_wQuantileLoss`
+        detailed documentation can be found in `gluonts.evaluation.Evaluator`. By default, `WQL`
         will be used.
     eval_metric_seasonal_period : int, optional
         Seasonal period used to compute the mean absolute scaled error (MASE) evaluation metric. This parameter is only

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/direct_tabular.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/direct_tabular.py
@@ -33,7 +33,7 @@ class DirectTabularModel(AbstractTimeSeriesModel):
 
     Features not known during the forecast horizon (e.g., future target values) are replaced by NaNs.
 
-    If ``eval_metric=="mean_wQuantileLoss"``, the TabularPredictor will be trained with ``"quantile"`` problem type.
+    If ``eval_metric=="WQL"``, the TabularPredictor will be trained with ``"quantile"`` problem type.
     Otherwise, TabularPredictor will be trained with ``"regression"`` problem type, and dummy quantiles will be
     obtained by assuming that the residuals follow zero-mean normal distribution.
 
@@ -87,7 +87,7 @@ class DirectTabularModel(AbstractTimeSeriesModel):
         self._known_covariates_lag_indices: np.array = None
         self._past_covariates_lag_indices: np.array = None
         self._time_features: List[Callable] = None
-        self.is_quantile_model = self.eval_metric == "mean_wQuantileLoss"
+        self.is_quantile_model = self.eval_metric == "WQL"
         if 0.5 not in self.quantile_levels:
             self.must_drop_median = True
             self.quantile_levels = sorted(set([0.5] + self.quantile_levels))

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -90,7 +90,7 @@ class RecursiveTabularModel(AbstractTimeSeriesModel):
         "MASE": "mean_absolute_error",
         "MAPE": "mean_absolute_percentage_error",
         "sMAPE": "mean_absolute_percentage_error",
-        "mean_wQuantileLoss": "mean_absolute_error",
+        "WQL": "mean_absolute_error",
         "MSE": "mean_squared_error",
         "RMSE": "root_mean_squared_error",
     }

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -126,7 +126,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
     name: str
         Name of the model. Also, name of subdirectory inside path where model will be saved.
     eval_metric: str
-        objective function the model intends to optimize, will use mean_wQuantileLoss by default.
+        objective function the model intends to optimize, will use WQL by default.
     hyperparameters:
         various hyperparameters that will be used by model (can be search spaces instead of
         fixed values). See *Other Parameters* in each inheriting model's documentation for

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -59,12 +59,12 @@ class TimeSeriesPredictor:
 
         If ``freq`` is provided when creating the predictor, all data passed to the predictor will be automatically
         resampled at this frequency.
-    eval_metric : str, default = "mean_wQuantileLoss"
+    eval_metric : str, default = "WQL"
         Metric by which predictions will be ultimately evaluated on future test data. AutoGluon tunes hyperparameters
         in order to improve this metric on validation data, and ranks models (on validation data) according to this
         metric. Available options:
 
-        - ``"mean_wQuantileLoss"``: mean weighted quantile loss, defined as average of quantile losses for the specified ``quantile_levels`` scaled by the total value of the time series
+        - ``"WQL"``: mean weighted quantile loss, defined as average of quantile losses for the specified ``quantile_levels`` scaled by the total value of the time series
         - ``"MAPE"``: mean absolute percentage error
         - ``"sMAPE"``: "symmetric" mean absolute percentage error
         - ``"MASE"``: mean absolute scaled error
@@ -162,6 +162,12 @@ class TimeSeriesPredictor:
             if std_freq != str(self.freq):
                 logger.info(f"Frequency '{self.freq}' stored as '{std_freq}'")
             self.freq = std_freq
+        if eval_metric == "mean_wQuantileLoss":
+            logger.warning(
+                "DeprecationWarning: Evaluation metric 'mean_wQuantileLoss' has been renamed to 'WQL'. "
+                "Support for the old name will be removed in v1.1.",
+            )
+            eval_metric = "WQL"
         self.eval_metric = eval_metric
         self.eval_metric_seasonal_period = eval_metric_seasonal_period
         if quantile_levels is None:

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -163,6 +163,7 @@ class TimeSeriesPredictor:
                 logger.info(f"Frequency '{self.freq}' stored as '{std_freq}'")
             self.freq = std_freq
         if eval_metric == "mean_wQuantileLoss":
+            # We don't use warnings.warn since DeprecationWarning may be silenced by the Python warning filters
             logger.warning(
                 "DeprecationWarning: Evaluation metric 'mean_wQuantileLoss' has been renamed to 'WQL'. "
                 "Support for the old name will be removed in v1.1.",

--- a/timeseries/tests/smoketests/test_features_and_covariates.py
+++ b/timeseries/tests/smoketests/test_features_and_covariates.py
@@ -58,7 +58,7 @@ def generate_train_and_test_data(
 @pytest.mark.parametrize("use_known_covariates", [True, False])
 @pytest.mark.parametrize("use_static_features_continuous", [True, False])
 @pytest.mark.parametrize("use_static_features_categorical", [True, False])
-@pytest.mark.parametrize("eval_metric", ["mean_wQuantileLoss", "MASE"])
+@pytest.mark.parametrize("eval_metric", ["WQL", "MASE"])
 def test_predictor_smoke_test(
     use_known_covariates,
     use_past_covariates,

--- a/timeseries/tests/unittests/models/test_direct_tabular.py
+++ b/timeseries/tests/unittests/models/test_direct_tabular.py
@@ -90,7 +90,7 @@ def test_when_static_features_present_then_prediction_works(temp_model_path):
     model.predict(data)
 
 
-@pytest.mark.parametrize("eval_metric", ["RMSE", "mean_wQuantileLoss", "MAPE", None])
+@pytest.mark.parametrize("eval_metric", ["RMSE", "WQL", "MAPE", None])
 def test_when_eval_metric_is_changed_then_model_can_predict(temp_model_path, eval_metric):
     data = DUMMY_VARIABLE_LENGTH_TS_DATAFRAME.copy()
     model = DirectTabularModel(path=temp_model_path, eval_metric=eval_metric)

--- a/timeseries/tests/unittests/test_evaluator.py
+++ b/timeseries/tests/unittests/test_evaluator.py
@@ -11,8 +11,8 @@ from autogluon.timeseries.models.gluonts.abstract_gluonts import AbstractGluonTS
 
 from .common import DUMMY_TS_DATAFRAME, get_data_frame_with_item_index
 
-GLUONTS_PARITY_METRICS = ["mean_wQuantileLoss", "MAPE", "sMAPE", "MSE", "RMSE", "MASE", "WAPE"]
-AG_TO_GLUONTS_METRIC = {"WAPE": "ND"}
+GLUONTS_PARITY_METRICS = ["WQL", "MAPE", "sMAPE", "MSE", "RMSE", "MASE", "WAPE"]
+AG_TO_GLUONTS_METRIC = {"WAPE": "ND", "WQL": "mean_wQuantileLoss"}
 
 
 pytestmark = pytest.mark.filterwarnings("ignore")


### PR DESCRIPTION
*Description of changes:*
- Replace all occurrences of `mean_wQuantileLoss` with `WQL`
- If user sets `eval_metric="mean_wQuantileLoss"`, log a warning and automatically change the metric name to `WQL`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
