### PR TITLE
Make the Last Layer's Post Hoc Ensemble (Weighted Ensemble) Use all Models

### DIFF
--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -550,7 +550,7 @@ class AbstractTrainer:
         if full_weighted_ensemble:
             full_aux_kwargs = aux_kwargs.copy()
             if additional_full_weighted_ensemble:
-                full_aux_kwargs["name_extra"] = "_FULL"
+                full_aux_kwargs["name_extra"] = "_ALL"
             all_base_model_names = self.get_model_names(stack_name="core")  # Fit weighted ensemble on all previously fitted core models
             aux_models += self._stack_new_level_aux(X_val, y_val, X, y, all_base_model_names, level, infer_limit, infer_limit_batch_size, **full_aux_kwargs)
 

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -707,7 +707,7 @@ class AbstractTrainer:
 
         if full_weighted_ensemble:
             # Fit weighted ensemble on all previously fitted core models
-            base_model_names = self.get_model_names(stack_name='core')
+            base_model_names = self.get_model_names(stack_name="core")
 
         base_model_names = self._filter_base_models_via_infer_limit(base_model_names=base_model_names, infer_limit=infer_limit, infer_limit_modifier=0.95)
         if len(base_model_names) == 0:

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -543,7 +543,7 @@ class AbstractTrainer:
             **core_kwargs,
         )
 
-        if last_level and (core_kwargs.get("ag_args_fit", None) is not None) and core_kwargs["ag_args_fit"].get("full_last_weighted_ensemble", False):
+        if last_level and core_kwargs.get("ag_args_fit", dict()).get("full_last_weighted_ensemble", True):
             aux_level_base_model_names = self.get_model_names(stack_name='core')  # get all fitted core models
         else:
             aux_level_base_model_names = core_models

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -389,6 +389,7 @@ class TabularPredictor:
         infer_limit_batch_size=None,
         fit_weighted_ensemble: bool = True,
         fit_full_last_level_weighted_ensemble: bool = True,
+        full_weighted_ensemble_additionally: bool = False,
         calibrate_decision_threshold=False,
         num_cpus="auto",
         num_gpus="auto",
@@ -638,8 +639,13 @@ class TabularPredictor:
             A weighted ensemble will often be stronger than an individual model while being very fast to train.
             It is recommended to keep this value set to True to maximize predictive quality.
         fit_full_last_level_weighted_ensemble : bool, default = True
-            If True, an additional WeightedEnsembleModel will be fit at the last stacking level with all models from all previous layers.
+            If True, the WeightedEnsembleModel of the last stacking level will be fit with all (successful) models from all previous layers as base models.
+            If stacking is disabled, settings this to True or False makes no difference because the WeightedEnsembleModel L2 always uses all models from L1.
             It is recommended to keep this value set to True to maximize predictive quality.
+        full_weighted_ensemble_additionally : bool, default = False
+            If True, AutoGluon will fit two WeightedEnsembleModels after training all stacking levels. Setting this to True, simulates calling
+            `fit_weighted_ensemble()` after calling `fit()`. Has no affect if `fit_full_last_level_weighted_ensemble` is False and does not fit an additional
+            WeightedEnsembleModel if stacking is disabled.
         calibrate_decision_threshold : bool, default = False
             [Experimental] This may be removed / changed without warning in a future release.
             If True, will automatically calibrate the decision threshold at the end of fit for calls to `.predict` based on the evaluation metric.
@@ -987,6 +993,7 @@ class TabularPredictor:
         if fit_weighted_ensemble is False:
             aux_kwargs["fit_weighted_ensemble"] = False
         aux_kwargs["fit_full_last_level_weighted_ensemble"] = fit_full_last_level_weighted_ensemble
