### PR TITLE
[AutoMM] Fix object detection prediction on COCO json files without annotations.

### DIFF
--- a/docs/tutorials/multimodal/object_detection/data_preparation/convert_data_to_coco_format.ipynb
+++ b/docs/tutorials/multimodal/object_detection/data_preparation/convert_data_to_coco_format.ipynb
@@ -113,12 +113,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "485f505e",
    "metadata": {},
    "source": [
     "For the sole purpose of running AutoMM, the fields ``\"info\"`` and ``\"licenses\"`` are optional. \n",
-    "``\"images\"``, ``\"categories\"``, and ``\"annotations\"`` are required."
+    "``\"images\"``, ``\"categories\"``, and ``\"annotations\"`` are required for training and evaluation, while for prediction only the ``\"images\"`` field is required."
    ]
   },
   {

--- a/multimodal/src/autogluon/multimodal/utils/object_detection.py
+++ b/multimodal/src/autogluon/multimodal/utils/object_detection.py
@@ -736,7 +736,7 @@ def from_coco(
     -------
     A dataframe with columns "image", "rois", and "image_attr".
     """
-    # construct from COCO format
+    # construct coco object from COCO format
     try_import_pycocotools()
     from pycocotools.coco import COCO
 
@@ -746,6 +746,7 @@ def from_coco(
         anno_file = os.path.expanduser(anno_file)
     coco = COCO(anno_file)
 
+    # get data root
     if isinstance(root, Path):
         root = str(root.expanduser().resolve())
     elif isinstance(root, str):
@@ -756,6 +757,13 @@ def from_coco(
         logger.info(f"Using default root folder: {root}. Specify `root=...` if you feel it is wrong...")
     else:
         raise ValueError("Unable to parse root: {}".format(root))
+    
+    # support prediction using data with no annotations
+    # note that data with annotation can be used for prediction without any changes
+    try:
+        num_annotations = len(coco.getAnnIds())
+    except KeyError:  # KeyError: 'annotations', there is no annotation entry
+        num_annotations = 0
 
     # synsets
     classes = [c["name"] for c in coco.loadCats(coco.getCatIds())]
@@ -778,6 +786,11 @@ def from_coco(
             use_crowd=use_crowd,
         )
         if not rois:
+            # discard the rows without valid annotation ONLY when data has annotation
+            # add default placeholder to data without annotation for prediction
+            if not num_annotations:
+                d["image"].append(abs_path)
+                d["rois"].append([[-1, -1, -1, -1, 0]])  # TODO: maybe remove this placeholder
             continue
         d["image"].append(abs_path)
         d["rois"].append(rois)

--- a/multimodal/src/autogluon/multimodal/utils/object_detection.py
+++ b/multimodal/src/autogluon/multimodal/utils/object_detection.py
@@ -757,7 +757,7 @@ def from_coco(
         logger.info(f"Using default root folder: {root}. Specify `root=...` if you feel it is wrong...")
     else:
         raise ValueError("Unable to parse root: {}".format(root))
-    
+
     # support prediction using data with no annotations
     # note that data with annotation can be used for prediction without any changes
     try:

--- a/multimodal/tests/unittests/others/test_object_detection.py
+++ b/multimodal/tests/unittests/others/test_object_detection.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import pytest
@@ -148,6 +149,16 @@ def test_mmdet_object_detection_inference_df(checkpoint_name):
     data_dir = download_sample_dataset()
 
     test_path = os.path.join(data_dir, "Annotations", "test_cocoformat.json")
+
+    test_path_without_annotations = os.path.join(data_dir, "Annotations", "test_cocoformat_nolabel.json")
+
+    with open(test_path, "r") as f:
+        test_data = json.load(f)
+    test_data.pop("annotations")
+    test_data["images"] = test_data["images"][:100]
+    with open(test_path_without_annotations, "w+") as f_wo_ann:
+        json.dump(test_data, f_wo_ann)
+
     # Init predictor
     predictor = MultiModalPredictor(
         hyperparameters={
@@ -160,6 +171,9 @@ def test_mmdet_object_detection_inference_df(checkpoint_name):
     test_df = from_coco_or_voc(test_path)
 
     pred = predictor.predict(test_df.iloc[:100])
+
+    # also test prediction on data without annotations
+    pred = predictor.predict(test_path_without_annotations)
 
 
 @pytest.mark.single_gpu


### PR DESCRIPTION
Fix object detection prediction on COCO json files without annotations.
Also add a test case for this issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
