### PR TITLE
Force versions link to always go to stable versions file

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -252,7 +252,7 @@ hidden:
 ---
 
 Cheat Sheets <cheatsheet.rst>
-Versions <versions.rst>
+Versions <https://auto.gluon.ai/dev/versions.html>
 Tabular FAQ <tutorials/tabular/tabular-faq.md>
 Multimodal FAQ <tutorials/multimodal/multimodal-faq.md>
 Time Series FAQ <tutorials/timeseries/forecasting-faq.md>

--- a/docs/index.md
+++ b/docs/index.md
@@ -252,7 +252,7 @@ hidden:
 ---
 
 Cheat Sheets <cheatsheet.rst>
-Versions <https://auto.gluon.ai/dev/versions.html>
+Versions <https://auto.gluon.ai/stable/versions.html>
 Tabular FAQ <tutorials/tabular/tabular-faq.md>
 Multimodal FAQ <tutorials/multimodal/multimodal-faq.md>
 Time Series FAQ <tutorials/timeseries/forecasting-faq.md>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Ensure versions link in website always links to dev documentation. This way it doesn't become outdated over time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