+        aux_kwargs["full_weighted_ensemble_additionally"] = full_weighted_ensemble_additionally
         self.save(silent=True)  # Save predictor to disk to enable prediction and training after interrupt
         self._learner.fit(
             X=train_data,
@@ -1096,6 +1103,7 @@ class TabularPredictor:
         base_model_names=None,
         fit_weighted_ensemble=True,
         fit_full_last_level_weighted_ensemble=True,
+        full_weighted_ensemble_additionally=False,
         num_cpus="auto",
         num_gpus="auto",
         **kwargs
@@ -1124,8 +1132,13 @@ class TabularPredictor:
             A weighted ensemble will often be stronger than an individual model while being very fast to train.
             It is recommended to keep this value set to True to maximize predictive quality.
         fit_full_last_level_weighted_ensemble : bool, default = True
-            If True, an additional WeightedEnsembleModel will be fit at the last stacking level with all models from all previous layers.
+            If True, the WeightedEnsembleModel of the last stacking level will be fit with all (successful) models from all previous layers as base models.
+            If stacking is disabled, settings this to True or False makes no difference because the WeightedEnsembleModel L2 always uses all models from L1.
             It is recommended to keep this value set to True to maximize predictive quality.
+        full_weighted_ensemble_additionally : bool, default = False
+            If True, AutoGluon will fit two WeightedEnsembleModels after training all stacking levels. Setting this to True, simulates calling
+            `fit_weighted_ensemble()` after calling `fit()`. Has no affect if `fit_full_last_level_weighted_ensemble` is False and does not fit an additional
+            WeightedEnsembleModel if stacking is disabled.
         num_cpus: int, default = "auto"
             The total amount of cpus you want AutoGluon predictor to use.
             Auto means AutoGluon will make the decision based on the total number of cpus available and the model requirement for best performance.
@@ -1200,6 +1213,7 @@ class TabularPredictor:
         if fit_weighted_ensemble is False:
             aux_kwargs = {"fit_weighted_ensemble": False}
         aux_kwargs["fit_full_last_level_weighted_ensemble"] = fit_full_last_level_weighted_ensemble
+        aux_kwargs["full_weighted_ensemble_additionally"] = full_weighted_ensemble_additionally
 
         if isinstance(hyperparameters, str):
             hyperparameters = get_hyperparameter_config(hyperparameters)

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -388,7 +388,7 @@ class TabularPredictor:
         infer_limit=None,
         infer_limit_batch_size=None,
         fit_weighted_ensemble: bool = True,
-        full_last_level_weighted_ensemble: bool = True,
+        fit_full_last_level_weighted_ensemble: bool = True,
         calibrate_decision_threshold=False,
         num_cpus="auto",
         num_gpus="auto",
@@ -637,9 +637,8 @@ class TabularPredictor:
             If True, a WeightedEnsembleModel will be fit in each stack layer.
             A weighted ensemble will often be stronger than an individual model while being very fast to train.
             It is recommended to keep this value set to True to maximize predictive quality.
-        full_last_level_weighted_ensemble : bool, default = True
-            If True, the WeightedEnsembleModel of the final stack level will be fit with all models from all previous layers.
-            If False, the WeightedEnsembleModel will only be fit with the last layer's models.
+        fit_full_last_level_weighted_ensemble : bool, default = True
+            If True, an additional WeightedEnsembleModel will be fit at the last stacking level with all models from all previous layers.
             It is recommended to keep this value set to True to maximize predictive quality.
         calibrate_decision_threshold : bool, default = False
             [Experimental] This may be removed / changed without warning in a future release.
@@ -987,7 +986,7 @@ class TabularPredictor:
         aux_kwargs = {}
         if fit_weighted_ensemble is False:
             aux_kwargs["fit_weighted_ensemble"] = False
-        aux_kwargs["full_last_level_weighted_ensemble"] = full_last_level_weighted_ensemble
+        aux_kwargs["fit_full_last_level_weighted_ensemble"] = fit_full_last_level_weighted_ensemble
         self.save(silent=True)  # Save predictor to disk to enable prediction and training after interrupt
         self._learner.fit(
             X=train_data,
@@ -1096,7 +1095,7 @@ class TabularPredictor:
         time_limit=None,
         base_model_names=None,
         fit_weighted_ensemble=True,
-        full_last_level_weighted_ensemble=True,
+        fit_full_last_level_weighted_ensemble=True,
         num_cpus="auto",
         num_gpus="auto",
         **kwargs
@@ -1124,9 +1123,8 @@ class TabularPredictor:
             If True, a WeightedEnsembleModel will be fit in each stack layer.
             A weighted ensemble will often be stronger than an individual model while being very fast to train.
             It is recommended to keep this value set to True to maximize predictive quality.
-        full_last_level_weighted_ensemble : bool, default = True
-            If True, the WeightedEnsembleModel of the final stack level will be fit with all models from all previous layers.
-            If False, the WeightedEnsembleModel will only be fit with the last layer's models.
+        fit_full_last_level_weighted_ensemble : bool, default = True
+            If True, an additional WeightedEnsembleModel will be fit at the last stacking level with all models from all previous layers.
             It is recommended to keep this value set to True to maximize predictive quality.
         num_cpus: int, default = "auto"
             The total amount of cpus you want AutoGluon predictor to use.
@@ -1201,7 +1199,7 @@ class TabularPredictor:
         aux_kwargs = {}
         if fit_weighted_ensemble is False:
             aux_kwargs = {"fit_weighted_ensemble": False}
-        aux_kwargs["full_last_level_weighted_ensemble"] = full_last_level_weighted_ensemble
+        aux_kwargs["fit_full_last_level_weighted_ensemble"] = fit_full_last_level_weighted_ensemble
 
         if isinstance(hyperparameters, str):
             hyperparameters = get_hyperparameter_config(hyperparameters)

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -387,7 +387,8 @@ class TabularPredictor:
         feature_metadata="infer",
         infer_limit=None,
         infer_limit_batch_size=None,
-        fit_weighted_ensemble=True,
+        fit_weighted_ensemble: bool = True,
+        full_last_level_weighted_ensemble: bool = True,
         calibrate_decision_threshold=False,
         num_cpus="auto",
         num_gpus="auto",
@@ -635,6 +636,10 @@ class TabularPredictor:
         fit_weighted_ensemble : bool, default = True
             If True, a WeightedEnsembleModel will be fit in each stack layer.
             A weighted ensemble will often be stronger than an individual model while being very fast to train.
+            It is recommended to keep this value set to True to maximize predictive quality.
+        full_last_level_weighted_ensemble : bool, default = True
+            If True, the WeightedEnsembleModel of the final stack level will be fit with all models from all previous layers.
+            If False, the WeightedEnsembleModel will only be fit with the last layer's models.
             It is recommended to keep this value set to True to maximize predictive quality.
         calibrate_decision_threshold : bool, default = False
             [Experimental] This may be removed / changed without warning in a future release.
@@ -982,6 +987,7 @@ class TabularPredictor:
         aux_kwargs = {}
         if fit_weighted_ensemble is False:
             aux_kwargs["fit_weighted_ensemble"] = False
+        aux_kwargs["full_last_level_weighted_ensemble"] = full_last_level_weighted_ensemble
         self.save(silent=True)  # Save predictor to disk to enable prediction and training after interrupt
         self._learner.fit(
             X=train_data,
@@ -1084,7 +1090,17 @@ class TabularPredictor:
             self.save_space()
 
     # TODO: Consider adding infer_limit to fit_extra
-    def fit_extra(self, hyperparameters, time_limit=None, base_model_names=None, fit_weighted_ensemble=True, num_cpus="auto", num_gpus="auto", **kwargs):
+    def fit_extra(
+        self,
+        hyperparameters,
+        time_limit=None,
+        base_model_names=None,
+        fit_weighted_ensemble=True,
+        full_last_level_weighted_ensemble=True,
+        num_cpus="auto",
+        num_gpus="auto",
+        **kwargs
+    ):
         """
         Fits additional models after the original :meth:`TabularPredictor.fit` call.
         The original train_data and tuning_data will be used to train the models.
@@ -1107,6 +1123,10 @@ class TabularPredictor:
         fit_weighted_ensemble : bool, default = True
             If True, a WeightedEnsembleModel will be fit in each stack layer.
             A weighted ensemble will often be stronger than an individual model while being very fast to train.
+            It is recommended to keep this value set to True to maximize predictive quality.
+        full_last_level_weighted_ensemble : bool, default = True
+            If True, the WeightedEnsembleModel of the final stack level will be fit with all models from all previous layers.
+            If False, the WeightedEnsembleModel will only be fit with the last layer's models.
             It is recommended to keep this value set to True to maximize predictive quality.
         num_cpus: int, default = "auto"
             The total amount of cpus you want AutoGluon predictor to use.
@@ -1181,6 +1201,7 @@ class TabularPredictor:
         aux_kwargs = {}
         if fit_weighted_ensemble is False:
             aux_kwargs = {"fit_weighted_ensemble": False}
+        aux_kwargs["full_last_level_weighted_ensemble"] = full_last_level_weighted_ensemble
 
         if isinstance(hyperparameters, str):
             hyperparameters = get_hyperparameter_config(hyperparameters)

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1106,7 +1106,7 @@ class TabularPredictor:
         full_weighted_ensemble_additionally=False,
         num_cpus="auto",
         num_gpus="auto",
-        **kwargs
+        **kwargs,
     ):
         """
         Fits additional models after the original :meth:`TabularPredictor.fit` call.

--- a/tabular/tests/unittests/edgecases/test_edgecases.py
+++ b/tabular/tests/unittests/edgecases/test_edgecases.py
@@ -20,11 +20,12 @@ def test_no_full_last_level_weighted_ensemble(fit_helper):
     """Tests that fit_weighted_ensemble=False works"""
     fit_args = dict(
         hyperparameters={"DUMMY": {}},
-        fit_weighted_ensemble=False,
+        fit_weighted_ensemble=True,
         full_last_level_weighted_ensemble=False,
         num_stack_levels=1,
         num_bag_folds=2,
-        num_bag_sets=5,
+        num_bag_sets=1,
+        ag_args_ensemble={"fold_fitting_strategy": "sequential_local"}
     )
     dataset_name = "adult"
     extra_metrics = list(METRICS[BINARY])
@@ -40,7 +41,8 @@ def test_full_last_level_weighted_ensemble(fit_helper):
         full_last_level_weighted_ensemble=True,
         num_stack_levels=1,
         num_bag_folds=2,
-        num_bag_sets=5,
+        num_bag_sets=1,
+        ag_args_ensemble={"fold_fitting_strategy": "sequential_local"}
     )
     dataset_name = "adult"
     extra_metrics = list(METRICS[BINARY])

--- a/tabular/tests/unittests/edgecases/test_edgecases.py
+++ b/tabular/tests/unittests/edgecases/test_edgecases.py
@@ -25,12 +25,51 @@ def test_no_full_last_level_weighted_ensemble(fit_helper):
         num_stack_levels=1,
         num_bag_folds=2,
         num_bag_sets=1,
-        ag_args_ensemble={"fold_fitting_strategy": "sequential_local"}
+        ag_args_ensemble={"fold_fitting_strategy": "sequential_local"},
     )
     dataset_name = "adult"
     extra_metrics = list(METRICS[BINARY])
 
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics, expected_model_count=4)
+
+
+def test_no_full_last_level_weighted_ensemble_additionally(fit_helper):
+    """Tests that fit_weighted_ensemble=False works"""
+    fit_args = dict(
+        hyperparameters={"DUMMY": {}},
+        fit_weighted_ensemble=True,
+        fit_full_last_level_weighted_ensemble=False,
+        full_weighted_ensemble_additionally=False,
+        num_stack_levels=1,
+        num_bag_folds=2,
+        num_bag_sets=1,
+        ag_args_ensemble={"fold_fitting_strategy": "sequential_local"},
+    )
+    dataset_name = "adult"
+    extra_metrics = list(METRICS[BINARY])
+
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics, expected_model_count=4)
+
+
+def test_full_last_level_weighted_ensemble_additionally(fit_helper):
+    """Tests that fit_weighted_ensemble=False works"""
+    fit_args = dict(
+        hyperparameters={"DUMMY": {}},
+        fit_weighted_ensemble=True,
+        fit_full_last_level_weighted_ensemble=True,
+        full_weighted_ensemble_additionally=True,
+        num_stack_levels=1,
+        num_bag_folds=2,
+        num_bag_sets=1,
+        ag_args_ensemble={"fold_fitting_strategy": "sequential_local"},
+    )
+    dataset_name = "adult"
+    extra_metrics = list(METRICS[BINARY])
+
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics, expected_model_count=5)
+
+    fit_args["num_stack_levels"] = 0
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics, expected_model_count=2)
 
 
 def test_full_last_level_weighted_ensemble(fit_helper):
