### PR TITLE
Support Dynamic Stacking to Avoid Stacked Overfitting

### DIFF
--- a/core/src/autogluon/core/learner/abstract_learner.py
+++ b/core/src/autogluon/core/learner/abstract_learner.py
@@ -23,7 +23,7 @@ class AbstractLearner:
     def __init__(self, path_context: str, random_state: int = 0, **kwargs):
         self.path, self.model_context, self.save_path = self.create_contexts(path_context)
 
-        self.org_path_context = path_context
+        self.path_context_og: str = path_context  # Saves path_context used to create the original context of the learner to enable sub-fits.
         self.is_trainer_present: bool = False
         self.trainer: Optional[AbstractTrainer] = None
         self.trainer_type: Optional[Type] = None

--- a/core/src/autogluon/core/learner/abstract_learner.py
+++ b/core/src/autogluon/core/learner/abstract_learner.py
@@ -23,6 +23,7 @@ class AbstractLearner:
     def __init__(self, path_context: str, random_state: int = 0, **kwargs):
         self.path, self.model_context, self.save_path = self.create_contexts(path_context)
 
+        self.org_path_context = path_context
         self.is_trainer_present: bool = False
         self.trainer: Optional[AbstractTrainer] = None
         self.trainer_type: Optional[Type] = None

--- a/core/src/autogluon/core/stacked_overfitting/utils.py
+++ b/core/src/autogluon/core/stacked_overfitting/utils.py
@@ -6,51 +6,52 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 
-def get_non_leaking_and_leaking_model_names(leaderboard: pd.DataFrame) -> Tuple[List[str], List[str]]:
-    non_leaking = []
-    leaking = []
+def get_affected_stacked_overfitting_model_names(leaderboard: pd.DataFrame) -> Tuple[List[str], List[str]]:
+    non_affected = []
+    affected = []
     for model_name in set(leaderboard["model"]):
         # TODO: move away from using names to metadata properties (somehow).
-        if model_name.startswith("WeightedEnsemble") and model_name.endswith("L2"):
-            non_leaking.append(model_name)
+        #   - include something like linear models once we are sure that they cannot leak
+        if (model_name.startswith("WeightedEnsemble") and model_name.endswith("L2")) or model_name.endswith("L1"):
+            non_affected.append(model_name)
         else:
-            leaking.append(model_name)
+            affected.append(model_name)
 
-    return non_leaking, leaking
+    return non_affected, affected
 
 
 def get_best_val_models(leaderboard: pd.DataFrame) -> Tuple[List[str], List[str], bool]:
-    non_leaking_names, leaking_names = get_non_leaking_and_leaking_model_names(leaderboard)
+    non_affected, affected = get_affected_stacked_overfitting_model_names(leaderboard)
 
-    best_non_leaking_model = leaderboard[leaderboard["model"].isin(non_leaking_names)].sort_values(by="score_val", ascending=False).iloc[0].loc["model"]
+    best_non_affected_model = leaderboard[leaderboard["model"].isin(non_affected)].sort_values(by="score_val", ascending=False).iloc[0].loc["model"]
 
-    leaking_models_exist = len(leaking_names) > 0
-    best_leaking_model = None
-    if leaking_models_exist:
-        best_leaking_model = leaderboard[leaderboard["model"].isin(leaking_names)].sort_values(by="score_val", ascending=False).iloc[0].loc["model"]
+    affected_models_exist = len(affected) > 0
+    best_affected_model = None
+    if affected_models_exist:
+        best_affected_model = leaderboard[leaderboard["model"].isin(affected)].sort_values(by="score_val", ascending=False).iloc[0].loc["model"]
 
-    return best_non_leaking_model, best_leaking_model, leaking_models_exist
+    return best_non_affected_model, best_affected_model, affected_models_exist
 
 
-def _check_stacked_overfitting_for_models(best_non_leaking_model: List[str], best_leaking_model: List[str], leaderboard: pd.DataFrame) -> bool:
-    score_non_leaking_oof = leaderboard.loc[leaderboard["model"] == best_non_leaking_model, "score_val"].iloc[0]
-    score_non_leaking_test = leaderboard.loc[leaderboard["model"] == best_non_leaking_model, "score_test"].iloc[0]
+def _check_stacked_overfitting_for_models(best_non_affected_model: List[str], best_affected_model: List[str], leaderboard: pd.DataFrame) -> bool:
+    score_non_affected_val = leaderboard.loc[leaderboard["model"] == best_non_affected_model, "score_val"].iloc[0]
+    score_non_affected_test = leaderboard.loc[leaderboard["model"] == best_non_affected_model, "score_test"].iloc[0]
 
-    score_leaking_oof = leaderboard.loc[leaderboard["model"] == best_leaking_model, "score_val"].iloc[0]
-    score_leaking_test = leaderboard.loc[leaderboard["model"] == best_leaking_model, "score_test"].iloc[0]
+    score_affected_val = leaderboard.loc[leaderboard["model"] == best_affected_model, "score_val"].iloc[0]
+    score_affected_test = leaderboard.loc[leaderboard["model"] == best_affected_model, "score_test"].iloc[0]
 
     # l1 worse val score than l2+
