### PR TITLE
[AutoMM] Add input_keys property in ft_transformer for late fusion

### DIFF
--- a/multimodal/src/autogluon/multimodal/models/ft_transformer.py
+++ b/multimodal/src/autogluon/multimodal/models/ft_transformer.py
@@ -610,6 +610,15 @@ class FT_Transformer(nn.Module):
         return f"{self.prefix}_{NUMERICAL}"
 
     @property
+    def input_keys(self):
+        input_keys = []
+        if self.categorical_feature_tokenizer:
+            input_keys.append(self.categorical_key)
+        if self.numerical_feature_tokenizer:
+            input_keys.append(self.numerical_key)
+        return input_keys
+
+    @property
     def label_key(self):
         return f"{self.prefix}_{LABEL}"
 

--- a/multimodal/src/autogluon/multimodal/models/fusion/fusion_mlp.py
+++ b/multimodal/src/autogluon/multimodal/models/fusion/fusion_mlp.py
@@ -181,7 +181,7 @@ class MultimodalFusionMLP(AbstractMultimodalFusionModel):
                 per_output = {per_model.prefix: {}}
                 per_output[per_model.prefix][WEIGHT] = torch.tensor(self.loss_weight).to(per_logits.dtype)
                 per_output[per_model.prefix][LOGITS] = per_logits
-            output.update(per_output)
+                output.update(per_output)
             fusion_output[self.prefix].update({WEIGHT: torch.tensor(1.0).to(logits)})
             output.update(fusion_output)
             return output

--- a/multimodal/tests/unittests/predictor/test_predictor.py
+++ b/multimodal/tests/unittests/predictor/test_predictor.py
@@ -135,7 +135,7 @@ def verify_no_redundant_model_configs(predictor):
         ),
         (
             "petfinder_bytearray",
-            ["numerical_mlp", "categorical_mlp", "timm_image", "fusion_mlp"],
+            ["ft_transformer", "timm_image", "fusion_mlp"],
             None,
             "mobilenetv3_small_100",
             GREEDY_SOUP,
@@ -144,7 +144,7 @@ def verify_no_redundant_model_configs(predictor):
         ),
         (
             "petfinder",
-            ["numerical_mlp", "categorical_mlp", "hf_text", "fusion_mlp"],
+            ["ft_transformer", "hf_text", "fusion_mlp"],
             "nlpaueb/legal-bert-small-uncased",
             None,
             UNIFORM_SOUP,
@@ -153,7 +153,7 @@ def verify_no_redundant_model_configs(predictor):
         ),
         (
             "petfinder",
-            ["numerical_mlp", "categorical_mlp", "fusion_mlp"],
+            ["ft_transformer"],
             None,
             None,
             BEST,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add input_keys property in ft_transformer for late fusion.
- Fixed the bug in fusion_mlp when getting outputs from single models.
- Add ft_transformer in test_predictor.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