@@ -42,12 +81,12 @@ def test_full_last_level_weighted_ensemble(fit_helper):
         num_stack_levels=1,
         num_bag_folds=2,
         num_bag_sets=1,
-        ag_args_ensemble={"fold_fitting_strategy": "sequential_local"}
+        ag_args_ensemble={"fold_fitting_strategy": "sequential_local"},
     )
     dataset_name = "adult"
     extra_metrics = list(METRICS[BINARY])
 
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics, expected_model_count=5)
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics, expected_model_count=4)
 
 
 def test_max_sets(fit_helper):

--- a/tabular/tests/unittests/edgecases/test_edgecases.py
+++ b/tabular/tests/unittests/edgecases/test_edgecases.py
@@ -16,6 +16,38 @@ def test_no_weighted_ensemble(fit_helper):
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics, expected_model_count=1)
 
 
+def test_no_full_last_level_weighted_ensemble(fit_helper):
+    """Tests that fit_weighted_ensemble=False works"""
+    fit_args = dict(
+        hyperparameters={"DUMMY": {}},
+        fit_weighted_ensemble=False,
+        full_last_level_weighted_ensemble=False,
+        num_stack_levels=1,
+        num_bag_folds=2,
+        num_bag_sets=5,
+    )
+    dataset_name = "adult"
+    extra_metrics = list(METRICS[BINARY])
+
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics, expected_model_count=2)
+
+
+def test_full_last_level_weighted_ensemble(fit_helper):
+    """Tests that fit_weighted_ensemble=False works"""
+    fit_args = dict(
+        hyperparameters={"DUMMY": {}},
+        fit_weighted_ensemble=True,
+        full_last_level_weighted_ensemble=True,
+        num_stack_levels=1,
+        num_bag_folds=2,
+        num_bag_sets=5,
+    )
+    dataset_name = "adult"
+    extra_metrics = list(METRICS[BINARY])
+
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics, expected_model_count=4)
+
+
 def test_max_sets(fit_helper):
     """Tests that max_sets works"""
     fit_args = dict(

--- a/tabular/tests/unittests/edgecases/test_edgecases.py
+++ b/tabular/tests/unittests/edgecases/test_edgecases.py
@@ -21,24 +21,7 @@ def test_no_full_last_level_weighted_ensemble(fit_helper):
     fit_args = dict(
         hyperparameters={"DUMMY": {}},
         fit_weighted_ensemble=True,
-        full_last_level_weighted_ensemble=False,
-        num_stack_levels=1,
-        num_bag_folds=2,
-        num_bag_sets=1,
-        ag_args_ensemble={"fold_fitting_strategy": "sequential_local"}
-    )
-    dataset_name = "adult"
-    extra_metrics = list(METRICS[BINARY])
-
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics, expected_model_count=2)
-
-
-def test_full_last_level_weighted_ensemble(fit_helper):
-    """Tests that fit_weighted_ensemble=False works"""
-    fit_args = dict(
-        hyperparameters={"DUMMY": {}},
-        fit_weighted_ensemble=True,
-        full_last_level_weighted_ensemble=True,
+        fit_full_last_level_weighted_ensemble=False,
         num_stack_levels=1,
         num_bag_folds=2,
         num_bag_sets=1,
@@ -48,6 +31,23 @@ def test_full_last_level_weighted_ensemble(fit_helper):
     extra_metrics = list(METRICS[BINARY])
 
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics, expected_model_count=4)
+
+
+def test_full_last_level_weighted_ensemble(fit_helper):
+    """Tests that fit_weighted_ensemble=False works"""
+    fit_args = dict(
+        hyperparameters={"DUMMY": {}},
+        fit_weighted_ensemble=True,
+        fit_full_last_level_weighted_ensemble=True,
+        num_stack_levels=1,
+        num_bag_folds=2,
+        num_bag_sets=1,
+        ag_args_ensemble={"fold_fitting_strategy": "sequential_local"}
+    )
+    dataset_name = "adult"
+    extra_metrics = list(METRICS[BINARY])
+
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics, expected_model_count=5)
 
 
 def test_max_sets(fit_helper):


