### PR TITLE
[timeseries] Fix smoketests for time series

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/local/statsforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/local/statsforecast.py
@@ -245,6 +245,17 @@ class AutoETSModel(AbstractStatsForecastModel):
 
         return AutoETS
 
+    def _predict_with_local_model(
+        self,
+        time_series: pd.Series,
+        local_model_args: dict,
+    ) -> pd.DataFrame:
+        # Disable seasonality if time series too short for chosen season_length, otherwise model will crash
+        if len(time_series) < 2 * local_model_args["season_length"]:
+            # changing last character to "N" disables seasonality, e.g., model="AAA" -> model="AAN"
+            local_model_args["model"] = local_model_args["model"][:-1] + "N"
+        return super()._predict_with_local_model(time_series=time_series, local_model_args=local_model_args)
+
 
 class ETSModel(AutoETSModel):
     """Exponential smoothing with trend and seasonality.
@@ -278,6 +289,7 @@ class ETSModel(AutoETSModel):
     def _update_local_model_args(self, local_model_args: dict) -> dict:
         local_model_args = super()._update_local_model_args(local_model_args)
         local_model_args.setdefault("model", "AAA")
+        local_model_args.setdefault("damped", False)
         return local_model_args
 
 

--- a/timeseries/tests/smoketests/test_features_and_covariates.py
+++ b/timeseries/tests/smoketests/test_features_and_covariates.py
@@ -79,8 +79,8 @@ def test_predictor_smoke_test(
         "TemporalFusionTransformer": DUMMY_MODEL_HPARAMS,
         "Theta": {},
         # Override default hyperparameters for faster training
-        "AutoARIMA": {"max_p": 2},
-        "AutoETS": {"model": "AAA"},
+        "AutoARIMA": {"max_p": 2, "use_fallback_model": False},
+        "AutoETS": {"model": "AAA", "use_fallback_model": False},
     }
 
     train_data, test_data = generate_train_and_test_data(


### PR DESCRIPTION
*Description of changes:*
- Gracefully handle the case when `ETSModel` and `AutoETSModel` fail if time series length < 2 * `season_length`.
- Disable damped trend for `ETSModel` (for compatibility with the `ETSModel` from statsmodels that was replaced in #3513).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
