### PR TITLE
FastAI Neural Network Clipping for Regression

### DIFF
--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -4,6 +4,7 @@ import copy
 import logging
 import time
 from builtins import classmethod
+from functools import partial
 from pathlib import Path
 from typing import Dict, Union
 
@@ -32,6 +33,7 @@ from autogluon.core.utils.exceptions import TimeLimitExceeded
 from autogluon.core.utils.files import make_temp_directory
 from autogluon.core.utils.loaders import load_pkl
 from autogluon.core.utils.savers import save_pkl
+from autogluon.tabular.models.tabular_nn.utils.nn_architecture_utils import infer_y_range
 
 from .hyperparameters.parameters import get_param_baseline
 from .hyperparameters.searchspaces import get_default_searchspace
@@ -59,11 +61,16 @@ class NNFastAiTabularModel(AbstractModel):
     """Class for fastai v1 neural network models that operate on tabular data.
 
     Hyperparameters:
-        y_scaler: on a regression problems, the model can give unreasonable predictions on unseen data.
-        This attribute allows to pass a scaler for y values to address this problem. Please note that intermediate
+        'y_scaler': on regression problems, the model can give unreasonable predictions on unseen data.
+        To address this problem, AutoGluon scales y values by default for regression problems.
+        This attribute allows to pass a custom scaler for y values. Please note that intermediate
         iteration metrics will be affected by this transform and as a result intermediate iteration scores will be
         different from the final ones (these will be correct).
         https://scikit-learn.org/stable/modules/classes.html#module-sklearn.preprocessing
+
+        'clipping': on regression problems, extreme outliers of y can hurt performance of the model during training and
+        on unseen data. To address this problem, AutoGluon clips input y values and output predictions by default to a
+        range inferred from the training data. Setting this attribute to False disables clipping.
 
         'layers': list of hidden layers sizes; None - use model's heuristics; default is None
 
@@ -97,6 +104,7 @@ class NNFastAiTabularModel(AbstractModel):
         self._cont_normalization = None
         self._load_model = None  # Whether to load inner model when loading.
         self._num_cpus_infer = None
+        self.clipping = None
 
     def _preprocess_train(self, X, y, X_val, y_val):
         from fastai.data.block import CategoryBlock, RegressionBlock
@@ -222,6 +230,18 @@ class NNFastAiTabularModel(AbstractModel):
                 self.y_scaler = sklearn.preprocessing.MinMaxScaler()
         else:
             self.y_scaler = copy.deepcopy(self.y_scaler)
+
+        self.clipping = params.pop("clipping", True)
+        if self.clipping and (self.problem_type == REGRESSION):
+            # use code and concepts from TorchNN to infer y range. 0.05 follows default from TorchNN.
+            y_min, y_max = infer_y_range(y, y_range_extend=0.05)
+            clip_func = partial(np.clip, a_min=y_min, a_max=y_max)
+
+            self.y_scaler = sklearn.pipeline.Pipeline(steps=[
+                # needs both func and inverse func, as the FastAI model calls inverse_transform.
+                ("clipper", sklearn.preprocessing.FunctionTransformer(func=clip_func, inverse_func=clip_func)),
+                ("scaler", self.y_scaler),
+            ])
 
         if num_gpus is not None:
             # TODO: Control CPU vs GPU usage during inference

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -237,11 +237,16 @@ class NNFastAiTabularModel(AbstractModel):
             y_min, y_max = infer_y_range(y, y_range_extend=0.05)
             clip_func = partial(np.clip, a_min=y_min, a_max=y_max)
 
-            self.y_scaler = sklearn.pipeline.Pipeline(steps=[
+            steps = [
                 # needs both func and inverse func, as the FastAI model calls inverse_transform.
                 ("clipper", sklearn.preprocessing.FunctionTransformer(func=clip_func, inverse_func=clip_func)),
-                ("scaler", self.y_scaler),
-            ])
+            ]
+
+            # Support the case where no scaler is defined.
+            if self.y_scaler is not None:
+                steps.append(("scaler", self.y_scaler))
+
+            self.y_scaler = sklearn.pipeline.Pipeline(steps=steps)
 
         if num_gpus is not None:
             # TODO: Control CPU vs GPU usage during inference


### PR DESCRIPTION
### Description of changes:

This PR adds clipping to FastAI neural networks for regression. The PR adjust the code such that it now clips the y values before training the model by default. Moreover, the predictions of the model are also clipped. This was done by replacing the scaler with a pipeline that includes a function transformer for clipping and the scaler (if available). The code follows the TorchNN model to determine the range for clipping. 

### Code Example 
The following code compares clipping vs. no clipping on a dataset with extreme outliers. 

<details>
<summary>
Script
</summary>

```python
import numpy as np
import openml
import pandas as pd
from autogluon.tabular import TabularPredictor

import sklearn

def get_data(tid: int, fold: int):
    # Get Task and dataset from OpenML and return split data
    oml_task = openml.tasks.get_task(tid, download_splits=True, download_data=True, download_qualities=False, download_features_meta_data=False)

    train_ind, test_ind = oml_task.get_train_test_split_indices(fold)
    X, *_ = oml_task.get_dataset().get_data(dataset_format="dataframe")

    return (
        X.iloc[train_ind, :].reset_index(drop=True),
        X.iloc[test_ind, :].reset_index(drop=True),
        oml_task.target_name,
        oml_task.task_type != "Supervised Classification",
    )


def _print_lb(leaderboard, task_id):
    # print("### Results for ", task_id)
    with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
        print(leaderboard[leaderboard["model"].str.endswith("L1")].sort_values(by="score_val", ascending=True))
        print(leaderboard[~leaderboard["model"].str.endswith("L1")].sort_values(by="score_val", ascending=False))


def _run(task_id, metric, fold=0, print_res=True):
    l2_train_data, l2_test_data, label, regression = get_data(task_id, fold)
    n_max_cols = 100
    n_max_train_instances = 10000
    n_max_test_instances = 2000

    # Sub sample instances
    l2_train_data = l2_train_data.sample(n=min(len(l2_train_data), n_max_train_instances), random_state=0).reset_index(drop=True)
    l2_test_data = l2_test_data.sample(n=min(len(l2_test_data), n_max_test_instances), random_state=0).reset_index(drop=True)

    # Sub sample columns
    cols = list(l2_train_data.columns)
    cols.remove(label)
    if len(cols) > n_max_cols:
        cols = list(np.random.RandomState(42).choice(cols, replace=False, size=n_max_cols))
    l2_train_data = l2_train_data[cols + [label]]
    l2_test_data = l2_test_data[cols + [label]]

    # Run AutoGluon
    print(f"### task {task_id} and fold {fold} and shape {(l2_train_data.shape, l2_test_data.shape)}.")
    predictor = TabularPredictor(eval_metric=metric, label=label, verbosity=2)
    predictor.fit(
        train_data=l2_train_data,
        hyperparameters={
            "FASTAI": [{}, {"clipping": False, "ag_args": {"name_suffix": "_no_clipping"}}, {"clipping": False, "y_scaler": sklearn.preprocessing.MinMaxScaler(), "ag_args": {"name_suffix": "_no_clipping_custom_scaler"}}],
        },
        num_stack_levels=1,
        num_bag_sets=5,
        num_bag_folds=8,
        fit_weighted_ensemble=False,
    )
    leaderboard = predictor.leaderboard(l2_test_data, silent=True)[["model", "score_test", "score_val"]].sort_values(by="model").reset_index(drop=True)

    if print_res:
        _print_lb(leaderboard, task_id)

    return leaderboard


if __name__ == "__main__":
    _run(359938, "rmse", fold=3)  # leak minimal

```

</details>

Final Leaderboard: 
```bash
                                              model    score_test    score_val
0                            NeuralNetFastAI_BAG_L1  -4260.196363 -8353.771541
4  NeuralNetFastAI_no_clipping_custom_scaler_BAG_L1 -23499.993082 -2406.030440
2                NeuralNetFastAI_no_clipping_BAG_L1 -89813.071286 -1977.816324
                                              model    score_test    score_val
3                NeuralNetFastAI_no_clipping_BAG_L2 -87508.922297 -1344.256196
5  NeuralNetFastAI_no_clipping_custom_scaler_BAG_L2 -64403.932087 -2785.520579
1                            NeuralNetFastAI_BAG_L2  -5651.611877 -8290.444348
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
