### PR TITLE
[timeseries] Update GluonTS to v0.14.0

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -28,7 +28,7 @@ DEPENDENT_PACKAGES = {
     "Pillow": ">=9.3,<9.6",  # "<{N+2}" upper cap
     "torch": ">=2.0,<2.1",  # "<{N+1}" upper cap, sync with common/src/autogluon/common/utils/try_import.py
     "lightning": ">=2.0.0,<2.1",  # "<{N+1}" upper cap
-    "pytorch_lightning": ">=2.0.0,<2.1",  # "<{N+1}" upper cap
+    "pytorch_lightning": ">=2.0.0,<2.1",  # "<{N+1}" upper cap, capping `lightning` does not cap `pytorch_lightning`!
 }
 if LITE_MODE:
     DEPENDENT_PACKAGES = {package: version for package, version in DEPENDENT_PACKAGES.items() if package not in ["psutil", "Pillow", "timm"]}

--- a/docs/tutorials/timeseries/forecasting-model-zoo.md
+++ b/docs/tutorials/timeseries/forecasting-model-zoo.md
@@ -58,6 +58,7 @@ Note that some of the models' hyperparameters have names and default values that
    PatchTSTModel
    SimpleFeedForwardModel
    TemporalFusionTransformerModel
+   WaveNetModel
    DirectTabularModel
    RecursiveTabularModel
 
