### PR TITLE
[timeseries] Enhancements for GluonTS models

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -100,8 +100,9 @@ class SimpleGluonTSDataset(GluonTSDataset):
         for j in range(len(self.indptr) - 1):
             start_idx = self.indptr[j]
             end_idx = self.indptr[j + 1]
+            # GluonTS expects item_id to be a string
             ts = {
-                FieldName.ITEM_ID: self.item_ids[j],
+                FieldName.ITEM_ID: str(self.item_ids[j]),
                 FieldName.START: pd.Period(self.timestamps[j], freq=self.freq),
                 FieldName.TARGET: self.target_array[start_idx:end_idx],
             }
@@ -295,7 +296,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         else:
             default_trainer_kwargs["accelerator"] = "cpu"
 
-        default_trainer_kwargs.update(init_args.get("trainer_kwargs", {}))
+        default_trainer_kwargs.update(init_args.pop("trainer_kwargs", {}))
         logger.debug(f"\tTraining on device '{default_trainer_kwargs['accelerator']}'")
 
         return from_hyperparameters(

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -433,6 +433,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
                 validation_data=self._to_gluonts_dataset(val_data),
                 cache_data=True,
             )
+            self.gts_predictor.batch_size = 500
 
         lightning_logs_dir = Path(self.path) / "lightning_logs"
         if lightning_logs_dir.exists() and lightning_logs_dir.is_dir():

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import shutil
-import time
 from datetime import timedelta
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterator, List, Optional, Type
@@ -112,8 +111,8 @@ class SimpleGluonTSDataset(GluonTSDataset):
                 ts[FieldName.PAST_FEAT_DYNAMIC_REAL] = self.past_feat_dynamic_real[start_idx:end_idx].T
             if self.feat_dynamic_real is not None:
                 if self.includes_future:
-                    start = start + j * self.prediction_length
-                    end = end + (j + 1) * self.prediction_length
+                    start_idx = start_idx + j * self.prediction_length
+                    end_idx = end_idx + (j + 1) * self.prediction_length
                 ts[FieldName.FEAT_DYNAMIC_REAL] = self.feat_dynamic_real[start_idx:end_idx].T
             yield ts
 
@@ -526,5 +525,5 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
 
         forecast_df.index = forecast_index
         if self.must_drop_median:
-            predictions = predictions.drop("0.5", axis=1)
+            forecast_df = forecast_df.drop("0.5", axis=1)
         return TimeSeriesDataFrame(forecast_df)

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -88,10 +88,10 @@ class SimpleGluonTSDataset(GluonTSDataset):
 
         # normalize freq str to handle peculiarities such as W-SUN
         offset_base_alias = norm_freq_str(pd_offset)
-        if freq not in GLUONTS_SUPPORTED_OFFSETS or offset_base_alias is None:
+        if offset_base_alias not in GLUONTS_SUPPORTED_OFFSETS:
             return "A"
         else:
-            return freq
+            return f"{pd_offset.n}{offset_base_alias}"
 
     def __len__(self):
         return len(self.indptr) - 1  # noqa

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -381,8 +381,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         init_args = self._get_estimator_init_args()
         callbacks = self._get_callbacks(
             time_limit=time_limit,
-            early_stopping_patience=init_args["early_stopping_patience"],
-            val_data_available=val_data is not None,
+            early_stopping_patience=None if val_data is None else init_args["early_stopping_patience"],
         )
         self._deferred_init_params_aux(dataset=train_data, callbacks=callbacks)
 
@@ -406,7 +405,6 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         self,
         time_limit: int,
         early_stopping_patience: Optional[int] = None,
-        val_data_available: bool = False,
     ) -> List[Callable]:
         """Retrieve a list of callback objects for the GluonTS trainer"""
         from pytorch_lightning.callbacks import EarlyStopping, Timer
@@ -414,7 +412,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         callbacks = []
         if time_limit is not None:
             callbacks.append(Timer(timedelta(seconds=time_limit)))
