### PR TITLE
[AutoMM] Fix a bug in FusionMLP when getting output from single models

### DIFF
--- a/multimodal/src/autogluon/multimodal/models/fusion/fusion_mlp.py
+++ b/multimodal/src/autogluon/multimodal/models/fusion/fusion_mlp.py
@@ -181,7 +181,7 @@ class MultimodalFusionMLP(AbstractMultimodalFusionModel):
                 per_output = {per_model.prefix: {}}
                 per_output[per_model.prefix][WEIGHT] = torch.tensor(self.loss_weight).to(per_logits.dtype)
                 per_output[per_model.prefix][LOGITS] = per_logits
-            output.update(per_output)
+                output.update(per_output)
             fusion_output[self.prefix].update({WEIGHT: torch.tensor(1.0).to(logits)})
             output.update(fusion_output)
             return output


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix a bug in FusionMLP when getting output from single models.
- Previously, only the output of the last single model will be returned.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
