### PR TITLE
[AutoMM] Fix onnx export for un-initialized predictor & example onnx_text.py

### DIFF
--- a/examples/automm/production/onnx_text.py
+++ b/examples/automm/production/onnx_text.py
@@ -32,11 +32,11 @@ def eval_cosine(predictor, df, onnx_session):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--checkpoint_name", default="sentence-transformers/msmarco-MiniLM-L-12-v3", type=str)
-    parser.add_argument("--onnx_path", default=None, type=str)
+    parser.add_argument("--model_path", default=None, type=str)
     parser.add_argument("--verbose", action="store_true")
     args = parser.parse_args()
-    if not args.onnx_path:
-        args.onnx_path = args.checkpoint_name.replace("/", "_") + ".onnx"
+    if not args.model_path:
+        args.model_path = args.checkpoint_name.replace("/", "_") + ".onnx"
 
     # Load Dataset
     val_df = load_dataset("wietsedv/stsbenchmark", split="validation").to_pandas()
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     )
 
     # Export ONNX model
-    onnx_path = predictor.export_onnx(data=val_df, path=args.onnx_path, verbose=args.verbose)
+    onnx_path = predictor.export_onnx(data=val_df, path=args.model_path, verbose=args.verbose)
 
     # Load ONNX model
     ort_sess = ort.InferenceSession(onnx_path, providers=["CUDAExecutionProvider"])

--- a/examples/automm/production/onnx_text.py
+++ b/examples/automm/production/onnx_text.py
@@ -17,8 +17,9 @@ def eval_cosine(predictor, df, onnx_session):
         "hf_text_text_valid_length",
         "hf_text_text_segment_ids",  # Remove for mpnet
     ]
-    QEmb = onnx_session.run(None, predictor.get_processed_batch_for_deployment(data=df[["sentence1"]], valid_input=valid_input))[0]
-    AEmb = onnx_session.run(None, predictor.get_processed_batch_for_deployment(data=df[["sentence2"]], valid_input=valid_input))[0]
+
+    QEmb = onnx_session.run(None, predictor._learner.get_processed_batch_for_deployment(data=df[["sentence1"]]))[0]
+    AEmb = onnx_session.run(None, predictor._learner.get_processed_batch_for_deployment(data=df[["sentence2"]]))[0]
 
     cosine_scores = 1 - (paired_cosine_distances(QEmb, AEmb))
     eval_pearson_cosine, _ = pearsonr(labels, cosine_scores)
@@ -43,18 +44,17 @@ if __name__ == "__main__":
 
     # Init Predictor
     predictor = MultiModalPredictor(
-        pipeline="feature_extraction",
+        problem_type="feature_extraction",
         hyperparameters={
             "model.hf_text.checkpoint_name": args.checkpoint_name,
         },
     )
 
     # Export ONNX model
-    # predictor.export_onnx(data=val_df, verbose=args.verbose, onnx_path=args.onnx_path)
-    predictor.export_onnx(verbose=args.verbose, onnx_path=args.onnx_path)
+    onnx_path = predictor.export_onnx(data=val_df, path=args.onnx_path, verbose=args.verbose)
 
     # Load ONNX model
-    ort_sess = ort.InferenceSession(args.onnx_path, providers=["CUDAExecutionProvider"])
+    ort_sess = ort.InferenceSession(onnx_path, providers=["CUDAExecutionProvider"])
 
     # Evaluate ONNX model
     eval_cosine(predictor, test_df, ort_sess)

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -813,6 +813,10 @@ class MultiModalPredictor:
             A string that indicates location of the exported onnx model, if `path` argument is provided.
             Otherwise, would return the onnx model as bytes.
         """
+
+        # Make sure _model is initialized
+        self._learner.on_predict_start()
+
         return self._learner.export_onnx(
             data=data,
             path=path,


### PR DESCRIPTION
*Issue*
https://github.com/autogluon/autogluon/blob/master/examples/automm/production/onnx_text.py is currently broken and has not been updated to handle some api changes.

1. `pipeline` arg is no longer used.
2. `predictor.export_onnx` always returns the onnx path now.
3. `get_processed_batch_for_deployment` has been refactored

Besides a even bigger problem was that if the predictor is not initialized, _model is set to `None` [here](https://github.com/autogluon/autogluon/blob/53a653f6c1f6d4fc8c026d3c60224cab22bda30a/multimodal/src/autogluon/multimodal/learners/base.py#L278) and then when `export_onnx` is called directly, it throws the following error due to [this](https://github.com/autogluon/autogluon/blob/53a653f6c1f6d4fc8c026d3c60224cab22bda30a/multimodal/src/autogluon/multimodal/utils/export.py#L117):
```
NotImplementedError: export_onnx doesn't support model type <class 'NoneType'>
```

*Description of changes:*

1. Fix func `export_onnx` in `predictor.py` by making sure predictor is prediction ready.
2. Fix old api usage in `onnx_text.py` example


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
