### PR TITLE
[timeseries] Align time series logs with Tabular

### DIFF
--- a/common/src/autogluon/common/utils/utils.py
+++ b/common/src/autogluon/common/utils/utils.py
@@ -181,6 +181,7 @@ def hash_pandas_df(df: Optional[pd.DataFrame]) -> str:
 
 def seed_everything(seed: int) -> None:
     """Set random seeds for numpy and PyTorch."""
+    logger.debug(f"Setting random seed to {seed}")
     np.random.seed(seed)
     try:
         import torch

--- a/docs/tutorials/timeseries/forecasting-quick-start.ipynb
+++ b/docs/tutorials/timeseries/forecasting-quick-start.ipynb
@@ -266,7 +266,7 @@
    "source": [
     "# The test score is computed using the last\n",
     "# prediction_length=48 timesteps of each time series in test_data\n",
-    "predictor.leaderboard(test_data, silent=True)"
+    "predictor.leaderboard(test_data)"
    ]
   },
   {

--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -82,18 +82,6 @@ class TimeSeriesLearner(AbstractLearner):
         self._time_limit = time_limit
         time_start = time.time()
 
-        logger.debug(
-            "Beginning AutoGluon training with TimeSeriesLearner "
-            + (f"Time limit = {time_limit}" if time_limit else "")
-        )
-        logger.info(f"AutoGluon will save models to {self.path}")
-
-        logger.info(f"AutoGluon will gauge predictive performance using evaluation metric: '{self.eval_metric}'")
-        if not self.eval_metric.greater_is_better_internal:
-            logger.info(
-                "\tThis metric's sign has been flipped to adhere to being 'higher is better'. "
-                "The reported score can be multiplied by -1 to get the metric value.",
-            )
         train_data = self.feature_generator.fit_transform(train_data, data_frame_name="train_data")
         if val_data is not None:
             val_data = self.feature_generator.transform(val_data, data_frame_name="tuning_data")
@@ -118,6 +106,14 @@ class TimeSeriesLearner(AbstractLearner):
         self.trainer = self.trainer_type(**trainer_init_kwargs)
         self.trainer_path = self.trainer.path
         self.save()
+
+        logger.info(f"\nAutoGluon will gauge predictive performance using evaluation metric: '{self.eval_metric}'")
+        if not self.eval_metric.greater_is_better_internal:
+            logger.info(
+                "\tThis metric's sign has been flipped to adhere to being higher_is_better. The metric score can be multiplied by -1 to get the metric value."
+            )
+
+        logger.info("===================================================")
 
         self.trainer.fit(
             train_data=train_data,

--- a/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
+++ b/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+import pprint
 from typing import Dict, List, Optional
 
 import numpy as np
@@ -130,6 +131,9 @@ class TimeSeriesGreedyEnsemble(AbstractTimeSeriesEnsembleModel):
         for model_name, weight in zip(predictions_per_window.keys(), ensemble_selection.weights_):
             if weight != 0:
                 self.model_to_weight[model_name] = weight
+
+        weights_for_printing = {model: round(weight, 2) for model, weight in self.model_to_weight.items()}
+        logger.info(f"\tEnsemble weights: {pprint.pformat(weights_for_printing, width=200)}")
 
     @property
     def model_names(self) -> List[str]:

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -618,6 +618,7 @@ class TimeSeriesPredictor:
         fit_args = dict(
             prediction_length=self.prediction_length,
             target=self.target,
+            known_covariates_names=self.known_covariates_names,
             eval_metric=self.eval_metric,
             eval_metric_seasonal_period=self.eval_metric_seasonal_period,
             quantile_levels=self.quantile_levels,


### PR DESCRIPTION
*Issue #, if available:* #3707

*Description of changes:*
- Make output of `TimeSeriesPredictor.fit` more aligned with `TabularPredictor.fit`
- Print learned ensemble weights
- Fix outdated `silent=True` flag in docs

Example output of `TimeSeriesPredictor.fit`:
```
Beginning AutoGluon training... Time limit = 60s
AutoGluon will save models to 'AutogluonModels/ag-20231116_111814'
=================== System Info ===================
AutoGluon Version:  0.8.3b20231107
Python Version:     3.10.12
Operating System:   Linux
Platform Machine:   x86_64
Platform Version:   #1 SMP Wed Oct 11 23:53:22 UTC 2023
CPU Count:          32
GPU Count:          4
Memory Avail:       230.66 GB / 239.87 GB (96.2%)
Disk Space Avail:   139.34 GB / 984.21 GB (14.2%)
===================================================

Fitting with arguments:
{'enable_ensemble': True,
 'eval_metric': WQL,
 'hyperparameters': {'Average': {},
                     'Naive': {},
                     'SeasonalAverage': {},
                     'SeasonalNaive': {}},
 'num_val_windows': 1,
 'prediction_length': 18,
 'quantile_levels': [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
 'random_seed': 123,
 'refit_every_n_windows': 1,
 'refit_full': False,
 'target': 'target',
 'time_limit': 60,
 'verbosity': 2}

Inferred time series frequency: 'M'
Provided train_data has 141858 rows, 1428 time series. Median time series length is 115 (min=48, max=126).
Provided tuning_data has 141858 rows, 1428 time series. Median time series length is 115 (min=48, max=126).
        Setting num_val_windows = 0 (disabling backtesting on train_data) because tuning_data is provided.

Provided dataset contains following columns:
        target:           'target'

AutoGluon will gauge predictive performance using evaluation metric: 'WQL'
        This metric's sign has been flipped to adhere to being higher_is_better. The metric score can be multiplied by -1 to get the metric value.
===================================================

Starting training. Start time is 2023-11-16 11:18:15
Models that will be trained: ['SeasonalNaive', 'SeasonalAverage', 'Average', 'Naive']
Training timeseries model SeasonalNaive. Training for up to 11.6s of the 58.2s of remaining time.
        -0.1211       = Validation score (-WQL)
        0.00    s     = Training runtime
        2.47    s     = Validation (prediction) runtime
Training timeseries model SeasonalAverage. Training for up to 13.9s of the 55.7s of remaining time.
        -0.1879       = Validation score (-WQL)
        0.00    s     = Training runtime
        6.50    s     = Validation (prediction) runtime
Training timeseries model Average. Training for up to 16.4s of the 49.1s of remaining time.
        -0.1856       = Validation score (-WQL)
        0.00    s     = Training runtime
        1.05    s     = Validation (prediction) runtime
Training timeseries model Naive. Training for up to 24.0s of the 48.0s of remaining time.
        -0.1601       = Validation score (-WQL)
        0.00    s     = Training runtime
        0.90    s     = Validation (prediction) runtime
Fitting simple weighted ensemble.
        Ensemble weights: {'Naive': 0.13, 'SeasonalNaive': 0.87}
        -0.1193       = Validation score (-WQL)
        5.22    s     = Training runtime
        3.37    s     = Validation (prediction) runtime
Training complete. Models trained: ['SeasonalNaive', 'SeasonalAverage', 'Average', 'Naive', 'WeightedEnsemble']
Total runtime: 16.49 s
Best model: WeightedEnsemble
Best model score: -0.1193
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
