### PR TITLE
Add get_simulation_artifact

### DIFF
--- a/common/setup.py
+++ b/common/setup.py
@@ -26,6 +26,7 @@ install_requires = (
         "boto3",  # version range defined in `core/_setup_utils.py`
         "psutil",  # version range defined in `core/_setup_utils.py`
         "tqdm",  # version range defined in `core/_setup_utils.py`
+        "s3fs",  # TODO FIXME: Add version range
         "setuptools",
     ]
     if not ag.LITE_MODE

--- a/common/setup.py
+++ b/common/setup.py
@@ -26,7 +26,7 @@ install_requires = (
         "boto3",  # version range defined in `core/_setup_utils.py`
         "psutil",  # version range defined in `core/_setup_utils.py`
         "tqdm",  # version range defined in `core/_setup_utils.py`
-        "s3fs",  # TODO FIXME: Add version range
+        "s3fs",  # version range defined in `core/_setup_utils.py`
         "setuptools",
     ]
     if not ag.LITE_MODE

--- a/common/src/autogluon/common/loaders/load_json.py
+++ b/common/src/autogluon/common/loaders/load_json.py
@@ -1,12 +1,22 @@
 import json
 import logging
 
+from ..utils import s3_utils
+
 logger = logging.getLogger(__name__)
 
 
-def load(path, *, verbose=True):
+def load(path: str, *, verbose=True) -> dict:
     if verbose:
         logger.log(15, "Loading: %s" % path)
-    with open(path, "r") as f:
-        out = json.load(f)
+    is_s3_path = s3_utils.is_s3_url(path)
+    if is_s3_path:
+        import boto3
+        bucket, key = s3_utils.s3_path_to_bucket_prefix(path)
+        s3_client = boto3.client('s3')
+        result = s3_client.get_object(Bucket=bucket, Key=key)
+        out = json.loads(result["Body"].read())
+    else:
+        with open(path, "r") as f:
+            out = json.load(f)
     return out

--- a/common/src/autogluon/common/loaders/load_json.py
+++ b/common/src/autogluon/common/loaders/load_json.py
@@ -12,8 +12,9 @@ def load(path: str, *, verbose=True) -> dict:
     is_s3_path = s3_utils.is_s3_url(path)
     if is_s3_path:
         import boto3
+
         bucket, key = s3_utils.s3_path_to_bucket_prefix(path)
-        s3_client = boto3.client('s3')
+        s3_client = boto3.client("s3")
         result = s3_client.get_object(Bucket=bucket, Key=key)
         out = json.loads(result["Body"].read())
     else:

--- a/common/src/autogluon/common/savers/save_json.py
+++ b/common/src/autogluon/common/savers/save_json.py
@@ -2,19 +2,31 @@
 import json
 import logging
 import os
+import tempfile
+
+from ..utils import s3_utils
 
 logger = logging.getLogger(__name__)
 
 
-# TODO: Support S3 paths
 def save(path, obj, sanitize=True):
     if sanitize:
         obj = sanitize_object_to_primitives(obj=obj)
-    dirname = os.path.dirname(path)
-    if dirname:
-        os.makedirs(dirname, exist_ok=True)
-    with open(path, "w") as fp:
-        json.dump(obj, fp, indent=2)
+    is_s3_path = s3_utils.is_s3_url(path)
+    if is_s3_path:
+        import boto3
+
+        data = json.dumps(obj).encode("UTF-8")
+
+        bucket, key = s3_utils.s3_path_to_bucket_prefix(path)
+        s3_client = boto3.client("s3")
+        s3_client.put_object(Body=data, Bucket=bucket, Key=key)
+    else:
+        dirname = os.path.dirname(path)
+        if dirname:
+            os.makedirs(dirname, exist_ok=True)
+        with open(path, "w") as fp:
+            json.dump(obj, fp, indent=2)
 
 
 def sanitize_object_to_primitives(obj):

