### PR TITLE
[timeseries] Automatically reduce num_val_windows if training data is too short

### DIFF
--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -307,15 +307,16 @@ class TimeSeriesPredictor:
             f"Median time series length is {median_length} (min={min_length}, max={max_length}). "
         )
 
-    def _recommend_num_val_windows(
+    def _reduce_num_val_windows_if_necessary(
         self,
         train_data: TimeSeriesDataFrame,
+        original_num_val_windows: int,
         val_step_size: int,
-        max_num_val_windows: int = 5,
     ) -> int:
-        """Automatically recommend num_val_windows based on the length of training time series.
+        """Adjust num_val_windows based on the length of time series in train_data.
 
-        Chooses num_val_windows such that TS with median length is long enough to perform num_val_windows validations.
+        Chooses num_val_windows such that TS with median length is long enough to perform num_val_windows validations
+        (at least 1, at most `original_num_val_windows`).
 
         In other words, find largest `num_val_windows` that satisfies
         median_length >= min_train_length + prediction_length + (num_val_windows - 1) * val_step_size
@@ -324,7 +325,13 @@ class TimeSeriesPredictor:
         num_val_windows_for_median_ts = int(
             (median_length - self._min_train_length - self.prediction_length) // val_step_size + 1
         )
-        return min(max_num_val_windows, max(1, num_val_windows_for_median_ts))
+        new_num_val_windows = min(original_num_val_windows, max(1, num_val_windows_for_median_ts))
+        if new_num_val_windows < original_num_val_windows:
+            logger.warning(
+                f"Time series in train_data are too short for chosen num_val_windows={original_num_val_windows}. "
+                f"Reducing num_val_windows to {new_num_val_windows}."
+            )
+        return new_num_val_windows
 
     def _filter_short_series(
         self,
@@ -471,9 +478,9 @@ class TimeSeriesPredictor:
                     ...
                     hyperparameters={
                         "DeepAR": {},
-                        "ETS": [
-                            {"seasonal": "add"},
-                            {"seasonal": None},
+                        "Theta": [
+                            {"decomposition_type": "additive"},
+                            {"seasonal_period": 1},
                         ],
                     }
                 )
@@ -481,8 +488,8 @@ class TimeSeriesPredictor:
             The above example will train three models:
 
             * ``DeepAR`` with default hyperparameters
-            * ``ETS`` with additive seasonality (all other parameters set to their defaults)
-            * ``ETS`` with seasonality disabled (all other parameters set to their defaults)
+            * ``Theta`` with additive seasonal decomposition (all other parameters set to their defaults)
+            * ``Theta`` with seasonality disabled (all other parameters set to their defaults)
 
             Full list of available models and their hyperparameters is provided in :ref:`forecasting_zoo`.
 
@@ -539,10 +546,10 @@ class TimeSeriesPredictor:
                     presets="high_quality",
                     excluded_model_types=["DeepAR"],
                 )
-        num_val_windows : int or None, default = 1
+        num_val_windows : int, default = 1
             Number of backtests done on ``train_data`` for each trained model to estimate the validation performance.
-            If ``num_val_windows=None``, the predictor will attempt to set this parameter automatically based on the
-            length of time series in ``train_data`` (at most to 5).
+            If ``num_val_windows > 1`` is provided, this value may be automatically reduced to ensure that the majority
+            of time series in ``train_data`` are long enough for the chosen number of backtests.
 
             Increasing this parameter increases the training time roughly by a factor of ``num_val_windows // refit_every_n_windows``.
             See :attr:`refit_every_n_windows` and :attr:`val_step_size`: for details.
@@ -620,8 +627,10 @@ class TimeSeriesPredictor:
         if val_step_size is None:
             val_step_size = self.prediction_length
 
-        if num_val_windows is None:
-            num_val_windows = self._recommend_num_val_windows(train_data, val_step_size=val_step_size)
+        if num_val_windows > 0:
+            num_val_windows = self._reduce_num_val_windows_if_necessary(
+                train_data, original_num_val_windows=num_val_windows, val_step_size=val_step_size
+            )
 
         if tuning_data is not None:
             tuning_data = self._check_and_prepare_data_frame(tuning_data, name="tuning_data")
@@ -630,7 +639,7 @@ class TimeSeriesPredictor:
             # TODO: Use num_val_windows to perform multi-window backtests on tuning_data
             if num_val_windows > 0:
                 logger.warning(
-                    "\tSetting num_val_windows = 0 (disabling backtesting) because tuning_data is provided."
+                    "\tSetting num_val_windows = 0 (disabling backtesting on train_data) because tuning_data is provided."
                 )
                 num_val_windows = 0
 

--- a/timeseries/tests/unittests/test_metrics.py
+++ b/timeseries/tests/unittests/test_metrics.py
@@ -143,11 +143,6 @@ def test_when_metric_evaluated_then_output_equal_to_gluonts(
 def test_given_all_zero_data_when_metric_evaluated_then_output_equal_to_gluonts(
     ag_metric_name, gts_metric_name, gts_metric, deepar_trained_zero_data
 ):
-    if ag_metric_name in ["WQL", "WAPE"]:
-        pytest.skip(
-            "GluonTS produces incorrect values for these metrics on all-zero data https://github.com/awslabs/gluonts/issues/3034"
-        )
-
     check_gluonts_parity(
         ag_metric_name,
         gts_metric_name,

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -780,10 +780,13 @@ def test_given_short_and_long_series_in_train_data_when_fit_called_then_trainer_
 ):
     predictor = TimeSeriesPredictor(path=temp_model_path, prediction_length=prediction_length, freq="H")
     min_train_length = predictor._min_train_length
+    min_val_length = min_train_length + prediction_length + (num_val_windows - 1) * val_step_size
 
     item_id_to_length = {
-        "long_series_1": min_train_length + prediction_length + num_val_windows * val_step_size,
-        "long_series_2": min_train_length + prediction_length + (num_val_windows - 1) * val_step_size,
+        "long_series_1": min_val_length + val_step_size,
+        "long_series_2": min_val_length,
+        "long_series_3": min_val_length,
+        "long_series_4": min_val_length,
         "short_series_1": min_train_length + (num_val_windows - 1) * val_step_size,
         "short_series_2": min_train_length + 1,
         "short_series_3": 2,
@@ -793,7 +796,9 @@ def test_given_short_and_long_series_in_train_data_when_fit_called_then_trainer_
         predictor.fit(data, num_val_windows=num_val_windows, val_step_size=val_step_size)
         learner_fit_kwargs = learner_fit.call_args[1]
         item_ids_received_by_learner = learner_fit_kwargs["train_data"].item_ids
-        assert (item_ids_received_by_learner == ["long_series_1", "long_series_2"]).all()
+        assert (
+            item_ids_received_by_learner == ["long_series_1", "long_series_2", "long_series_3", "long_series_4"]
+        ).all()
 
 
 @pytest.mark.parametrize("prediction_length", [1, 7])
@@ -816,7 +821,7 @@ def test_given_short_and_long_series_in_train_data_and_tuning_data_when_fit_call
         assert (item_ids_received_by_learner == ["long_series_1"]).all()
 
 
-@pytest.mark.parametrize("num_val_windows", [1, 3, None])
+@pytest.mark.parametrize("num_val_windows", [1, 3, 5])
 def test_given_tuning_data_when_fit_called_then_num_val_windows_is_set_to_zero(temp_model_path, num_val_windows):
     predictor = TimeSeriesPredictor(path=temp_model_path)
     with mock.patch("autogluon.timeseries.learner.TimeSeriesLearner.fit") as learner_fit:
@@ -827,18 +832,17 @@ def test_given_tuning_data_when_fit_called_then_num_val_windows_is_set_to_zero(t
 
 @pytest.mark.parametrize("prediction_length", [1, 5, 7])
 @pytest.mark.parametrize("val_step_size", [1, 3])
-def test_when_num_val_windows_is_recommended_then_increasing_num_val_windows_raises_error(
-    temp_model_path, prediction_length, val_step_size
+@pytest.mark.parametrize("original_num_val_windows, expected_num_val_windows", [(4, 1), (4, 3), (1, 1), (4, 4)])
+def test_given_num_val_windows_too_high_for_given_data_then_num_val_windows_is_reduced(
+    temp_model_path, prediction_length, val_step_size, original_num_val_windows, expected_num_val_windows
 ):
-    df = DUMMY_TS_DATAFRAME.copy()
     predictor = TimeSeriesPredictor(path=temp_model_path, prediction_length=prediction_length)
-    recommended_num_val_windows = predictor._recommend_num_val_windows(
-        df, max_num_val_windows=100, val_step_size=val_step_size
+    min_val_length = predictor._min_train_length + prediction_length + (expected_num_val_windows - 1) * val_step_size
+    df = get_data_frame_with_variable_lengths({item_id: min_val_length for item_id in ["A", "B", "C"]})
+    reduced_num_val_windows = predictor._reduce_num_val_windows_if_necessary(
+        df, original_num_val_windows=original_num_val_windows, val_step_size=val_step_size
     )
-    # assert that recommended_num_val_windows is the highest value for num_val_windows that doesn't raise an exception
-    assert predictor._filter_short_series(df, recommended_num_val_windows, val_step_size).num_items == df.num_items
-    with pytest.raises(ValueError, match="At least some time series in train\_data must have length"):
-        predictor._filter_short_series(df, recommended_num_val_windows + 1, val_step_size).num_items < df.num_items
+    assert reduced_num_val_windows == expected_num_val_windows
 
 
 @pytest.mark.parametrize("prediction_length", [1, 7])
@@ -861,8 +865,9 @@ def test_given_only_short_series_in_train_data_when_fit_called_then_exception_is
 
 
 @pytest.mark.parametrize("prediction_length", [1, 7])
-def test_given_only_short_series_when_num_val_windows_is_recommended_then_exception_is_raised(
-    temp_model_path, prediction_length
+@pytest.mark.parametrize("num_val_windows", [1, 2])
+def test_given_only_short_series_in_train_data_then_exception_is_raised(
+    temp_model_path, prediction_length, num_val_windows
 ):
     predictor = TimeSeriesPredictor(path=temp_model_path, prediction_length=prediction_length, freq="H")
     min_train_length = predictor._min_train_length
@@ -874,7 +879,7 @@ def test_given_only_short_series_when_num_val_windows_is_recommended_then_except
     }
     data = get_data_frame_with_variable_lengths(item_id_to_length, freq="H")
     with pytest.raises(ValueError, match="At least some time series in train\_data must have length"):
-        predictor.fit(data, num_val_windows=None)
+        predictor.fit(data, num_val_windows=num_val_windows, hyperparameters=TEST_HYPERPARAMETER_SETTINGS[0])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
*Description of changes:*
- Automatically reduce `num_val_windows` so that median time series length in `train_data` is sufficient to perform `num_val_windows` backtests.

    If `num_val_windows` provided by the user is too high, the log message looks as follows:
    ```
    Provided train_data has 6244 rows, 72 time series. Median time series length is 108 (min=16, max=108).
    Time series in train_data are too short for chosen num_val_windows=100. Reducing num_val_windows to 7.
            Removing 24 short time series from train_data. Only series with length >= 97 will be used for training.
            After removing short series, train_data has 5184 rows, 48 time series. Median time series length is 108 (min=108, max=108).
    ```
- Fix typo in docstring to `fit`
- Remove `pytest.skip` in metric tests since the new release of GluonTS v0.14.1 fixed the bug.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
