### PR TITLE
Address warnings from log_loss metric

### DIFF
--- a/core/src/autogluon/core/metrics/__init__.py
+++ b/core/src/autogluon/core/metrics/__init__.py
@@ -511,7 +511,7 @@ def customized_log_loss(y_true, y_pred, eps=1e-15):
     else:
         assert y_pred.ndim == 2, "Only ndim=2 is supported"
         labels = np.arange(y_pred.shape[1], dtype=np.int32)
-        return sklearn.metrics.log_loss(y_true.astype(np.int32), y_pred, labels=labels, eps=eps)
+        return sklearn.metrics.log_loss(y_true.astype(np.int32), y_pred, labels=labels)
 
 
 # Score function for probabilistic classification

--- a/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py
+++ b/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py
@@ -110,6 +110,9 @@ class EnsembleSelection(AbstractWeightedEnsemble):
             fant_ensemble_prediction = np.zeros(weighted_ensemble_prediction.shape)
             for j, pred in enumerate(predictions):
                 fant_ensemble_prediction[:] = weighted_ensemble_prediction + (1.0 / float(s + 1)) * pred
+                if self.problem_type in ["multiclass", "softclass"]:
+                    # Renormalize
+                    fant_ensemble_prediction[:] = fant_ensemble_prediction / fant_ensemble_prediction.sum(axis=1)[:, np.newaxis]
                 scores[j] = self._calculate_regret(y_true=labels, y_pred_proba=fant_ensemble_prediction, metric=self.metric, sample_weight=sample_weight)
                 if round_scores:
                     scores[j] = scores[j].round(round_decimals)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Address warnings from log_loss metric
- `eps` arg is deprecated in sklearn.metrics.log_loss
- Have to renormalize during weighted ensemble fit to avoid warnings in the log_loss metric.

Mainline:

```
Fitting model: LightGBM ...
/opt/conda/envs/code310new/lib/python3.10/site-packages/sklearn/metrics/_classification.py:2851: FutureWarning: Setting the eps parameter is deprecated and will be removed in 1.5. Instead eps will always havea default value of `np.finfo(y_pred.dtype).eps`.
  warnings.warn(
/opt/conda/envs/code310new/lib/python3.10/site-packages/sklearn/metrics/_classification.py:2922: UserWarning: The y_pred values do not sum to one. Starting from 1.5 thiswill result in an error.
  warnings.warn(
	-1.1347	 = Validation score   (-log_loss)
	1.8s	 = Training   runtime
	0.0s	 = Validation runtime
```

This PR:

```
Fitting model: LightGBM ...
	-1.1347	 = Validation score   (-log_loss)
	1.84s	 = Training   runtime
	0.0s	 = Validation runtime
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