--- a/common/src/autogluon/common/utils/simulation_utils.py
+++ b/common/src/autogluon/common/utils/simulation_utils.py
@@ -1,0 +1,73 @@
+from typing import Any, Dict, Tuple
+
+import pandas as pd
+
+
+def convert_simulation_artifacts_to_tabular_predictions_dict(simulation_artifacts: Dict[str, Dict[int, Dict[str, Any]]]) -> Tuple[dict, dict]:
+    """
+    Converts raw simulation artifacts to the format required for ensemble simulation.
+
+    Parameters
+    ----------
+    simulation_artifacts : Dict[str, Dict[int, Dict[str, Any]]]
+        Dictionary of simulation artifacts.
+        This is a nested dictionary of dataset_name -> fold -> simulation_artifact.
+        simulation_artifact is a dictionary acquired for a given dataset-fold via calling `predictor.get_simulation_artifact(test_data=test_data)` post-fit.
+
+    Returns
+    -------
+    aggregated_pred_proba: Nested dictionary of dataset_name -> fold -> pred_proba
+        pred_proba is a dictionary with the following keys:
+            "pred_proba_dict_val",  # a dictionary of validation prediction probabilities for each model
+            "pred_proba_dict_test",  # a dictionary of test prediction probabilities for each model
+    aggregated_ground_truth: Nested dictionary of dataset_name -> fold -> task_metadata
+        task_metadata is a dictionary with the following keys:
+            "y_val",  # The validation ground truth
+            "y_test",  # The test ground truth
+            "eval_metric",  # The name of the evaluation metric
+            "problem_type",  # The problem type
+            "ordered_class_labels",  # The original class labels
+            "ordered_class_labels_transformed",  # The transformed class labels
+            "problem_type_transform",  # The transformed problem type
+            "num_classes",  # The number of classes
+            "label",  # The label column name
+    """
+    aggregated_pred_proba = {}
+    aggregated_ground_truth = {}
+    for task_name in simulation_artifacts.keys():
+        for fold in simulation_artifacts[task_name].keys():
+            zeroshot_metadata = simulation_artifacts[task_name][fold]
+            fold = int(fold)
+
+            if task_name not in aggregated_ground_truth:
+                aggregated_ground_truth[task_name] = {}
+            if fold not in aggregated_ground_truth[task_name]:
+                aggregated_ground_truth[task_name][fold] = {}
+                for k in [
+                    "y_val",
+                    "y_test",
+                    "eval_metric",
+                    "problem_type",
+                    "ordered_class_labels",
+                    "ordered_class_labels_transformed",
+                    "problem_type_transform",
+                    "num_classes",
+                    "label",
+                ]:
+                    aggregated_ground_truth[task_name][fold][k] = zeroshot_metadata[k]
+                aggregated_ground_truth[task_name][fold]["task"] = task_name
+            if task_name not in aggregated_pred_proba:
+                aggregated_pred_proba[task_name] = {}
+            if fold not in aggregated_pred_proba[task_name]:
+                aggregated_pred_proba[task_name][fold] = {}
+            for k in ["pred_proba_dict_val", "pred_proba_dict_test"]:
+                if k not in aggregated_pred_proba[task_name][fold]:
+                    aggregated_pred_proba[task_name][fold][k] = {}
+                for m, pred_proba in zeroshot_metadata[k].items():
+                    if aggregated_ground_truth[task_name][fold]["problem_type"] == "binary":
+                        if isinstance(pred_proba, pd.DataFrame):
+                            assert len(pred_proba.columns) == 2
+                            pred_proba = pred_proba[1]
+                        assert isinstance(pred_proba, pd.Series)
+                    aggregated_pred_proba[task_name][fold][k][m] = pred_proba
+    return aggregated_pred_proba, aggregated_ground_truth

--- a/common/src/autogluon/common/utils/simulation_utils.py
+++ b/common/src/autogluon/common/utils/simulation_utils.py
@@ -48,9 +48,9 @@ def convert_simulation_artifacts_to_tabular_predictions_dict(simulation_artifact
                     "y_test",
                     "eval_metric",
                     "problem_type",
+                    "problem_type_transform",
                     "ordered_class_labels",
                     "ordered_class_labels_transformed",
-                    "problem_type_transform",
                     "num_classes",
                     "label",
                 ]:

--- a/common/src/autogluon/common/utils/simulation_utils.py
+++ b/common/src/autogluon/common/utils/simulation_utils.py
@@ -64,7 +64,6 @@ def convert_simulation_artifacts_to_tabular_predictions_dict(simulation_artifact
                     "label",
                 ]:
                     aggregated_ground_truth[task_name][fold][k] = zeroshot_metadata[k]
