### PR TITLE
[timeseries] Add scaled quantile loss metric

### DIFF
--- a/timeseries/src/autogluon/timeseries/metrics/__init__.py
+++ b/timeseries/src/autogluon/timeseries/metrics/__init__.py
@@ -3,7 +3,7 @@ from typing import Type, Union
 
 from .abstract import TimeSeriesScorer
 from .point import MAE, MAPE, MASE, MSE, RMSE, RMSSE, WAPE, sMAPE
-from .quantile import WQL
+from .quantile import SQL, WQL
 
 __all__ = [
     "MAE",
@@ -13,6 +13,7 @@ __all__ = [
     "MSE",
     "RMSE",
     "RMSSE",
+    "SQL",
     "WAPE",
     "WQL",
 ]
@@ -26,6 +27,7 @@ AVAILABLE_METRICS = {
     "RMSE": RMSE,
     "RMSSE": RMSSE,
     "WAPE": WAPE,
+    "SQL": SQL,
     "WQL": WQL,
     # Exist for compatibility
     "MSE": MSE,

--- a/timeseries/src/autogluon/timeseries/metrics/abstract.py
+++ b/timeseries/src/autogluon/timeseries/metrics/abstract.py
@@ -196,6 +196,6 @@ class TimeSeriesScorer:
         """
         quantile_columns = [col for col in predictions.columns if col != "mean"]
         y_true = data_future[target]
-        q_pred = predictions[quantile_columns]
+        q_pred = pd.DataFrame(predictions[quantile_columns])
         quantile_levels = np.array(quantile_columns, dtype=float)
         return y_true, q_pred, quantile_levels

--- a/timeseries/src/autogluon/timeseries/metrics/point.py
+++ b/timeseries/src/autogluon/timeseries/metrics/point.py
@@ -99,11 +99,7 @@ class MASE(TimeSeriesScorer):
         self._past_abs_seasonal_error: Optional[pd.Series] = None
 
     def save_past_metrics(
-        self,
-        data_past: TimeSeriesDataFrame,
-        target: str = "target",
-        seasonal_period: int = 1,
-        **kwargs,
+        self, data_past: TimeSeriesDataFrame, target: str = "target", seasonal_period: int = 1, **kwargs
     ) -> None:
         self._past_abs_seasonal_error = _in_sample_abs_seasonal_error(
             y_past=data_past[target], seasonal_period=seasonal_period
@@ -132,11 +128,7 @@ class RMSSE(TimeSeriesScorer):
         self._past_squared_seasonal_error: Optional[pd.Series] = None
 
     def save_past_metrics(
-        self,
-        data_past: TimeSeriesDataFrame,
-        target: str = "target",
-        seasonal_period: int = 1,
-        **kwargs,
+        self, data_past: TimeSeriesDataFrame, target: str = "target", seasonal_period: int = 1, **kwargs
     ) -> None:
         self._past_squared_seasonal_error = _in_sample_squared_seasonal_error(
             y_past=data_past[target], seasonal_period=seasonal_period

--- a/timeseries/src/autogluon/timeseries/metrics/quantile.py
+++ b/timeseries/src/autogluon/timeseries/metrics/quantile.py
@@ -1,8 +1,12 @@
-import numpy as np
+from typing import Optional
 
-from autogluon.timeseries import TimeSeriesDataFrame
+import numpy as np
+import pandas as pd
+
+from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TimeSeriesDataFrame
 
 from .abstract import TimeSeriesScorer
+from .utils import _in_sample_abs_seasonal_error
 
 
 class WQL(TimeSeriesScorer):
@@ -24,3 +28,36 @@ class WQL(TimeSeriesScorer):
             np.abs((values_true - values_pred) * ((values_true <= values_pred) - quantile_levels)).sum(axis=0)
             / np.abs(values_true).sum()
         )
+
+
+class SQL(TimeSeriesScorer):
+    """Scaled quantile loss.
+
+    Also known as scaled pinball loss.
+    """
+
+    needs_quantile = True
+
+    def __init__(self):
+        self._past_abs_seasonal_error: Optional[pd.Series] = None
+
+    def save_past_metrics(
+        self, data_past: TimeSeriesDataFrame, target: str = "target", seasonal_period: int = 1, **kwargs
+    ) -> None:
+        self._past_abs_seasonal_error = _in_sample_abs_seasonal_error(
+            y_past=data_past[target], seasonal_period=seasonal_period
+        )
+
+    def clear_past_metrics(self) -> None:
+        self._past_abs_seasonal_error = None
+
+    def compute_metric(
+        self, data_future: TimeSeriesDataFrame, predictions: TimeSeriesDataFrame, target: str = "target", **kwargs
+    ) -> float:
+        y_true, q_pred, quantile_levels = self._get_quantile_forecast_score_inputs(data_future, predictions, target)
+        values_true = y_true.values[:, None]  # shape [N, 1]
+
+        ql = ((q_pred - values_true) * ((values_true <= q_pred) - quantile_levels)).mean(axis=1).abs()
+        # TODO: Speed up computation by using np.arrays & replace groupby with reshapes [-1, prediction_length]?
+        ql_per_item = ql.groupby(level=ITEMID, sort=False).mean()
+        return 2 * self._safemean(ql_per_item / self._past_abs_seasonal_error)

--- a/timeseries/src/autogluon/timeseries/metrics/quantile.py
+++ b/timeseries/src/autogluon/timeseries/metrics/quantile.py
@@ -54,6 +54,9 @@ class SQL(TimeSeriesScorer):
     def compute_metric(
         self, data_future: TimeSeriesDataFrame, predictions: TimeSeriesDataFrame, target: str = "target", **kwargs
     ) -> float:
+        if self._past_abs_seasonal_error is None:
+            raise AssertionError("Call `save_past_metrics` before `compute_metric`")
+
         y_true, q_pred, quantile_levels = self._get_quantile_forecast_score_inputs(data_future, predictions, target)
         values_true = y_true.values[:, None]  # shape [N, 1]
 

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -66,6 +66,7 @@ class TimeSeriesPredictor:
         Probabilistic forecast metrics (evaluated on quantile forecasts for the specified ``quantile_levels``):
 
         - ``"WQL"``: mean weighted quantile loss, defined as average of quantile losses divided by the sum of absolute time series values in the forecast horizon.
+        - ``"SQL"``: scaled quantile loss, defined as average of quantile losses divided by the in-sample seasonal error.
 
         Point forecast metrics (these are always evaluated on the ``"mean"`` column of the predictions):
 

--- a/timeseries/tests/unittests/test_metrics.py
+++ b/timeseries/tests/unittests/test_metrics.py
@@ -1,21 +1,23 @@
+from typing import List, Tuple
+
 import numpy as np
 import pandas as pd
 import pytest
-from gluonts.evaluation import Evaluator as GluonTSEvaluator
-from gluonts.model.forecast import QuantileForecast
 from gluonts.dataset.split import split
 from gluonts.ev.metrics import (
-    MeanWeightedSumQuantileLoss,
-    Metric,
-    MAPE,
-    SMAPE,
-    MSE,
-    RMSE,
-    MASE,
-    ND,
     MAE,
+    MAPE,
+    MASE,
+    MSE,
+    ND,
+    RMSE,
+    SMAPE,
     AverageMeanScaledQuantileLoss,
+    MeanWeightedSumQuantileLoss,
 )
+from gluonts.ev.metrics import Metric as GluonTSMetric
+from gluonts.model.evaluation import evaluate_forecasts
+from gluonts.model.forecast import QuantileForecast
 
 from autogluon.timeseries import TimeSeriesPredictor
 from autogluon.timeseries.metrics import AVAILABLE_METRICS, DEFAULT_METRIC_NAME, check_get_evaluation_metric
@@ -27,20 +29,23 @@ from .common import DUMMY_TS_DATAFRAME, get_data_frame_with_item_index
 pytestmark = pytest.mark.filterwarnings("ignore")
 
 
-def get_ag_to_gluonts_metric_mapping() -> Dict[str, (Metric, str)]:
+def get_ag_and_gts_metrics() -> List[Tuple[str, str, GluonTSMetric]]:
+    # Each entry is a tuple (ag_metric_name, gts_metric_name, gts_metric_object)
     default_quantile_levels = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
-    ag_to_gluonts_metric = {
-        "WQL": (MeanWeightedSumQuantileLoss(default_quantile_levels), "mean_weighted_sum_quantile_loss"),
-        "SQL": (AverageMeanScaledQuantileLoss(default_quantile_levels), "average_mean_scaled_quantile_loss"),
-        "WAPE": (ND("mean"), "ND[mean]"),
-    }
+    # Metric that have different names in AutoGluon and GluonTS
+    ag_and_gts_metrics = [
+        ("WQL", "mean_weighted_sum_quantile_loss", MeanWeightedSumQuantileLoss(default_quantile_levels)),
+        ("SQL", "average_mean_scaled_quantile_loss", AverageMeanScaledQuantileLoss(default_quantile_levels)),
+        ("WAPE", "ND[mean]", ND("mean")),
+    ]
+    # Metric that have same names in AutoGluon and GluonTS
     for point_metric_cls in [MAPE, SMAPE, MSE, RMSE, MASE, MAE]:
         name = str(point_metric_cls.__name__)
-        ag_to_gluonts_metric[name] = (point_metric_cls("mean"), f"{name}[mean]")
-    return ag_to_gluonts_metric
+        ag_and_gts_metrics.append((name, f"{name}[mean]", point_metric_cls("mean")))
+    return ag_and_gts_metrics
 
 
-AG_TO_GLUONTS_METRIC_MAPPING = get_ag_to_gluonts_metric_mapping()
+AG_AND_GTS_METRICS = get_ag_and_gts_metrics()
 
 
 @pytest.fixture(scope="module")
@@ -89,20 +94,22 @@ def to_gluonts_forecast(forecast_df, freq):
 def to_gluonts_test_set(data, prediction_length):
     ts_list = []
     for item_id, ts in data.groupby(level="item_id", sort=False):
-        ts = {"target": ts.loc[item_id]["target"], "start": pd.Period(ts.loc[item_id].index[0], freq=data.freq)}
-        ts_list.append(ts)
+        entry = {"target": ts.loc[item_id]["target"], "start": pd.Period(ts.loc[item_id].index[0], freq=data.freq)}
+        ts_list.append(entry)
     _, test_template = split(dataset=ts_list, offset=-prediction_length)
     return test_template.generate_instances(prediction_length, windows=1)
 
 
-def check_gluonts_parity(metric_name, data, model, zero_forecast=False, equal_nan=False):
+def check_gluonts_parity(
+    ag_metric_name, gts_metric_name, gts_metric, data, model, zero_forecast=False, equal_nan=False
+):
     data_train, data_test = data.train_test_split(model.prediction_length)
     forecast_df = model.predict(data_train)
     forecast_df["mean"] = forecast_df["0.5"]
     if zero_forecast:
         forecast_df = forecast_df * 0
     seasonal_period = 3
-    ag_metric = check_get_evaluation_metric(metric_name)
+    ag_metric = check_get_evaluation_metric(ag_metric_name)
 
     ag_value = ag_metric.sign * ag_metric(
         data_test,
@@ -111,32 +118,58 @@ def check_gluonts_parity(metric_name, data, model, zero_forecast=False, equal_na
         seasonal_period=seasonal_period,
     )
 
-    forecast_list = to_gluonts_forecast(forecast_df, freq=data_train.freq)
-    ts_list = to_gluonts_test_set(data_test)
-    gts_evaluator = GluonTSEvaluator(seasonality=seasonal_period)
-    gts_results, _ = gts_evaluator(ts_iterator=ts_list, fcst_iterator=forecast_list)
-    gts_metric_name = AG_TO_GLUONTS_METRIC.get(metric_name, metric_name)
-    assert np.isclose(gts_results[gts_metric_name], ag_value, atol=1e-5, equal_nan=equal_nan)
+    gts_forecast = to_gluonts_forecast(forecast_df, freq=data_train.freq)
+    gts_test_set = to_gluonts_test_set(data_test, model.prediction_length)
+    gts_value = evaluate_forecasts(
+        gts_forecast, test_data=gts_test_set, seasonality=seasonal_period, metrics=[gts_metric]
+    ).values.item()
+    assert np.isclose(gts_value, ag_value, atol=1e-5, equal_nan=equal_nan)
 
 
-@pytest.mark.parametrize("metric_name", GLUONTS_PARITY_METRICS)
-def test_when_given_learned_model_when_evaluator_called_then_output_equal_to_gluonts(metric_name, deepar_trained):
-    check_gluonts_parity(metric_name, DUMMY_TS_DATAFRAME, deepar_trained)
-
-
-@pytest.mark.parametrize("metric_name", GLUONTS_PARITY_METRICS)
-def test_when_given_all_zero_data_when_evaluator_called_then_output_equal_to_gluonts(
-    metric_name, deepar_trained_zero_data
+@pytest.mark.parametrize("ag_metric_name, gts_metric_name, gts_metric", AG_AND_GTS_METRICS)
+def test_when_metric_evaluated_then_output_equal_to_gluonts(
+    ag_metric_name, gts_metric_name, gts_metric, deepar_trained
 ):
-    if metric_name == "MASE":
-        pytest.skip("MASE is undefined if all data is constant")
+    check_gluonts_parity(
+        ag_metric_name,
+        gts_metric_name,
+        gts_metric,
+        data=DUMMY_TS_DATAFRAME,
+        model=deepar_trained,
+    )
 
-    check_gluonts_parity(metric_name, DUMMY_TS_DATAFRAME.copy() * 0, deepar_trained_zero_data, equal_nan=True)
+
+@pytest.mark.parametrize("ag_metric_name, gts_metric_name, gts_metric", AG_AND_GTS_METRICS)
+def test_given_all_zero_data_when_metric_evaluated_then_output_equal_to_gluonts(
+    ag_metric_name, gts_metric_name, gts_metric, deepar_trained_zero_data
+):
+    if ag_metric_name in ["WQL", "WAPE"]:
+        pytest.skip(
+            "GluonTS produces incorrect values for these metrics on all-zero data https://github.com/awslabs/gluonts/issues/3034"
+        )
+
+    check_gluonts_parity(
+        ag_metric_name,
+        gts_metric_name,
+        gts_metric,
+        data=DUMMY_TS_DATAFRAME.copy() * 0,
+        model=deepar_trained_zero_data,
+        equal_nan=True,
+    )
 
 
-@pytest.mark.parametrize("metric_name", GLUONTS_PARITY_METRICS)
-def test_when_given_zero_forecasts_when_evaluator_called_then_output_equal_to_gluonts(metric_name, deepar_trained):
-    check_gluonts_parity(metric_name, DUMMY_TS_DATAFRAME, deepar_trained, zero_forecast=True)
+@pytest.mark.parametrize("ag_metric_name, gts_metric_name, gts_metric", AG_AND_GTS_METRICS)
+def test_given_zero_forecasts_when_metric_evaluated_then_output_equal_to_gluonts(
+    ag_metric_name, gts_metric_name, gts_metric, deepar_trained
+):
+    check_gluonts_parity(
+        ag_metric_name,
+        gts_metric_name,
+        gts_metric,
+        data=DUMMY_TS_DATAFRAME,
+        model=deepar_trained,
+        zero_forecast=True,
+    )
 
 
 def test_available_metrics_have_coefficients():

--- a/timeseries/tests/unittests/test_metrics.py
+++ b/timeseries/tests/unittests/test_metrics.py
@@ -136,7 +136,7 @@ def test_given_unavailable_input_and_raise_check_get_eval_metric_raises():
         check_get_evaluation_metric("some_nonsense_eval_metric")
 
 
-@pytest.mark.parametrize("eval_metric", ["MASE", "RMSSE"])
+@pytest.mark.parametrize("eval_metric", ["MASE", "RMSSE", "SQL"])
 def test_given_historic_data_not_cached_when_scoring_then_exception_is_raised(eval_metric):
     prediction_length = 3
     evaluator = check_get_evaluation_metric(eval_metric)


### PR DESCRIPTION
*Description of changes:*
- Add scaled quantile loss metric
- Use new GluonTS metrics from `gluonts.ev` instead of the old Evaluator from `gluonts.evaluation` in the parity checks.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