-    stacked_overfitting = score_non_leaking_oof < score_leaking_oof
+    stacked_overfitting = score_non_affected_val < score_affected_val
     # l2+ worse test score than L1
-    stacked_overfitting = stacked_overfitting and (score_non_leaking_test >= score_leaking_test)
+    stacked_overfitting = stacked_overfitting and (score_non_affected_test >= score_affected_test)
 
     return stacked_overfitting
 
 
 def check_stacked_overfitting_from_leaderboard(leaderboard: pd.DataFrame) -> bool:
-    best_non_leaking_model, best_leaking_model, leaking_models_exist = get_best_val_models(leaderboard)
+    best_non_affected_model, best_affected_model, affected_models_exist = get_best_val_models(leaderboard)
 
-    if not leaking_models_exist:
+    if not affected_models_exist:
         return False
 
-    return _check_stacked_overfitting_for_models(best_non_leaking_model, best_leaking_model, leaderboard)
+    return _check_stacked_overfitting_for_models(best_non_affected_model, best_affected_model, leaderboard)

--- a/core/src/autogluon/core/stacked_overfitting/utils.py
+++ b/core/src/autogluon/core/stacked_overfitting/utils.py
@@ -7,6 +7,22 @@ logger = logging.getLogger(__name__)
 
 
 def get_affected_stacked_overfitting_model_names(leaderboard: pd.DataFrame) -> Tuple[List[str], List[str]]:
+    """
+    Given a leaderboard from `predictor.leaderboard(test_data)`, return the names of all models that are affected by stacked overfitting and the names of all
+    models that are not affected.
+
+    Parameters
+    ----------
+    leaderboard : pd.DataFrame
+        A leaderboard produced by `predictor.leaderboard(test_data)`.
+        The leaderboard needs to contain `model` as column.
+
+    Returns
+    -------
+    non_affected, List of str, names of all non-affected models in the leaderboard.
+    affected, List of str, names of all affected models in the leaderboard.
+    """
+
     non_affected = []
     affected = []
     for model_name in set(leaderboard["model"]):
@@ -20,8 +36,24 @@ def get_affected_stacked_overfitting_model_names(leaderboard: pd.DataFrame) -> T
     return non_affected, affected
 
 
-def get_best_val_models(leaderboard: pd.DataFrame) -> Tuple[List[str], List[str], bool]:
-    non_affected, affected = get_affected_stacked_overfitting_model_names(leaderboard)
+def get_best_val_models(leaderboard: pd.DataFrame) -> Tuple[str, str, bool]:
+    """
+    Given a leaderboard from `predictor.leaderboard(test_data)`, determine the best model based on validation score that is affected by stacked overfitting,
+    the best model that is not affected, and whether any affected models exist at all.
+
+    Parameters
+    ----------
+    leaderboard : pd.DataFrame
+        A leaderboard produced by `predictor.leaderboard(test_data)`.
+        The leaderboard needs to contain `score_val` and `model` as columns.
+
+    Returns
+    -------
+    best_non_affected_model, str, name of the best model that is not affected.
+    best_affected_model, str, name of the best model that is affected.
+    affected_models_exist, bool, that specifics whether any affected models exist in the given leaderboard.
+    """
+    non_affected, affected = get_affected_stacked_overfitting_model_names(leaderboard=leaderboard)
 
     best_non_affected_model = leaderboard[leaderboard["model"].isin(non_affected)].sort_values(by="score_val", ascending=False).iloc[0].loc["model"]
 