-                aggregated_ground_truth[task_name][fold]["task"] = task_name
             for k in ["pred_proba_dict_val", "pred_proba_dict_test"]:
                 for m, pred_proba in zeroshot_metadata[k].items():
                     if aggregated_ground_truth[task_name][fold]["problem_type"] == "binary":

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -16,13 +16,13 @@ PYTHON_REQUIRES = ">=3.8, <3.12"
 
 # Only put packages here that would otherwise appear multiple times across different module's setup.py files.
 DEPENDENT_PACKAGES = {
-    # note: if python 3.7 is used, the open CVEs are present: CVE-2021-41496 | CVE-2021-34141; fixes are available in 1.22.x, but python 3.8 only
     "boto3": ">=1.10,<2",  # <2 because unlikely to introduce breaking changes in minor releases. >=1.10 because 1.10 is 3 years old, no need to support older
     "numpy": ">=1.21,<1.27",  # "<{N+3}" upper cap, where N is the latest released minor version, assuming no warnings using N
     "pandas": ">=2.0.0,<2.2.0",  # "<{N+1}" upper cap
     "scikit-learn": ">=1.3.0,<1.5",  # "<{N+1}" upper cap
     "scipy": ">=1.5.4,<1.12",  # "<{N+2}" upper cap
     "psutil": ">=5.7.3,<6",  # Major version cap
+    "s3fs": ">=2023.1,<2025",  # Yearly cap
     "networkx": ">=3.0,<4",  # Major version cap
     "tqdm": ">=4.38,<5",  # Major version cap
     "Pillow": ">=10.0.1,<11",  # Major version cap

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -849,10 +849,13 @@ class AbstractTabularLearner(AbstractLearner):
                 inference_time_col = "pred_time_val"
             leaderboard = get_leaderboard_pareto_frontier(leaderboard=leaderboard, score_col=score_col, inference_time_col=inference_time_col)
         if score_format == "error":
-            leaderboard.rename(columns={
-                "score_test": "metric_error_test",
-                "score_val": "metric_error_val",
-            }, inplace=True)
+            leaderboard.rename(
+                columns={
+                    "score_test": "metric_error_test",
+                    "score_val": "metric_error_val",
+                },
+                inplace=True,
+            )
             if "metric_error_test" in leaderboard:
                 leaderboard["metric_error_test"] = leaderboard["metric_error_test"].apply(self.eval_metric.convert_score_to_error)
             leaderboard["metric_error_val"] = leaderboard["metric_error_val"].apply(self.eval_metric.convert_score_to_error)

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -608,6 +608,7 @@ class AbstractTabularLearner(AbstractLearner):
             explicit_order += extra_metrics_names
         explicit_order += [
             "score_val",
+            "eval_metric",
             "pred_time_test",
             "pred_time_val",
             "fit_time",
@@ -818,8 +819,18 @@ class AbstractTabularLearner(AbstractLearner):
         return X, y
 
     def leaderboard(
-        self, X=None, y=None, extra_info=False, extra_metrics=None, decision_threshold=None, only_pareto_frontier=False, skip_score=False, silent=False
+        self,
+        X=None,
+        y=None,
+        extra_info=False,
+        extra_metrics=None,
+        decision_threshold=None,
+        only_pareto_frontier=False,
+        skip_score=False,
+        score_format: str = "score",
+        silent=False,
     ) -> pd.DataFrame:
+        assert score_format in ["score", "error"]
         if X is not None:
             leaderboard = self.score_debug(
                 X=X, y=y, extra_info=extra_info, extra_metrics=extra_metrics, decision_threshold=decision_threshold, skip_score=skip_score, silent=True
@@ -837,6 +848,14 @@ class AbstractTabularLearner(AbstractLearner):
                 score_col = "score_val"
                 inference_time_col = "pred_time_val"
             leaderboard = get_leaderboard_pareto_frontier(leaderboard=leaderboard, score_col=score_col, inference_time_col=inference_time_col)
+        if score_format == "error":
+            leaderboard.rename(columns={
+                "score_test": "metric_error_test",
+                "score_val": "metric_error_val",
+            }, inplace=True)
+            if "metric_error_test" in leaderboard:
+                leaderboard["metric_error_test"] = leaderboard["metric_error_test"].apply(self.eval_metric.convert_score_to_error)
+            leaderboard["metric_error_val"] = leaderboard["metric_error_val"].apply(self.eval_metric.convert_score_to_error)
         if not silent:
             with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
                 print(leaderboard)

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -4547,22 +4547,32 @@ class TabularPredictor:
         predictor_clone.save_space()
         return predictor_clone if return_clone else predictor_clone.path
 
-    # TODO: Cleanup, unit test, add docs
     def get_simulation_artifact(self, test_data: pd.DataFrame) -> dict:
         """
         [Advanced] Computes and returns the necessary information to perform zeroshot HPO simulation.
+        For a usage example, refer to https://github.com/autogluon/tabrepo/blob/main/examples/run_quickstart_from_scratch.py
 
         Parameters
         ----------
         test_data: pd.DataFrame
-            The test data.
+            The test data to predict with.
 
         Returns
         -------
         simulation_dict: dict
-            The dictionary of information requires for zeroshot HPO simulation.
-            TODO: Describe keys
-
+            The dictionary of information required for zeroshot HPO simulation.
+            Keys are as follows:
+                pred_proba_dict_val: Dictionary of model name to prediction probabilities (or predictions if regression) on the validation data
+                pred_proba_dict_test: Dictionary of model name to prediction probabilities (or predictions if regression) on the test data
+                y_val: Pandas Series of ground truth labels for the validation data (internal representation)
+                y_test: Pandas Series of ground truth labels for the test data (internal representation)
+                eval_metric: The string name of the evaluation metric (obtained via `predictor.eval_metric.name`)
+                problem_type: The problem type (obtained via `predictor.problem_type`)
+                problem_type_transform: The transformed (internal) problem type (obtained via `predictor._learner.label_cleaner.problem_type_transform,`)
+                ordered_class_labels: The original class labels (`predictor._learner.label_cleaner.ordered_class_labels`)
+                ordered_Class_labels_transformed: The transformed (internal) class labels (`predictor._learner.label_cleaner.ordered_class_labels_transformed`)
+                num_classes: The number of internal classes (`self._learner.label_cleaner.num_classes`)
+                label: The label column name (`predictor.label`)
         """
         models = self.get_model_names(can_infer=True)
 
@@ -4585,9 +4595,9 @@ class TabularPredictor:
             y_test=y_test,
             eval_metric=self.eval_metric.name,
             problem_type=self.problem_type,
+            problem_type_transform=self._learner.label_cleaner.problem_type_transform,
             ordered_class_labels=self._learner.label_cleaner.ordered_class_labels,
             ordered_class_labels_transformed=self._learner.label_cleaner.ordered_class_labels_transformed,
-            problem_type_transform=self._learner.label_cleaner.problem_type_transform,
             num_classes=self._learner.label_cleaner.num_classes,
             label=self.label,
         )

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -2126,6 +2126,7 @@ class TabularPredictor:
         extra_info: bool = False,
         extra_metrics: list | None = None,
         decision_threshold: float | None = None,
+        score_format: str = "score",
         only_pareto_frontier: bool = False,
         skip_score: bool = False,
         silent: bool = False,
@@ -2140,6 +2141,8 @@ class TabularPredictor:
                 NOTE: Metrics scores always show in higher is better form.
                 This means that metrics such as log_loss and root_mean_squared_error will have their signs FLIPPED, and values will be negative.
                 This is necessary to avoid the user needing to know the metric to understand if higher is better when looking at leaderboard.
+            'eval_metric': The evaluation metric name used to calculate the scores.
+                This should be identical to `predictor.eval_metric.name`.
             'pred_time_val': The inference time required to compute predictions on the validation data end-to-end.
                 Equivalent to the sum of all 'pred_time_val_marginal' values for the model and all of its base models.
             'fit_time': The fit time required to train the model end-to-end (Including base models if the model is a stack ensemble).
@@ -2245,6 +2248,11 @@ class TabularPredictor:
             NOTE: `score_val` will not be impacted by this value in v0.8.
                 `score_val` will always show the validation scores achieved with a decision threshold of `0.5`.
                 Only test scores will be properly updated.
+        score_format : {'score', 'error'}
+            If "score", leaderboard is returned as normal.
+            If "error", the column "score_val" is converted to "metric_error_val", and "score_test" is converted to "metric_error_test".
+                "metric_error" is calculated by taking `predictor.eval_metric.convert_score_to_error(score)`.
+                This will result in errors where 0 is perfect and lower is better.
         only_pareto_frontier : bool, default = False
             If `True`, only return model information of models in the Pareto frontier of the accuracy/latency trade-off (models which achieve the highest score within their end-to-end inference time).
             At minimum this will include the model with the highest score and the model with the lowest inference time.
@@ -2271,6 +2279,7 @@ class TabularPredictor:
             extra_metrics=extra_metrics,
             decision_threshold=decision_threshold,
             only_pareto_frontier=only_pareto_frontier,
+            score_format=score_format,
             skip_score=skip_score,
             silent=silent,
         )

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -366,6 +366,14 @@ class TabularPredictor:
             raise ValueError(f"Unknown feature_stage: '{feature_stage}'. Must be one of {['original', 'transformed']}")
 
     @property
+    def has_val(self) -> bool:
+        """
+        Return True if holdout validation data was used during fit, else return False.
+        """
+        self._assert_is_fit("has_val")
+        return self._trainer.has_val
+
+    @property
     def feature_metadata(self):
         return self._trainer.feature_metadata
 
@@ -2335,7 +2343,7 @@ class TabularPredictor:
         data : str or DataFrame, default = None
             The data to predict on.
             If None:
-                If self.trainer.has_val, the validation data is used.
+                If self.has_val, the validation data is used.
                 Else, the out-of-fold prediction probabilities are used.
         models : List[str], default = None
             The list of models to get predictions for.
@@ -2403,7 +2411,7 @@ class TabularPredictor:
         data : DataFrame, default = None
             The data to predict on.
             If None:
-                If self.trainer.has_val, the validation data is used.
+                If self.has_val, the validation data is used.
                 Else, the out-of-fold prediction probabilities are used.
         models : List[str], default = None
             The list of models to get predictions for.
@@ -4527,7 +4535,7 @@ class TabularPredictor:
     # TODO: Cleanup, unit test, add docs
     def get_simulation_artifact(self, test_data: pd.DataFrame) -> dict:
         """
-        Computes and returns the necessary information to perform zeroshot HPO simulation.
+        [Advanced] Computes and returns the necessary information to perform zeroshot HPO simulation.
 
         Parameters
         ----------

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -278,15 +278,21 @@ class TabularPredictor:
         self._stacked_overfitting_occurred: bool | None = None
 
     @property
-    def class_labels(self):
+    def classes_(self) -> list:
+        """Returns the class labels"""
         return self._learner.class_labels
 
     @property
-    def class_labels_internal(self):
+    def class_labels(self) -> list:
+        """Alias to self.classes_"""
+        return self.classes_
+
+    @property
+    def class_labels_internal(self) -> list:
         return self._learner.label_cleaner.ordered_class_labels_transformed
 
     @property
-    def class_labels_internal_map(self):
+    def class_labels_internal_map(self) -> dict:
         return self._learner.label_cleaner.inv_map
 
     @property
@@ -4558,7 +4564,7 @@ class TabularPredictor:
             pred_proba_dict_val = self.predict_multi(inverse_transform=False, models=models)
             pred_proba_dict_test = self.predict_multi(test_data, inverse_transform=False, models=models)
 
-        val_data_source = 'val' if self._trainer.has_val else 'train'
+        val_data_source = 'val' if self.has_val else 'train'
         _, y_val = self.load_data_internal(data=val_data_source, return_X=False, return_y=True)
         y_test = test_data[self.label]
         y_test = self.transform_labels(y_test, inverse=False)

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -4564,7 +4564,7 @@ class TabularPredictor:
             pred_proba_dict_val = self.predict_multi(inverse_transform=False, models=models)
             pred_proba_dict_test = self.predict_multi(test_data, inverse_transform=False, models=models)
 
-        val_data_source = 'val' if self.has_val else 'train'
+        val_data_source = "val" if self.has_val else "train"
         _, y_val = self.load_data_internal(data=val_data_source, return_X=False, return_y=True)
         y_test = test_data[self.label]
         y_test = self.transform_labels(y_test, inverse=False)

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -163,13 +163,17 @@ def test_advanced_functionality():
         predictor.plot_ensemble_model()
 
     # Test get_simulation_artifact
-    simulation_artifact = predictor.get_simulation_artifact(test_data=test_data)
-    assert simulation_artifact["label"] == predictor.label
-    assert sorted(list(simulation_artifact["pred_proba_dict_val"].keys())) == sorted(predictor.get_model_names(can_infer=True))
+    simulation_artifact_no_test = predictor.simulation_artifact()
+    assert "pred_proba_dict_test" not in simulation_artifact_no_test
+    assert "y_test" not in simulation_artifact_no_test
+    simulation_artifact = predictor.simulation_artifact(test_data=test_data)
     assert sorted(list(simulation_artifact["pred_proba_dict_test"].keys())) == sorted(predictor.get_model_names(can_infer=True))
     assert simulation_artifact["y_test"].equals(predictor.transform_labels(test_data[label]))
-    assert simulation_artifact["eval_metric"] == predictor.eval_metric.name
-    assert simulation_artifact["problem_type"] == predictor.problem_type
+    for sim_artifact in [simulation_artifact, simulation_artifact_no_test]:
+        assert sim_artifact["label"] == predictor.label
+        assert sorted(list(sim_artifact["pred_proba_dict_val"].keys())) == sorted(predictor.get_model_names(can_infer=True))
+        assert sim_artifact["eval_metric"] == predictor.eval_metric.name
+        assert sim_artifact["problem_type"] == predictor.problem_type
     simulation_artifacts = {dataset["name"]: {0: simulation_artifact}}
 
     # Test convert_simulation_artifacts_to_tabular_predictions_dict

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -144,6 +144,20 @@ def test_advanced_functionality():
     savedir_predictor_original = savedir + "predictor/"
     predictor: TabularPredictor = TabularPredictor(label=label, path=savedir_predictor_original).fit(train_data)
     leaderboard = predictor.leaderboard(data=test_data)
+
+    # test metric_error leaderboard
+    leaderboard_error = predictor.leaderboard(data=test_data, score_format="error")
+    assert leaderboard["model"].to_list() == leaderboard_error["model"].to_list()
+    leaderboard_combined = pd.merge(leaderboard, leaderboard_error[["model", "metric_error_test", "metric_error_val"]], on=["model"])
+    score_test = leaderboard_combined["score_test"].to_list()
+    score_val = leaderboard_combined["score_val"].to_list()
+    metric_error_test = leaderboard_combined["metric_error_test"].to_list()
+    metric_error_val = leaderboard_combined["metric_error_val"].to_list()
+    for score, error in zip(score_test, metric_error_test):
+        assert predictor.eval_metric.convert_score_to_error(score) == error
+    for score, error in zip(score_val, metric_error_val):
+        assert predictor.eval_metric.convert_score_to_error(score) == error
+
     if not on_windows:
         predictor.plot_ensemble_model()
 

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -146,6 +146,16 @@ def test_advanced_functionality():
     leaderboard = predictor.leaderboard(data=test_data)
     if not on_windows:
         predictor.plot_ensemble_model()
+
+    # Test get_simulation_artifact
+    simulation_artifact = predictor.get_simulation_artifact(test_data=test_data)
+    assert simulation_artifact["label"] == predictor.label
+    assert sorted(list(simulation_artifact["pred_proba_dict_val"].keys())) == sorted(predictor.get_model_names(can_infer=True))
+    assert sorted(list(simulation_artifact["pred_proba_dict_test"].keys())) == sorted(predictor.get_model_names(can_infer=True))
+    assert simulation_artifact["y_test"].equals(predictor.transform_labels(test_data[label]))
+    assert simulation_artifact["eval_metric"] == predictor.eval_metric.name
+    assert simulation_artifact["problem_type"] == predictor.problem_type
+
     extra_metrics = ["accuracy", "roc_auc", "log_loss"]
     test_data_no_label = test_data.drop(columns=[label])
     with pytest.raises(ValueError):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add get_simulation_artifact for zeroshot HPO
- Added s3 save/load support to `save_json` and `load_json`
- Added s3fs to default dependencies as it is lightweight and is needed to access s3 files via pandas.
- Added eval_metric column to leaderboard output
- Added stopping_metric column to leaderboard output when `extra_info=True`.
- Added `score_format` argument to leaderboard to add the option to return the error instead of the score.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