-        if early_stopping_patience is not None and val_data_available:
+        if early_stopping_patience is not None:
             callbacks.append(EarlyStopping(monitor="val_loss", patience=early_stopping_patience))
         return callbacks
 

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -481,8 +481,8 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
 
     def _stack_distribution_forecasts(self, forecasts: List[Forecast], item_ids: pd.Index) -> pd.DataFrame:
         import torch
-        from torch.distributions import Distribution
         from gluonts.torch.distributions import AffineTransformed
+        from torch.distributions import Distribution
 
         # Sort forecasts in the same order as in the dataset
         item_id_to_forecast = {str(f.item_id): f for f in forecasts}

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -64,10 +64,16 @@ class DeepARModel(AbstractGluonTSModel):
         Number of epochs the model will be trained for
     batch_size : int, default = 64
         Size of batches used during training
+    predict_batch_size : int, default = 500
+        Size of batches used during prediction.
     num_batches_per_epoch : int, default = 50
         Number of batches processed every epoch
     learning_rate : float, default = 1e-3,
         Learning rate used during training
+    trainer_kwargs : dict, optional
+        Optional keyword arguments passed to ``lightning.Trainer``.
+    early_stopping_patience : int or None, default = 20
+        Early stop training if the validation loss doesn't improve for this many epochs.
     """
 
     default_num_samples: int = 250
@@ -84,8 +90,8 @@ class DeepARModel(AbstractGluonTSModel):
         init_kwargs["num_feat_static_real"] = self.num_feat_static_real
         init_kwargs["cardinality"] = self.feat_static_cat_cardinality
         init_kwargs["num_feat_dynamic_real"] = self.num_feat_dynamic_real
-        init_kwargs["lags_seq"] = get_lags_for_frequency(self.freq)
-        init_kwargs["time_features"] = get_time_features_for_frequency(self.freq)
+        init_kwargs.setdefault("lags_seq", get_lags_for_frequency(self.freq))
+        init_kwargs.setdefault("time_features", get_time_features_for_frequency(self.freq))
         return init_kwargs
 
 
@@ -112,10 +118,16 @@ class SimpleFeedForwardModel(AbstractGluonTSModel):
         Number of epochs the model will be trained for
     batch_size : int, default = 64
         Size of batches used during training
+    predict_batch_size : int, default = 500
+        Size of batches used during prediction.
     num_batches_per_epoch : int, default = 50
         Number of batches processed every epoch
     learning_rate : float, default = 1e-3,
         Learning rate used during training
+    trainer_kwargs : dict, optional
+        Optional keyword arguments passed to ``lightning.Trainer``.
+    early_stopping_patience : int or None, default = 20
+        Early stop training if the validation loss doesn't improve for this many epochs.
     """
 
     def _get_estimator_class(self) -> Type[GluonTSEstimator]:
@@ -163,10 +175,16 @@ class TemporalFusionTransformerModel(AbstractGluonTSModel):
         Number of epochs the model will be trained for
     batch_size : int, default = 64
         Size of batches used during training
+    predict_batch_size : int, default = 500
+        Size of batches used during prediction.
     num_batches_per_epoch : int, default = 50
         Number of batches processed every epoch
     learning_rate : float, default = 1e-3,
         Learning rate used during training