@@ -167,6 +168,14 @@ Deep learning models use neural networks to capture complex patterns in the data
 
 ```
 
+
+```{eval-rst}
+.. autoclass:: WaveNetModel
+   :members: init
+
+
+```
+
 ## Tabular models
 
 Tabular models convert time series forecasting into a tabular regression problem.
@@ -227,4 +236,9 @@ Models not included in this table currently do not support any additional featur
      - ✓
      - ✓
      - ✓
+   * - :class:`~autogluon.timeseries.models.WaveNetModel`
+     - ✓
+     - ✓
+     - ✓
+     - 
 ```

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -29,7 +29,7 @@ install_requires = [
     "lightning",  # version range defined in `core/_setup_utils.py`
     "pytorch_lightning",  # version range defined in `core/_setup_utils.py`
     "statsmodels>=0.13.0,<0.15",
-    "gluonts==0.14.0rc2",
+    "gluonts>=0.14.0,<0.15",
     "networkx",  # version range defined in `core/_setup_utils.py`
     # TODO: update statsforecast to v1.5.0 - resolve antlr4-python3-runtime dependency clash with multimodal
     "statsforecast>=1.4.0,<1.5",

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -29,7 +29,7 @@ install_requires = [
     "lightning",  # version range defined in `core/_setup_utils.py`
     "pytorch_lightning",  # version range defined in `core/_setup_utils.py`
     "statsmodels>=0.13.0,<0.15",
-    "gluonts==0.14.0rc1",
+    "gluonts==0.14.0rc2",
     "networkx",  # version range defined in `core/_setup_utils.py`
     # TODO: update statsforecast to v1.5.0 - resolve antlr4-python3-runtime dependency clash with multimodal
     "statsforecast>=1.4.0,<1.5",

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -29,7 +29,7 @@ install_requires = [
     "lightning",  # version range defined in `core/_setup_utils.py`
     "pytorch_lightning",  # version range defined in `core/_setup_utils.py`
     "statsmodels>=0.13.0,<0.15",
-    "gluonts>=0.13.1,<0.14",
+    "gluonts==0.14.0rc1",
     "networkx",  # version range defined in `core/_setup_utils.py`
     # TODO: update statsforecast to v1.5.0 - resolve antlr4-python3-runtime dependency clash with multimodal
     "statsforecast>=1.4.0,<1.5",

--- a/timeseries/src/autogluon/timeseries/models/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/__init__.py
@@ -1,5 +1,5 @@
 from .autogluon_tabular import DirectTabularModel, RecursiveTabularModel
-from .gluonts import DeepARModel, DLinearModel, PatchTSTModel, SimpleFeedForwardModel, TemporalFusionTransformerModel
+from .gluonts import DeepARModel, DLinearModel, PatchTSTModel, SimpleFeedForwardModel, TemporalFusionTransformerModel, WaveNetModel
 from .local import (
     ARIMAModel,
     AutoARIMAModel,
@@ -33,4 +33,5 @@ __all__ = [
     "SimpleFeedForwardModel",
     "TemporalFusionTransformerModel",
     "ThetaModel",
+    "WaveNetModel",
 ]

--- a/timeseries/src/autogluon/timeseries/models/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/__init__.py
@@ -1,5 +1,12 @@
 from .autogluon_tabular import DirectTabularModel, RecursiveTabularModel
-from .gluonts import DeepARModel, DLinearModel, PatchTSTModel, SimpleFeedForwardModel, TemporalFusionTransformerModel, WaveNetModel
+from .gluonts import (
+    DeepARModel,
+    DLinearModel,
+    PatchTSTModel,
+    SimpleFeedForwardModel,
+    TemporalFusionTransformerModel,
+    WaveNetModel,
+)
 from .local import (
     ARIMAModel,
     AutoARIMAModel,

--- a/timeseries/src/autogluon/timeseries/models/gluonts/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/__init__.py
@@ -1,4 +1,11 @@
-from .torch.models import DeepARModel, DLinearModel, PatchTSTModel, SimpleFeedForwardModel, TemporalFusionTransformerModel, WaveNetModel
+from .torch.models import (
+    DeepARModel,
+    DLinearModel,
+    PatchTSTModel,
+    SimpleFeedForwardModel,
+    TemporalFusionTransformerModel,
+    WaveNetModel,
+)
 
 __all__ = [
     "DeepARModel",

--- a/timeseries/src/autogluon/timeseries/models/gluonts/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/__init__.py
@@ -1,4 +1,4 @@
-from .torch import DeepARModel, DLinearModel, PatchTSTModel, SimpleFeedForwardModel, TemporalFusionTransformerModel
+from .torch.models import DeepARModel, DLinearModel, PatchTSTModel, SimpleFeedForwardModel, TemporalFusionTransformerModel, WaveNetModel
 
 __all__ = [
     "DeepARModel",
@@ -6,4 +6,5 @@ __all__ = [
     "PatchTSTModel",
     "SimpleFeedForwardModel",
     "TemporalFusionTransformerModel",
+    "WaveNetModel",
 ]

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -403,6 +403,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
     ) -> List[Callable]:
         """Retrieve a list of callback objects for the GluonTS trainer"""
         from pytorch_lightning.callbacks import EarlyStopping, Timer
+        return []
 
         callbacks = []
         if time_limit is not None:

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -25,7 +25,7 @@ from autogluon.timeseries.utils.datetime import norm_freq_str
 from autogluon.timeseries.utils.forecast import get_forecast_horizon_index_ts_dataframe
 from autogluon.timeseries.utils.warning_filters import disable_root_logger, warning_filter
 
-# NOTE: We avoid imports for torch and pytorch_lightning at the top level and hide them inside class methods.
+# NOTE: We avoid imports for torch and lightning.pytorch at the top level and hide them inside class methods.
 # This is done to skip these imports during multiprocessing (which may cause bugs)
 
 logger = logging.getLogger(__name__)
@@ -176,6 +176,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         self.num_feat_dynamic_real = 0
         self.num_past_feat_dynamic_real = 0
         self.feat_static_cat_cardinality: List[int] = []
+        self.negative_data = True
 
     def save(self, path: str = None, verbose: bool = True) -> str:
         # we flush callbacks instance variable if it has been set. it can keep weak references which breaks training
@@ -232,6 +233,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
             disable_past_covariates = model_params.get("disable_past_covariates", False)
             if not disable_past_covariates and self.supports_past_covariates:
                 self.num_past_feat_dynamic_real = len(self.metadata.past_covariates_real)
+            self.negative_data = (ds[self.target] < 0).any()
 
         if "callbacks" in kwargs:
             self.callbacks += kwargs["callbacks"]
@@ -257,7 +259,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         )
         # Support MXNet kwarg names for backwards compatibility
         init_args.setdefault("lr", init_args.get("learning_rate", 1e-3))
-        init_args.setdefault("max_epochs", init_args.get("epochs"))
+        init_args.setdefault("max_epochs", init_args.get("epochs", 100))
         return init_args
 
     def _get_estimator_init_args(self) -> Dict[str, Any]:
@@ -355,11 +357,11 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         **kwargs,
     ) -> None:
         # necessary to initialize the loggers
-        import pytorch_lightning  # noqa
+        import lightning.pytorch  # noqa
 
         verbosity = kwargs.get("verbosity", 2)
         for logger_name in logging.root.manager.loggerDict:
-            if "pytorch_lightning" in logger_name:
+            if "lightning" in logger_name:
                 pl_logger = logging.getLogger(logger_name)
                 pl_logger.setLevel(logging.ERROR if verbosity <= 3 else logging.INFO)
         set_logger_verbosity(verbosity, logger=logger)
@@ -402,8 +404,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         early_stopping_patience: Optional[int] = None,
     ) -> List[Callable]:
         """Retrieve a list of callback objects for the GluonTS trainer"""
-        from pytorch_lightning.callbacks import EarlyStopping, Timer
-        return []
+        from lightning.pytorch.callbacks import EarlyStopping, Timer
 
         callbacks = []
         if time_limit is not None:

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -146,7 +146,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
 
     gluonts_model_path = "gluon_ts"
     # default number of samples for prediction
-    default_num_samples: int = 1000
+    default_num_samples: int = 250
     supports_known_covariates: bool = False
     supports_past_covariates: bool = False
 

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/__init__.py
@@ -1,9 +1,0 @@
-from .models import DeepARModel, DLinearModel, PatchTSTModel, SimpleFeedForwardModel, TemporalFusionTransformerModel
-
-__all__ = [
-    "DeepARModel",
-    "DLinearModel",
-    "PatchTSTModel",
-    "SimpleFeedForwardModel",
-    "TemporalFusionTransformerModel",
-]

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -395,4 +395,6 @@ class WaveNetModel(AbstractGluonTSModel):
         init_kwargs.setdefault("negative_data", self.negative_data)
         init_kwargs.setdefault("seasonality", get_seasonality(self.freq))
         init_kwargs.setdefault("time_features", get_time_features_for_frequency(self.freq))
+        # WaveNet model fails if an unsupported frequency such as "SM" is provided. We provide a dummy freq instead
+        init_kwargs["freq"] = "H"
         return init_kwargs

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -390,9 +390,7 @@ class WaveNetModel(AbstractGluonTSModel):
         init_kwargs = super()._get_estimator_init_args()
         init_kwargs["num_feat_static_cat"] = self.num_feat_static_cat
         init_kwargs["num_feat_static_real"] = self.num_feat_static_real
-        init_kwargs["cardinality"] = (
-            [1] if len(self.feat_static_cat_cardinality) == 0 else self.feat_static_cat_cardinality
-        )
+        init_kwargs["cardinality"] = [1] if self.num_feat_static_cat == 0 else self.feat_static_cat_cardinality
         init_kwargs["num_feat_dynamic_real"] = self.num_feat_dynamic_real
         init_kwargs.setdefault("negative_data", self.negative_data)
         init_kwargs.setdefault("seasonality", get_seasonality(self.freq))

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -80,7 +80,6 @@ class DeepARModel(AbstractGluonTSModel):
         Early stop training if the validation loss doesn't improve for this many epochs.
     """
 
-    default_num_samples: int = 250
     supports_known_covariates = True
 
     def _get_estimator_class(self) -> Type[GluonTSEstimator]:
@@ -380,7 +379,6 @@ class WaveNetModel(AbstractGluonTSModel):
         Weight decay regularization parameter.
     """
 
-    default_num_samples: int = 250
     supports_known_covariates = True
 
     def _get_estimator_class(self) -> Type[GluonTSEstimator]:

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -13,7 +13,7 @@ from autogluon.timeseries.utils.datetime import (
     get_seasonality,
 )
 
-# NOTE: We avoid imports for torch and pytorch_lightning at the top level and hide them inside class methods.
+# NOTE: We avoid imports for torch and lightning.pytorch at the top level and hide them inside class methods.
 # This is done to skip these imports during multiprocessing (which may cause bugs)
 
 # FIXME: introduces cpflows dependency. We exclude this model until a future release.
@@ -64,7 +64,7 @@ class DeepARModel(AbstractGluonTSModel):
         Distribution to use to evaluate observations and sample predictions
     scaling: bool, default = True
         Whether to automatically scale the target values
-    epochs : int, default = 100
+    max_epochs : int, default = 100
         Number of epochs the model will be trained for
     batch_size : int, default = 64
         Size of batches used during training
@@ -72,7 +72,7 @@ class DeepARModel(AbstractGluonTSModel):
         Size of batches used during prediction.
     num_batches_per_epoch : int, default = 50
         Number of batches processed every epoch
-    learning_rate : float, default = 1e-3,
+    lr : float, default = 1e-3,
         Learning rate used during training
     trainer_kwargs : dict, optional
         Optional keyword arguments passed to ``lightning.Trainer``.
@@ -118,7 +118,7 @@ class SimpleFeedForwardModel(AbstractGluonTSModel):
         Whether to use batch normalization
     mean_scaling : bool, default = True
         Scale the network input by the data mean and the network output by its inverse
-    epochs : int, default = 100
+    max_epochs : int, default = 100
         Number of epochs the model will be trained for
     batch_size : int, default = 64
         Size of batches used during training
@@ -126,7 +126,7 @@ class SimpleFeedForwardModel(AbstractGluonTSModel):
         Size of batches used during prediction.
     num_batches_per_epoch : int, default = 50
         Number of batches processed every epoch
-    learning_rate : float, default = 1e-3,
+    lr : float, default = 1e-3,
         Learning rate used during training
     trainer_kwargs : dict, optional
         Optional keyword arguments passed to ``lightning.Trainer``.
@@ -175,7 +175,7 @@ class TemporalFusionTransformerModel(AbstractGluonTSModel):
         Number of attention heads in self-attention layer in the decoder.
     dropout_rate : float, default = 0.1
         Dropout regularization parameter
-    epochs : int, default = 100
+    max_epochs : int, default = 100
         Number of epochs the model will be trained for
     batch_size : int, default = 64
         Size of batches used during training
@@ -183,7 +183,7 @@ class TemporalFusionTransformerModel(AbstractGluonTSModel):
         Size of batches used during prediction.
     num_batches_per_epoch : int, default = 50
         Number of batches processed every epoch
-    learning_rate : float, default = 1e-3,
+    lr : float, default = 1e-3,
         Learning rate used during training
     trainer_kwargs : dict, optional
         Optional keyword arguments passed to ``lightning.Trainer``.
@@ -239,7 +239,7 @@ class DLinearModel(AbstractGluonTSModel):
         Distribution to fit.
     scaling : {"mean", "std", None}, default = "mean"
         Scaling applied to the inputs. One of ``"mean"`` (mean absolute scaling), ``"std"`` (standardization), ``None`` (no scaling).
-    epochs : int, default = 100
+    max_epochs : int, default = 100
         Number of epochs the model will be trained for
     batch_size : int, default = 64
         Size of batches used during training
@@ -247,7 +247,7 @@ class DLinearModel(AbstractGluonTSModel):
         Size of batches used during prediction.
     num_batches_per_epoch : int, default = 50
         Number of batches processed every epoch
-    learning_rate : float, default = 1e-3,
+    lr : float, default = 1e-3,
         Learning rate used during training
     trainer_kwargs : dict, optional
         Optional keyword arguments passed to ``lightning.Trainer``.
@@ -297,13 +297,13 @@ class PatchTSTModel(AbstractGluonTSModel):
         Distribution to fit.
     scaling : {"mean", "std", None}, default = "mean"
         Scaling applied to the inputs. One of ``"mean"`` (mean absolute scaling), ``"std"`` (standardization), ``None`` (no scaling).
-    epochs : int, default = 100
+    max_epochs : int, default = 100
         Number of epochs the model will be trained for
     batch_size : int, default = 64
         Size of batches used during training
     num_batches_per_epoch : int, default = 50
         Number of batches processed every epoch
-    learning_rate : float, default = 1e-3,
+    lr : float, default = 1e-3,
         Learning rate used during training
     weight_decay : float, default = 1e-8
         Weight decay regularization parameter.
@@ -327,7 +327,8 @@ class PatchTSTModel(AbstractGluonTSModel):
 class WaveNetModel(AbstractGluonTSModel):
     """WaveNet estimator that uses the architecture proposed in [Oord2016] with quantized targets.
 
-    The model is trained using the cross-entropy loss.
+    The model is based on a CNN architecture with dilated convolutions. Time series values are quantized into buckets
+    and the model is trained using the cross-entropy loss.
 
     Based on `gluonts.torch.model.wavenet.WaveNetEstimator <https://ts.gluon.ai/stable/api/gluonts/gluonts.torch.model.wavenet.html>`_.
     See GluonTS documentation for additional hyperparameters.
@@ -340,15 +341,28 @@ class WaveNetModel(AbstractGluonTSModel):
 
     Other Parameters
     ----------------
-    context_length : int, default = 96
-        Number of time units that condition the predictions
-    hidden_dimension: int, default = 20
-        Size of hidden layers in the feedforward network
-    distr_output : gluonts.torch.distributions.DistributionOutput, default = StudentTOutput()
-        Distribution to fit.
-    scaling : {"mean", "std", None}, default = "mean"
-        Scaling applied to the inputs. One of ``"mean"`` (mean absolute scaling), ``"std"`` (standardization), ``None`` (no scaling).
-    epochs : int, default = 100
+    num_bins : int, default = 1024
+        Number of bins used for quantization of the time series.
+    num_residual_channels : int, default = 24
+        Number of residual channels in WaveNet architecture.
+    num_skip_channels : int, default = 32
+        Number of skip channels in WaveNet architecture, by default 32
+    dilation_depth : int or None, default = None
+        Number of dilation layers in WaveNet architecture. If set to None (default), dilation_depth is set such that 
+        the receptive length is at least as long as the ``seasonality`` and at least ``2 * prediction_length``.
+    num_stacks : int, default = 1
+        Number of dilation stacks in WaveNet architecture.
+    temperature : float, default = 1.0
+        Temperature used for sampling from softmax distribution.
+    seasonality : int, optional
+        The seasonality of the time series. By default is set based on the ``freq`` of the data.
+    embedding_dimension : int, default = 5
+        The dimension of the embeddings for categorical features.
+    use_log_scale_feature : bool, default = True
+        If True, logarithm of the scale of the past data will be used as an additional static feature.
+    negative_data : bool, default = True
+        Flag indicating whether the time series take negative values.
+    max_epochs : int, default = 100
         Number of epochs the model will be trained for
     batch_size : int, default = 64
         Size of batches used during training
@@ -356,7 +370,7 @@ class WaveNetModel(AbstractGluonTSModel):
         Size of batches used during prediction.
     num_batches_per_epoch : int, default = 50
         Number of batches processed every epoch
-    learning_rate : float, default = 1e-3,
+    lr : float, default = 1e-3,
         Learning rate used during training
     trainer_kwargs : dict, optional
         Optional keyword arguments passed to ``lightning.Trainer``.
@@ -365,6 +379,9 @@ class WaveNetModel(AbstractGluonTSModel):
     weight_decay : float, default = 1e-8
         Weight decay regularization parameter.
     """
+
+    default_num_samples: int = 250
+    supports_known_covariates = True
 
     def _get_estimator_class(self) -> Type[GluonTSEstimator]:
         from gluonts.torch.model.wavenet import WaveNetEstimator
@@ -379,6 +396,7 @@ class WaveNetModel(AbstractGluonTSModel):
             [1] if len(self.feat_static_cat_cardinality) == 0 else self.feat_static_cat_cardinality
         )
         init_kwargs["num_feat_dynamic_real"] = self.num_feat_dynamic_real
+        init_kwargs.setdefault("negative_data", self.negative_data)
         init_kwargs.setdefault("seasonality", get_seasonality(self.freq))
         init_kwargs.setdefault("time_features", get_time_features_for_frequency(self.freq))
         return init_kwargs

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -9,8 +9,8 @@ from gluonts.model.estimator import Estimator as GluonTSEstimator
 from autogluon.timeseries.models.gluonts.abstract_gluonts import AbstractGluonTSModel
 from autogluon.timeseries.utils.datetime import (
     get_lags_for_frequency,
-    get_time_features_for_frequency,
     get_seasonality,
+    get_time_features_for_frequency,
 )
 
 # NOTE: We avoid imports for torch and lightning.pytorch at the top level and hide them inside class methods.
@@ -348,7 +348,7 @@ class WaveNetModel(AbstractGluonTSModel):
     num_skip_channels : int, default = 32
         Number of skip channels in WaveNet architecture, by default 32
     dilation_depth : int or None, default = None
-        Number of dilation layers in WaveNet architecture. If set to None (default), dilation_depth is set such that 
+        Number of dilation layers in WaveNet architecture. If set to None (default), dilation_depth is set such that
         the receptive length is at least as long as the ``seasonality`` and at least ``2 * prediction_length``.
     num_stacks : int, default = 1
         Number of dilation stacks in WaveNet architecture.

--- a/timeseries/src/autogluon/timeseries/models/local/npts.py
+++ b/timeseries/src/autogluon/timeseries/models/local/npts.py
@@ -79,7 +79,6 @@ class NPTSModel(AbstractLocalModel):
         dummy_freq = "S"
         ts.index = ts.index.to_period(freq=dummy_freq)
         predictor = NPTSPredictor(
-            freq=dummy_freq,
             prediction_length=self.prediction_length,
             use_default_time_features=False,
             **local_model_args,

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -26,6 +26,7 @@ from . import (
     SimpleFeedForwardModel,
     TemporalFusionTransformerModel,
     ThetaModel,
+    WaveNetModel,
 )
 from .abstract import AbstractTimeSeriesModel
 from .multi_window.multi_window_model import MultiWindowBacktestingModel
@@ -44,6 +45,7 @@ MODEL_TYPES = dict(
     DLinear=DLinearModel,
     PatchTST=PatchTSTModel,
     TemporalFusionTransformer=TemporalFusionTransformerModel,
+    WaveNet=WaveNetModel,
     RecursiveTabular=RecursiveTabularModel,
     DirectTabular=DirectTabularModel,
     Average=AverageModel,

--- a/timeseries/tests/smoketests/test_all_models.py
+++ b/timeseries/tests/smoketests/test_all_models.py
@@ -71,6 +71,7 @@ ALL_MODELS = {
     "SimpleFeedForward": DUMMY_MODEL_HPARAMS,
     "TemporalFusionTransformer": DUMMY_MODEL_HPARAMS,
     "Theta": DUMMY_MODEL_HPARAMS,
+    "WaveNet": DUMMY_MODEL_HPARAMS,
     # Override default hyperparameters for faster training
     "AutoARIMA": {"max_p": 2, "use_fallback_model": False},
 }

--- a/timeseries/tests/unittests/models/test_gluonts.py
+++ b/timeseries/tests/unittests/models/test_gluonts.py
@@ -10,13 +10,14 @@ from autogluon.timeseries.models.gluonts import (
     PatchTSTModel,
     SimpleFeedForwardModel,
     TemporalFusionTransformerModel,
+    WaveNetModel,
 )
 from autogluon.timeseries.utils.features import TimeSeriesFeatureGenerator
 
 from ..common import DATAFRAME_WITH_COVARIATES, DATAFRAME_WITH_STATIC, DUMMY_TS_DATAFRAME
 
-MODELS_WITH_STATIC_FEATURES = [DeepARModel, TemporalFusionTransformerModel]
-MODELS_WITH_KNOWN_COVARIATES = [DeepARModel, TemporalFusionTransformerModel]
+MODELS_WITH_STATIC_FEATURES = [DeepARModel, TemporalFusionTransformerModel, WaveNetModel]
+MODELS_WITH_KNOWN_COVARIATES = [DeepARModel, TemporalFusionTransformerModel, WaveNetModel]
 MODELS_WITH_STATIC_FEATURES_AND_KNOWN_COVARIATES = [
     m for m in MODELS_WITH_STATIC_FEATURES if m in MODELS_WITH_KNOWN_COVARIATES
 ]
@@ -26,6 +27,7 @@ TESTABLE_MODELS = [
     PatchTSTModel,
     SimpleFeedForwardModel,
     TemporalFusionTransformerModel,
+    WaveNetModel,
 ]
 
 
@@ -254,7 +256,7 @@ def test_given_custom_predict_batch_size_then_predictor_uses_correct_batch_size(
 
 
 def catch_trainer_kwargs(model):
-    with mock.patch("pytorch_lightning.Trainer") as mock_trainer:
+    with mock.patch("lightning.pytorch.Trainer") as mock_trainer:
         try:
             model.fit(train_data=DUMMY_TS_DATAFRAME, val_data=DUMMY_TS_DATAFRAME)
         except IsADirectoryError:
@@ -264,7 +266,7 @@ def catch_trainer_kwargs(model):
 
 
 def test_when_custom_callbacks_passed_via_trainer_kwargs_then_trainer_receives_them():
-    from pytorch_lightning.callbacks import RichModelSummary
+    from lightning.pytorch.callbacks import RichModelSummary
 
     callback = RichModelSummary()
     model = DLinearModel(hyperparameters={"trainer_kwargs": {"callbacks": [callback]}, **DUMMY_HYPERPARAMETERS})
@@ -273,7 +275,7 @@ def test_when_custom_callbacks_passed_via_trainer_kwargs_then_trainer_receives_t
 
 
 def test_when_early_stopping_patience_provided_then_early_stopping_callback_created():
-    from pytorch_lightning.callbacks import EarlyStopping
+    from lightning.pytorch.callbacks import EarlyStopping
 
     patience = 7
     model = SimpleFeedForwardModel(hyperparameters={"early_stopping_patience": patience, **DUMMY_HYPERPARAMETERS})
@@ -284,7 +286,7 @@ def test_when_early_stopping_patience_provided_then_early_stopping_callback_crea
 
 
 def test_when_early_stopping_patience_is_none_then_early_stopping_callback_not_created():
-    from pytorch_lightning.callbacks import EarlyStopping
+    from lightning.pytorch.callbacks import EarlyStopping
 
     model = SimpleFeedForwardModel(hyperparameters={"early_stopping_patience": None, **DUMMY_HYPERPARAMETERS})
     received_trainer_kwargs = catch_trainer_kwargs(model)

--- a/timeseries/tests/unittests/models/test_local.py
+++ b/timeseries/tests/unittests/models/test_local.py
@@ -252,7 +252,7 @@ def test_when_npts_fit_with_default_seasonal_features_then_predictions_match_glu
         prediction_length=prediction_length,
         hyperparameters={"n_jobs": 1, "use_fallback_model": False},
     )
-    npts_gts = NPTSPredictor(freq=freq, prediction_length=prediction_length)
+    npts_gts = NPTSPredictor(prediction_length=prediction_length)
     npts_ag.fit(train_data=data)
 
     np.random.seed(123)


### PR DESCRIPTION
*Description of changes:*
- Bump GluonTS to v0.14.0.
- Change all `pytorch_lightning` references to `lightning.pytorch`.
- Add wrapper for the `WaveNet` model.
- Rename old MXNet argument names `learning_rate` / `epochs` to `lr` / `max_epochs` for compatibility with PyTorch-Lightning naming (both versions are still supported, only docstrings are updated).

------
**To Do:**
- [x] Change dependency in `setup.py`  to `gluonts~=0.14.0`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
