### PR TITLE
[timeseries] Fix bug caused by `known_covariates_names` provided as a pd.Index instead of list

### DIFF
--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -156,7 +156,7 @@ class TimeSeriesPredictor:
             )
         if self.target in known_covariates_names:
             raise ValueError(f"Target column {self.target} cannot be one of the known covariates.")
-        self.known_covariates_names = known_covariates_names
+        self.known_covariates_names = list(known_covariates_names)
 
         self.prediction_length = prediction_length
         # For each validation fold, all time series in training set must have length >= _min_train_length

--- a/timeseries/src/autogluon/timeseries/utils/features.py
+++ b/timeseries/src/autogluon/timeseries/utils/features.py
@@ -59,7 +59,7 @@ class TimeSeriesFeatureGenerator:
     def __init__(self, target: str, known_covariates_names: List[str]):
         self.target = target
         self._is_fit = False
-        self.known_covariates_names = known_covariates_names
+        self.known_covariates_names = list(known_covariates_names)
         self.past_covariates_names = []
         self.static_feature_pipeline = ContinuousAndCategoricalFeatureGenerator()
         self.covariate_metadata: CovariateMetadata = None


### PR DESCRIPTION
*Description of changes:*
- If user provides `known_covariates_names` as a `np.ndarray` or `pd.Index` instead of `List`, this causes a bug for [MLForecsat models](https://github.com/autogluon/autogluon/blob/master/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py#L212C7-L212C7). Instead of concatenating two lists like `["1", "2"] + ["B"] = ["1", "2", "B"]`, we accidentally append to each entry in the first list as `np.array(["1", "2"]) + ["B"] = ["1B", "2B"]`. Then, the model fails because it cannot find these columns if the dataframe.
- Fix the test that is supposed to catch this bug.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
