### PR TITLE
[common] Fix FutureWarning in get_approximate_df_mem_usage

### DIFF
--- a/common/src/autogluon/common/utils/pandas_utils.py
+++ b/common/src/autogluon/common/utils/pandas_utils.py
@@ -47,7 +47,7 @@ def get_approximate_df_mem_usage(df: DataFrame, sample_ratio=0.2):
                 num_categories = len(df[column].cat.categories)
                 num_categories_sample = math.ceil(sample_ratio * num_categories)
                 sample_ratio_cat = num_categories_sample / num_categories
-                memory_usage[column] = (
+                memory_usage[column] = int(
                     df[column].cat.codes.dtype.itemsize * num_rows
                     + df[column].cat.categories[:num_categories_sample].memory_usage(deep=True) / sample_ratio_cat
                 )


### PR DESCRIPTION
*Description of changes:*
- Currently, the method `get_approximate_df_mem_usage` produces the following warning with `pandas` `v2.1`:
```
/local/home/shchuro/workspace/autogluon/common/src/autogluon/common/utils/pandas_utils.py:50: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas. Value '1283.3714285714286' has dtype incompatible with int64, please explicitly cast to a compatible dtyp
e first.
```
This PR fixes this warning.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
