### PR TITLE
[timeseries] Use per-item residuals in MLForecast models

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -291,7 +291,6 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
     def _compute_residuals_std(self, val_df: pd.DataFrame) -> float:
         residuals = val_df[MLF_TARGET] - self._mlf.models_["mean"].predict(val_df)
         return residuals.pow(2).groupby(val_df[MLF_ITEMID]).mean().pow(0.5)
-        # return np.sqrt(residuals.pow(2.0).mean())
 
     def _get_scale_per_item(self, item_ids: pd.Index) -> pd.Series:
         """Extract the '_scale' values from the scaler object, if available."""

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -352,7 +352,8 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
 
         residuals_std_per_timestep = self._residuals_std_per_item.reindex(repeated_item_ids)
         # Use avg_residuals_std in case unseen item received for prediction
-        residuals_std_per_timestep = residuals_std_per_timestep.fillna(self._avg_residuals_std)
+        if residuals_std_per_timestep.isna().any():
+            residuals_std_per_timestep = residuals_std_per_timestep.fillna(value=self._avg_residuals_std)
         std_per_timestep = residuals_std_per_timestep * scale_per_item * normal_scale_per_timestep
         for q in self.quantile_levels:
             predictions[str(q)] = predictions["mean"] + norm.ppf(q) * std_per_timestep.to_numpy()

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -435,7 +435,7 @@ class DirectTabularModel(AbstractMLForecastModel):
             self._residuals_std_per_item = pd.Series(1.0, index=val_df[MLF_ITEMID].unique())
             self._avg_residuals_std = 1.0
         else:
-            return super()._compute_residuals_std(val_df=val_df)
+            super()._save_residuals_std(val_df=val_df)
 
     def _predict(
         self,

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -286,7 +286,7 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
             )
 
         self._residuals_std_per_item = self._compute_residuals_std(val_df)
-        self._avg_residuals_std = self._residuals_std_per_item.mean()
+        self._avg_residuals_std = np.mean(self._residuals_std_per_item)
 
     def _compute_residuals_std(self, val_df: pd.DataFrame) -> float:
         residuals = val_df[MLF_TARGET] - self._mlf.models_["mean"].predict(val_df)

--- a/timeseries/tests/unittests/models/test_mlforecast.py
+++ b/timeseries/tests/unittests/models/test_mlforecast.py
@@ -50,7 +50,11 @@ def test_when_covariates_and_features_present_then_train_and_val_dfs_have_correc
     model.fit(train_data=data, time_limit=3)
     train_df, val_df = model._generate_train_val_dfs(data)
     expected_num_features = (
-        len(lags) + len(known_covariates_names) + len(static_features_names) + len(model._date_features) + 1
+        len(lags)
+        + len(known_covariates_names)
+        + len(static_features_names)
+        + len(model._date_features)
+        + 2  # target, item_id
     )
     # sum(differences) rows  dropped per item, prediction_length rows are reserved for validation
     expected_num_train_rows = len(data) - (sum(differences) + model.prediction_length) * data.num_items

--- a/timeseries/tests/unittests/models/test_mlforecast.py
+++ b/timeseries/tests/unittests/models/test_mlforecast.py
@@ -195,12 +195,11 @@ def test_given_some_time_series_are_too_short_then_seasonal_naive_forecast_is_us
 def test_when_point_forecast_metric_is_used_then_per_item_residuals_are_used_for_prediction(
     temp_model_path, model_type
 ):
-    data = DUMMY_VARIABLE_LENGTH_TS_DATAFRAME.copy()
+    data = DUMMY_VARIABLE_LENGTH_TS_DATAFRAME.sort_index()
     prediction_length = 5
     model = model_type(
         path=temp_model_path,
         freq=data.freq,
-        hyperparameters={},
         prediction_length=prediction_length,
         eval_metric="MASE",
     )

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -399,7 +399,7 @@ def test_when_custom_metric_passed_to_model_then_model_can_score(model_class):
         eval_metric=CustomMetric(),
     )
     model.fit(train_data=DUMMY_TS_DATAFRAME)
-    score = model.score(DUMMY_TS_DATAFRAME)
+    score = model.score(DUMMY_TS_DATAFRAME.sort_index())
     assert isinstance(score, float)
 
 
@@ -424,7 +424,7 @@ def test_when_custom_metric_passed_to_model_then_model_can_hyperparameter_tune(m
     if isinstance(model, MultiWindowBacktestingModel):
         val_data = None
     else:
-        val_data = DUMMY_TS_DATAFRAME
+        val_data = DUMMY_TS_DATAFRAME.sort_index()
 
     num_trials = 2
 


### PR DESCRIPTION
*Description of changes:*
- Estimate the standard deviation of the residuals separately for each item in `DirectTabular` model (with point forecast metric) and `RecursiveTabular` model. Before, we used to estimate a single standard deviation across all items.
- Fix typo in docstring.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
