### PR TITLE
[timeseries] Support passing multiple evaluation metrics to TimeSeriesPredictor.evaluate

### DIFF
--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -185,11 +185,11 @@ class TimeSeriesLearner(AbstractLearner):
         self,
         data: TimeSeriesDataFrame,
         model: AbstractTimeSeriesModel = None,
-        metric: Union[str, TimeSeriesScorer, None] = None,
+        metrics: Optional[Union[str, TimeSeriesScorer, List[Union[str, TimeSeriesScorer]]]] = None,
         use_cache: bool = True,
     ) -> float:
         data = self.feature_generator.transform(data)
-        return self.load_trainer().score(data=data, model=model, metric=metric, use_cache=use_cache)
+        return self.load_trainer().score(data=data, model=model, metrics=metrics, use_cache=use_cache)
 
     def leaderboard(self, data: Optional[TimeSeriesDataFrame] = None, use_cache: bool = True) -> pd.DataFrame:
         if data is not None:

--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -185,11 +185,21 @@ class TimeSeriesLearner(AbstractLearner):
         self,
         data: TimeSeriesDataFrame,
         model: AbstractTimeSeriesModel = None,
-        metrics: Optional[Union[str, TimeSeriesScorer, List[Union[str, TimeSeriesScorer]]]] = None,
+        metric: Union[str, TimeSeriesScorer, None] = None,
         use_cache: bool = True,
     ) -> float:
         data = self.feature_generator.transform(data)
-        return self.load_trainer().score(data=data, model=model, metrics=metrics, use_cache=use_cache)
+        return self.load_trainer().score(data=data, model=model, metric=metric, use_cache=use_cache)
+
+    def evaluate(
+        self,
+        data: Union[TimeSeriesDataFrame, pd.DataFrame, str],
+        model: Optional[str] = None,
+        metrics: Optional[Union[str, TimeSeriesScorer, List[Union[str, TimeSeriesScorer]]]] = None,
+        use_cache: bool = True,
+    ) -> Dict[str, float]:
+        data = self.feature_generator.transform(data)
+        return self.load_trainer().evaluate(data=data, model=model, metrics=metrics, use_cache=use_cache)
 
     def leaderboard(self, data: Optional[TimeSeriesDataFrame] = None, use_cache: bool = True) -> pd.DataFrame:
         if data is not None:

--- a/timeseries/src/autogluon/timeseries/metrics/__init__.py
+++ b/timeseries/src/autogluon/timeseries/metrics/__init__.py
@@ -29,9 +29,13 @@ AVAILABLE_METRICS = {
     "WAPE": WAPE,
     "SQL": SQL,
     "WQL": WQL,
-    # Exist for compatibility
     "MSE": MSE,
     "MAE": MAE,
+}
+
+# For backward compatibility
+DEPRECATED_METRICS = {
+    "mean_wQuantileLoss": "WQL",
 }
 
 
