### PR TITLE
[timeseries] Fix logger verbosity for ensemble

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
+++ b/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional
 import numpy as np
 
 import autogluon.core as ag
+from autogluon.common.utils.log_utils import set_logger_verbosity
 from autogluon.core.models.greedy_ensemble.ensemble_selection import EnsembleSelection
 from autogluon.timeseries import TimeSeriesDataFrame
 from autogluon.timeseries.metrics import TimeSeriesScorer
@@ -111,8 +112,10 @@ class TimeSeriesGreedyEnsemble(AbstractTimeSeriesEnsembleModel):
         predictions_per_window: Dict[str, List[TimeSeriesDataFrame]],
         data_per_window: List[TimeSeriesDataFrame],
         time_limit: Optional[int] = None,
+        verbosity: int = 2,
         **kwargs,
     ):
+        set_logger_verbosity(verbosity, logger=logger)
         if self.eval_metric_seasonal_period is None:
             self.eval_metric_seasonal_period = get_seasonality(self.freq)
         ensemble_selection = TimeSeriesEnsembleSelection(

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -688,7 +688,9 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
             quantile_levels=self.quantile_levels,
             metadata=self.metadata,
         )
-        ensemble.fit_ensemble(model_preds, data_per_window=data_per_window, time_limit=time_limit)
+        ensemble.fit_ensemble(
+            model_preds, data_per_window=data_per_window, time_limit=time_limit, verbosity=self.verbosity
+        )
         ensemble.fit_time = time.time() - time_start
 
         predict_time = 0


### PR DESCRIPTION
*Description of changes:*
- Make sure that correct verbosity is set for the logger in ensemble. Currently, incorrect logger configuration leads to the ensemble weights not being printed to the console.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