### PR DESCRIPTION
### Description of changes:

This PR adds code to enable and make it the default that the final weighted ensemble (post hoc ensemble) uses all models from **all** previous stacking layers. Previous, the final weighted ensemble used only the models from the last layer. 
Thus, now AutoGluon by default mirrors the behavior of calling `TabularPredictor.fit_weighted_ensemble` after a fit.

This change can be manually controlled via `fit_full_last_level_weighted_ensemble` at `fit` or `fit_extra`.
Moreover, the PR adds the options to set `full_weighted_ensemble_additionally` at `fit` or `fit_extra`. If this and  `fit_full_last_level_weighted_ensemble` are set to True, then AutoGluon will fit two ensembles post hoc: one only for the models from the last level and one with all trained models. By default `full_weighted_ensemble_additionally` is False. 

### Code Example 
The following code compares using a full last layer post hoc ensemble vs. not using a full ensemble.

<details>
<summary>
Script
</summary>

```python
import numpy as np
import openml
import pandas as pd
from autogluon.tabular import TabularPredictor


def get_data(tid: int, fold: int):
    # Get Task and dataset from OpenML and return split data
    oml_task = openml.tasks.get_task(tid, download_splits=True, download_data=True, download_qualities=False, download_features_meta_data=False)

    train_ind, test_ind = oml_task.get_train_test_split_indices(fold)
    X, *_ = oml_task.get_dataset().get_data(dataset_format="dataframe")

    return (
        X.iloc[train_ind, :].reset_index(drop=True),
        X.iloc[test_ind, :].reset_index(drop=True),
        oml_task.target_name,
        oml_task.task_type != "Supervised Classification",
    )


def _print_lb(leaderboard, task_id):
    with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
        print(leaderboard[leaderboard["model"].str.endswith("L1")].sort_values(by="score_val", ascending=True))
        print(leaderboard[~leaderboard["model"].str.endswith("L1")].sort_values(by="score_val", ascending=False))


def _run(task_id, metric, fold=0, print_res=True, enable_test=False):
    train_data, test_data, label, regression = get_data(task_id, fold)
    n_max_cols = 100
    n_max_train_instances = 500
    n_max_test_instances = 200

    # Sub sample instances
    train_data = train_data.sample(n=min(len(train_data), n_max_train_instances), random_state=0).reset_index(drop=True)
    test_data = test_data.sample(n=min(len(test_data), n_max_test_instances), random_state=0).reset_index(drop=True)

    # Sub sample columns
    cols = list(train_data.columns)
    cols.remove(label)
    if len(cols) > n_max_cols:
        cols = list(np.random.RandomState(42).choice(cols, replace=False, size=n_max_cols))
    train_data = train_data[cols + [label]]
    test_data = test_data[cols + [label]]

    # Run AutoGluon
    print(f"### task {task_id} and fold {fold} and shape {(train_data.shape, test_data.shape)}.")
    predictor = TabularPredictor(eval_metric=metric, label=label, verbosity=0)
    predictor.fit(
        train_data=train_data,
        num_gpus=0,
        num_bag_sets=1,
        num_stack_levels=1,
        num_bag_folds=6,
        hyperparameters={
                "FASTAI": [{}],
                "NN_TORCH": [{}],
                "RF": [{}],
                "XT": [{}],
                "GBM": [{}],
        },
        fit_weighted_ensemble=True,
        fit_full_last_level_weighted_ensemble=enable_test,
        full_weighted_ensemble_additionally=True,
        presets="best_quality",
        # time_limit=60
    )
    leaderboard = predictor.leaderboard(test_data, silent=True)[["model", "score_test", "score_val"]].sort_values(by="model").reset_index(drop=True)

    if print_res:
        _print_lb(leaderboard, task_id)

    return leaderboard


if __name__ == "__main__":
    _run(359938, "mse", enable_test=True)
    _run(359938, "mse")

    _run(359955, "roc_auc", enable_test=True)
    _run(359955, "roc_auc")
    
    _run(146217, "log_loss", enable_test=True)
    _run(146217, "log_loss")
```

</details>

### Benchmark Results:
Only for folds from regression and multi-class because stacking is disabled for `best_quality` and binary. 

```bash
AutoGluon := preset=best_quality
AutoGluon-FLL :=  fit_full_last_level_weighted_ensemble=True, preset=best_quality
AutoGluon-FLLA  :=  fit_full_last_level_weighted_ensemble=True, full_weighted_ensemble_additionally=True, preset=best_quality

     framework   winrate    >    <    = sig (p-val)
 AutoGluon-FLL  0.512019  206  191  227   ns (0.59)
AutoGluon-FLLA  0.511182  206  192  228   ns (0.84)
     AutoGluon  0.500000    0    0  627           -

- z-score win rate 
Win 4 : AutoGluon
Win 7 : AutoGluon-FLLA 
Tie 48

Win 4 : AutoGluon
Win 8 : AutoGluon-FLL
Tie 45
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


