### PR TITLE
[timeseries] Bugfixes for MLForecast models

### DIFF
--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -33,8 +33,8 @@ install_requires = [
     "networkx",  # version range defined in `core/_setup_utils.py`
     # TODO: update statsforecast to v1.5.0 - resolve antlr4-python3-runtime dependency clash with multimodal
     "statsforecast>=1.4.0,<1.5",
-    "mlforecast>=0.10.0,<0.10.1",
-    "utilsforecast>=0.0.10,<0.0.11",
+    "mlforecast>=0.11.0,<0.11.1",
+    "utilsforecast>=0.0.14,<0.0.15",
     "tqdm",  # version range defined in `core/_setup_utils.py`
     "ujson>=5,<6",  # needed to silence GluonTS warning
     f"autogluon.core[raytune]=={version}",

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -33,8 +33,8 @@ install_requires = [
     "networkx",  # version range defined in `core/_setup_utils.py`
     # TODO: update statsforecast to v1.5.0 - resolve antlr4-python3-runtime dependency clash with multimodal
     "statsforecast>=1.4.0,<1.5",
-    "mlforecast>=0.11.0,<0.11.1",
-    "utilsforecast>=0.0.14,<0.0.15",
+    "mlforecast>=0.10.0,<0.10.1",
+    "utilsforecast>=0.0.10,<0.0.11",
     "tqdm",  # version range defined in `core/_setup_utils.py`
     "ujson>=5,<6",  # needed to silence GluonTS warning
     f"autogluon.core[raytune]=={version}",

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -89,7 +89,7 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
 
     def _get_model_params(self) -> dict:
         model_params = super()._get_model_params().copy()
-        model_params.setdefault("max_num_items", 20_000)
+        model_params.setdefault("max_num_items", 10_000)
         model_params.setdefault("max_num_samples", 1_000_000)
         model_params.setdefault("tabular_hyperparameters", {"GBM": {}})
         model_params.setdefault("tabular_fit_kwargs", {})
@@ -328,7 +328,7 @@ class DirectTabularModel(AbstractMLForecastModel):
         Defaults to ``{"GBM": {}}``.
     tabular_fit_kwargs : Dict[str, Any], optional
         Additional keyword arguments passed to ``TabularPredictor.fit``. Defaults to an empty dict.
-    max_num_items : int or None, default = 20_000
+    max_num_items : int or None, default = 10_000
         If not None, the model will randomly select this many time series for training and validation.
     max_num_samples : int or None, default = 1_000_000
         If not None, training dataset passed to TabularPredictor will contain at most this many rows (starting from the
@@ -462,7 +462,7 @@ class RecursiveTabularModel(AbstractMLForecastModel):
         Defaults to ``{"GBM": {}}``.
     tabular_fit_kwargs : Dict[str, Any], optional
         Additional keyword arguments passed to ``TabularPredictor.fit``. Defaults to an empty dict.
-    max_num_items : int or None, default = 20_000
+    max_num_items : int or None, default = 10_000
         If not None, the model will randomly select this many time series for training and validation.
     max_num_samples : int or None, default = 1_000_000
         If not None, training dataset passed to TabularPredictor will contain at most this many rows (starting from the

--- a/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
+++ b/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
@@ -8,6 +8,7 @@ import pandas as pd
 from joblib import Parallel, delayed
 from scipy.stats import norm
 
+from autogluon.common.utils.log_utils import set_logger_verbosity
 from autogluon.core.utils.exceptions import TimeLimitExceeded
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
@@ -86,8 +87,10 @@ class AbstractLocalModel(AbstractTimeSeriesModel):
         self._seasonal_period: Optional[int] = None
         self.time_limit: Optional[float] = None
 
-    def _fit(self, train_data: TimeSeriesDataFrame, time_limit: int = None, **kwargs):
+    def _fit(self, train_data: TimeSeriesDataFrame, time_limit: Optional[int] = None, verbosity: int = 2, **kwargs):
         self._check_fit_params()
+        set_logger_verbosity(verbosity, logger=logger)
+
         if time_limit is not None and time_limit < self.init_time_in_seconds:
             raise TimeLimitExceeded
 

--- a/timeseries/src/autogluon/timeseries/models/local/statsforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/local/statsforecast.py
@@ -225,6 +225,8 @@ class AutoETSModel(AbstractStatsForecastModel):
         When set to None, seasonal_period will be inferred from the frequency of the training data. Can also be
         specified manually by providing an integer > 1.
         If seasonal_period (inferred or provided) is equal to 1, seasonality will be disabled.
+    damped : bool, default = True
+        Whether to dampen the trend.
     n_jobs : int or float, default = 0.5
         Number of CPU cores used to fit the models in parallel.
         When set to a float between 0.0 and 1.0, that fraction of available CPU cores is used.
@@ -236,6 +238,7 @@ class AutoETSModel(AbstractStatsForecastModel):
     """
 
     allowed_local_model_args = [
+        "damped",
         "model",
         "seasonal_period",
     ]
@@ -283,6 +286,8 @@ class ETSModel(AutoETSModel):
         When set to None, seasonal_period will be inferred from the frequency of the training data. Can also be
         specified manually by providing an integer > 1.
         If seasonal_period (inferred or provided) is equal to 1, seasonality will be disabled.
+    damped : bool, default = False
+        Whether to dampen the trend.
     n_jobs : int or float, default = 0.5
         Number of CPU cores used to fit the models in parallel.
         When set to a float between 0.0 and 1.0, that fraction of available CPU cores is used.


### PR DESCRIPTION
*Description of changes:*
- Avoid high memory usage by shortening time series before calling `MLForecast.preprocess`
   - Increase default `num_items` to 20K because we don't suffer from OOM problems anymore with the above change
- Generate dummy forecast for time series that are shorter than `sum(differences)` (before we used to get NaN predictions for these series)
- Add dummy quantiles to predictions of `DirectTabular` model if point forecast metric is provided (before there was a bug, where mean forecast was just repeated for all quantiles)
- Expose `damped` parameter of `AutoETS` model from StatsForecast


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
