### PR TITLE
Avoid Memory Leak by Using a Sequential Version of ParallelFoldFittingStrategy instead of SequentialLocalFoldFittingStrategy If Not Enough Memory to Fit Models in Parallel

### DIFF
--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -666,8 +666,8 @@ class BaggedEnsembleModel(AbstractModel):
         fold_fitting_strategy: FoldFittingStrategy = fold_fitting_strategy_cls(**fold_fitting_strategy_args)
 
         if type(fold_fitting_strategy) == ParallelLocalFoldFittingStrategy and not fold_fitting_strategy.is_mem_sufficient():
-            # If memory is not sufficient, fall back to sequential fold strategy
-            fold_fitting_strategy: FoldFittingStrategy = SequentialLocalFoldFittingStrategy(**fold_fitting_strategy_args)
+            fold_fitting_strategy_args["num_folds_parallel"] = 1
+            fold_fitting_strategy: FoldFittingStrategy = fold_fitting_strategy_cls(**fold_fitting_strategy_args)
             logger.log(
                 30,
                 f"\tMemory not enough to fit {model_base.__class__.__name__} folds in parallel. Will do sequential fitting instead. "

--- a/tabular/tests/unittests/edgecases/test_edgecases.py
+++ b/tabular/tests/unittests/edgecases/test_edgecases.py
@@ -189,7 +189,7 @@ def test_use_bag_holdout_calibrate(fit_helper):
 
 
 def test_num_folds_parallel(fit_helper, capsys):
-    """Tests that num_folds works"""
+    """Tests that num_folds_parallel equal to 1 works"""
     fit_args = dict(hyperparameters={"DUMMY": {}}, fit_weighted_ensemble=False, num_bag_folds=2, num_bag_sets=1, ag_args_ensemble=dict(num_folds_parallel=1))
     dataset_name = "adult"
 

--- a/tabular/tests/unittests/edgecases/test_edgecases.py
+++ b/tabular/tests/unittests/edgecases/test_edgecases.py
@@ -186,3 +186,20 @@ def test_use_bag_holdout_calibrate(fit_helper):
         expected_model_count=2,
         refit_full=False,
     )
+
+
+def test_num_folds_parallel(fit_helper, capsys):
+    """Tests that num_folds works"""
+    fit_args = dict(hyperparameters={"DUMMY": {}}, fit_weighted_ensemble=False, num_bag_folds=2, num_bag_sets=1, ag_args_ensemble=dict(num_folds_parallel=1))
+    dataset_name = "adult"
+
+    predictor = fit_helper.fit_and_validate_dataset(
+        dataset_name=dataset_name,
+        fit_args=fit_args,
+        expected_model_count=1,
+        refit_full=False,
+        delete_directory=False,
+    )
+    leaderboard = predictor.leaderboard(extra_info=True)
+    assert leaderboard.iloc[0]["num_models"] == 2
+    shutil.rmtree(predictor.path, ignore_errors=True)


### PR DESCRIPTION
### Problem that is to be solved:
By default, AutoGluon uses the ParallelFoldFittingStrategy. In edge cases where AutoGluon detects that there is not enough memory to fit folds in parallel, AutoGluon switches to SequentialLocalFoldFittingStrategy instead.

While this is the most time efficient alternative, I observed that this leads to memory leaks after training models; reducing the already too small memory even further in the above-mentioned edge case. Consequently, certain models won’t be fit and the available memory is reduced for the rest of the run of AutoGluon.

The reasons that this happens is that Python's garbage collector works in mysterious and unreliable ways. In this case, it also makes no difference to manually delete objects from memory, use sub-functions, or calling the garbage collector explicitly. The only reliable solution I found so far that avoids memory leakage, is to execute memory-consuming code in a subprocess such that when leaving the subprocess no trace of unwanted memory remains.  

Luckily, AutoGluon already has a functionality to fit all models in a subprocess via ray - as it is done in the ParallelFoldFittingStrategy. I.e., usually, we do not have to worry about memory leakage but once we switch to SequentialLocalFoldFittingStrategy, we do need to worry. 

Thus, I propose to adjust ParallelFoldFittingStrategy instead of switching to SequentialLocalFoldFittingStrategy in the edge cases where there is not enough memory to fit folds in parallel. In essence, we adjust ParallelFoldFittingStrategy such that it only fits one fold at most in a sequential manner, see the code for more details. 

One downside of this PR is that ParallelFoldFittingStrategy introduces a time overhead that makes it less efficient than SequentialLocalFoldFittingStrategy. But considering that we have a serious memory and not a time problem in the above-mentioned edge case, this should be a tolerable trade-off. One additional downside would be debugging, as it becomes harder for the user to debug the edge-case. As the log messages explains, the user can still overrule the behavior in the edge case by passing setting SequentialLocalFoldFittingStrategy to be run for the model in question.  

### Description of changes:

Adjust the reaction to not having enough memory in `bagged_ensemble_model.py` and adjust `fold_fitting_strategy.py` to support a sequential version of ParallelFoldFittingStrategy in a memory-optimal way. 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
