### PR TITLE
[core] Add symmetric_mean_absolute_percentage error

### DIFF
--- a/core/src/autogluon/core/metrics/__init__.py
+++ b/core/src/autogluon/core/metrics/__init__.py
@@ -412,13 +412,13 @@ mean_absolute_percentage_error = make_scorer(
 )
 mean_absolute_percentage_error.add_alias("mape")
 
+
 def smape_func(y_true, y_pred) -> float:
     epsilon = np.finfo(np.float64).eps
     return np.average(np.abs(y_pred - y_true) / np.maximum(np.abs(y_true) + np.abs(y_pred), epsilon))
 
-symmetric_mean_absolute_percentage_error = make_scorer(
-    "symmetric_mean_absolute_percentage_error", smape_func, optimum=0.0, greater_is_better=False
-)
+
+symmetric_mean_absolute_percentage_error = make_scorer("symmetric_mean_absolute_percentage_error", smape_func, optimum=0.0, greater_is_better=False)
 symmetric_mean_absolute_percentage_error.add_alias("smape")
 
 

--- a/core/src/autogluon/core/metrics/__init__.py
+++ b/core/src/autogluon/core/metrics/__init__.py
@@ -412,6 +412,15 @@ mean_absolute_percentage_error = make_scorer(
 )
 mean_absolute_percentage_error.add_alias("mape")
 
+def smape_func(y_true, y_pred) -> float:
+    epsilon = np.finfo(np.float64).eps
+    return np.average(np.abs(y_pred - y_true) / np.maximum(np.abs(y_true) + np.abs(y_pred), epsilon))
+
+symmetric_mean_absolute_percentage_error = make_scorer(
+    "symmetric_mean_absolute_percentage_error", smape_func, optimum=0.0, greater_is_better=False
+)
+symmetric_mean_absolute_percentage_error.add_alias("smape")
+
 
 def local_spearmanr(y_true, y_pred):
     return float(scipy.stats.spearmanr(y_true, y_pred)[0])
@@ -512,6 +521,7 @@ for scorer in [
     mean_absolute_error,
     median_absolute_error,
     mean_absolute_percentage_error,
+    symmetric_mean_absolute_percentage_error,
     spearmanr,
     pearsonr,
 ]:

--- a/core/tests/unittests/metrics/test_metrics.py
+++ b/core/tests/unittests/metrics/test_metrics.py
@@ -73,6 +73,7 @@ EXPECTED_REGRESSION_METRICS = {
     "rmse",
     "root_mean_squared_error",
     "spearmanr",
+    "symmetric_mean_absolute_percentage_error",
 }
 
 EXPECTED_QUANTILE_METRICS = {

--- a/core/tests/unittests/metrics/test_metrics.py
+++ b/core/tests/unittests/metrics/test_metrics.py
@@ -72,6 +72,7 @@ EXPECTED_REGRESSION_METRICS = {
     "r2",
     "rmse",
     "root_mean_squared_error",
+    "smape",
     "spearmanr",
     "symmetric_mean_absolute_percentage_error",
 }

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -101,7 +101,7 @@ class TabularPredictor:
             'roc_auc', 'roc_auc_ovo_macro', 'average_precision', 'precision', 'precision_macro', 'precision_micro',
             'precision_weighted', 'recall', 'recall_macro', 'recall_micro', 'recall_weighted', 'log_loss', 'pac_score']
         Options for regression:
-            ['root_mean_squared_error', 'mean_squared_error', 'mean_absolute_error', 'median_absolute_error', 'mean_absolute_percentage_error', 'r2']
+            ['root_mean_squared_error', 'mean_squared_error', 'mean_absolute_error', 'median_absolute_error', 'mean_absolute_percentage_error', 'r2', 'symmetric_mean_absolute_percentage_error']
         For more information on these options, see `sklearn.metrics`: https://scikit-learn.org/stable/modules/classes.html#sklearn-metrics-metrics
         For metric source code, see `autogluon.core.metrics`.
 

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -335,7 +335,7 @@ class DirectTabularModel(AbstractMLForecastModel):
 
     TIMESERIES_METRIC_TO_TABULAR_METRIC = {
         "MAPE": "mean_absolute_percentage_error",
-        "sMAPE": "mean_absolute_percentage_error",
+        "sMAPE": "symmetric_mean_absolute_percentage_error",
         "WQL": "pinball_loss",
         "MASE": "mean_absolute_error",
         "WAPE": "mean_absolute_error",
@@ -477,7 +477,7 @@ class RecursiveTabularModel(AbstractMLForecastModel):
 
     TIMESERIES_METRIC_TO_TABULAR_METRIC = {
         "MAPE": "mean_absolute_percentage_error",
-        "sMAPE": "mean_absolute_percentage_error",
+        "sMAPE": "symmetric_mean_absolute_percentage_error",
         "WQL": "mean_absolute_error",
         "MASE": "mean_absolute_error",
         "WAPE": "mean_absolute_error",


### PR DESCRIPTION
*Description of changes:*
- Add `symmetric_mean_absolute_percentage_error` regression metric. This metric corresponds to one of the metrics used in TimeSeries module, and it would be helpful to use this metric inside `DirectTabular` and `RecursiveTabular` forecasting models.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
