### PR TITLE
Fix memory size estimate after AutoMM refactor

### DIFF
--- a/tabular/src/autogluon/tabular/models/automm/automm_model.py
+++ b/tabular/src/autogluon/tabular/models/automm/automm_model.py
@@ -259,7 +259,7 @@ class MultiModalPredictorModel(AbstractModel):
         memory_size
             The total memory size in bytes.
         """
-        total_size = sum(param.numel() for param in self.model._model.parameters())
+        total_size = self.model.model_size * 1e6  # convert from megabytes to bytes
 
         return total_size
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fix memory size estimate after AutoMM refactor
- Mainline crashes if training an AutoMM model via tabular and then calling `predictor.persist_models()` because `self.model._model` does not exist anymore.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
