### PR TITLE
Add version cap for pytorch_lightning

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -28,6 +28,7 @@ DEPENDENT_PACKAGES = {
     "Pillow": ">=9.3,<9.6",  # "<{N+2}" upper cap
     "torch": ">=2.0,<2.1",  # "<{N+1}" upper cap, sync with common/src/autogluon/common/utils/try_import.py
     "lightning": ">=2.0.0,<2.1",  # "<{N+1}" upper cap
+    "pytorch_lightning": ">=2.0.0,<2.1",  # "<{N+1}" upper cap
 }
 if LITE_MODE:
     DEPENDENT_PACKAGES = {package: version for package, version in DEPENDENT_PACKAGES.items() if package not in ["psutil", "Pillow", "timm"]}

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -27,6 +27,7 @@ install_requires = [
     "pandas",  # version range defined in `core/_setup_utils.py`
     "torch",  # version range defined in `core/_setup_utils.py`
     "lightning",  # version range defined in `core/_setup_utils.py`
+    "pytorch_lightning",  # version range defined in `core/_setup_utils.py`
     "statsmodels>=0.13.0,<0.15",
     "gluonts>=0.13.1,<0.14",
     "networkx",  # version range defined in `core/_setup_utils.py`


### PR DESCRIPTION
*Description of changes:*
- The new release of `lightning` v2.1.0 introduces a backwards-incompatible change that breaks all GluonTS models. We have capped `lightning<2.1`, but for some reason that doesn't prevent the installation of `pytorch_lightning==2.1.0`, where the breaking change is introduced. This PR caps the version of `pytorch_lightning`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