+    trainer_kwargs : dict, optional
+        Optional keyword arguments passed to ``lightning.Trainer``.
+    early_stopping_patience : int or None, default = 20
+        Early stop training if the validation loss doesn't improve for this many epochs.
     """
 
     supports_known_covariates = True
@@ -191,7 +209,7 @@ class TemporalFusionTransformerModel(AbstractGluonTSModel):
             init_kwargs["static_dims"] = [self.num_feat_static_real]
         if len(self.feat_static_cat_cardinality):
             init_kwargs["static_cardinalities"] = self.feat_static_cat_cardinality
-        init_kwargs["time_features"] = get_time_features_for_frequency(self.freq)
+        init_kwargs.setdefault("time_features", get_time_features_for_frequency(self.freq))
         return init_kwargs
 
 
@@ -221,10 +239,16 @@ class DLinearModel(AbstractGluonTSModel):
         Number of epochs the model will be trained for
     batch_size : int, default = 64
         Size of batches used during training
+    predict_batch_size : int, default = 500
+        Size of batches used during prediction.
     num_batches_per_epoch : int, default = 50
         Number of batches processed every epoch
     learning_rate : float, default = 1e-3,
         Learning rate used during training
+    trainer_kwargs : dict, optional
+        Optional keyword arguments passed to ``lightning.Trainer``.
+    early_stopping_patience : int or None, default = 20
+        Early stop training if the validation loss doesn't improve for this many epochs.
     weight_decay : float, default = 1e-8
         Weight decay regularization parameter.
     """

--- a/timeseries/tests/unittests/models/test_gluonts.py
+++ b/timeseries/tests/unittests/models/test_gluonts.py
@@ -105,7 +105,7 @@ def df_with_covariates():
 @pytest.mark.parametrize("model_class", MODELS_WITH_STATIC_FEATURES)
 def test_when_static_features_present_then_they_are_passed_to_dataset(model_class, df_with_static):
     df, metadata = df_with_static
-    model = model_class(hyperparameters=DUMMY_HYPERPARAMETERS, metadata=metadata)
+    model = model_class(hyperparameters=DUMMY_HYPERPARAMETERS, metadata=metadata, freq=df.freq)
     with mock.patch(
         "autogluon.timeseries.models.gluonts.abstract_gluonts.SimpleGluonTSDataset.__init__"
     ) as patch_dataset:
