### PR TITLE
[timeseries] Improve handling of static_features by TimeSeriesDataFrame

### DIFF
--- a/docs/tutorials/timeseries/forecasting-indepth.ipynb
+++ b/docs/tutorials/timeseries/forecasting-indepth.ipynb
@@ -85,12 +85,12 @@
    "outputs": [],
    "source": [
     "!pip install autogluon.timeseries\n",
-    "!pip uninstall torchaudio -y  # fix incompatible torchaudio version on Colab"
+    "!pip uninstall torchaudio -y  # fix incompatible torchaudio version on Colab\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "9e18ec03-e804-4bba-9cc2-9923eaf2cce7",
    "metadata": {
     "tags": [
@@ -100,18 +100,18 @@
    "outputs": [],
    "source": [
     "import warnings\n",
-    "warnings.filterwarnings(action=\"ignore\")"
+    "warnings.filterwarnings(action=\"ignore\")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "b75c8851-1fb8-4464-9e13-e8124e4b7fa2",
    "metadata": {},
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "from autogluon.timeseries import TimeSeriesDataFrame, TimeSeriesPredictor"
+    "from autogluon.timeseries import TimeSeriesDataFrame, TimeSeriesPredictor\n"
    ]
   },
   {
@@ -120,13 +120,199 @@
    "id": "2aaa2954-42ee-466f-8db2-2c0bf3678efd",
    "metadata": {},
    "source": [
-    "We download a subset of 100 time series as a TimeSeriesDataFrame"
+    "We download a subset of 100 time series from the M4 Daily dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f4f1d173-1fe6-4616-a55a-09a914e4ae57",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>item_id</th>\n",
+       "      <th>timestamp</th>\n",
+       "      <th>target</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>D1737</td>\n",
+       "      <td>1995-05-23 12:00:00</td>\n",
+       "      <td>1900.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>D1737</td>\n",
+       "      <td>1995-05-24 12:00:00</td>\n",
+       "      <td>1877.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>D1737</td>\n",
+       "      <td>1995-05-25 12:00:00</td>\n",
+       "      <td>1873.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>D1737</td>\n",
+       "      <td>1995-05-26 12:00:00</td>\n",
+       "      <td>1859.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>D1737</td>\n",
+       "      <td>1995-05-27 12:00:00</td>\n",
+       "      <td>1876.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  item_id            timestamp  target\n",
+       "0   D1737  1995-05-23 12:00:00  1900.0\n",
+       "1   D1737  1995-05-24 12:00:00  1877.0\n",
+       "2   D1737  1995-05-25 12:00:00  1873.0\n",
+       "3   D1737  1995-05-26 12:00:00  1859.0\n",
+       "4   D1737  1995-05-27 12:00:00  1876.0"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = pd.read_csv(\"https://autogluon.s3.amazonaws.com/datasets/timeseries/m4_daily_subset/train.csv\")\n",
+    "df.head()\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "94f6bac4-3eb3-4ba6-a051-46077dcc1e17",
+   "metadata": {},
+   "source": [
+    "We also load the corresponding static features.\n",
+    "In the M4 Daily dataset, there is a single categorical static feature that denotes the domain of origin for each time series.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "f4f1d173-1fe6-4616-a55a-09a914e4ae57",
+   "id": "191776df-83a3-47a6-b6c2-6bd7c2383d6b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>item_id</th>\n",
+       "      <th>domain</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>D1737</td>\n",
+       "      <td>Industry</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>D1843</td>\n",
+       "      <td>Industry</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>D2246</td>\n",
+       "      <td>Finance</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>D909</td>\n",
+       "      <td>Micro</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>D1345</td>\n",
+       "      <td>Micro</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  item_id    domain\n",
+       "0   D1737  Industry\n",
+       "1   D1843  Industry\n",
+       "2   D2246   Finance\n",
+       "3    D909     Micro\n",
+       "4   D1345     Micro"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "static_features_df = pd.read_csv(\"https://autogluon.s3.amazonaws.com/datasets/timeseries/m4_daily_subset/metadata.csv\")\n",
+    "static_features_df.head()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c9c4533",
+   "metadata": {},
+   "source": [
+    "AutoGluon expects static features as a pandas.DataFrame object. The `item_id` column indicates which item (=individual time series) in `df` each row of `static_features` corresponds to.\n",
+    "\n",
+    "We can now create a `TimeSeriesDataFrame` that contains both the time series values and the static features."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cd796511",
    "metadata": {},
    "outputs": [
     {
@@ -195,31 +381,32 @@
        "        1995-05-27 12:00:00  1876.0"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "train_data = TimeSeriesDataFrame.from_path(\n",
-    "    \"https://autogluon.s3.amazonaws.com/datasets/timeseries/m4_daily_subset/train.csv\",\n",
+    "train_data = TimeSeriesDataFrame.from_data_frame(\n",
+    "    df,\n",
+    "    id_column=\"item_id\",\n",
+    "    static_features_df=static_features_df,\n",
     ")\n",
-    "train_data.head()"
+    "train_data.head()\n"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "id": "94f6bac4-3eb3-4ba6-a051-46077dcc1e17",
+   "id": "bfc8ba1a",
    "metadata": {},
    "source": [
-    "AutoGluon expects static features as a pandas.DataFrame object, where the index column includes all the `item_id`s present in the respective TimeSeriesDataFrame."
+    "We can validate that `train_data` now also includes the static features using the `.static_features` attribute"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "191776df-83a3-47a6-b6c2-6bd7c2383d6b",
+   "execution_count": 6,
+   "id": "5c413a5e",
    "metadata": {},
    "outputs": [
     {
@@ -285,17 +472,13 @@
        "D1345       Micro"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "static_features = pd.read_csv(\n",
-    "    \"https://autogluon.s3.amazonaws.com/datasets/timeseries/m4_daily_subset/metadata.csv\",\n",
-    "    index_col=\"item_id\",\n",
-    ")\n",
-    "static_features.head()"
+    "train_data.static_features.head()\n"
    ]
   },
   {
@@ -304,13 +487,24 @@
    "id": "b7688edf-21ba-4466-afdf-beff0ef23fb7",
    "metadata": {},
    "source": [
-    "In the M4 Daily dataset, there is a single categorical static feature that denotes the domain of origin for each time series.\n",
-    "\n",
-    "We attach the static features to a TimeSeriesDataFrame as follows\n",
-    "\n",
-    "```python\n",
-    "train_data.static_features = static_features\n",
-    "```\n",
+    "Alternatively, we can attach static features to an existing `TimeSeriesDataFrame` by assigning the `.static_features` attribute"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "d57f22ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_data.static_features = static_features_df\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3461dd93",
+   "metadata": {},
+   "source": [
     "\n",
     "If `static_features` doesn't contain some `item_id`s that are present in `train_data`, an exception will be raised.\n",
     "\n",
@@ -380,7 +574,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 9,
    "id": "26472067-a3d3-44fb-be77-82b173bfac1c",
    "metadata": {},
    "outputs": [
@@ -464,7 +658,7 @@
        "        1995-05-27 12:00:00  1876.0    7.536897      1.0"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -477,7 +671,7 @@
     "timestamps = train_data.index.get_level_values(\"timestamp\")\n",
     "train_data[\"weekend\"] = timestamps.weekday.isin(WEEKEND_INDICES).astype(float)\n",
     "\n",
-    "train_data.head()"
+    "train_data.head()\n"
    ]
   },
   {
@@ -514,7 +708,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "id": "876427f0",
    "metadata": {},
    "outputs": [
@@ -584,7 +778,7 @@
        "        1997-06-01 12:00:00      1.0"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -597,7 +791,7 @@
     "known_covariates = pd.DataFrame(index=future_index)\n",
     "known_covariates[\"weekend\"] = future_timestamps.weekday.isin(WEEKEND_INDICES).astype(float)\n",
     "\n",
-    "known_covariates.head()"
+    "known_covariates.head()\n"
    ]
   },
   {
@@ -656,7 +850,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "id": "1f7cbfd4-bdbd-4b4a-86b7-bba7d038ee51",
    "metadata": {},
    "outputs": [
@@ -727,7 +921,7 @@
        "        2022-01-04       5"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -742,7 +936,7 @@
     "        }\n",
     "    )\n",
     ")\n",
-    "df_irregular"
+    "df_irregular\n"
    ]
   },
   {
@@ -772,7 +966,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "id": "4e7f0ab1-a056-4b5d-a912-1a1008044544",
    "metadata": {},
    "outputs": [
@@ -858,14 +1052,14 @@
        "        2022-01-04     5.0"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "df_regular = df_irregular.convert_frequency(freq=\"D\")\n",
-    "df_regular"
+    "df_regular\n"
    ]
   },
   {
@@ -879,7 +1073,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "id": "50c58d1b-445d-4a92-a16e-55fd0b783953",
    "metadata": {},
    "outputs": [
@@ -892,7 +1086,7 @@
     }
    ],
    "source": [
-    "print(f\"Data has frequency '{df_regular.freq}'\")"
+    "print(f\"Data has frequency '{df_regular.freq}'\")\n"
    ]
   },
   {
@@ -907,7 +1101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "id": "1440ea27-ff0e-4cda-90a2-0f5021f78514",
    "metadata": {},
    "outputs": [
@@ -993,14 +1187,14 @@
        "        2022-01-04     5.0"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "df_filled = df_regular.fill_missing_values()\n",
-    "df_filled"
+    "df_filled\n"
    ]
   },
   {
@@ -1017,14 +1211,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "a989f8e2",
    "metadata": {},
    "outputs": [],
    "source": [
     "prediction_length = 48\n",
     "data = TimeSeriesDataFrame.from_path(\"https://autogluon.s3.amazonaws.com/datasets/timeseries/m4_hourly_subset/train.csv\")\n",
-    "train_data, test_data = data.train_test_split(prediction_length)"
+    "train_data, test_data = data.train_test_split(prediction_length)\n"
    ]
   },
   {
@@ -1040,7 +1234,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "id": "5fb03059",
    "metadata": {},
    "outputs": [
@@ -1070,7 +1264,7 @@
     "for ax in (ax1, ax2):\n",
     "    ax.fill_between(np.array([train_ts.index[-1], test_ts.index[-1]]), test_ts.min(), test_ts.max(), color=\"C1\", alpha=0.3, label=\"Forecast horizon\")\n",
     "plt.legend()\n",
-    "plt.show()"
+    "plt.show()\n"
    ]
   },
   {
@@ -1356,7 +1550,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.17"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -180,7 +180,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
             if not isinstance(value, pd.DataFrame):
                 raise ValueError(f"static_features must be a pandas DataFrame (received object of type {type(value)})")
             if isinstance(value.index, pd.MultiIndex):
-                raise ValueError(f"static_features cannot have a MultiIndex")
+                raise ValueError("static_features cannot have a MultiIndex")
 
             # Avoid modifying static features inplace
             value = value.copy()

--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -113,7 +113,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
         constructing a TimeSeriesDataFrame using format 1 (DataFrame without multi-index) or 2 (path to a file).
     num_cpus : int, default = -1
         Number of CPU cores used to process the iterable dataset in parallel. Set to -1 to use all cores. This argument
-        is only used when constructing a TimeSeriesDataFrame using format 3 (iterable dataset).
+        is only used when constructing a TimeSeriesDataFrame using format 4 (iterable dataset).
 
     Attributes
     ----------

--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -184,7 +184,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
 
             # Avoid modifying static features inplace
             value = value.copy()
-            if ITEMID in value.columns:
+            if ITEMID in value.columns and value.index.name != ITEMID:
                 value = value.set_index(ITEMID)
             if value.index.name != ITEMID:
                 value.index.rename(ITEMID, inplace=True)

--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -73,9 +73,9 @@ class TimeSeriesDataFrame(pd.DataFrame):
                 ]
 
     static_features : Optional[pd.DataFrame]
-        An optional data frame describing the time-independent attributes of each individual time series. These can be
-        real-valued or categorical. For example, if ``TimeSeriesDataFrame`` contains sales of various products, static
-        features may refer to time-independent features like color or brand.
+        An optional data frame describing the metadata of each individual time series that does not change with time.
+        Can take real-valued or categorical values. For example, if ``TimeSeriesDataFrame`` contains sales of various
+        products, static features may refer to time-independent features like color or brand.
 
         The index of the ``static_features`` index must contain a single entry for each item present in the respective
         ``TimeSeriesDataFrame``. For example, the following ``TimeSeriesDataFrame``::

--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -153,7 +153,9 @@ class TimeSeriesDataFrame(pd.DataFrame):
                     data, id_column=id_column, timestamp_column=timestamp_column
                 )
         elif isinstance(data, (str, Path)):
-            data = self._load_tsdf_from_path(data, id_column=id_column, timestamp_column=timestamp_column)
+            data = self._construct_tsdf_from_data_frame(
+                load_pd.load(str(data)), id_column=id_column, timestamp_column=timestamp_column
+            )
         elif isinstance(data, Iterable):
             data = self._construct_tsdf_from_iterable_dataset(data, num_cpus=num_cpus)
         else:
@@ -208,16 +210,6 @@ class TimeSeriesDataFrame(pd.DataFrame):
 
         cls._validate_data_frame(df)
         return df.set_index([ITEMID, TIMESTAMP])
-
-    @classmethod
-    def _load_tsdf_from_path(
-        cls,
-        path: Union[str, Path],
-        id_column: Optional[str] = None,
-        timestamp_column: Optional[str] = None,
-    ) -> pd.DataFrame:
-        df = load_pd.load(str(path))
-        return cls._construct_tsdf_from_data_frame(df, id_column=id_column, timestamp_column=timestamp_column)
 
     @classmethod
     def _construct_tsdf_from_iterable_dataset(cls, iterable_dataset: Iterable, num_cpus: int = -1) -> pd.DataFrame:

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -2,6 +2,7 @@ import logging
 import os
 import pprint
 import time
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import pandas as pd
@@ -97,7 +98,7 @@ class TimeSeriesPredictor:
     quantile_levels : List[float], optional
         List of increasing decimals that specifies which quantiles should be estimated when making distributional
         forecasts. Defaults to ``[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]``.
-    path : str, optional
+    path : str or Path, optional
         Path to the directory where models and intermediate outputs will be saved. Defaults to a timestamped folder
         ``AutogluonModels/ag-[TIMESTAMP]`` that will be created in the working directory.
     verbosity : int, default = 2
@@ -128,7 +129,7 @@ class TimeSeriesPredictor:
         freq: str = None,
         eval_metric: Union[str, TimeSeriesScorer, None] = None,
         eval_metric_seasonal_period: Optional[int] = None,
-        path: Optional[str] = None,
+        path: Optional[Union[str, Path]] = None,
         verbosity: int = 2,
         quantile_levels: Optional[List[float]] = None,
         cache_predictions: bool = True,
@@ -800,12 +801,12 @@ class TimeSeriesPredictor:
         return version
 
     @classmethod
-    def load(cls, path: str, require_version_match: bool = True) -> "TimeSeriesPredictor":
+    def load(cls, path: Union[str, Path], require_version_match: bool = True) -> "TimeSeriesPredictor":
         """Load an existing ``TimeSeriesPredictor`` from given ``path``.
 
         Parameters
         ----------
-        path : str
+        path : str or Path
             Path where the predictor was saved via :meth:`~autogluon.timeseries.TimeSeriesPredictor.save`.
         require_version_match : bool, default = True
             If True, will raise an AssertionError if the ``autogluon.timeseries`` version of the loaded predictor does
@@ -824,7 +825,7 @@ class TimeSeriesPredictor:
         """
         if not path:
             raise ValueError("`path` cannot be None or empty in load().")
-        path = setup_outputdir(path, warn_if_exist=False)
+        path: str = setup_outputdir(path, warn_if_exist=False)
 
         try:
             version_saved = cls._load_version_file(path=path)

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -98,7 +98,7 @@ class TimeSeriesPredictor:
     quantile_levels : List[float], optional
         List of increasing decimals that specifies which quantiles should be estimated when making distributional
         forecasts. Defaults to ``[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]``.
-    path : str or Path, optional
+    path : str or pathlib.Path, optional
         Path to the directory where models and intermediate outputs will be saved. Defaults to a timestamped folder
         ``AutogluonModels/ag-[TIMESTAMP]`` that will be created in the working directory.
     verbosity : int, default = 2
@@ -806,7 +806,7 @@ class TimeSeriesPredictor:
 
         Parameters
         ----------
-        path : str or Path
+        path : str or pathlib.Path
             Path where the predictor was saved via :meth:`~autogluon.timeseries.TimeSeriesPredictor.save`.
         require_version_match : bool, default = True
             If True, will raise an AssertionError if the ``autogluon.timeseries`` version of the loaded predictor does

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -1,6 +1,7 @@
 """Unit tests for predictors"""
 import copy
 import tempfile
+from pathlib import Path
 from unittest import mock
 
 import numpy as np
@@ -54,6 +55,18 @@ def test_given_hyperparameters_when_predictor_called_then_model_can_predict(temp
     assert all(predicted_item_index == DUMMY_TS_DATAFRAME.item_ids)  # noqa
     assert all(len(predictions.loc[i]) == 3 for i in predicted_item_index)
     assert not np.any(np.isnan(predictions))
+
+
+def test_when_pathlib_path_provided_to_predictor_then_loaded_predictor_can_predict(temp_model_path):
+    predictor = TimeSeriesPredictor(path=Path(temp_model_path))
+    predictor.fit(
+        train_data=DUMMY_TS_DATAFRAME,
+        hyperparameters={"SimpleFeedForward": {"epochs": 1}},
+    )
+    predictor.save()
+    loaded_predictor = TimeSeriesPredictor.load(predictor.path)
+    predictions = loaded_predictor.predict(DUMMY_TS_DATAFRAME)
+    assert isinstance(predictions, TimeSeriesDataFrame)
 
 
 @pytest.mark.parametrize("hyperparameters", TEST_HYPERPARAMETER_SETTINGS + ["fast_training"])  # noqa

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -718,6 +718,16 @@ def test_given_item_id_is_stored_as_column_and_not_index_in_static_features_then
     assert ts_df.static_features.equals(SAMPLE_TS_DATAFRAME_STATIC.static_features)
 
 
+def test_given_item_id_stored_in_both_index_and_column_when_constructing_tsdf_then_values_in_index_are_used():
+    df = SAMPLE_DATAFRAME.copy()
+    static_df = SAMPLE_STATIC_DATAFRAME.copy()
+    static_df = static_df.set_index(ITEMID)
+    static_df[ITEMID] = ["B", "C", "A"]  # these shouldn't be used; static_df.index should be used instead
+    ts_df = TimeSeriesDataFrame(df)
+    ts_df.static_features = static_df
+    assert (ts_df.static_features[ITEMID] == ["B", "C", "A"]).all()
+
+
 SAMPLE_DATAFRAME_WITH_MIXED_INDEX = pd.DataFrame(
     [
         {ITEMID: 2, TIMESTAMP: pd.Timestamp("2020-01-01"), "target": 2.5},

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -53,6 +53,7 @@ SAMPLE_TS_DATAFRAME_STATIC = _build_ts_dataframe(
     ),
 )
 SAMPLE_DATAFRAME = pd.DataFrame(SAMPLE_TS_DATAFRAME).reset_index()
+SAMPLE_STATIC_DATAFRAME = SAMPLE_TS_DATAFRAME_STATIC.static_features.reset_index()
 
 
 SAMPLE_ITERABLE = [
@@ -691,6 +692,32 @@ def test_when_dataframe_reindexed_view_called_then_static_features_stay_consiste
     assert view._static_features.equals(SAMPLE_TS_DATAFRAME_STATIC._static_features)
 
 
+def test_given_wrong_ids_stored_in_item_id_column_when_constructing_tsdf_then_exception_is_raised():
+    df = SAMPLE_DATAFRAME.copy()
+    static_df = SAMPLE_STATIC_DATAFRAME.copy()
+    static_df.index = ["B", "C", "A"]
+    static_df["item_id"] = ["B", "C", "A"]
+    with pytest.raises(ValueError, match="ids are missing from the index"):
+        TimeSeriesDataFrame(df, static_features=static_df)
+
+
+def test_given_static_features_have_multiindex_when_constructing_tsdf_then_exception_is_raised():
+    df = SAMPLE_DATAFRAME.copy()
+    static_df = SAMPLE_STATIC_DATAFRAME.copy()
+    static_df.index = pd.MultiIndex.from_arrays([ITEM_IDS, ["B", "C", "A"]], names=["item_id", "extra_level"])
+    with pytest.raises(ValueError, match="cannot have a MultiIndex"):
+        TimeSeriesDataFrame(df, static_features=static_df)
+
+
+def test_given_item_id_is_stored_as_column_and_not_index_in_static_features_then_tsdf_is_constructed_correctly():
+    df = SAMPLE_DATAFRAME.copy()
+    static_df = SAMPLE_STATIC_DATAFRAME.copy()
+    static_df.index = ["B", "C", "A"]
+    static_df["item_id"] = ITEM_IDS
+    ts_df = TimeSeriesDataFrame(df, static_features=static_df)
+    assert ts_df.static_features.equals(SAMPLE_TS_DATAFRAME_STATIC.static_features)
+
+
 SAMPLE_DATAFRAME_WITH_MIXED_INDEX = pd.DataFrame(
     [
         {ITEMID: 2, TIMESTAMP: pd.Timestamp("2020-01-01"), "target": 2.5},
@@ -708,7 +735,7 @@ SAMPLE_DATAFRAME_WITH_MIXED_INDEX = pd.DataFrame(
         SAMPLE_DATAFRAME_WITH_MIXED_INDEX.set_index([ITEMID, TIMESTAMP]),
     ],
 )
-def test_when_item_id_index_has_mixed_dtype_then_value_error_is_raied(input_df):
+def test_when_item_id_index_has_mixed_dtype_then_value_error_is_raised(input_df):
     with pytest.raises(ValueError, match="must be of integer or string dtype"):
         TimeSeriesDataFrame(input_df)
 
@@ -744,6 +771,43 @@ def test_when_path_is_given_to_constructor_then_tsdf_is_constructed_correctly():
         assert isinstance(ts_df.index, pd.MultiIndex)
         assert ts_df.index.names == [ITEMID, TIMESTAMP]
         assert len(ts_df) == len(SAMPLE_TS_DATAFRAME)
+
+
+def test_given_custom_id_column_when_data_and_static_are_loaded_from_path_them_tsdf_is_constructed_correctly():
+    df = pd.DataFrame(SAMPLE_TS_DATAFRAME_STATIC).reset_index()
+    static_df = SAMPLE_TS_DATAFRAME_STATIC.static_features.reset_index()
+
+    df = df.rename(columns={ITEMID: "custom_item_id"})
+    static_df = static_df.rename(columns={ITEMID: "custom_item_id"})
+
+    with TemporaryDirectory() as temp_dir:
+        temp_file = Path(temp_dir) / "data.csv"
+        df.to_csv(temp_file, index=False)
+
+        temp_static_file = Path(temp_dir) / "static.csv"
+        static_df.to_csv(temp_static_file, index=False)
+
+        ts_df = TimeSeriesDataFrame.from_path(
+            temp_file, id_column="custom_item_id", static_features_path=temp_static_file
+        )
+    assert isinstance(ts_df, TimeSeriesDataFrame)
+    assert isinstance(ts_df.index, pd.MultiIndex)
+    assert ts_df.index.names == [ITEMID, TIMESTAMP]
+    assert len(ts_df) == len(SAMPLE_TS_DATAFRAME_STATIC)
+
+    assert ts_df.static_features.index.equals(SAMPLE_TS_DATAFRAME_STATIC.static_features.index)
+    assert ts_df.static_features.columns.equals(SAMPLE_TS_DATAFRAME_STATIC.static_features.columns)
+
+
+def test_given_static_features_are_missing_when_loading_from_path_then_tsdf_can_be_constructed():
+    df = SAMPLE_DATAFRAME.copy()
+    with TemporaryDirectory() as temp_dir:
+        temp_file = Path(temp_dir) / "data.csv"
+        df.to_csv(temp_file, index=False)
+
+        ts_df = TimeSeriesDataFrame.from_path(temp_file, id_column=ITEMID, static_features_path=None)
+    assert isinstance(ts_df, TimeSeriesDataFrame)
+    assert ts_df.static_features is None
 
 
 FILL_METHODS = ["auto", "ffill", "pad", "backfill", "bfill", "interpolate", "constant"]
@@ -787,11 +851,30 @@ def test_when_dropna_called_then_missing_values_are_dropped():
     assert not df_dropped.isna().any().any()
 
 
+def test_given_static_features_dont_contain_custom_id_column_when_from_data_frame_called_then_exception_is_raised():
+    df = SAMPLE_DATAFRAME.copy()
+    df = df.rename(columns={ITEMID: "custom_id"})
+    static_df = SAMPLE_STATIC_DATAFRAME.copy()
+    with pytest.raises(AssertionError, match="id' not found in static"):
+        TimeSeriesDataFrame.from_data_frame(df, id_column="custom_id", static_features_df=static_df)
+
+
 def test_when_data_contains_item_id_column_that_is_unused_then_column_is_renamed():
     df = SAMPLE_DATAFRAME.copy()
     df["custom_id"] = df[ITEMID]
     ts_df = TimeSeriesDataFrame.from_data_frame(df, id_column="custom_id")
     assert f"__{ITEMID}" in ts_df.columns
+
+
+def test_when_static_features_contain_item_id_column_that_is_unused_then_column_is_renamed():
+    df = SAMPLE_DATAFRAME.copy()
+    df["custom_id"] = df[ITEMID]
+
+    static_df = SAMPLE_STATIC_DATAFRAME.copy()
+    static_df["custom_id"] = static_df[ITEMID]
+
+    ts_df = TimeSeriesDataFrame.from_data_frame(df, id_column="custom_id", static_features_df=static_df)
+    assert f"__{ITEMID}" in ts_df.static_features.columns
 
 
 def test_when_data_contains_timestamp_column_that_is_unused_then_column_is_renamed():


### PR DESCRIPTION
## Problem

Currently, there are only two ways for the user to create a `TimeSeriesDataFrame` with `static_features`.

1. After creating a TSDF in any way (e.g., using `from_data_frame`, `from_path`), we attach the static features as
    ```python
    tsdf = TimeSeriesDataFrame.from_data_frame(...)
    tsdf.static_features = static_df
    ```
2. Set at creation time (this approach is not documented)
    ```python
    tsdf = TimeSeriesDataFrame(..., static_features=static_df)
   ```

In both of these cases, `static_df` must be a `pd.DataFrame` with `item_id` **set as index**. This is rather restrictive and is not compatible with other methods for TSDF creation such as `TimeSeriesDataFrame.from_data_frame`:
- What if `item_id` is a column and not the index?
- What if the item ID column is not called `item_id`?

## Proposed solution

This PR adds support for new ways to attach `static_features` to a `TimeSeriesDataFrame`.

3. Using [`from_data_frame`](https://auto.gluon.ai/stable/api/autogluon.timeseries.TimeSeriesDataFrame.from_data_frame.html) constructor
    ```python
    tsdf = TimeSeriesDataFrame.from_data_frame(data, id_column="custom_id_column", static_features_df=static_df)
    ```
    This method assumes that `static_df` has a column with name `"custom_id_column"` that contains the item ids.
4. Using [`from_path`](https://auto.gluon.ai/stable/api/autogluon.timeseries.TimeSeriesDataFrame.from_path.html) constructor
    ```python
    tsdf = TimeSeriesDataFrame.from_path(data_path, id_column="custom_id_column", static_features_path="static.csv")
    ```
    This method assumes that `static.csv` contains a column with name `"custom_id_column"` that contains the item ids.
5. Methods (1) and (2) described above now also work if `item_id` is a column of `static_df` and not necessarily the index.
--------
## This PR

*Description of changes*:
- Enable passing `static_features` in `TimeSeriesDataFrame.from_data_frame` and `TimeSeriesDataFrame.from_path` methods.
- Automatically use the `item_id` column as index, if it's present in `static_features`.
- Support passing paths as `pathlib.Path` type (before only `str` was supported).
- Update `forecasting-indepth` tutorial to reflect new changes to the API.
- Simplify the internal logic of `TimeSeriesDataFrame` creation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
