### PR TITLE
Update Pillow to v10.

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -31,11 +31,7 @@ DEPENDENT_PACKAGES = {
     "pytorch_lightning": ">=2.0.0,<2.1",  # "<{N+1}" upper cap
 }
 if LITE_MODE:
-    DEPENDENT_PACKAGES = {
-        package: version
-        for package, version in DEPENDENT_PACKAGES.items()
-        if package not in ["psutil", "Pillow", "timm"]
-    }
+    DEPENDENT_PACKAGES = {package: version for package, version in DEPENDENT_PACKAGES.items() if package not in ["psutil", "Pillow", "timm"]}
 
 DEPENDENT_PACKAGES = {package: package + version for package, version in DEPENDENT_PACKAGES.items()}
 # TODO: Use DOCS_PACKAGES and TEST_PACKAGES

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -25,13 +25,17 @@ DEPENDENT_PACKAGES = {
     "psutil": ">=5.7.3,<6",  # Major version cap
     "networkx": ">=3.0,<4",  # Major version cap
     "tqdm": ">=4.38,<5",  # Major version cap
-    "Pillow": ">=9.3,<9.6",  # "<{N+2}" upper cap
+    "Pillow": ">=10.0.1,<11",  # Major version cap
     "torch": ">=2.0,<2.1",  # "<{N+1}" upper cap, sync with common/src/autogluon/common/utils/try_import.py
     "lightning": ">=2.0.0,<2.1",  # "<{N+1}" upper cap
     "pytorch_lightning": ">=2.0.0,<2.1",  # "<{N+1}" upper cap
 }
 if LITE_MODE:
-    DEPENDENT_PACKAGES = {package: version for package, version in DEPENDENT_PACKAGES.items() if package not in ["psutil", "Pillow", "timm"]}
+    DEPENDENT_PACKAGES = {
+        package: version
+        for package, version in DEPENDENT_PACKAGES.items()
+        if package not in ["psutil", "Pillow", "timm"]
+    }
 
 DEPENDENT_PACKAGES = {package: package + version for package, version in DEPENDENT_PACKAGES.items()}
 # TODO: Use DOCS_PACKAGES and TEST_PACKAGES


### PR DESCRIPTION
Pillow `10.0.1` addresses [CVE-2023-4863](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4863), see: https://pillow.readthedocs.io/en/stable/releasenotes/10.0.1.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
