### PR TITLE
[AutoMM] Fix log gpu info

### DIFF
--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -53,6 +53,7 @@ install_requires = [
     "jinja2>=3.0.3,<3.2",
     "tensorboard>=2.9,<3",
     "pytesseract>=0.3.9,<0.3.11",
+    "nvidia-ml-py3==7.352.0",
 ]
 
 install_requires = ag.get_dependency_version_ranges(install_requires)

--- a/multimodal/src/autogluon/multimodal/utils/log.py
+++ b/multimodal/src/autogluon/multimodal/utils/log.py
@@ -210,7 +210,7 @@ def get_gpu_message(detected_num_gpus: int, used_num_gpus: int, strategy: str):
     gpu_message = f"{detected_num_gpus} GPUs are detected, and {used_num_gpus} GPUs will be used.\n"
     for i in range(detected_num_gpus):
         import nvidia_smi
-        
+
         nvidia_smi.nvmlInit()
         handle = nvidia_smi.nvmlDeviceGetHandleByIndex(i)
         info = nvidia_smi.nvmlDeviceGetMemoryInfo(handle)

--- a/multimodal/src/autogluon/multimodal/utils/log.py
+++ b/multimodal/src/autogluon/multimodal/utils/log.py
@@ -203,23 +203,22 @@ def get_gpu_message(detected_num_gpus: int, used_num_gpus: int, strategy: str):
     -------
     A string with the GPU info.
     """
-    import nvidia_smi
 
     def _bytes_to_gigabytes(bytes):
         return round((bytes / 1024) / 1024 / 1024, 2)
 
     gpu_message = f"{detected_num_gpus} GPUs are detected, and {used_num_gpus} GPUs will be used.\n"
-    if not is_interactive_strategy(strategy):
-        for i in range(detected_num_gpus):
-            nvidia_smi.nvmlInit()
-            handle = nvidia_smi.nvmlDeviceGetHandleByIndex(i)
-            info = nvidia_smi.nvmlDeviceGetMemoryInfo(handle)
+    for i in range(detected_num_gpus):
+        import nvidia_smi
+        nvidia_smi.nvmlInit()
+        handle = nvidia_smi.nvmlDeviceGetHandleByIndex(i)
+        info = nvidia_smi.nvmlDeviceGetMemoryInfo(handle)
 
-            gpu_mem_used = _bytes_to_gigabytes(info.used)
-            gpu_mem_total = _bytes_to_gigabytes(info.total)
+        gpu_mem_used = _bytes_to_gigabytes(info.used)
+        gpu_mem_total = _bytes_to_gigabytes(info.total)
 
-            gpu_message += f"   - GPU {i} name: {torch.cuda.get_device_name(i)}\n"
-            gpu_message += f"   - GPU {i} memory: {gpu_mem_used}GB/{gpu_mem_total}GB (Used/Total)\n"
+        gpu_message += f"   - GPU {i} name: {torch.cuda.get_device_name(i)}\n"
+        gpu_message += f"   - GPU {i} memory: {gpu_mem_used}GB/{gpu_mem_total}GB (Used/Total)\n"
 
     if torch.cuda.is_available():
         gpu_message += f"CUDA version is {torch.version.cuda}.\n"

--- a/multimodal/src/autogluon/multimodal/utils/log.py
+++ b/multimodal/src/autogluon/multimodal/utils/log.py
@@ -206,7 +206,7 @@ def get_gpu_message(detected_num_gpus: int, used_num_gpus: int, strategy: str):
     import nvidia_smi
 
     def _bytes_to_gigabytes(bytes):
-        return round((bytes/1024)/1024/1024,2)
+        return round((bytes / 1024) / 1024 / 1024, 2)
     
     gpu_message = f"{detected_num_gpus} GPUs are detected, and {used_num_gpus} GPUs will be used.\n"
     if not is_interactive_strategy(strategy):
@@ -219,9 +219,8 @@ def get_gpu_message(detected_num_gpus: int, used_num_gpus: int, strategy: str):
             gpu_mem_total = _bytes_to_gigabytes(info.total)
 
             gpu_message += f"   - GPU {i} name: {torch.cuda.get_device_name(i)}\n"
-            gpu_message += (
-                f"   - GPU {i} memory: {gpu_mem_used}GB/{gpu_mem_total}GB (Used/Total)\n"
-            )
+            gpu_message += f"   - GPU {i} memory: {gpu_mem_used}GB/{gpu_mem_total}GB (Used/Total)\n"
+
     if torch.cuda.is_available():
         gpu_message += f"CUDA version is {torch.version.cuda}.\n"
 

--- a/multimodal/src/autogluon/multimodal/utils/log.py
+++ b/multimodal/src/autogluon/multimodal/utils/log.py
@@ -207,7 +207,7 @@ def get_gpu_message(detected_num_gpus: int, used_num_gpus: int, strategy: str):
 
     def _bytes_to_gigabytes(bytes):
         return round((bytes / 1024) / 1024 / 1024, 2)
-    
+
     gpu_message = f"{detected_num_gpus} GPUs are detected, and {used_num_gpus} GPUs will be used.\n"
     if not is_interactive_strategy(strategy):
         for i in range(detected_num_gpus):

--- a/multimodal/src/autogluon/multimodal/utils/log.py
+++ b/multimodal/src/autogluon/multimodal/utils/log.py
@@ -203,22 +203,24 @@ def get_gpu_message(detected_num_gpus: int, used_num_gpus: int, strategy: str):
     -------
     A string with the GPU info.
     """
