### PR TITLE
[timeseries] Add documentation for forecasting metrics

### DIFF
--- a/docs/tutorials/timeseries/forecasting-faq.md
+++ b/docs/tutorials/timeseries/forecasting-faq.md
@@ -14,7 +14,7 @@ Currently, AutoGluon does not support features such as hierarchical forecasting 
 To maximize the forecast accuracy, set the `predictor.fit()` argument `presets="best_quality"` and provide a high `time_limit`.
 
 ## How should I choose the evaluation metric?
-See ["How to choose and interpret the evaluation metric?" in the In Depth Tutorial](forecasting-indepth.ipynb)
+See [Evaluation Metrics](forecasting-metrics.md)
 
 ## Are there any restrictions on the data that I can pass to TimeSeriesPredictor?
 See ["What data format is expected by `TimeSeriesPredictor`?" in the In Depth Tutorial](forecasting-indepth.ipynb)
@@ -31,7 +31,7 @@ Multi-GPU training is not yet supported.
 AutoGluon can be run on any machine including your laptop.
 It is not necessary to use a GPU to train `TimeSeriesPredictor`, so CPU machines are fine.
 Using a machine with more CPU cores and more RAM will lead to faster training and allow you to quickly generate forecasts for larger datasets.
-For example if using AWS instances for Tabular: we recommend [M6 instances](https://aws.amazon.com/ec2/instance-types/m6i/) instances, where a `m6i.24xlarge` machine should be able to handle most datasets.
+For example if using AWS instances: we recommend [M6 instances](https://aws.amazon.com/ec2/instance-types/m6i/) instances, where a `m6i.24xlarge` machine should be able to handle most datasets.
 
 
 ## Issues not addressed here

--- a/docs/tutorials/timeseries/forecasting-indepth.ipynb
+++ b/docs/tutorials/timeseries/forecasting-indepth.ipynb
@@ -1296,7 +1296,9 @@
     "Finally, the scores are averaged over all time series in the dataset.\n",
     "\n",
     "The crucial detail here is that `evaluate` always computes the score on the last `prediction_length` time steps of each time series.\n",
-    "The beginning of each time series (except the last `prediction_length` time steps) is only used to initialize the models before forecasting."
+    "The beginning of each time series (except the last `prediction_length` time steps) is only used to initialize the models before forecasting.\n",
+    "\n",
+    "For more details about the evaluation metrics, see https://auto.gluon.ai/stable/tutorials/timeseries/forecasting-metrics.html."
    ]
   },
   {
@@ -1333,22 +1335,6 @@
    "id": "68f7f14d",
    "metadata": {},
    "source": [
-    "### How to choose and interpret the evaluation metric?\n",
-    "Different evaluation metrics capture different properties of the forecast, and therefore depend on the application that the user has in mind.\n",
-    "Here is a very rough guide outlining some scenarios when you can prefer different metrics:\n",
-    "\n",
-    "- `WQL` - if you care about the quantile forecasts (all other metrics ignore the quantile forecasts)\n",
-    "- `MASE` or `sMAPE` - if you care about an accurate forecast for each time series, regardless of its scale\n",
-    "- `MAE` - if you care about accurately predicting time series with larger scale (e.g., accurately predicting demand for popular items)\n",
-    "- `RMSE` - similar to `MAE`, but penalizes large mispredictions more strongly\n",
-    "\n",
-    "For more details about the available metrics, see the documentation for [autogluon.timeseries.evaluator.TimeSeriesEvaluator](https://github.com/autogluon/autogluon/blob/master/timeseries/src/autogluon/timeseries/evaluator.py#L53) or this [article](https://docs.aws.amazon.com/forecast/latest/dg/metrics.html).\n",
-    "\n",
-    "Note that AutoGluon always reports all metrics in a **higher-is-better** format.\n",
-    "For this purpose, some metrics are multiplied by -1.\n",
-    "For example, if we set `eval_metric=\"MASE\"`, the predictor will actually report `-MASE` (i.e., MASE score multiplied by -1). This means the `test_score` will be between 0 (best possible forecast) and $-\\infty$ (worst possible forecast).\n",
-    "\n",
-    "\n",
     "### How does AutoGluon perform validation?\n",
     "When we fit the predictor with `predictor.fit(train_data=train_data)`, under the hood AutoGluon further splits the original dataset `train_data` into train and validation parts.\n",
     "\n",

--- a/docs/tutorials/timeseries/forecasting-metrics.md
+++ b/docs/tutorials/timeseries/forecasting-metrics.md
@@ -1,7 +1,7 @@
 # Forecasting Time Series - Evaluation Metrics
 
 Picking the right evaluation metric is one of the most important choices when using an AutoML framework.
-This page lists the forecast evaluation metrics available in AutoGluon, explains when different metrics should be used, and describes how to define custom metrics.
+This page lists the forecast evaluation metrics available in AutoGluon and explains when different metrics should be used. 
 
 When using AutoGluon, you can specify the metric using the `eval_metric` argument to `TimeSeriesPredictor`, for example:
 ```python
@@ -193,49 +193,3 @@ $$
 ```{eval-rst}
 .. autoclass:: WQL
 ```
-
-
-## Custom metrics
-If none of the built-in metrics meet your requirements, you can train provide a custom evaluation metric to AutoGluon.
-To define a custom metric, you need to create a class that inherits from `TimeSeriesScorer` and implements the `compute_metric` method according to the following API specification:
-```{eval-rst}
-.. automethod:: TimeSeriesScorer.compute_metric
-```
-
-Here is an example of how you can define a custom Mean Absolute Error (MAE) metric
-
-```python
-from autogluon.timeseries.metrics import TimeSeriesScorer
-
-class CustomMeanAbsoluteError(TimeSeriesScorer):
-   greater_is_better_internal = False
-
-   def compute_metric(self, data_future, predictions, target, **kwargs):
-      return np.abs(np.mean((data_future[target] - predictions["mean"])))
-```
-
-To better understand the inputs 
-
-
-Here is an example of what the inputs to the `compute_metric_methods` may look like:
-```python
-import pandas as pd
-from autogluon.timeseries import TimeSeriesPredictor, TimeSeriesDataFrame
-
-data = TimeSeriesDataFrame.from_iterable_dataset(
-   {"start": pd.Period("2023-01-01", freq="D"), "target": range(20)}
-)
-prediction_length = 3
-train_data, test_data = data.train_test_split(prediction_length=prediction_length)
-predictor = TimeSeriesPredictor(prediction_length=prediction_length, verbosity=0).fit(train_data, hyperparameters={"SeasonalNaive": {}})
-
-predictions = predictor.predict(train_data)
-predictions
-```
-
-
-```python
-data_future = test_data.slice_by_timestep(-prediction_length, None)
-```
-
-

--- a/docs/tutorials/timeseries/forecasting-metrics.md
+++ b/docs/tutorials/timeseries/forecasting-metrics.md
@@ -1,0 +1,339 @@
+# Forecasting Time Series - Evaluation Metrics
+
+Picking the right evaluation metric is one of the most important choices when using an AutoML framework.
+
+This page lists the forecast evaluation metrics available in AutoGluon, explains when different metrics should be used, and describes how to define custom metrics.
+
+When using AutoGluon, you can specify the metric using the `eval_metric` argument to `TimeSeriesPredictor`, for example:
+```python
+from autogluon.timeseries import TimeSeriesPredictor
+
+predictor = TimeSeriesPredictor(eval_metric="MASE")
+```
+AutoGluon will use the provided metric to tune model hyperparameters, rank models, and construct the final ensemble for prediction.
+
+If you are not sure which evaluation metric to pick, here are three questions that can help you make the right choice for your use case.
+
+**Are you interested in a point forecast or a probabilistic forecast?**
+
+If your goal is to generate an accurate **probabilistic** forecast, you should use `WQL` or `SQL` metrics.
+These metrics are based on the [quantile loss](https://en.wikipedia.org/wiki/Quantile_regression) and measure the accuracy of the quantile forecasts.
+By default, AutoGluon predicts quantile levels `[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]`.
+To predict a different set of quantiles, you can use `quantile_levels` argument:
+```python
+predictor = TimeSeriesPredictor(eval_metric="WQL", quantile_levels=[0.1, 0.5, 0.75, 0.9])
+```
+
+All remaining forecast metrics described on this page are **point** forecast metrics.
+Note that if you select a point forecast metric in AutoGluon, then the forecast minimizing this metric will always be provided in the `"mean"` column of the predictions data frame.
+
+**(Point forecast only) Do you want to estimate the mean or the median?**
+
+To estimate the **median**, you need to use metrics such as `MAE`, `MASE` or `WAPE`.
+If your goal is to predict the **mean** (expected value), you should use `MSE`, `RMSE` or `RMSSE` metrics.
+
+**Do you care more about accurately predicting time series with large values?**
+
+If the answer is "yes" (for example, if it's important to more accurately predict sales of popular products), you should use **scale-dependent** metrics like `WQL`, `MAE`, `RMSE`, or `WAPE`.
+These metrics are also well-suited for dealing with sparse (intermittent) time series that have lots of zeros.
+
+If the answer is "no" (you care equally about all time series in the dataset), consider **scaled** metrics like `SQL`, `MASE` and `RMSSE`. Alternatively, **percentage-based** metrics `MAPE` and `SMAPE` can also be used to equalize the scale across time series. However, these precentage-based metrics have some [well-documented limitations](https://robjhyndman.com/publications/another-look-at-measures-of-forecast-accuracy/), so we don't recommend using them in practice.
+Note that both scaled and percentage-based metrics are poorly suited for sparse (intermittent) data.
+
+
+
+```{eval-rst}
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :align: center
+   :widths: 40 20 20 20
+
+   * - Metric
+     - Probabilistic?
+     - Scale-dependent?
+     - Predicts median or mean?
+   * - :class:`~autogluon.timeseries.metrics.SQL` 
+     - ✅
+     -  
+     -  
+   * - :class:`~autogluon.timeseries.metrics.WQL` 
+     - ✅
+     - ✅
+     - 
+   * - :class:`~autogluon.timeseries.metrics.MAE`
+     - 
+     - ✅
+     - median
+   * - :class:`~autogluon.timeseries.metrics.MASE` 
+     - 
+     - 
+     - median
+   * - :class:`~autogluon.timeseries.metrics.WAPE`
+     - 
+     - ✅
+     - median
+   * - :class:`~autogluon.timeseries.metrics.MSE`
+     - 
+     - ✅
+     - mean
+   * - :class:`~autogluon.timeseries.metrics.RMSE`
+     - 
+     - ✅
+     - mean
+   * - :class:`~autogluon.timeseries.metrics.RMSSE`
+     - 
+     - 
+     - mean
+   * - :class:`~autogluon.timeseries.metrics.MAPE`
+     - 
+     - 
+     - 
+   * - :class:`~autogluon.timeseries.metrics.SMAPE` 
+     - 
+     - 
+     - 
+```
+
+## Overview
+
+## Probabilistic forecast metrics
+
+```{eval-rst}
+.. autoclass:: SQL
+```
+
+```{eval-rst}
+.. autoclass:: WQL
+```
+
+## Point forecast metrics
+
+```{eval-rst}
+.. autoclass:: MAE
+```
+
+```{eval-rst}
+.. autoclass:: MAPE
+```
+
+```{eval-rst}
+.. autoclass:: MASE
+```
+
+```{eval-rst}
+.. autoclass:: MSE
+```
+
+```{eval-rst}
+.. autoclass:: RMSE
+```
+
+```{eval-rst}
+.. autoclass:: RMSSE
+```
+
+```{eval-rst}
+.. autoclass:: SMAPE
+```
+
+```{eval-rst}
+.. autoclass:: WAPE
+```
+
+
+
+
+## Custom metrics
+If none of the built-in metrics meet your requirements, you can train provide a custom evaluation metric to AutoGluon.
+
+```python
+from autogluon.timeseries.metrics import TimeSeriesScorer
+```
+
+
+Below is the full documentation
+```{eval-rst}
+.. autoclass:: TimeSeriesScorer
+   :members: compute_metric, save_past_metrics, clear_past_metrics
+
+```
+
+<!-- ## Baseline models
+
+Baseline models are simple approaches that use minimal historical data to make predictions. They serve as benchmarks for evaluating more complex methods.
+
+```{eval-rst}
+.. autoclass:: NaiveModel
+   :members: init
+```
+
+
+```{eval-rst}
+.. autoclass:: SeasonalNaiveModel
+   :members: init
+
+```
+
+
+```{eval-rst}
+.. autoclass:: AverageModel
+   :members: init
+```
+
+
+```{eval-rst}
+.. autoclass:: SeasonalAverageModel
+   :members: init
+
+```
+
+## Statistical models
+
+Statistical models capture simple patterns in the data like trends and seasonality.
+
+
+```{eval-rst}
+.. autoclass:: ETSModel
+   :members: init
+
+```
+
+
+```{eval-rst}
+.. autoclass:: AutoARIMAModel
+   :members: init
+```
+
+
+```{eval-rst}
+.. autoclass:: AutoETSModel
+   :members: init
+```
+
+
+```{eval-rst}
+.. autoclass:: ThetaModel
+   :members: init
+```
+
+
+```{eval-rst}
+.. autoclass:: NPTSModel
+   :members: init
+
+```
+
+## Deep learning models
+
+Deep learning models use neural networks to capture complex patterns in the data.
+
+```{eval-rst}
+.. autoclass:: DeepARModel
+   :members: init
+
+```
+
+
+```{eval-rst}
+.. autoclass:: DLinearModel
+   :members: init
+
+```
+
+
+```{eval-rst}
+.. autoclass:: PatchTSTModel
+   :members: init
+
+```
+
+
+```{eval-rst}
+.. autoclass:: SimpleFeedForwardModel
+   :members: init
+
+```
+
+
+```{eval-rst}
+.. autoclass:: TemporalFusionTransformerModel
+   :members: init
+
+
+```
+
+
+```{eval-rst}
+.. autoclass:: WaveNetModel
+   :members: init
+
+
+```
+
+## Tabular models
+
+Tabular models convert time series forecasting into a tabular regression problem.
+
+
+```{eval-rst}
+.. autoclass:: DirectTabularModel
+   :members: init
+
+```
+
+
+```{eval-rst}
+.. autoclass:: RecursiveTabularModel
+   :members: init
+
+```
+
+## MXNet Models
+
+MXNet models from GluonTS have been deprecated because of dependency conflicts caused by MXNet.
+
+
+## Additional features
+
+Overview of the additional features and covariates supported by different models.
+Models not included in this table currently do not support any additional features.
+
+```{eval-rst}
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :align: center
+   :widths: 40 15 15 15 15
+
+   * - Model
+     - Static features (continuous)
+     - Static features (categorical)
+     - Known covariates (continuous)
+     - Past covariates (continuous)
+   * - :class:`~autogluon.timeseries.models.DirectTabularModel`
+     - ✓
+     - ✓
+     - ✓
+     -
+   * - :class:`~autogluon.timeseries.models.RecursiveTabularModel`
+     - ✓
+     - ✓
+     - ✓
+     -
+   * - :class:`~autogluon.timeseries.models.DeepARModel`
+     - ✓
+     - ✓
+     - ✓
+     -
+   * - :class:`~autogluon.timeseries.models.TemporalFusionTransformerModel`
+     - ✓
+     - ✓
+     - ✓
+     - ✓
+   * - :class:`~autogluon.timeseries.models.WaveNetModel`
+     - ✓
+     - ✓
+     - ✓
+     - 
+``` -->

--- a/docs/tutorials/timeseries/forecasting-metrics.md
+++ b/docs/tutorials/timeseries/forecasting-metrics.md
@@ -9,8 +9,13 @@ from autogluon.timeseries import TimeSeriesPredictor
 
 predictor = TimeSeriesPredictor(eval_metric="MASE")
 ```
-
 AutoGluon will use the provided metric to tune model hyperparameters, rank models, and construct the final ensemble for prediction.
+
+:::{note}
+AutoGluon always reports all metrics in a **higher-is-better** format.
+For this purpose, some metrics are multiplied by -1.
+For example, if we set `eval_metric="MASE"`, the predictor will actually report `-MASE` (i.e., MASE score multiplied by -1). This means the `test_score` will be between 0 (best possible forecast) and $-\infty$ (worst possible forecast).
+:::
 
 
 Currently, AutoGluon supports following evaluation metrics:

--- a/docs/tutorials/timeseries/forecasting-metrics.md
+++ b/docs/tutorials/timeseries/forecasting-metrics.md
@@ -10,11 +10,43 @@ from autogluon.timeseries import TimeSeriesPredictor
 
 predictor = TimeSeriesPredictor(eval_metric="MASE")
 ```
+
 AutoGluon will use the provided metric to tune model hyperparameters, rank models, and construct the final ensemble for prediction.
+
+
+Currently, AutoGluon supports following evaluation metrics:
+
+```{eval-rst}
+.. automodule:: autogluon.timeseries.metrics
+```
+
+```{eval-rst}
+.. currentmodule:: autogluon.timeseries.metrics
+```
+
+
+```{eval-rst}
+.. autosummary::
+   :nosignatures:
+
+   SQL
+   WQL
+   MAE
+   MAPE
+   MASE
+   MSE
+   RMSE
+   RMSSE
+   SMAPE
+   WAPE
+
+``` 
+
+## Which evaluation metric to choose?
 
 If you are not sure which evaluation metric to pick, here are three questions that can help you make the right choice for your use case.
 
-**Are you interested in a point forecast or a probabilistic forecast?**
+**1. Are you interested in a point forecast or a probabilistic forecast?**
 
 If your goal is to generate an accurate **probabilistic** forecast, you should use `WQL` or `SQL` metrics.
 These metrics are based on the [quantile loss](https://en.wikipedia.org/wiki/Quantile_regression) and measure the accuracy of the quantile forecasts.
@@ -27,18 +59,18 @@ predictor = TimeSeriesPredictor(eval_metric="WQL", quantile_levels=[0.1, 0.5, 0.
 All remaining forecast metrics described on this page are **point** forecast metrics.
 Note that if you select a point forecast metric in AutoGluon, then the forecast minimizing this metric will always be provided in the `"mean"` column of the predictions data frame.
 
-**(Point forecast only) Do you want to estimate the mean or the median?**
-
-To estimate the **median**, you need to use metrics such as `MAE`, `MASE` or `WAPE`.
-If your goal is to predict the **mean** (expected value), you should use `MSE`, `RMSE` or `RMSSE` metrics.
-
-**Do you care more about accurately predicting time series with large values?**
+**2. Do you care more about accurately predicting time series with large values?**
 
 If the answer is "yes" (for example, if it's important to more accurately predict sales of popular products), you should use **scale-dependent** metrics like `WQL`, `MAE`, `RMSE`, or `WAPE`.
 These metrics are also well-suited for dealing with sparse (intermittent) time series that have lots of zeros.
 
 If the answer is "no" (you care equally about all time series in the dataset), consider **scaled** metrics like `SQL`, `MASE` and `RMSSE`. Alternatively, **percentage-based** metrics `MAPE` and `SMAPE` can also be used to equalize the scale across time series. However, these precentage-based metrics have some [well-documented limitations](https://robjhyndman.com/publications/another-look-at-measures-of-forecast-accuracy/), so we don't recommend using them in practice.
 Note that both scaled and percentage-based metrics are poorly suited for sparse (intermittent) data.
+
+**3. (Point forecast only) Do you want to estimate the mean or the median?**
+
+To estimate the **median**, you need to use metrics such as `MAE`, `MASE` or `WAPE`.
+If your goal is to predict the **mean** (expected value), you should use `MSE`, `RMSE` or `RMSSE` metrics.
 
 
 
@@ -95,17 +127,7 @@ Note that both scaled and percentage-based metrics are poorly suited for sparse 
      - 
 ```
 
-## Overview
 
-## Probabilistic forecast metrics
-
-```{eval-rst}
-.. autoclass:: SQL
-```
-
-```{eval-rst}
-.. autoclass:: WQL
-```
 
 ## Point forecast metrics
 
@@ -142,6 +164,15 @@ Note that both scaled and percentage-based metrics are poorly suited for sparse 
 ```
 
 
+## Probabilistic forecast metrics
+
+```{eval-rst}
+.. autoclass:: SQL
+```
+
+```{eval-rst}
+.. autoclass:: WQL
+```
 
 
 ## Custom metrics

--- a/docs/tutorials/timeseries/forecasting-model-zoo.md
+++ b/docs/tutorials/timeseries/forecasting-model-zoo.md
@@ -273,28 +273,28 @@ Models not included in this table currently do not support any additional featur
      - Known covariates (continuous)
      - Past covariates (continuous)
    * - :class:`~autogluon.timeseries.models.DirectTabularModel`
-     - ✓
-     - ✓
-     - ✓
+     - ✅
+     - ✅
+     - ✅
      -
    * - :class:`~autogluon.timeseries.models.RecursiveTabularModel`
-     - ✓
-     - ✓
-     - ✓
+     - ✅
+     - ✅
+     - ✅
      -
    * - :class:`~autogluon.timeseries.models.DeepARModel`
-     - ✓
-     - ✓
-     - ✓
+     - ✅
+     - ✅
+     - ✅
      -
    * - :class:`~autogluon.timeseries.models.TemporalFusionTransformerModel`
-     - ✓
-     - ✓
-     - ✓
-     - ✓
+     - ✅
+     - ✅
+     - ✅
+     - ✅
    * - :class:`~autogluon.timeseries.models.WaveNetModel`
-     - ✓
-     - ✓
-     - ✓
+     - ✅
+     - ✅
+     - ✅
      - 
 ```

--- a/docs/tutorials/timeseries/index.md
+++ b/docs/tutorials/timeseries/index.md
@@ -33,6 +33,12 @@ Check out the [Quick Start Tutorial](forecasting-quick-start.ipynb) to learn how
   List of available forecasting models in AutoGluon-TimeSeries.
 :::
 
+:::{grid-item-card} Metrics
+  :link: forecasting-metrics.html
+
+  Evaluation metrics available in AutoGluon-TimeSeries.
+:::
+
 ::::
 
 ```{toctree}

--- a/docs/tutorials/timeseries/index.md
+++ b/docs/tutorials/timeseries/index.md
@@ -50,4 +50,5 @@ hidden: true
 Quick Start <forecasting-quick-start>
 In Depth <forecasting-indepth>
 Model Zoo <forecasting-model-zoo>
+Metrics <forecasting-metrics>
 ```

--- a/timeseries/src/autogluon/timeseries/metrics/__init__.py
+++ b/timeseries/src/autogluon/timeseries/metrics/__init__.py
@@ -2,7 +2,7 @@ from pprint import pformat
 from typing import Type, Union
 
 from .abstract import TimeSeriesScorer
-from .point import MAE, MAPE, MASE, MSE, RMSE, RMSSE, WAPE, SMAPE
+from .point import MAE, MAPE, MASE, MSE, RMSE, RMSSE, SMAPE, WAPE
 from .quantile import SQL, WQL
 
 __all__ = [

--- a/timeseries/src/autogluon/timeseries/metrics/__init__.py
+++ b/timeseries/src/autogluon/timeseries/metrics/__init__.py
@@ -2,14 +2,14 @@ from pprint import pformat
 from typing import Type, Union
 
 from .abstract import TimeSeriesScorer
-from .point import MAE, MAPE, MASE, MSE, RMSE, RMSSE, WAPE, sMAPE
+from .point import MAE, MAPE, MASE, MSE, RMSE, RMSSE, WAPE, SMAPE
 from .quantile import SQL, WQL
 
 __all__ = [
     "MAE",
     "MAPE",
     "MASE",
-    "sMAPE",
+    "SMAPE",
     "MSE",
     "RMSE",
     "RMSSE",
@@ -23,7 +23,7 @@ DEFAULT_METRIC_NAME = "WQL"
 AVAILABLE_METRICS = {
     "MASE": MASE,
     "MAPE": MAPE,
-    "SMAPE": sMAPE,
+    "SMAPE": SMAPE,
     "RMSE": RMSE,
     "RMSSE": RMSSE,
     "WAPE": WAPE,

--- a/timeseries/src/autogluon/timeseries/metrics/point.py
+++ b/timeseries/src/autogluon/timeseries/metrics/point.py
@@ -22,13 +22,13 @@ class RMSE(TimeSeriesScorer):
 
 
     Properties:
-    
+
     - scale-dependent (time series with large absolute value contribute more to the loss)
     - heavily penalizes models that cannot quickly adapt to abrupt changes in the time series
     - sensitive to outliers
     - prefers models that accurately estimate the mean (expected value)
 
-    
+
     References
     ----------
     - `Wikipedia <https://en.wikipedia.org/wiki/Root-mean-square_deviation>`_
@@ -54,16 +54,16 @@ class MSE(TimeSeriesScorer):
         \operatorname{MSE} = \frac{1}{N} \frac{1}{H} \sum_{i=1}^{N}\sum_{t=T+1}^{T+H}  (y_{i,t} - f_{i,t})^2
 
     Properties:
-    
+
     - scale-dependent (time series with large absolute value contribute more to the loss)
     - heavily penalizes models that cannot quickly adapt to abrupt changes in the time series
     - sensitive to outliers
     - prefers models that accurately estimate the mean (expected value)
-    
+
     References
     ----------
     - `Wikipedia <https://en.wikipedia.org/wiki/Mean_squared_error>`_
-    
+
     """
 
     equivalent_tabular_regression_metric = "mean_squared_error"
@@ -83,7 +83,7 @@ class MAE(TimeSeriesScorer):
         \operatorname{MAE} = \frac{1}{N} \frac{1}{H} \sum_{i=1}^{N}\sum_{t=T+1}^{T+H}  |y_{i,t} - f_{i,t}|
 
     Properties:
-    
+
     - scale-dependent (time series with large absolute value contribute more to the loss)
     - not sensitive to outliers
     - prefers models that accurately estimate the median
@@ -114,12 +114,12 @@ class WAPE(TimeSeriesScorer):
         \operatorname{WAPE} = \frac{1}{\sum_{i=1}^{N} \sum_{t=T+1}^{T+H} |y_{i, t}|} \sum_{i=1}^{N} \sum_{t=T+1}^{T+H}  |y_{i,t} - f_{i,t}|
 
     Properties:
-    
+
     - scale-dependent (time series with large absolute value contribute more to the loss)
     - not sensitive to outliers
     - prefers models that accurately estimate the median
 
-    
+
     References
     ----------
     - `Wikipedia <https://en.wikipedia.org/wiki/Mean_absolute_percentage_error#WMAPE>`_
@@ -139,15 +139,15 @@ class SMAPE(TimeSeriesScorer):
     r"""Symmetric mean absolute percentage error.
 
     .. math::
-        
+
         \operatorname{SMAPE} = 2 \frac{1}{N} \frac{1}{H} \sum_{i=1}^{N} \sum_{t=T+1}^{T+H} \frac{ |y_{i,t} - f_{i,t}|}{|y_{i,t}| + |f_{i,t}|}
 
     Properties:
-    
+
     - should only be used if all time series have positive values
     - poorly suited for sparse & intermittent time series that contain zero values
     - penalizes overprediction more heavily than underprediction
-    
+
     References
     ----------
     - `Wikipedia <https://en.wikipedia.org/wiki/Symmetric_mean_absolute_percentage_error>`_
@@ -168,15 +168,15 @@ class MAPE(TimeSeriesScorer):
     r"""Mean absolute percentage error.
 
     .. math::
-        
+
         \operatorname{MAPE} = \frac{1}{N} \frac{1}{H} \sum_{i=1}^{N} \sum_{t=T+1}^{T+H} \frac{ |y_{i,t} - f_{i,t}|}{|y_{i,t}|}
 
     Properties:
-    
+
     - should only be used if all time series have positive values
     - undefined for time series that contain zero values
     - penalizes overprediction more heavily than underprediction
-    
+
     References
     ----------
     - `Wikipedia <https://en.wikipedia.org/wiki/Mean_absolute_percentage_error>`_
@@ -195,28 +195,28 @@ class MAPE(TimeSeriesScorer):
 
 class MASE(TimeSeriesScorer):
     r"""Mean absolute scaled error.
-    
+
     Normalizes the absolute error for each time series by the historic seasonal error of this time series.
 
     .. math::
-    
+
         \operatorname{MASE} = \frac{1}{N} \frac{1}{H} \sum_{i=1}^{N} \frac{1}{a_i} \sum_{t=T+1}^{T+H} |y_{i,t} - f_{i,t}|
 
     where :math:`a_i` is the historic absolute seasonal error defined as
-    
+
     .. math::
 
         a_i = \frac{1}{T-m} \sum_{t=m+1}^T |y_{i,t} - y_{i,t-m}|
-    
+
     and :math:`m` is the seasonal period of the time series (``eval_metric_seasonal_period``).
 
     Properties:
-    
+
     - scaled metric (normalizes the error for each time series by the scale of that time series)
     - undefined for constant time series
     - not sensitive to outliers
     - prefers models that accurately estimate the median
- 
+
     References
     ----------
     - `Wikipedia <https://en.wikipedia.org/wiki/Mean_absolute_scaled_error>`_
@@ -256,11 +256,11 @@ class RMSSE(TimeSeriesScorer):
     Normalizes the absolute error for each time series by the historic seasonal error of this time series.
 
     .. math::
-    
+
         \operatorname{RMSSE} = \sqrt{\frac{1}{N} \frac{1}{H} \sum_{i=1}^{N} \frac{1}{s_i} \sum_{t=T+1}^{T+H} (y_{i,t} - f_{i,t})^2}
 
     where :math:`s_i` is the historic squared seasonal error defined as
-    
+
     .. math::
 
         s_i = \frac{1}{T-m} \sum_{t=m+1}^T (y_{i,t} - y_{i,t-m})^2
@@ -269,14 +269,14 @@ class RMSSE(TimeSeriesScorer):
 
 
     Properties:
-    
+
     - scaled metric (normalizes the error for each time series by the scale of that time series)
     - undefined for constant time series
     - heavily penalizes models that cannot quickly adapt to abrupt changes in the time series
     - sensitive to outliers
     - prefers models that accurately estimate the mean (expected value)
 
-    
+
     References
     ----------
     - `Forecasting: Principles and Practice <https://otexts.com/fpp3/accuracy.html#scaled-errors>`_

--- a/timeseries/src/autogluon/timeseries/metrics/point.py
+++ b/timeseries/src/autogluon/timeseries/metrics/point.py
@@ -71,7 +71,6 @@ class MSE(TimeSeriesScorer):
 class MAE(TimeSeriesScorer):
     r"""Mean absolute error.
 
-    Using this metric will lead to forecast of the median.
 
     .. math::
 
@@ -96,13 +95,12 @@ class MAE(TimeSeriesScorer):
 class WAPE(TimeSeriesScorer):
     r"""Weighted absolute percentage error.
 
-    Properties:
-    
-    - Using this metric will lead to forecast of the median.
+    Defined as sum of absolute errors divided by the sum of absolute time series values in the forecast horizon.
 
     .. math::
 
-        \frac{1}{\sum_{i, t} |y_{i, t}|} \sum_{i,t}  |y_{i,t} - f_{i,t}|
+        \operatorname{WAPE} = \frac{1}{\sum_{i, t} |y_{i, t}|} \sum_{i,t}  |y_{i,t} - f_{i,t}|
+
     
     References
     ----------

--- a/timeseries/src/autogluon/timeseries/metrics/point.py
+++ b/timeseries/src/autogluon/timeseries/metrics/point.py
@@ -14,7 +14,26 @@ logger = logging.getLogger(__name__)
 
 
 class RMSE(TimeSeriesScorer):
-    """Root mean squared error."""
+    r"""Root mean squared error.
+
+    Defined as
+    
+    .. math::
+
+        \sqrt{\sum_{i,t}  (y_{i,t} - f_{i,t})^2}
+
+
+    Properties:
+    
+    - estimates the mean (expected value) of the time series
+    - scale-dependent
+
+    
+    References
+    ----------
+    - `Wikipedia <https://en.wikipedia.org/wiki/Root-mean-square_deviation>`_
+    - `Forecasting: Principles and Practice <https://otexts.com/fpp3/accuracy.html#scale-dependent-errors>`_
+    """
 
     equivalent_tabular_regression_metric = "root_mean_squared_error"
 
@@ -26,7 +45,19 @@ class RMSE(TimeSeriesScorer):
 
 
 class MSE(TimeSeriesScorer):
-    """Mean squared error."""
+    r"""Mean squared error.
+
+    Using this metric will lead to forecast of the mean.
+
+    .. math::
+
+        \sum_{i,t}  (y_{i,t} - f_{i,t})^2
+    
+    References
+    ----------
+    - `Wikipedia <https://en.wikipedia.org/wiki/Mean_squared_error>`_
+    
+    """
 
     equivalent_tabular_regression_metric = "mean_squared_error"
 
@@ -38,7 +69,19 @@ class MSE(TimeSeriesScorer):
 
 
 class MAE(TimeSeriesScorer):
-    """Mean absolute error."""
+    r"""Mean absolute error.
+
+    Using this metric will lead to forecast of the median.
+
+    .. math::
+
+        \sum_{i,t}  |y_{i,t} - f_{i,t}|
+
+    References
+    ----------
+    - `Wikipedia <https://en.wikipedia.org/wiki/Mean_absolute_percentage_error#WMAPE>`_
+    - `Forecasting: Principles and Practice <https://otexts.com/fpp3/accuracy.html#scale-dependent-errors>`_
+    """
 
     optimized_by_median = True
     equivalent_tabular_regression_metric = "mean_absolute_error"
@@ -51,7 +94,20 @@ class MAE(TimeSeriesScorer):
 
 
 class WAPE(TimeSeriesScorer):
-    """Weighted absolute percentage error."""
+    r"""Weighted absolute percentage error.
+
+    Properties:
+    
+    - Using this metric will lead to forecast of the median.
+
+    .. math::
+
+        \frac{1}{\sum_{i, t} |y_{i, t}|} \sum_{i,t}  |y_{i,t} - f_{i,t}|
+    
+    References
+    ----------
+    - `Wikipedia <https://en.wikipedia.org/wiki/Mean_absolute_percentage_error#WMAPE>`_
+    """
 
     optimized_by_median = True
     equivalent_tabular_regression_metric = "mean_absolute_error"
@@ -63,8 +119,23 @@ class WAPE(TimeSeriesScorer):
         return (y_true - y_pred).abs().sum() / y_true.abs().sum()
 
 
-class sMAPE(TimeSeriesScorer):
-    """Symmetric mean absolute percentage error."""
+class SMAPE(TimeSeriesScorer):
+    r"""Symmetric mean absolute percentage error.
+
+    Properties:
+    
+    - Poorly suited 
+    - Penalizes overpredictions stronger than underpredictions
+
+    .. math::
+        
+        2 \cdot \sum_{i,t} \frac{ |y_{i,t} - f_{i,t}|}{|y_{i,t}| + |f_{i,t}|}
+    
+    References
+    ----------
+    - `Wikipedia <https://en.wikipedia.org/wiki/Symmetric_mean_absolute_percentage_error>`_
+    - `Forecasting: Principles and Practice <https://otexts.com/fpp3/accuracy.html#percentage-errors>`_
+    """
 
     optimized_by_median = True
     equivalent_tabular_regression_metric = "symmetric_mean_absolute_percentage_error"
@@ -77,7 +148,17 @@ class sMAPE(TimeSeriesScorer):
 
 
 class MAPE(TimeSeriesScorer):
-    """Mean Absolute Percentage Error."""
+    r"""Mean absolute percentage error.
+
+    .. math::
+        
+        \sum_{i,t} \frac{ |y_{i,t} - f_{i,t}|}{|y_{i,t}|}
+    
+    References
+    ----------
+    - `Wikipedia <https://en.wikipedia.org/wiki/Mean_absolute_percentage_error>`_
+    - `Forecasting: Principles and Practice <https://otexts.com/fpp3/accuracy.html#percentage-errors>`_
+    """
 
     optimized_by_median = True
     equivalent_tabular_regression_metric = "mean_absolute_percentage_error"
@@ -90,7 +171,13 @@ class MAPE(TimeSeriesScorer):
 
 
 class MASE(TimeSeriesScorer):
-    """Mean absolute scaled error."""
+    r"""Mean absolute scaled error.
+ 
+    References
+    ----------
+    - `Wikipedia <https://en.wikipedia.org/wiki/Mean_absolute_scaled_error>`_
+    - `Forecasting: Principles and Practice <https://otexts.com/fpp3/accuracy.html#scaled-errors>`_
+    """
 
     optimized_by_median = True
     equivalent_tabular_regression_metric = "mean_absolute_error"
@@ -120,7 +207,12 @@ class MASE(TimeSeriesScorer):
 
 
 class RMSSE(TimeSeriesScorer):
-    """Root mean squared scaled error."""
+    r"""Root mean squared scaled error.
+    
+    References
+    ----------
+    - `Forecasting: Principles and Practice <https://otexts.com/fpp3/accuracy.html#scaled-errors>`_
+    """
 
     equivalent_tabular_regression_metric = "root_mean_squared_error"
 

--- a/timeseries/src/autogluon/timeseries/metrics/quantile.py
+++ b/timeseries/src/autogluon/timeseries/metrics/quantile.py
@@ -13,15 +13,15 @@ class WQL(TimeSeriesScorer):
     r"""Weighted quantile loss.
 
     Also known as weighted pinball loss.
-    
+
     Defined as total quantile loss divided by the sum of absolute time series values in the forecast horizon.
-    
+
     .. math::
 
         \operatorname{WQL} = \frac{1}{\sum_{i=1}^{N} \sum_{t=T+1}^{T+H} |y_{i, t}|} \sum_{i=1}^{N} \sum_{t=T+1}^{T+H} \sum_{q}  \rho_q(y_{i,t}, f^q_{i,t})
 
     Properties:
-    
+
     - scale-dependent (time series with large absolute value contribute more to the loss)
     - equivalent to WAPE if ``quantile_levels = [0.5]``
 
@@ -58,16 +58,16 @@ class SQL(TimeSeriesScorer):
         \operatorname{SQL} = \frac{1}{\sum_{i=1}^{N} \sum_{t=T+1}^{T+H} |y_{i, t}|} \sum_{i=1}^{N} \sum_{t=T+1}^{T+H} \sum_{q}  \rho_q(y_{i,t}, f^q_{i,t})
 
     where :math:`a_i` is the historic absolute seasonal error defined as
-    
+
     .. math::
 
         a_i = \frac{1}{T-m} \sum_{t=m+1}^T |y_{i,t} - y_{i,t-m}|
-    
+
     and :math:`m` is the seasonal period of the time series (``eval_metric_seasonal_period``).
 
 
     Properties:
-    
+
     - scaled metric (normalizes the error for each time series by the scale of that time series)
     - undefined for constant time series
     - equivalent to MASE if ``quantile_levels = [0.5]``

--- a/timeseries/src/autogluon/timeseries/metrics/quantile.py
+++ b/timeseries/src/autogluon/timeseries/metrics/quantile.py
@@ -13,6 +13,14 @@ class WQL(TimeSeriesScorer):
     """Weighted quantile loss.
 
     Also known as weighted pinball loss.
+
+    When to use:
+    
+        - Data 
+
+    When not to use:
+    
+        - 
     """
 
     needs_quantile = True

--- a/timeseries/src/autogluon/timeseries/metrics/quantile.py
+++ b/timeseries/src/autogluon/timeseries/metrics/quantile.py
@@ -10,17 +10,25 @@ from .utils import _in_sample_abs_seasonal_error
 
 
 class WQL(TimeSeriesScorer):
-    """Weighted quantile loss.
+    r"""Weighted quantile loss.
 
     Also known as weighted pinball loss.
-
-    When to use:
     
-        - Data 
-
-    When not to use:
+    Defined as total quantile loss divided by the sum of absolute time series values in the forecast horizon.
     
-        - 
+    .. math::
+
+        \operatorname{WQL} = \frac{1}{\sum_{i=1}^{N} \sum_{t=T+1}^{T+H} |y_{i, t}|} \sum_{i=1}^{N} \sum_{t=T+1}^{T+H} \sum_{q}  \rho_q(y_{i,t}, f^q_{i,t})
+
+    Properties:
+    
+    - scale-dependent (time series with large absolute value contribute more to the loss)
+    - equivalent to WAPE if ``quantile_levels = [0.5]``
+
+
+    References
+    ----------
+    - `Forecasting: Principles and Practice <https://otexts.com/fpp3/distaccuracy.html#quantile-scores>`_
     """
 
     needs_quantile = True
@@ -39,9 +47,34 @@ class WQL(TimeSeriesScorer):
 
 
 class SQL(TimeSeriesScorer):
-    """Scaled quantile loss.
+    r"""Scaled quantile loss.
 
     Also known as scaled pinball loss.
+
+    Normalizes the quantile loss for each time series by the historic seasonal error of this time series.
+
+    .. math::
+
+        \operatorname{SQL} = \frac{1}{\sum_{i=1}^{N} \sum_{t=T+1}^{T+H} |y_{i, t}|} \sum_{i=1}^{N} \sum_{t=T+1}^{T+H} \sum_{q}  \rho_q(y_{i,t}, f^q_{i,t})
+
+    where :math:`a_i` is the historic absolute seasonal error defined as
+    
+    .. math::
+
+        a_i = \frac{1}{T-m} \sum_{t=m+1}^T |y_{i,t} - y_{i,t-m}|
+    
+    and :math:`m` is the seasonal period of the time series (``eval_metric_seasonal_period``).
+
+
+    Properties:
+    
+    - scaled metric (normalizes the error for each time series by the scale of that time series)
+    - undefined for constant time series
+    - equivalent to MASE if ``quantile_levels = [0.5]``
+
+    References
+    ----------
+    - `Forecasting: Principles and Practice <https://otexts.com/fpp3/distaccuracy.html#quantile-scores>`_
     """
 
     needs_quantile = True

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -68,20 +68,21 @@ class TimeSeriesPredictor:
 
         Probabilistic forecast metrics (evaluated on quantile forecasts for the specified ``quantile_levels``):
 
-        - ``"WQL"``: mean weighted quantile loss, defined as average of quantile losses divided by the sum of absolute time series values in the forecast horizon.
-        - ``"SQL"``: scaled quantile loss, defined as average of quantile losses divided by the in-sample seasonal error.
+        - ``"SQL"``: scaled quantile loss, defined as average of quantile losses divided by the in-sample seasonal error
+        - ``"WQL"``: mean weighted quantile loss, defined as average of quantile losses divided by the sum of absolute time series values in the forecast horizon
 
         Point forecast metrics (these are always evaluated on the ``"mean"`` column of the predictions):
 
+        - ``"MAE"``: mean absolute error
         - ``"MAPE"``: mean absolute percentage error
-        - ``"SMAPE"``: "symmetric" mean absolute percentage error
         - ``"MASE"``: mean absolute scaled error
         - ``"MSE"``: mean squared error
         - ``"RMSE"``: root mean squared error
+        - ``"RMSSE"``: root mean squared scaled error
+        - ``"SMAPE"``: "symmetric" mean absolute percentage error
         - ``"WAPE"``: weighted absolute percentage error
-        - ``"RMSSE"``: Root Mean Squared Scaled Error . See https://otexts.com/fpp3/accuracy.html#scaled-errors
 
-        For more information about these metrics, see https://docs.aws.amazon.com/forecast/latest/dg/metrics.html.
+        For more information about these metrics, see https://auto.gluon.ai/stable/tutorials/timeseries/forecasting-metrics.html.
     eval_metric_seasonal_period : int, optional
         Seasonal period used to compute some evaluation metrics such as mean absolute scaled error (MASE). Defaults to
         ``None``, in which case the seasonal period is computed based on the data frequency.

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -74,7 +74,7 @@ class TimeSeriesPredictor:
         Point forecast metrics (these are always evaluated on the ``"mean"`` column of the predictions):
 
         - ``"MAPE"``: mean absolute percentage error
-        - ``"sMAPE"``: "symmetric" mean absolute percentage error
+        - ``"SMAPE"``: "symmetric" mean absolute percentage error
         - ``"MASE"``: mean absolute scaled error
         - ``"MSE"``: mean squared error
         - ``"RMSE"``: root mean squared error


### PR DESCRIPTION
*Description of changes:*
- Add documentation for evaluation metrics available in AutoGluon.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
