### PR TITLE
handle str type in sampled ray.tune hyperparameter

### DIFF
--- a/multimodal/src/autogluon/multimodal/optimization/losses.py
+++ b/multimodal/src/autogluon/multimodal/optimization/losses.py
@@ -307,6 +307,12 @@ class FocalLoss(nn.Module):
         self.reduction = reduction
         self.eps = eps
         if alpha is not None:
+            if isinstance(alpha, str):  # handles Ray Tune HPO sampled hyperparameter
+                try:
+                    numbers = alpha.strip("()").split(",")
+                    alpha = [float(num) for num in numbers]
+                except:
+                    raise ValueError(f"{type(alpha)} {alpha} is not in a supported format.")
             alpha = torch.tensor(alpha)
         self.nll_loss = nn.NLLLoss(weight=alpha, reduction="none")
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/autogluon/autogluon/issues/3441
In `FocalLoss`, the expected `alpha` is a tensor or an iterable type, e.g. `[0.1, 0.3, 0.5, 0.1]`. However, when `ray.tune` is used for HPO, the sampled hyperparameter per trial converts `alpha` to a `tuple` in `str`, e.g.: `"(0.1, 0.3, 0.5, 0.1)"`.

*Description of changes:*
We are patching this bug by parsing the erroneous `str` type sampled hyperparameters from `ray.tune` to be a list so that the logic doesn't break during HPO.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