+    import nvidia_smi
+
+    def _bytes_to_gigabytes(bytes):
+        return round((bytes/1024)/1024/1024,2)
+    
     gpu_message = f"{detected_num_gpus} GPUs are detected, and {used_num_gpus} GPUs will be used.\n"
     if not is_interactive_strategy(strategy):
-        free_memories_command = "nvidia-smi --query-gpu=memory.free --format=csv"
-        free_memories_info = sp.check_output(free_memories_command.split()).decode("ascii").split("\n")[:-1][1:]
-        free_memories = [int(x.split()[0]) for i, x in enumerate(free_memories_info)]
-
-        total_memories_command = "nvidia-smi --query-gpu=memory.total --format=csv"
-        total_memories_info = sp.check_output(total_memories_command.split()).decode("ascii").split("\n")[:-1][1:]
-        total_memories = [int(x.split()[0]) for i, x in enumerate(total_memories_info)]
-
         for i in range(detected_num_gpus):
-            free_memory = free_memories[i]
-            total_memory = total_memories[i]
+            nvidia_smi.nvmlInit()
+            handle = nvidia_smi.nvmlDeviceGetHandleByIndex(i)
+            info = nvidia_smi.nvmlDeviceGetMemoryInfo(handle)
+
+            gpu_mem_used = _bytes_to_gigabytes(info.used)
+            gpu_mem_total = _bytes_to_gigabytes(info.total)
+
             gpu_message += f"   - GPU {i} name: {torch.cuda.get_device_name(i)}\n"
             gpu_message += (
-                f"   - GPU {i} memory: {free_memory * 1e-9:.2f}GB/{total_memory * 1e-9:.2f}GB (Free/Total)\n"
+                f"   - GPU {i} memory: {gpu_mem_used}GB/{gpu_mem_total}GB (Used/Total)\n"
             )
     if torch.cuda.is_available():
         gpu_message += f"CUDA version is {torch.version.cuda}.\n"

--- a/multimodal/src/autogluon/multimodal/utils/log.py
+++ b/multimodal/src/autogluon/multimodal/utils/log.py
@@ -210,6 +210,7 @@ def get_gpu_message(detected_num_gpus: int, used_num_gpus: int, strategy: str):
     gpu_message = f"{detected_num_gpus} GPUs are detected, and {used_num_gpus} GPUs will be used.\n"
     for i in range(detected_num_gpus):
         import nvidia_smi
+        
         nvidia_smi.nvmlInit()
         handle = nvidia_smi.nvmlDeviceGetHandleByIndex(i)
         info = nvidia_smi.nvmlDeviceGetMemoryInfo(handle)


### PR DESCRIPTION
Using `subprocess` + `nvidia-smi` command caused both free and total GPU mem returns 0 in `log_gpu_info`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