@@ -44,6 +48,7 @@ def check_get_evaluation_metric(
         # e.g., user passed `eval_metric=CustomMetric` instead of `eval_metric=CustomMetric()`
         eval_metric = eval_metric()
     elif isinstance(eval_metric, str):
+        eval_metric = DEPRECATED_METRICS.get(eval_metric, eval_metric)
         if eval_metric.upper() not in AVAILABLE_METRICS:
             raise ValueError(
                 f"Time series metric {eval_metric} not supported. Available metrics are:\n"

--- a/timeseries/src/autogluon/timeseries/metrics/__init__.py
+++ b/timeseries/src/autogluon/timeseries/metrics/__init__.py
@@ -1,4 +1,4 @@
-import json
+from pprint import pformat
 from typing import Type, Union
 
 from .abstract import TimeSeriesScorer
@@ -47,7 +47,7 @@ def check_get_evaluation_metric(
         if eval_metric.upper() not in AVAILABLE_METRICS:
             raise ValueError(
                 f"Time series metric {eval_metric} not supported. Available metrics are:\n"
-                f"{json.dumps(list(AVAILABLE_METRICS.keys()), indent=2)}"
+                f"{pformat(sorted(AVAILABLE_METRICS.keys()))}"
             )
         eval_metric = AVAILABLE_METRICS[eval_metric.upper()]()
     elif eval_metric is None:

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -758,11 +758,13 @@ class TimeSeriesPredictor:
         self,
         data: Union[TimeSeriesDataFrame, pd.DataFrame, str],
         model: Optional[str] = None,
-        metric: Union[str, TimeSeriesScorer, None] = None,
+        metrics: Optional[Union[str, TimeSeriesScorer, List[Union[str, TimeSeriesScorer]]]] = None,
         use_cache: bool = True,
-    ):
-        """Evaluate the performance for given dataset, computing the score determined by ``self.eval_metric``
-        on the given data set, and with the same ``prediction_length`` used when training models.
+    ) -> Dict[str, float]:
+        """Evaluate the forecast accuracy for given dataset.
+
+        This method measures the forecast accuracy using the last ``self.prediction_length`` time steps of each time
+        series in ``data`` as a hold-out set.
 
         Parameters
         ----------
@@ -781,23 +783,24 @@ class TimeSeriesPredictor:
         model : str, optional
             Name of the model that you would like to evaluate. By default, the best model during training
             (with highest validation score) will be used.
-        metric : str or TimeSeriesScorer, optional
-            Evaluation metric to compute scores with. Defaults to ``self.eval_metric``
+        metrics : str, TimeSeriesScorer or List[Union[str, TimeSeriesScorer]], optional
+            Metric or a list of metrics to compute scores with. Defaults to ``self.eval_metric``. Supports both
+            metric names as strings and custom metrics based on TimeSeriesScorer.
         use_cache : bool, default = True
             If True, will attempt to use the cached predictions. If False, cached predictions will be ignored.
             This argument is ignored if ``cache_predictions`` was set to False when creating the ``TimeSeriesPredictor``.
 
         Returns
         -------
-        score : float
-            A forecast accuracy score, where higher values indicate better quality. For consistency, error metrics
+        scores_dict : Dict[str, float]
+            Dictionary where keys = metrics, values = performance along each metric. For consistency, error metrics
             will have their signs flipped to obey this convention. For example, negative MAPE values will be reported.
         """
         data = self._check_and_prepare_data_frame(data)
         self._check_data_for_evaluation(data)
-        return self._learner.score(data, model=model, metric=metric, use_cache=use_cache)
+        return self._learner.score(data, model=model, metrics=metrics, use_cache=use_cache)
 
-    def score(self, data: Union[TimeSeriesDataFrame, pd.DataFrame, str], **kwargs):
+    def score(self, data: Union[TimeSeriesDataFrame, pd.DataFrame, str], **kwargs) -> Dict[str, float]:
         """See, :meth:`~autogluon.timeseries.TimeSeriesPredictor.evaluate`."""
         return self.evaluate(data, **kwargs)
 

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -5,7 +5,7 @@ import time
 import traceback
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union, Iterable
 
 import networkx as nx
 import numpy as np
@@ -817,30 +817,37 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         self,
         data: TimeSeriesDataFrame,
         predictions: TimeSeriesDataFrame,
-        metric: Union[str, TimeSeriesScorer, None] = None,
-    ) -> float:
+        metrics: Optional[Union[str, TimeSeriesScorer, List[Union[str, TimeSeriesScorer]]]] = None,
+    ) -> Dict[str, float]:
         """Compute the score measuring how well the predictions align with the data."""
-        eval_metric = self.eval_metric if metric is None else check_get_evaluation_metric(metric)
-        return eval_metric.score(
-            data=data,
-            predictions=predictions,
-            prediction_length=self.prediction_length,
-            target=self.target,
-            seasonal_period=self.eval_metric_seasonal_period,
-        )
+        if metrics is None:
+            metrics = [self.eval_metric]
+        if not isinstance(metrics, Iterable):
+            metrics = [metrics]
+        scores_dict = {}
+        for metric in metrics:
+            eval_metric = check_get_evaluation_metric(metric)
+            scores_dict[eval_metric.name] = eval_metric.score(
+                data=data,
+                predictions=predictions,
+                prediction_length=self.prediction_length,
+                target=self.target,
+                seasonal_period=self.eval_metric_seasonal_period,
+            )
+        return scores_dict
 
     def score(
         self,
         data: TimeSeriesDataFrame,
         model: Optional[Union[str, AbstractTimeSeriesModel]] = None,
-        metric: Union[str, TimeSeriesScorer, None] = None,
+        metrics: Optional[Union[str, TimeSeriesScorer, List[Union[str, TimeSeriesScorer]]]] = None,
         use_cache: bool = True,
-    ) -> float:
+    ) -> Dict[str, float]:
         past_data, known_covariates = data.get_model_inputs_for_scoring(
             prediction_length=self.prediction_length, known_covariates_names=self.metadata.known_covariates_real
         )
         predictions = self.predict(data=past_data, known_covariates=known_covariates, model=model, use_cache=use_cache)
-        return self._score_with_predictions(data=data, predictions=predictions, metric=metric)
+        return self._score_with_predictions(data=data, predictions=predictions, metrics=metrics)
 
     def _predict_model(
         self,

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -5,7 +5,7 @@ import time
 import traceback
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Type, Union, Iterable
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 
 import networkx as nx
 import numpy as np

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -5,7 +5,7 @@ import time
 import traceback
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import networkx as nx
 import numpy as np
@@ -851,7 +851,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
             prediction_length=self.prediction_length, known_covariates_names=self.metadata.known_covariates_real
         )
         predictions = self.predict(data=past_data, known_covariates=known_covariates, model=model, use_cache=use_cache)
-        if not isinstance(metrics, Iterable):  # a single metric is provided
+        if not isinstance(metrics, list):  # a single metric is provided
             metrics = [metrics]
         scores_dict = {}
         for metric in metrics:

--- a/timeseries/tests/smoketests/test_all_models.py
+++ b/timeseries/tests/smoketests/test_all_models.py
@@ -117,7 +117,7 @@ def test_all_models_can_handle_all_covariates(
         eval_metric=eval_metric,
     )
     predictor.fit(train_data, hyperparameters=ALL_MODELS)
-    predictor.score(test_data)
+    predictor.evaluate(test_data)
     leaderboard = predictor.leaderboard(test_data)
 
     assert_leaderboard_contains_all_models(leaderboard)
@@ -152,7 +152,7 @@ def test_all_models_handle_all_pandas_frequencies(freq):
         known_covariates_names=known_covariates_names if len(known_covariates_names) > 0 else None,
     )
     predictor.fit(train_data, hyperparameters=ALL_MODELS)
-    predictor.score(test_data)
+    predictor.evaluate(test_data)
     leaderboard = predictor.leaderboard(test_data)
 
     assert_leaderboard_contains_all_models(leaderboard)

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -451,7 +451,7 @@ def test_when_some_time_series_contain_only_nans_then_exception_is_raised(temp_m
         predictor._check_and_prepare_data_frame(df)
 
 
-@pytest.mark.parametrize("method", ["score", "leaderboard"])
+@pytest.mark.parametrize("method", ["evaluate", "leaderboard"])
 def test_when_scoring_method_receives_only_future_data_then_exception_is_raised(temp_model_path, method):
     prediction_length = 3
     predictor = TimeSeriesPredictor(path=temp_model_path, prediction_length=prediction_length)
@@ -584,7 +584,7 @@ def test_when_excluded_model_names_provided_then_excluded_models_are_not_trained
     assert leaderboard["model"].values == ["SimpleFeedForward"]
 
 
-@pytest.mark.parametrize("method_name", ["leaderboard", "predict", "score", "evaluate"])
+@pytest.mark.parametrize("method_name", ["leaderboard", "predict", "evaluate"])
 @pytest.mark.parametrize("use_cache", [True, False])
 def test_when_use_cache_is_set_to_false_then_cached_predictions_are_ignored(temp_model_path, use_cache, method_name):
     predictor = TimeSeriesPredictor(path=temp_model_path, cache_predictions=True).fit(

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -309,7 +309,7 @@ def test_given_model_fails_when_predictor_scores_then_exception_is_raised(temp_m
     with mock.patch("autogluon.timeseries.models.local.statsforecast.ETSModel.predict") as arima_predict:
         arima_predict.side_effect = RuntimeError("Numerical error")
         with pytest.raises(RuntimeError, match="Following models failed to predict: \\['ETS'\\]"):
-            predictor.score(DUMMY_TS_DATAFRAME)
+            predictor.evaluate(DUMMY_TS_DATAFRAME)
 
 
 def test_given_no_searchspace_and_hyperparameter_tune_kwargs_when_predictor_fits_then_exception_is_raised(
@@ -473,7 +473,7 @@ def test_given_data_is_in_dataframe_format_then_predictor_works(temp_model_path)
     predictor = TimeSeriesPredictor(path=temp_model_path)
     predictor.fit(df, hyperparameters={"Naive": {}})
     predictor.leaderboard(df)
-    predictor.score(df)
+    predictor.evaluate(df)
     predictions = predictor.predict(df)
     assert isinstance(predictions, TimeSeriesDataFrame)
 
@@ -485,7 +485,7 @@ def test_given_data_is_in_str_format_then_predictor_works(temp_model_path):
         predictor = TimeSeriesPredictor(path=temp_model_path)
         predictor.fit(df, hyperparameters={"Naive": {}})
         predictor.leaderboard(df)
-        predictor.score(df)
+        predictor.evaluate(df)
         predictions = predictor.predict(df)
         assert isinstance(predictions, TimeSeriesDataFrame)
 
@@ -878,15 +878,16 @@ def test_given_refit_every_n_windows_when_fit_then_model_is_fit_correct_number_o
     assert actual_num_refits == expected_num_refits
 
 
-def test_given_custom_metric_when_creating_predictor_then_predictor_can_score(temp_model_path):
+def test_given_custom_metric_when_creating_predictor_then_predictor_can_evaluate(temp_model_path):
     predictor = TimeSeriesPredictor(path=temp_model_path, eval_metric=CustomMetric())
     predictor.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}})
-    score = predictor.score(DUMMY_TS_DATAFRAME)
-    assert isinstance(score, float)
+    scores = predictor.evaluate(DUMMY_TS_DATAFRAME)
+    assert isinstance(scores[predictor.eval_metric.name], float)
 
 
-def test_when_custom_metric_passed_to_score_then_predictor_can_score(temp_model_path):
+def test_when_custom_metric_passed_to_score_then_predictor_can_evaluate(temp_model_path):
     predictor = TimeSeriesPredictor(path=temp_model_path, eval_metric="MASE")
     predictor.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}})
-    score = predictor.score(DUMMY_TS_DATAFRAME, metric=CustomMetric())
-    assert isinstance(score, float)
+    eval_metric = CustomMetric()
+    scores = predictor.evaluate(DUMMY_TS_DATAFRAME, metric=eval_metric)
+    assert isinstance(scores[eval_metric.name], float)


### PR DESCRIPTION
*Description of changes:*
-  The behavior of `TimeSeriesPredictor.evaluate` now aligns with Tabular/Multimodal predictors:
   - it now returns a dictionary where keys = metric names, values = scores along each metric
   - user can now pass multiple metrics to `evaluate`
- Deprecate the method  `TimeSeriesPredictor.score` as it's just an alias for `TimeSeriesPredictor.evaluate`.
- Do not log a warning if user provides the old name for the `mean_wQuantileLoss` metric. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
