### PR TITLE
[timeseries] Bump mlforecast dependency + fix covariates usage

### DIFF
--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -33,7 +33,8 @@ install_requires = [
     "networkx",  # version range defined in `core/_setup_utils.py`
     # TODO: update statsforecast to v1.5.0 - resolve antlr4-python3-runtime dependency clash with multimodal
     "statsforecast>=1.4.0,<1.5",
-    "mlforecast>=0.9.3,<0.9.4",
+    "mlforecast>=0.10.0,<0.10.1",
+    "utilsforecast>=0.0.10,<0.0.11",
     "tqdm",  # version range defined in `core/_setup_utils.py`
     "ujson>=5,<6",  # needed to silence GluonTS warning
     f"autogluon.core[raytune]=={version}",

--- a/timeseries/src/autogluon/timeseries/metrics/point.py
+++ b/timeseries/src/autogluon/timeseries/metrics/point.py
@@ -64,7 +64,8 @@ class WAPE(TimeSeriesScorer):
 
 
 class sMAPE(TimeSeriesScorer):
-    "Symmetric mean absolute percentage error."
+    """Symmetric mean absolute percentage error."""
+
     optimized_by_median = True
     equivalent_tabular_regression_metric = "symmetric_mean_absolute_percentage_error"
 
@@ -76,7 +77,8 @@ class sMAPE(TimeSeriesScorer):
 
 
 class MAPE(TimeSeriesScorer):
-    "Mean Absolute Percentage Error."
+    """Mean Absolute Percentage Error."""
+
     optimized_by_median = True
     equivalent_tabular_regression_metric = "mean_absolute_percentage_error"
 

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -471,14 +471,14 @@ class RecursiveTabularModel(AbstractMLForecastModel):
 
         new_df = self._to_mlforecast_df(data, data.static_features)
         if known_covariates is not None:
-            dynamic_dfs = [self._to_mlforecast_df(known_covariates, data.static_features, include_target=False)]
+            X_df = self._to_mlforecast_df(known_covariates, data.static_features, include_target=False)
         else:
-            dynamic_dfs = None
+            X_df = None
         with warning_filter():
             raw_predictions = self._mlf.predict(
                 h=self.prediction_length,
                 new_df=new_df,
-                dynamic_dfs=dynamic_dfs,
+                X_df=X_df,
             )
         predictions = raw_predictions.rename(columns={MLF_ITEMID: ITEMID, MLF_TIMESTAMP: TIMESTAMP})
 

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -406,12 +406,9 @@ class DirectTabularModel(AbstractMLForecastModel):
                 "eval_metric": "pinball_loss",
             }
         else:
-            tabular_metric = self.eval_metric.equivalent_tabular_regression_metric
-            if tabular_metric is None:
-                tabular_metric = "mean_absolute_error"
             return {
                 "problem_type": ag.constants.REGRESSION,
-                "eval_metric": tabular_metric,
+                "eval_metric": self.eval_metric.equivalent_tabular_regression_metric or "mean_absolute_error",
             }
 
 
@@ -499,10 +496,7 @@ class RecursiveTabularModel(AbstractMLForecastModel):
         return TimeSeriesDataFrame(predictions).reindex(data.item_ids, level=ITEMID)
 
     def _get_extra_tabular_init_kwargs(self) -> dict:
-        tabular_metric = self.eval_metric.equivalent_tabular_regression_metric
-        if tabular_metric is None:
-            tabular_metric = "mean_absolute_error"
         return {
             "problem_type": ag.constants.REGRESSION,
-            "eval_metric": tabular_metric,
+            "eval_metric": self.eval_metric.equivalent_tabular_regression_metric or "mean_absolute_error",
         }


### PR DESCRIPTION
*Description of changes:*
- Bump `mlforecast` dependency to v0.10.0 as it includes an important bugfix
- Fix a bug because of which `RecursiveTabular` model did not use the covariates
- Fix typos in docstrings


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