@@ -33,7 +65,27 @@ def get_best_val_models(leaderboard: pd.DataFrame) -> Tuple[List[str], List[str]
     return best_non_affected_model, best_affected_model, affected_models_exist
 
 
-def _check_stacked_overfitting_for_models(best_non_affected_model: List[str], best_affected_model: List[str], leaderboard: pd.DataFrame) -> bool:
+def _check_stacked_overfitting_for_models(best_non_affected_model: str, best_affected_model: str, leaderboard: pd.DataFrame) -> bool:
+    """
+    Determine whether stacked overfitting occurred for the given two models and a leaderboard containing their scores.
+
+    Stacked overfitting occurred, if the validation score of the `best_non_affected_model` is lower than the validation score of the `best_affected_model`
+    while the test score of the `best_affected_model` is lower or equal to the test score of `best_non_affected_model`.
+
+    Parameters
+    ----------
+    best_non_affected_model : str
+        Name of the best model, based on validation score, that is not affected by stacked overfitting in principle.
+    best_affected_model : str
+        Name of the best model, based on validation score, that is affected by stacked overfitting in principle.
+    leaderboard : pd.DataFrame
+        A leaderboard produced by `predictor.leaderboard(test_data)`.
+        The leaderboard needs to contain `score_val` and `model` as columns.
+
+    Returns
+    -------
+    Bool that is True if stacked overfitting occurred, otherwise False.
+    """
     score_non_affected_val = leaderboard.loc[leaderboard["model"] == best_non_affected_model, "score_val"].iloc[0]
     score_non_affected_test = leaderboard.loc[leaderboard["model"] == best_non_affected_model, "score_test"].iloc[0]
 
@@ -49,9 +101,26 @@ def _check_stacked_overfitting_for_models(best_non_affected_model: List[str], be
 
 
 def check_stacked_overfitting_from_leaderboard(leaderboard: pd.DataFrame) -> bool:
-    best_non_affected_model, best_affected_model, affected_models_exist = get_best_val_models(leaderboard)
+    """
+    Determine if stacked overfitting occurred given a leaderboard from `predictor.leaderboard(test_data)`.
+
+    Returns False if there is no model that could have been affected by stacked overfitting in the leaderboard (e.g., no L2 model exists).
+
+    Parameters
+    ----------
+    leaderboard : pd.DataFrame
+        A leaderboard produced by `predictor.leaderboard(test_data)`.
+        The leaderboard needs to contain `score_val`, `score_test`, and `model` as columns.
+
+    Returns
+    -------
+    Bool that is True if stacked overfitting occurred, otherwise False.
+    """
+    best_non_affected_model, best_affected_model, affected_models_exist = get_best_val_models(leaderboard=leaderboard)
 
     if not affected_models_exist:
         return False
 
-    return _check_stacked_overfitting_for_models(best_non_affected_model, best_affected_model, leaderboard)
+    return _check_stacked_overfitting_for_models(
+        best_non_affected_model=best_non_affected_model, best_affected_model=best_affected_model, leaderboard=leaderboard
+    )

--- a/core/src/autogluon/core/stacked_overfitting/utils.py
+++ b/core/src/autogluon/core/stacked_overfitting/utils.py
@@ -1,0 +1,59 @@
+import pandas as pd
+import logging
+from typing import Tuple, List
+
+logger = logging.getLogger(__name__)
+
+
+def get_non_leaking_and_leaking_model_names(leaderboard: pd.DataFrame) -> Tuple[List[str], List[str], bool]:
+    # TODO: move away from names.
+    NON_LEAKING_MODEL_NAMES_IN_AUTOGLUON = ["WeightedEnsemble_L2", "WeightedEnsemble_BAG_L2", "WeightedEnsemble_ALL_L2", "WeightedEnsemble_FULL_L2"]
+
+    non_leaking = []
+    leaking = []
+    for model_name in set(leaderboard["model"]):
+
+        if (model_name in NON_LEAKING_MODEL_NAMES_IN_AUTOGLUON) or model_name.endswith("L1"):
+            non_leaking.append(model_name)
+        else:
+            leaking.append(model_name)
+
+    leaking_models_exist = len(leaking) > 0
+
+    return non_leaking, leaking, leaking_models_exist
+
+
+def get_best_val_models(leaderboard: pd.DataFrame) -> Tuple[List[str], List[str], bool]:
+    non_leaking_names, leaking_names, leaking_models_exist = get_non_leaking_and_leaking_model_names(leaderboard)
+
+    best_non_leaking_model = leaderboard[leaderboard["model"].isin(non_leaking_names)].sort_values(by="score_val", ascending=False).iloc[0].loc["model"]
+
+    best_leaking_model = None
+    if leaking_names:
+        best_leaking_model = leaderboard[leaderboard["model"].isin(leaking_names)].sort_values(by="score_val", ascending=False).iloc[0].loc["model"]
+
+    return best_non_leaking_model, best_leaking_model, leaking_models_exist
+
+
+def _check_so_for_models(best_non_leaking_model: List[str], best_leaking_model: List[str], leaderboard: pd.DataFrame) -> bool:
+    score_non_leaking_oof = leaderboard.loc[leaderboard["model"] == best_non_leaking_model, "score_val"].iloc[0]
+    score_non_leaking_test = leaderboard.loc[leaderboard["model"] == best_non_leaking_model, "score_test"].iloc[0]
+
+    score_leaking_oof = leaderboard.loc[leaderboard["model"] == best_leaking_model, "score_val"].iloc[0]
+    score_leaking_test = leaderboard.loc[leaderboard["model"] == best_leaking_model, "score_test"].iloc[0]
+
+    # l1 worse val score than l2+
+    stacked_overfitting = score_non_leaking_oof < score_leaking_oof
+    # l2+ worse test score than L1
+    stacked_overfitting = stacked_overfitting and (score_non_leaking_test >= score_leaking_test)
+
+    return stacked_overfitting
+
+
+def check_stacked_overfitting_from_leaderboard(leaderboard: pd.DataFrame) -> bool:
+    best_non_leaking_model, best_leaking_model, leaking_models_exist = get_best_val_models(leaderboard)
+
+    if not leaking_models_exist:
+        return False
+
+    return _check_so_for_models(best_non_leaking_model, best_leaking_model, leaderboard)

--- a/core/src/autogluon/core/stacked_overfitting/utils.py
+++ b/core/src/autogluon/core/stacked_overfitting/utils.py
@@ -1,41 +1,38 @@
-import pandas as pd
 import logging
-from typing import Tuple, List
+from typing import List, Tuple
+
+import pandas as pd
 
 logger = logging.getLogger(__name__)
 
 
-def get_non_leaking_and_leaking_model_names(leaderboard: pd.DataFrame) -> Tuple[List[str], List[str], bool]:
-    # TODO: move away from names.
-    NON_LEAKING_MODEL_NAMES_IN_AUTOGLUON = ["WeightedEnsemble_L2", "WeightedEnsemble_BAG_L2", "WeightedEnsemble_ALL_L2", "WeightedEnsemble_FULL_L2"]
-
+def get_non_leaking_and_leaking_model_names(leaderboard: pd.DataFrame) -> Tuple[List[str], List[str]]:
     non_leaking = []
     leaking = []
     for model_name in set(leaderboard["model"]):
-
-        if (model_name in NON_LEAKING_MODEL_NAMES_IN_AUTOGLUON) or model_name.endswith("L1"):
+        # TODO: move away from using names to metadata properties (somehow).
+        if model_name.startswith("WeightedEnsemble") and model_name.endswith("L2"):
             non_leaking.append(model_name)
         else:
             leaking.append(model_name)
 
-    leaking_models_exist = len(leaking) > 0
-
-    return non_leaking, leaking, leaking_models_exist
+    return non_leaking, leaking
 
 
 def get_best_val_models(leaderboard: pd.DataFrame) -> Tuple[List[str], List[str], bool]:
-    non_leaking_names, leaking_names, leaking_models_exist = get_non_leaking_and_leaking_model_names(leaderboard)
+    non_leaking_names, leaking_names = get_non_leaking_and_leaking_model_names(leaderboard)
 
     best_non_leaking_model = leaderboard[leaderboard["model"].isin(non_leaking_names)].sort_values(by="score_val", ascending=False).iloc[0].loc["model"]
 
+    leaking_models_exist = len(leaking_names) > 0
     best_leaking_model = None
-    if leaking_names:
+    if leaking_models_exist:
         best_leaking_model = leaderboard[leaderboard["model"].isin(leaking_names)].sort_values(by="score_val", ascending=False).iloc[0].loc["model"]
 
     return best_non_leaking_model, best_leaking_model, leaking_models_exist
 
 
-def _check_so_for_models(best_non_leaking_model: List[str], best_leaking_model: List[str], leaderboard: pd.DataFrame) -> bool:
+def _check_stacked_overfitting_for_models(best_non_leaking_model: List[str], best_leaking_model: List[str], leaderboard: pd.DataFrame) -> bool:
     score_non_leaking_oof = leaderboard.loc[leaderboard["model"] == best_non_leaking_model, "score_val"].iloc[0]
     score_non_leaking_test = leaderboard.loc[leaderboard["model"] == best_non_leaking_model, "score_test"].iloc[0]
 
@@ -56,4 +53,4 @@ def check_stacked_overfitting_from_leaderboard(leaderboard: pd.DataFrame) -> boo
     if not leaking_models_exist:
         return False
 
-    return _check_so_for_models(best_non_leaking_model, best_leaking_model, leaderboard)
+    return _check_stacked_overfitting_for_models(best_non_leaking_model, best_leaking_model, leaderboard)

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1234,8 +1234,8 @@ class TabularPredictor:
         if holdout_data is None:
             ag_fit_kwargs["X"] = X
         else:
-            logger.log(20, "Concatenating holdout data from dynamic stacking to the training for the full fit.")
-            ag_fit_kwargs["X"] = pd.concat([X, holdout_data])
+            logger.log(20, "Concatenating holdout data from dynamic stacking to the training data for the full fit (and reset the index).")
+            ag_fit_kwargs["X"] = pd.concat([X, holdout_data], ignore_index=True)
 
         ag_fit_kwargs["X_val"] = X_val
         ag_fit_kwargs["X_unlabeled"] = X_unlabeled

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -14,7 +14,6 @@ from typing import List, Optional, Tuple, Union
 import networkx as nx
 import numpy as np
 import pandas as pd
-import ray
 
 from autogluon.common.loaders import load_json
 from autogluon.common.savers import save_json

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -9,8 +9,8 @@ import pprint
 import shutil
 import time
 import warnings
-from typing import List, Optional, Tuple, Union
 from concurrent.futures import ProcessPoolExecutor
+from typing import List, Optional, Tuple, Union
 
 import networkx as nx
 import numpy as np
@@ -43,6 +43,7 @@ from autogluon.core.metrics import Scorer
 from autogluon.core.problem_type import problem_type_info
 from autogluon.core.pseudolabeling.pseudolabeling import filter_ensemble_pseudo, filter_pseudo
 from autogluon.core.scheduler.scheduler_factory import scheduler_factory
+from autogluon.core.stacked_overfitting.utils import check_stacked_overfitting_from_leaderboard
 from autogluon.core.trainer import AbstractTrainer
 from autogluon.core.utils import (
     get_pred_from_proba_df,
@@ -54,7 +55,6 @@ from autogluon.core.utils.decorators import apply_presets
 from autogluon.core.utils.loaders import load_pkl, load_str
 from autogluon.core.utils.savers import save_pkl, save_str
 from autogluon.core.utils.utils import default_holdout_frac
-from autogluon.core.stacked_overfitting.utils import check_stacked_overfitting_from_leaderboard
 
 from ..configs.feature_generator_presets import get_default_feature_generator
 from ..configs.hyperparameter_configs import get_hyperparameter_config

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1113,7 +1113,8 @@ class TabularPredictor:
         clean_up_fits: bool,
         holdout_data: Optional[Union[str, pd.DataFrame, None]] = None,
     ):
-        """Dynamically determines if stacking is used or not by validating the behavior of a sub-fit of AutoGluon that uses stacking on held out data."""
+        """Dynamically determines if stacking is used or not by validating the behavior of a sub-fit of AutoGluon that uses stacking on held out data.
+        See `ds_args` in the docstring of `fit()` for details on the parameters."""
         time_start = time.time()
         time_limit_og = ag_fit_kwargs["time_limit"]
         org_num_stack_levels = ag_fit_kwargs["num_stack_levels"]

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1186,7 +1186,7 @@ class TabularPredictor:
                 else:
                     time_spend_sub_fits_so_far = int(time.time() - time_start)
                     rest_time = time_limit - time_spend_sub_fits_so_far
-                    sub_fit_time = 1 / (n_splits - split_index) * rest_time  # if we are faster, give more time to rest of the folds.
+                    sub_fit_time = int(1 / (n_splits - split_index) * rest_time)  # if we are faster, give more time to rest of the folds.
                     if sub_fit_time <= 0:
                         logger.info(f"Stop cross-validation during dynamic stacking early as no more time left. Consider specifying a larger time_limit.")
                         break
@@ -1215,7 +1215,7 @@ class TabularPredictor:
         if org_time_limit is None:
             time_limit_fit_full = None
         else:
-            time_limit_fit_full = org_time_limit - time_spend_sub_fits
+            time_limit_fit_full = int(org_time_limit - time_spend_sub_fits)
             logger.info(f"Time left for full fit of AutoGluon: {time_limit_fit_full} seconds.")
 
         num_stack_levels = 0 if stacked_overfitting else org_num_stack_levels

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -755,7 +755,7 @@ class TabularPredictor:
                 See the `ag_args_ensemble` argument from "Advanced functionality: Custom AutoGluon model arguments" in the `hyperparameters` argument documentation for valid values.
                 Identical to specifying `ag_args_ensemble` parameter for all models in `hyperparameters`.
                 If a key in `ag_args_ensemble` is already specified for a model in `hyperparameters`, it will not be altered through this argument.
-            ds_args : dict, see bleow for default,
+            ds_args : dict, see bleow for default
                 Keyword arguments for dynamic stacking, only used if `dynamic_stacking=True`. These keyword arguments control the behavior of dynamic stacking
                 and determine how AutoGluon tries to detect stacked overfitting. To detect stacked overfitting, AutoGluon will fit itself (so called sub-fits)
                 on a subset (for holdout) or multiple subsets (for repeated cross-validation) and use the predictions of AutoGluon on the validation data to

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -56,7 +56,7 @@ from autogluon.core.utils import (
 from autogluon.core.utils.decorators import apply_presets
 from autogluon.core.utils.loaders import load_pkl, load_str
 from autogluon.core.utils.savers import save_pkl, save_str
-from autogluon.core.utils.utils import default_holdout_frac, generate_train_test_split_combined, CVSplitter
+from autogluon.core.utils.utils import CVSplitter, default_holdout_frac, generate_train_test_split_combined
 
 from ..configs.feature_generator_presets import get_default_feature_generator
 from ..configs.hyperparameter_configs import get_hyperparameter_config

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -4202,6 +4202,7 @@ class TabularPredictor:
             raise ValueError(f"`calibrate` must be a value in {valid_calibrate_options}, but is: {calibrate}")
 
         # -- Validate dynamic stacking extra args
+        kwargs_sanitized["ds_args"].update(fit_extra_kwargs_default["ds_args"])
         ds_args = kwargs_sanitized["ds_args"]
         allowed_kes = set(fit_extra_kwargs_default["ds_args"].keys())
         key_missmatch = set(ds_args.keys()) - allowed_kes

--- a/tabular/tests/unittests/dynamic_stacking/test_dynamic_stacking.py
+++ b/tabular/tests/unittests/dynamic_stacking/test_dynamic_stacking.py
@@ -82,7 +82,7 @@ def test_dynamic_stacking_hps(fit_helper, dataset_loader_helper, stacked_overfit
         tmp_fit_args["ds_args"] = tmp_ds_args
         if expect_raise is None:
             predictor = fit_helper.fit_dataset(train_data=train_data, init_args=dict(label=label), fit_args=tmp_fit_args, sample_size=1000)
-            if ('holdout_data' in ds_args_update) and (ds_args_update['holdout_data'] is not None):
+            if ("holdout_data" in ds_args_update) and (ds_args_update["holdout_data"] is not None):
                 n_expected = 1000 + n_test_data
                 assert len(predictor.get_oof_pred()) == n_expected, "Verify that holdout data was used for training"
             lb = predictor.leaderboard(test_data, extra_info=True)
@@ -90,7 +90,7 @@ def test_dynamic_stacking_hps(fit_helper, dataset_loader_helper, stacked_overfit
             shutil.rmtree(predictor.path)
         else:
             with pytest.raises(expect_raise):
-                predictor = fit_helper.fit_dataset(train_data=train_data, init_args=dict(label=label), fit_args=tmp_fit_args, sample_size=1000)
+                fit_helper.fit_dataset(train_data=train_data, init_args=dict(label=label), fit_args=tmp_fit_args, sample_size=1000)
 
 
 def test_no_dynamic_stacking(fit_helper):

--- a/tabular/tests/unittests/dynamic_stacking/test_dynamic_stacking.py
+++ b/tabular/tests/unittests/dynamic_stacking/test_dynamic_stacking.py
@@ -1,0 +1,200 @@
+import shutil
+
+import pytest
+
+from autogluon.core.constants import BINARY
+from autogluon.core.metrics import METRICS
+
+DS_ARGS_TEST_DEFAULTS = dict(
+    use_holdout=True,
+    detection_time_frac=1 / 4,
+    holdout_frac=1 / 9,
+    n_folds=2,
+    n_repeats=1,
+    memory_safe_fits=True,
+    clean_up_fits=True,
+    custom_val_data=None,
+)
+
+
+def test_spot_and_avoid_stacked_overfitting(fit_helper, dataset_loader_helper):
+    """Tests that dynamic stacking works."""
+    fit_args = dict(
+        hyperparameters={"RF": {}, "GBM": {}},
+        fit_weighted_ensemble=False,
+        dynamic_stacking=True,
+        num_stack_levels=1,
+        num_bag_folds=2,
+        num_bag_sets=1,
+        time_limit=None,
+        ds_args=DS_ARGS_TEST_DEFAULTS,
+        ag_args_ensemble={"fold_fitting_strategy": "sequential_local"},
+    )
+    dataset_name = "adult"
+    extra_metrics = list(METRICS[BINARY])
+
+    fit_helper.fit_and_validate_dataset(
+        dataset_name=dataset_name,
+        fit_args=fit_args,
+        extra_metrics=extra_metrics,
+        expected_model_count=2,
+        refit_full=False,
+        allowed_dataset_features=["age"],
+        expected_stacked_overfitting_at_test=False,
+        expected_stacked_overfitting_at_val=True,
+    )
+
+
+def test_dynamic_stacking_hps(fit_helper, dataset_loader_helper, stacked_overfitting_assert_func):
+    """Tests dynamic stacking arguments."""
+    fit_args = dict(
+        hyperparameters={"DUMMY": {}},
+        fit_weighted_ensemble=False,
+        dynamic_stacking=True,
+        num_stack_levels=1,
+        num_bag_folds=2,
+        num_bag_sets=1,
+        time_limit=None,
+        ag_args_ensemble={"fold_fitting_strategy": "sequential_local"},
+    )
+
+    # Get custom val data (the test data)
+    train_data, test_data, dataset_info = dataset_loader_helper.load_dataset(name="adult", directory_prefix="./datasets/")
+    label = dataset_info["label"]
+    allowed_cols = ["age", label]
+    train_data = train_data[allowed_cols]
+    test_data = test_data[allowed_cols]
+
+    for ds_args_update in [
+        dict(use_holdout=True, holdout_frac=1 / 5),  # holdout
+        dict(use_holdout=False),  # 2-fold CV
+        dict(use_holdout=False, n_repeats=2),  # 2-repeated 2-fold CV
+        dict(memory_safe_fits=False, clean_up_fits=False),  # fit options False
+        dict(custom_val_data=test_data),
+    ]:
+        print(ds_args_update)
+        tmp_ds_args = DS_ARGS_TEST_DEFAULTS.copy()
+        if ds_args_update is not None:
+            tmp_ds_args.update(ds_args_update)
+        tmp_fit_args = fit_args.copy()
+        tmp_fit_args["ds_args"] = tmp_ds_args
+        predictor = fit_helper.fit_dataset(train_data=train_data, init_args=dict(label=label), fit_args=tmp_fit_args, sample_size=1000)
+        lb = predictor.leaderboard(test_data, extra_info=True)
+        stacked_overfitting_assert_func(lb, predictor, False, False)
+        shutil.rmtree(predictor.path)
+
+
+def test_no_dynamic_stacking(fit_helper):
+    """Tests that dynamic stacking does not run if stacking is disabled."""
+    fit_args = dict(
+        hyperparameters={"DUMMY": {}},
+        dynamic_stacking=True,
+        fit_weighted_ensemble=False,
+        num_stack_levels=0,
+        ag_args_ensemble={"fold_fitting_strategy": "sequential_local"},
+    )
+    dataset_name = "adult"
+    extra_metrics = list(METRICS[BINARY])
+
+    predictor = fit_helper.fit_and_validate_dataset(
+        dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics, expected_model_count=1, refit_full=False
+    )
+    assert predictor._stacked_overfitting_occurred is None
+
+
+def test_dynamic_stacking_fit_extra(fit_helper):
+    """Tests that dynamic stacking does not run if stacking is disabled."""
+    fit_args = dict(
+        hyperparameters={"RF": {}},
+        dynamic_stacking=True,
+        fit_weighted_ensemble=False,
+        num_bag_folds=2,
+        num_bag_sets=1,
+        num_stack_levels=1,
+        ds_args=DS_ARGS_TEST_DEFAULTS,
+        ag_args_ensemble={"fold_fitting_strategy": "sequential_local"},
+    )
+    dataset_name = "adult"
+    extra_metrics = list(METRICS[BINARY])
+
+    predictor = fit_helper.fit_and_validate_dataset(
+        dataset_name=dataset_name,
+        fit_args=fit_args,
+        extra_metrics=extra_metrics,
+        expected_model_count=2,
+        refit_full=False,
+        delete_directory=False,
+        allowed_dataset_features=["age"],
+        expected_stacked_overfitting_at_test=True,
+        # This also check that we only consider something to be stacked overfitting if the dynamic stacking holdout score gets worse.
+        expected_stacked_overfitting_at_val=False,
+    )
+
+    fit_extra_args = dict(
+        hyperparameters={"GBM": {}},
+        fit_weighted_ensemble=False,
+    )
+
+    predictor.fit_extra(**fit_extra_args)
+    shutil.rmtree(predictor.path, ignore_errors=True)
+
+
+def test_dynamic_stacking_with_time_limit(fit_helper):
+    """Tests that dynamic stacking does not run if stacking is disabled."""
+    ds_args = DS_ARGS_TEST_DEFAULTS.copy()
+    ds_args["holdout_frac"] = 0.5
+    fit_args = dict(
+        hyperparameters={"DUMMY": {}},
+        dynamic_stacking=True,
+        fit_weighted_ensemble=False,
+        num_bag_folds=2,
+        num_bag_sets=1,
+        num_stack_levels=1,
+        time_limit=60,  # won't take 60s, but we need a number here instead of None.
+        ds_args=ds_args,
+        ag_args_ensemble={"fold_fitting_strategy": "sequential_local"},
+    )
+    dataset_name = "adult"
+    extra_metrics = list(METRICS[BINARY])
+
+    fit_helper.fit_and_validate_dataset(
+        dataset_name=dataset_name,
+        fit_args=fit_args,
+        extra_metrics=extra_metrics,
+        expected_model_count=2,
+        refit_full=False,
+        delete_directory=False,
+        allowed_dataset_features=["age"],
+        expected_stacked_overfitting_at_test=False,
+        expected_stacked_overfitting_at_val=False,
+    )
+
+
+@pytest.mark.timeout(120)  # if running AutoGluon twice fails due to a multiprocessing bug, we want to hang up and crash.
+def test_dynamic_stacking_run_twice_parallel_fold_fitting_strategy(fit_helper, dataset_loader_helper, stacked_overfitting_assert_func):
+    """Tests that dynamic stacking memory save fit works."""
+    ds_args = DS_ARGS_TEST_DEFAULTS.copy()
+    ds_args["memory_safe_fits"] = True  # guarantee for sanity
+    fit_args = dict(
+        hyperparameters={"DUMMY": {}},
+        fit_weighted_ensemble=False,
+        dynamic_stacking=True,
+        num_stack_levels=1,
+        num_bag_folds=2,
+        num_bag_sets=1,
+        time_limit=None,
+        ds_args=ds_args,
+    )
+
+    # Get custom val data (the test data)
+    train_data, test_data, dataset_info = dataset_loader_helper.load_dataset(name="adult", directory_prefix="./datasets/")
+    label = dataset_info["label"]
+    allowed_cols = ["age", label]
+    train_data = train_data[allowed_cols]
+    test_data = test_data[allowed_cols]
+
+    for _ in range(2):
+        predictor = fit_helper.fit_dataset(train_data=train_data, init_args=dict(label=label), fit_args=fit_args, sample_size=1000)
+        lb = predictor.leaderboard(test_data, extra_info=True)
+        stacked_overfitting_assert_func(lb, predictor, False, False)
+        shutil.rmtree(predictor.path)

--- a/tabular/tests/unittests/dynamic_stacking/test_dynamic_stacking.py
+++ b/tabular/tests/unittests/dynamic_stacking/test_dynamic_stacking.py
@@ -70,6 +70,7 @@ def test_dynamic_stacking_hps(fit_helper, dataset_loader_helper, stacked_overfit
         dict(validation_procedure="cv"),  # 2-fold CV
         dict(validation_procedure="cv", n_repeats=2),  # 2-repeated 2-fold CV
         dict(memory_safe_fits=False, clean_up_fits=False),  # fit options False
+        dict(holdout_data=test_data),
         dict(holdout_data=test_data, validation_procedure="cv", expect_raise=ValueError),
     ]:
         expect_raise = ds_args_update.pop("expect_raise", None)

--- a/tabular/tests/unittests/dynamic_stacking/test_dynamic_stacking.py
+++ b/tabular/tests/unittests/dynamic_stacking/test_dynamic_stacking.py
@@ -64,6 +64,7 @@ def test_dynamic_stacking_hps(fit_helper, dataset_loader_helper, stacked_overfit
     allowed_cols = ["age", label]
     train_data = train_data[allowed_cols]
     test_data = test_data[allowed_cols]
+    n_test_data = len(test_data)
 
     for ds_args_update in [
         dict(validation_procedure="holdout", holdout_frac=1 / 5),  # holdout
@@ -81,6 +82,9 @@ def test_dynamic_stacking_hps(fit_helper, dataset_loader_helper, stacked_overfit
         tmp_fit_args["ds_args"] = tmp_ds_args
         if expect_raise is None:
             predictor = fit_helper.fit_dataset(train_data=train_data, init_args=dict(label=label), fit_args=tmp_fit_args, sample_size=1000)
+            if ('holdout_data' in ds_args_update) and (ds_args_update['holdout_data'] is not None):
+                n_expected = 1000 + n_test_data
+                assert len(predictor.get_oof_pred()) == n_expected, "Verify that holdout data was used for training"
             lb = predictor.leaderboard(test_data, extra_info=True)
             stacked_overfitting_assert_func(lb, predictor, False, False)
             shutil.rmtree(predictor.path)


### PR DESCRIPTION
Rel.: #2779 

### Description of changes:
This PR adds support for dynamic stacking. The idea of dynamic stacking is to avoid stacked overfitting (a.k.a. stacked information leakage) by fitting AutoGluon at least twice. All but the last fits are done on a subset of the training data whereby a holdout set is used to determine if stacked overfitting occurs for the provided data. Afterwards, we run the last fit with or without  multi-layer stacking depending on whether stacked overfitting has not occurred in a previous fit.

We understand dynamic stacking as a baseline solution to avoid stacked overfitting. Nevertheless, so far, it is the best solution we have benchmarked due to it being most consistent (which is very important for AutoML systems). Moreover, due to having a holdout set as a result of this approach, we have an empirical source of truth to determine if stacked overfitting occurred. While this source of truth may not necessarily generalize to the test data, it has so far still been better than any heuristic alternative or adjustment to the out-of-fold predictions. 

The default version of the code in this PR has an accuracy (_!preliminary numbers!_) of correctly determining whether stacked overfitting occurs for each fold of the AutoML benchmark of ~74% (balanced accuracy: ~69%). This translates into better predictive performance on average.

### Code Example 

<details>
<summary>
Script (outdated, see tests for newest examples)
</summary>

```python
import numpy as np
import openml
import pandas as pd
from autogluon.tabular import TabularPredictor


def get_data(tid: int, fold: int):
    # Get Task and dataset from OpenML and return split data
    oml_task = openml.tasks.get_task(tid, download_splits=True, download_data=True, download_qualities=False, download_features_meta_data=False)

    train_ind, test_ind = oml_task.get_train_test_split_indices(fold)
    X, *_ = oml_task.get_dataset().get_data(dataset_format="dataframe")

    return (
        X.iloc[train_ind, :].reset_index(drop=True),
        X.iloc[test_ind, :].reset_index(drop=True),
        oml_task.target_name,
        oml_task.task_type != "Supervised Classification",
    )


def _print_lb(leaderboard, task_id):
    with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
        print(leaderboard[leaderboard["model"].str.endswith("L1")].sort_values(by="score_val", ascending=True))
        print(leaderboard[~leaderboard["model"].str.endswith("L1")].sort_values(by="score_val", ascending=False))


def _run(task_id, metric, fold=0, print_res=True, enable_test=False):
    train_data, test_data, label, regression = get_data(task_id, fold)
    n_max_cols = 100
    n_max_train_instances = 500
    n_max_test_instances = 200

    # Sub sample instances
    train_data = train_data.sample(n=min(len(train_data), n_max_train_instances), random_state=0).reset_index(drop=True)
    test_data = test_data.sample(n=min(len(test_data), n_max_test_instances), random_state=0).reset_index(drop=True)

    # Sub sample columns
    cols = list(train_data.columns)
    cols.remove(label)
    if len(cols) > n_max_cols:
        cols = list(np.random.RandomState(42).choice(cols, replace=False, size=n_max_cols))
    train_data = train_data[cols + [label]]
    test_data = test_data[cols + [label]]

    # Run AutoGluon
    print(f"### task {task_id} and fold {fold} and shape {(train_data.shape, test_data.shape)}.")
    predictor = TabularPredictor(eval_metric=metric, label=label, verbosity=2)
    predictor.fit(
        train_data=train_data,
        hyperparameters={
            "FASTAI": [{}],
            "NN_TORCH": [{}],
            "RF": [{}],
            "XT": [{}],
            "GBM": [{}],
        },
        num_bag_sets=2,
        num_bag_folds=2,
        num_gpus=0,
        num_stack_levels=1,
        fit_weighted_ensemble=True,
        dynamic_stacking=True,
        time_limit=240,
        ds_args=dict(use_holdout=True, detection_time_frac=1 / 4, holdout_frac=1 / 9),
    )
    leaderboard = predictor.leaderboard(train_data, silent=True)[["model", "score_test", "score_val"]].sort_values(by="model").reset_index(drop=True)

    if print_res:
        _print_lb(leaderboard, task_id)

    return leaderboard


if __name__ == "__main__":
    _run(359955, "roc_auc")
    _run(146217, "log_loss")
    _run(359938, "mse")
```

</details>

### TODOs and Open Questions for Merge

- Determine how to include this in presets and decide on default split ratio


Write tests:

- No time limit and time limit 
- Extra fit works with dynamic stacking at first fit 
- holdout, cv, repeated cv, custom val data. 


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