@@ -124,7 +124,7 @@ def test_when_static_features_present_then_they_are_passed_to_dataset(model_clas
 @pytest.mark.parametrize("model_class", MODELS_WITH_STATIC_FEATURES)
 def test_given_fit_with_static_features_when_predicting_then_static_features_are_used(model_class, df_with_static):
     df, metadata = df_with_static
-    model = model_class(hyperparameters=DUMMY_HYPERPARAMETERS, metadata=metadata)
+    model = model_class(hyperparameters=DUMMY_HYPERPARAMETERS, metadata=metadata, freq=df.freq)
     model.fit(train_data=df)
     predictor_method = "gluonts.torch.model.predictor.PyTorchPredictor.predict"
     with mock.patch(predictor_method) as mock_predict:
@@ -142,7 +142,7 @@ def test_given_fit_with_static_features_when_predicting_then_static_features_are
 @pytest.mark.parametrize("model_class", MODELS_WITH_STATIC_FEATURES)
 def test_when_static_features_present_then_model_attributes_set_correctly(model_class, df_with_static):
     df, metadata = df_with_static
-    model = model_class(hyperparameters=DUMMY_HYPERPARAMETERS, metadata=metadata)
+    model = model_class(hyperparameters=DUMMY_HYPERPARAMETERS, metadata=metadata, freq=df.freq)
     model.fit(train_data=df)
     assert model.num_feat_static_cat > 0
     assert model.num_feat_static_real > 0
@@ -153,7 +153,9 @@ def test_when_static_features_present_then_model_attributes_set_correctly(model_
 @pytest.mark.parametrize("model_class", MODELS_WITH_STATIC_FEATURES)
 def test_when_disable_static_features_set_to_true_then_static_features_are_not_used(model_class, df_with_static):
     df, metadata = df_with_static
-    model = model_class(hyperparameters={**DUMMY_HYPERPARAMETERS, "disable_static_features": True}, metadata=metadata)
+    model = model_class(
+        hyperparameters={**DUMMY_HYPERPARAMETERS, "disable_static_features": True}, metadata=metadata, freq=df.freq
+    )
     with mock.patch(
         "autogluon.timeseries.models.gluonts.abstract_gluonts.SimpleGluonTSDataset.__init__"
     ) as patch_dataset:
@@ -172,7 +174,7 @@ def test_when_disable_static_features_set_to_true_then_static_features_are_not_u
 @pytest.mark.parametrize("model_class", MODELS_WITH_KNOWN_COVARIATES)
 def test_when_known_covariates_present_then_they_are_passed_to_dataset(model_class, df_with_covariates):
     df, metadata = df_with_covariates
-    model = model_class(hyperparameters=DUMMY_HYPERPARAMETERS, metadata=metadata)
+    model = model_class(hyperparameters=DUMMY_HYPERPARAMETERS, metadata=metadata, freq=df.freq)
     with mock.patch(
         "autogluon.timeseries.models.gluonts.abstract_gluonts.SimpleGluonTSDataset.__init__"
     ) as patch_dataset:
@@ -189,7 +191,7 @@ def test_when_known_covariates_present_then_they_are_passed_to_dataset(model_cla
 @pytest.mark.parametrize("model_class", MODELS_WITH_KNOWN_COVARIATES)
 def test_when_known_covariates_present_then_model_attributes_set_correctly(model_class, df_with_covariates):
     df, metadata = df_with_covariates
-    model = model_class(hyperparameters=DUMMY_HYPERPARAMETERS, metadata=metadata)
+    model = model_class(hyperparameters=DUMMY_HYPERPARAMETERS, metadata=metadata, freq=df.freq)
     model.fit(train_data=df)
     assert model.num_feat_dynamic_real > 0
 
@@ -197,7 +199,9 @@ def test_when_known_covariates_present_then_model_attributes_set_correctly(model
 @pytest.mark.parametrize("model_class", MODELS_WITH_KNOWN_COVARIATES)
 def test_when_disable_known_covariates_set_to_true_then_known_covariates_are_not_used(model_class, df_with_covariates):
     df, metadata = df_with_covariates
-    model = model_class(hyperparameters={**DUMMY_HYPERPARAMETERS, "disable_known_covariates": True}, metadata=metadata)
+    model = model_class(
+        hyperparameters={**DUMMY_HYPERPARAMETERS, "disable_known_covariates": True}, metadata=metadata, freq=df.freq
+    )
     with mock.patch(
         "autogluon.timeseries.models.gluonts.abstract_gluonts.SimpleGluonTSDataset.__init__"
     ) as patch_dataset:
@@ -223,6 +227,6 @@ def test_when_static_and_dynamic_covariates_present_then_model_trains_normally(m
     gen = TimeSeriesFeatureGenerator(target="target", known_covariates_names=known_covariates_names)
     df = gen.fit_transform(dataframe_with_static_and_covariates)
 
-    model = model_class(hyperparameters=DUMMY_HYPERPARAMETERS, metadata=gen.covariate_metadata)
+    model = model_class(hyperparameters=DUMMY_HYPERPARAMETERS, metadata=gen.covariate_metadata, freq=df.freq)
     model.fit(train_data=df)
     model.score_and_cache_oof(df)

--- a/timeseries/tests/unittests/models/test_multi_window_model.py
+++ b/timeseries/tests/unittests/models/test_multi_window_model.py
@@ -36,7 +36,9 @@ def test_when_mw_model_trained_then_oof_predictions_and_stats_are_saved(
     temp_model_path, prediction_length, num_val_windows
 ):
     val_splitter = ExpandingWindowSplitter(prediction_length=prediction_length, num_val_windows=num_val_windows)
-    mw_model = get_multi_window_deepar(path=temp_model_path, prediction_length=prediction_length)
+    mw_model = get_multi_window_deepar(
+        path=temp_model_path, prediction_length=prediction_length, freq=DUMMY_TS_DATAFRAME.freq
+    )
     mw_model.fit(train_data=DUMMY_TS_DATAFRAME, val_splitter=val_splitter)
 
     assert len(mw_model.get_oof_predictions()) == num_val_windows
@@ -54,7 +56,7 @@ def test_when_val_data_passed_to_mw_model_fit_then_exception_is_raised(temp_mode
 
 def test_when_saved_model_moved_then_model_can_be_loaded_with_updated_path():
     original_path = tempfile.mkdtemp() + os.sep
-    model = get_multi_window_deepar(path=original_path)
+    model = get_multi_window_deepar(path=original_path, freq=DUMMY_TS_DATAFRAME.freq)
     model.fit(train_data=DUMMY_TS_DATAFRAME)
     model.save()
     new_path = tempfile.mkdtemp() + os.sep

--- a/timeseries/tests/unittests/test_evaluator.py
+++ b/timeseries/tests/unittests/test_evaluator.py
@@ -62,7 +62,6 @@ def test_when_given_learned_model_when_evaluator_called_then_output_equal_to_glu
     forecast_index = DUMMY_TS_DATAFRAME.slice_by_timestep(-prediction_length, None).index
     forecast_df = model._gluonts_forecasts_to_data_frame(
         fcast_list,
-        quantile_levels=model.quantile_levels,
         forecast_index=forecast_index,
     )
 
@@ -101,7 +100,6 @@ def test_when_given_all_zero_data_when_evaluator_called_then_output_equal_to_glu
     forecast_index = DUMMY_TS_DATAFRAME.slice_by_timestep(-prediction_length, None).index
     forecast_df = model._gluonts_forecasts_to_data_frame(
         fcast_list,
-        quantile_levels=model.quantile_levels,
         forecast_index=forecast_index,
     )
 
@@ -139,7 +137,6 @@ def test_when_given_zero_forecasts_when_evaluator_called_then_output_equal_to_gl
     forecast_index = DUMMY_TS_DATAFRAME.slice_by_timestep(-prediction_length, None).index
     forecast_df = model._gluonts_forecasts_to_data_frame(
         zero_forecast_list,
-        quantile_levels=model.quantile_levels,
         forecast_index=forecast_index,
     )
 

--- a/timeseries/tests/unittests/test_evaluator.py
+++ b/timeseries/tests/unittests/test_evaluator.py
@@ -2,8 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from gluonts.evaluation import Evaluator as GluonTSEvaluator
-from gluonts.evaluation import make_evaluation_predictions
-from gluonts.model.forecast import SampleForecast
+from gluonts.model.forecast import QuantileForecast
 
 from autogluon.timeseries import TimeSeriesPredictor
 from autogluon.timeseries.evaluator import TimeSeriesEvaluator, in_sample_abs_seasonal_error
@@ -47,35 +46,45 @@ def deepar_trained_zero_data() -> AbstractGluonTSModel:
     return pred._trainer.load_model("DeepAR")
 
 
+def to_gluonts_forecast(forecast_df, freq):
+    forecast_list = []
+    for item_id, fcast in forecast_df.groupby(level="item_id", sort=False):
+        start_date = fcast.index[0][1].to_period(freq=freq)
+        qf = QuantileForecast(
+            forecast_arrays=fcast.values.T,
+            start_date=start_date,
+            forecast_keys=fcast.columns,
+            item_id=item_id,
+        )
+        forecast_list.append(qf)
+    return forecast_list
+
+
+def to_gluonts_test_set(data):
+    ts_list = []
+    for item_id, ts in data.groupby(level="item_id", sort=False):
+        ts = ts.loc[item_id]["target"]
+        ts.index = ts.index.to_period(freq=data.freq)
+        ts_list.append(ts)
+    return ts_list
+
+
 @pytest.mark.parametrize("metric_name", GLUONTS_PARITY_METRICS)
 def test_when_given_learned_model_when_evaluator_called_then_output_equal_to_gluonts(metric_name, deepar_trained):
     model = deepar_trained
+    data_train, data_test = DUMMY_TS_DATAFRAME.train_test_split(model.prediction_length)
 
-    forecast_iter, ts_iter = make_evaluation_predictions(
-        dataset=model._to_gluonts_dataset(DUMMY_TS_DATAFRAME),
-        predictor=model.gts_predictor,
-        num_samples=100,
-    )
-    fcast_list, ts_list = list(forecast_iter), list(ts_iter)
-    prediction_length = 2
+    forecast_df = model.predict(data_train)
     seasonal_period = 3
-    forecast_index = DUMMY_TS_DATAFRAME.slice_by_timestep(-prediction_length, None).index
-    forecast_df = model._gluonts_forecasts_to_data_frame(
-        fcast_list,
-        forecast_index=forecast_index,
-    )
-
     ag_evaluator = TimeSeriesEvaluator(
-        eval_metric=metric_name, prediction_length=prediction_length, eval_metric_seasonal_period=seasonal_period
+        eval_metric=metric_name, prediction_length=model.prediction_length, eval_metric_seasonal_period=seasonal_period
     )
     ag_value = ag_evaluator(DUMMY_TS_DATAFRAME, forecast_df)
 
+    forecast_list = to_gluonts_forecast(forecast_df, freq=data_train.freq)
+    ts_list = to_gluonts_test_set(data_test)
     gts_evaluator = GluonTSEvaluator(seasonality=seasonal_period)
-    gts_results, _ = gts_evaluator(
-        ts_iterator=ts_list,
-        fcst_iterator=fcast_list,
-    )
-
+    gts_results, _ = gts_evaluator(ts_iterator=ts_list, fcst_iterator=forecast_list)
     gts_metric_name = AG_TO_GLUONTS_METRIC.get(metric_name, metric_name)
     assert np.isclose(gts_results[gts_metric_name], ag_value, atol=1e-5)
 
@@ -89,25 +98,19 @@ def test_when_given_all_zero_data_when_evaluator_called_then_output_equal_to_glu
 
     model = deepar_trained_zero_data
     data = DUMMY_TS_DATAFRAME.copy() * 0
+    data_train, data_test = data.train_test_split(model.prediction_length)
 
-    forecast_iter, ts_iter = make_evaluation_predictions(
-        dataset=model._to_gluonts_dataset(data),
-        predictor=model.gts_predictor,
-        num_samples=100,
+    forecast_df = model.predict(data_train)
+    seasonal_period = 3
+    ag_evaluator = TimeSeriesEvaluator(
+        eval_metric=metric_name, prediction_length=model.prediction_length, eval_metric_seasonal_period=seasonal_period
     )
-    fcast_list, ts_list = list(forecast_iter), list(ts_iter)
-    prediction_length = 2
-    forecast_index = DUMMY_TS_DATAFRAME.slice_by_timestep(-prediction_length, None).index
-    forecast_df = model._gluonts_forecasts_to_data_frame(
-        fcast_list,
-        forecast_index=forecast_index,
-    )
-
-    ag_evaluator = TimeSeriesEvaluator(eval_metric=metric_name, prediction_length=prediction_length)
     ag_value = ag_evaluator(data, forecast_df)
 
-    gts_evaluator = GluonTSEvaluator()
-    gts_results, _ = gts_evaluator(ts_iterator=ts_list, fcst_iterator=fcast_list)
+    forecast_list = to_gluonts_forecast(forecast_df, freq=data_train.freq)
+    ts_list = to_gluonts_test_set(data_test)
+    gts_evaluator = GluonTSEvaluator(seasonality=seasonal_period)
+    gts_results, _ = gts_evaluator(ts_iterator=ts_list, fcst_iterator=forecast_list)
 
     gts_metric_name = AG_TO_GLUONTS_METRIC.get(metric_name, metric_name)
     assert np.isclose(gts_results[gts_metric_name], ag_value, atol=1e-5, equal_nan=True)
@@ -116,38 +119,19 @@ def test_when_given_all_zero_data_when_evaluator_called_then_output_equal_to_glu
 @pytest.mark.parametrize("metric_name", GLUONTS_PARITY_METRICS)
 def test_when_given_zero_forecasts_when_evaluator_called_then_output_equal_to_gluonts(metric_name, deepar_trained):
     model = deepar_trained
-    forecast_iter, ts_iter = make_evaluation_predictions(
-        dataset=model._to_gluonts_dataset(DUMMY_TS_DATAFRAME),
-        predictor=model.gts_predictor,
-        num_samples=100,
-    )
-    fcast_list, ts_list = list(forecast_iter), list(ts_iter)
+    data_train, data_test = DUMMY_TS_DATAFRAME.train_test_split(model.prediction_length)
 
-    zero_forecast_list = []
-    for s in fcast_list:
-        zero_forecast_list.append(
-            SampleForecast(
-                samples=np.zeros_like(s.samples),  # noqa
-                start_date=pd.Period(s.start_date, freq=s.freq),
-                item_id=s.item_id,
-            )
-        )
-    prediction_length = 2
+    forecast_df = model.predict(data_train) * 0
     seasonal_period = 3
-    forecast_index = DUMMY_TS_DATAFRAME.slice_by_timestep(-prediction_length, None).index
-    forecast_df = model._gluonts_forecasts_to_data_frame(
-        zero_forecast_list,
-        forecast_index=forecast_index,
-    )
-
     ag_evaluator = TimeSeriesEvaluator(
-        eval_metric=metric_name, prediction_length=prediction_length, eval_metric_seasonal_period=seasonal_period
+        eval_metric=metric_name, prediction_length=model.prediction_length, eval_metric_seasonal_period=seasonal_period
     )
     ag_value = ag_evaluator(DUMMY_TS_DATAFRAME, forecast_df)
 
+    forecast_list = to_gluonts_forecast(forecast_df, freq=data_train.freq)
+    ts_list = to_gluonts_test_set(data_test)
     gts_evaluator = GluonTSEvaluator(seasonality=seasonal_period)
-    gts_results, _ = gts_evaluator(ts_iterator=ts_list, fcst_iterator=zero_forecast_list)
-
+    gts_results, _ = gts_evaluator(ts_iterator=ts_list, fcst_iterator=forecast_list)
     gts_metric_name = AG_TO_GLUONTS_METRIC.get(metric_name, metric_name)
     assert np.isclose(gts_results[gts_metric_name], ag_value, atol=1e-5)
 


### PR DESCRIPTION
*Description of changes:*
- Enable early stopping to GluonTS models using `early_stopping_patience` hyperparameter
- Allow passing custom trainer arguments using `trainer_kwargs` hyperparameter
- Log whether GPU is used at DEBUG level (fixes #3309)
- Speed up inference for GluonTS models (fixes #3564)
  - Instead of using pandas DataFrames + `loc` accessing, we use numpy arrays + indptr accessing.
  - Use larger batch size during inference (32->500).
  - Speed up the conversion of GluonTS forecast objects to a predictions DataFrame in AutoGluon.

Here is an ablation that demonstrates the effect of each change. We compare master branch (top row), this PR with all changes (bottom row), and this PR with each of the 3 changes removed. Results are for the M4-Monthly dataset with 48000 time series.
| inference time (s) | GPU |  |  | CPU | |  |
|--------|--------|--------|--------|--------|--|--|
| Version | DeepAR | TFT | SimpleFeedForward|  DeepAR | TFT | SimpleFeedForward| 
| master branch | 160 | 72 | 167 | 330 | 77 | 125 |
| this PR - new dataset | 88 | 56 | | | | |
| this PR - inference batch size | 125 | 42 | 41 | | | | 
| this PR - fast converstion | 92 | 45 | 147 |  | | |
| this PR | 69 | 36 | 38 | 250 |36 |23 |

*To Do*:
- [x] Fix existing tests
- [x] Add new tests for added functionality

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
