### PR TITLE
[AutoMM] Fix test_predictor coverage of categorical mlp

### DIFF
--- a/multimodal/tests/unittests/predictor/test_predictor.py
+++ b/multimodal/tests/unittests/predictor/test_predictor.py
@@ -223,6 +223,7 @@ def test_predictor_basic(
         "optimization.efficient_finetune": efficient_finetune,
         "optimization.loss_function": loss_function,
         "data.categorical.convert_to_text": False,  # ensure the categorical model is used.
+        "data.categorical.minimum_cat_count": 10,  # ensure the categorical model is used on a small subset of dataset (e.g., petfinder).
         "data.numerical.convert_to_text": False,  # ensure the numerical model is used.
     }
     if text_backbone is not None:
@@ -342,6 +343,7 @@ def test_predictor_realtime_inference(
         "optimization.efficient_finetune": efficient_finetune,
         "optimization.loss_function": loss_function,
         "data.categorical.convert_to_text": False,  # ensure the categorical model is used.
+        "data.categorical.minimum_cat_count": 10,  # ensure the categorical model is used on a small subset of dataset (e.g., petfinder).
         "data.numerical.convert_to_text": False,  # ensure the numerical model is used.
     }
     if text_backbone is not None:

--- a/multimodal/tests/unittests/predictor/test_predictor.py
+++ b/multimodal/tests/unittests/predictor/test_predictor.py
@@ -223,7 +223,6 @@ def test_predictor_basic(
         "optimization.efficient_finetune": efficient_finetune,
         "optimization.loss_function": loss_function,
         "data.categorical.convert_to_text": False,  # ensure the categorical model is used.
-        "data.categorical.minimum_cat_count": 10,  # ensure the categorical model is used on a small subset of dataset (e.g., petfinder).
         "data.numerical.convert_to_text": False,  # ensure the numerical model is used.
     }
     if text_backbone is not None:
@@ -343,7 +342,6 @@ def test_predictor_realtime_inference(
         "optimization.efficient_finetune": efficient_finetune,
         "optimization.loss_function": loss_function,
         "data.categorical.convert_to_text": False,  # ensure the categorical model is used.
-        "data.categorical.minimum_cat_count": 10,  # ensure the categorical model is used on a small subset of dataset (e.g., petfinder).
         "data.numerical.convert_to_text": False,  # ensure the numerical model is used.
     }
     if text_backbone is not None:

--- a/multimodal/tests/unittests/utils/unittest_datasets.py
+++ b/multimodal/tests/unittests/utils/unittest_datasets.py
@@ -50,13 +50,13 @@ class PetFinderDataset:
 
         _, self._train_df = train_test_split(
             self._train_df,
-            test_size=0.1,
+            test_size=0.3,
             random_state=np.random.RandomState(123),
             stratify=self._train_df[self.label_columns[0]],
         )
         _, self._test_df = train_test_split(
             self._test_df,
-            test_size=0.1,
+            test_size=0.3,
             random_state=np.random.RandomState(123),
             stratify=self._test_df[self.label_columns[0]],
         )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Categorical MLP is not used in unit test test_predictor because categorical data is filtered out when dataset is too small. Fixed it by using larger subset of `petfinder` dataset.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
