### PR TITLE
[timeseries] Fix GluonTS models using high context_length

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -245,7 +245,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
 
     @property
     def default_context_length(self) -> int:
-        return max(10, 2 * self.prediction_length)
+        return min(512, max(10, 2 * self.prediction_length))
 
     def _get_model_params(self) -> dict:
         """Gets params that are passed to the inner model."""

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -195,7 +195,7 @@ class TemporalFusionTransformerModel(AbstractGluonTSModel):
 
     @property
     def default_context_length(self) -> int:
-        return max(64, 2 * self.prediction_length)
+        return min(512, max(64, 2 * self.prediction_length))
 
     def _get_estimator_class(self) -> Type[GluonTSEstimator]:
         from gluonts.torch.model.tft import TemporalFusionTransformerEstimator

--- a/timeseries/tests/unittests/models/test_gluonts.py
+++ b/timeseries/tests/unittests/models/test_gluonts.py
@@ -35,6 +35,15 @@ DUMMY_HYPERPARAMETERS = {"epochs": 1, "num_batches_per_epoch": 1}
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
+def test_when_context_length_is_not_set_then_default_context_length_is_used(model_class):
+    data = DUMMY_TS_DATAFRAME
+    model = model_class(freq=data.freq, hyperparameters=DUMMY_HYPERPARAMETERS)
+    model.fit(train_data=data)
+    estimator_init_args = model._get_estimator_init_args()
+    assert estimator_init_args["context_length"] == model.default_context_length
+
+
+@pytest.mark.parametrize("model_class", TESTABLE_MODELS)
 @pytest.mark.parametrize("time_limit", [10, None])
 def test_given_time_limit_when_fit_called_then_models_train_correctly(model_class, time_limit, temp_model_path):
     model = model_class(


### PR DESCRIPTION
*Description of changes:*
- Currently, if user provides a very large `prediction_length` (more than 1000), it will result in extremely high `context_length` used by GluonTS models. This may lead to OOM errors (e.g., for TemporalFusionTransformer model that scales quadratically with sequence length).
- We clip the `context_length` to be at most 512 to avoid these issues.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
