### PR TITLE
[timeseries] Fix TimeSeriesFeatureGenerator failing if duplicate static features are present

### DIFF
--- a/timeseries/src/autogluon/timeseries/utils/features.py
+++ b/timeseries/src/autogluon/timeseries/utils/features.py
@@ -98,9 +98,9 @@ class TimeSeriesFeatureGenerator:
 
             unused = []
             for col_name in data.static_features.columns:
-                if static[col_name].dtype == "category":
+                if col_name in static.columns and static[col_name].dtype == "category":
                     static_features_cat.append(col_name)
-                elif static[col_name].dtype == np.float64:
+                elif col_name in static.columns and static[col_name].dtype == np.float64:
                     static_features_real.append(col_name)
                 else:
                     unused.append(col_name)
@@ -109,7 +109,7 @@ class TimeSeriesFeatureGenerator:
             logger.info(f"\tcategorical:        {static_features_cat}")
             logger.info(f"\tcontinuous (float): {static_features_real}")
             if len(unused) > 0:
-                logger.info(f"\tremoved (neither categorical nor continuous): {unused}")
+                logger.info(f"\tremoved (uninformative columns): {unused}")
             logger.info(
                 "To learn how to fix incorrectly inferred types, please see documentation for TimeSeriesPredictor.fit "
             )

--- a/timeseries/tests/unittests/test_features.py
+++ b/timeseries/tests/unittests/test_features.py
@@ -4,7 +4,7 @@ import pytest
 
 from autogluon.timeseries.utils.features import TimeSeriesFeatureGenerator
 
-from .common import get_data_frame_with_variable_lengths
+from .common import DATAFRAME_WITH_STATIC, get_data_frame_with_variable_lengths
 
 
 @pytest.mark.parametrize("known_covariates_names", [["known_1", "known_2"], []])
@@ -30,3 +30,12 @@ def test_when_covariates_present_in_data_then_they_are_included_in_metadata(
     assert metadata.past_covariates_real == past_covariates_names
     assert metadata.static_features_cat == static_features_cat
     assert metadata.static_features_real == static_features_real
+
+
+def test_given_duplicate_static_features_then_generator_can_fit_transform():
+    feat_generator = TimeSeriesFeatureGenerator(target="target", known_covariates_names=[])
+    data = DATAFRAME_WITH_STATIC.copy()
+    data.static_features["feat5"] = data.static_features["feat1"]
+    feat_generator.fit(data)
+    out = feat_generator.transform(data)
+    assert isinstance(out.static_features, pd.DataFrame)


### PR DESCRIPTION
Currently, `TimeSeriesFeatureGenerator` raises an exception if some static features columns are exact duplicates. This happens because the `autogluon.features.generators.PipelineFeatureGenerator` removes these duplicate features from the `static_features` DataFrame, leading to KeyError.

*Description of changes:*
- Ensure that the column hasn't been removed by the `PipelineFeatureGenerator` when reporting metadata for static features.
- Add test that catches this failure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
