### PR TITLE
[timeseries] Adjust how time limit is split across models

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -296,6 +296,7 @@ class AbstractTimeSeriesModel(AbstractModel):
             of input items.
         """
         predictions = self._predict(data=data, known_covariates=known_covariates, **kwargs)
+        logger.debug(f"Predicting with model {self.name}")
         # "0.5" might be missing from the quantiles if self is a wrapper (MultiWindowBacktestingModel or ensemble)
         if "0.5" in predictions.columns:
             if self.eval_metric.optimized_by_median:

--- a/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
+++ b/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
@@ -127,6 +127,7 @@ class MultiWindowBacktestingModel(AbstractTimeSeriesModel):
                     **kwargs,
                 )
                 model.fit_time = time.time() - model_fit_start_time
+                most_recent_refit_window = f"W{window_index}"
             model.score_and_cache_oof(val_fold, store_val_score=True, store_predict_time=True)
 
             oof_predictions_per_window.append(model.get_oof_predictions()[0])
@@ -149,7 +150,7 @@ class MultiWindowBacktestingModel(AbstractTimeSeriesModel):
 
         # Only the model trained on most recent data is saved & used for prediction
         self.most_recent_model = model
-        self.most_recent_model_folder = model.name.rsplit("/")[-1]
+        self.most_recent_model_folder = most_recent_refit_window
         self.predict_time = self.most_recent_model.predict_time
         self.fit_time = time.time() - global_fit_start_time - self.predict_time
         self._oof_predictions = oof_predictions_per_window

--- a/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
+++ b/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
@@ -149,7 +149,7 @@ class MultiWindowBacktestingModel(AbstractTimeSeriesModel):
 
         # Only the model trained on most recent data is saved & used for prediction
         self.most_recent_model = model
-        self.most_recent_model_folder = f"W{window_index}"
+        self.most_recent_model_folder = model.name.rsplit("/")[-1]
         self.predict_time = self.most_recent_model.predict_time
         self.fit_time = time.time() - global_fit_start_time - self.predict_time
         self._oof_predictions = oof_predictions_per_window

--- a/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
+++ b/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
@@ -1,6 +1,7 @@
 import copy
 import inspect
 import logging
+import math
 import os
 import time
 from typing import Dict, Optional, Type, Union
@@ -110,9 +111,11 @@ class MultiWindowBacktestingModel(AbstractTimeSeriesModel):
                     # Local models cannot early stop, we allocate all remaining time and hope that they finish in time
                     time_left_for_window = time_left
                 else:
-                    num_future_refits = (val_splitter.num_val_windows - window_index) // refit_every_n_windows
+                    num_refits_remaining = math.ceil(
+                        (val_splitter.num_val_windows - window_index) / refit_every_n_windows
+                    )
                     # Reserve 10% of the remaining time for prediction, use 90% of time for training
-                    time_left_for_window = 0.9 * time_left / (refit_this_window + num_future_refits)
+                    time_left_for_window = 0.9 * time_left / num_refits_remaining
 
             if refit_this_window:
                 model = self.get_child_model(window_index)

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -558,9 +558,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
 
         logger.info(f"Models that will be trained: {list(m.name for m in models)}")
 
-        num_models = len(models)
-        if num_models > 1:  # ensemble is only fit len(models) > 1
-            num_models += int(self.enable_ensemble)
+        num_base_models = len(models)
         model_names_trained = []
         for i, model in enumerate(models):
             if time_limit is None:
@@ -568,7 +566,12 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
                 time_left_for_model = None
             else:
                 time_left = time_limit - (time.time() - time_start)
-                time_left_for_model = time_left / (num_models - i)
+                if num_base_models > 1 and self.enable_ensemble:
+                    time_reserved_for_ensemble = min(600.0, time_left / (num_base_models - i + 1))
+                    logger.debug(f"Reserving {time_reserved_for_ensemble:.1f}s for ensemble")
+                else:
+                    time_reserved_for_ensemble = 0.0
+                time_left_for_model = (time_left - time_reserved_for_ensemble) / (num_base_models - i)
                 if time_left <= 0:
                     logger.info(f"Stopping training due to lack of time remaining. Time left: {time_left:.1f} seconds")
                     break

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -890,19 +890,20 @@ def test_given_only_short_series_in_train_data_then_exception_is_raised(
 @pytest.mark.parametrize(
     "num_val_windows, refit_every_n_windows, expected_num_refits", [(5, None, 1), (7, 7, 1), (5, 1, 5), (6, 2, 3)]
 )
+@pytest.mark.parametrize("model_name", ["Naive", "RecursiveTabular"])
 def test_given_refit_every_n_windows_when_fit_then_model_is_fit_correct_number_of_times(
-    temp_model_path, num_val_windows, refit_every_n_windows, expected_num_refits
+    temp_model_path, num_val_windows, refit_every_n_windows, expected_num_refits, model_name
 ):
     predictor = TimeSeriesPredictor(path=temp_model_path)
     predictor.fit(
         DUMMY_TS_DATAFRAME,
         num_val_windows=num_val_windows,
         refit_every_n_windows=refit_every_n_windows,
-        hyperparameters={"Naive": {}},
+        hyperparameters={model_name: {}},
     )
-    models_info = predictor._trainer.get_models_info(["Naive"])
+    models_info = predictor._trainer.get_models_info([model_name])
     actual_num_refits = 0
-    for window_info in models_info["Naive"]["info_per_val_window"]:
+    for window_info in models_info[model_name]["info_per_val_window"]:
         actual_num_refits += window_info["refit_this_window"]
     assert actual_num_refits == expected_num_refits
 


### PR DESCRIPTION
*Description of changes:*
- Do not allocate more than 600 seconds for fitting ensemble
- Evenly split the time limit across all validation windows in MultiWindowBacktestingModel
- Fix a bug where incorrect model suffix was saved if no refit happened in the most recent window

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
