### PR TITLE
[timeseries] Speed up inference for WaveNet model

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -380,6 +380,7 @@ class WaveNetModel(AbstractGluonTSModel):
     """
 
     supports_known_covariates = True
+    default_num_samples: int = 100
 
     def _get_estimator_class(self) -> Type[GluonTSEstimator]:
         from gluonts.torch.model.wavenet import WaveNetEstimator


### PR DESCRIPTION
*Description of changes:*
- Inference is extremely slow for WaveNet model on CPU. Reducing `num_samples` used in GluonTS SampleForecast for this model from 250 to to its default value of 100 reduces the inference time by a factor of 2.5x.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
