### PR TITLE
[timeseries] Speed up TimeSeriesDataFrame.convert_frequency using joblib

### DIFF
--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -962,6 +962,8 @@ class TimeSeriesDataFrame(pd.DataFrame):
                 resampled_dfs.append(pd.concat({item_id: resampled_df}, names=[ITEMID]))
             return pd.concat(resampled_dfs)
 
+        # Resampling time for 1 item < overhead time for a single parallel job. Therefore, we group items into chunks
+        # so that the speedup from parallelization isn't dominated by the communication costs.
         chunks = split_into_chunks(pd.DataFrame(self).groupby(level=ITEMID, sort=False), chunk_size)
         resampled_chunks = Parallel(n_jobs=num_cpus)(delayed(resample_chunk)(chunk) for chunk in chunks)
         resampled_df = TimeSeriesDataFrame(pd.concat(resampled_chunks))

--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -952,6 +952,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
                 aggregation[col] = agg_categorical
 
         def split_into_chunks(iterable: Iterable, size: int) -> Iterable[Iterable]:
+            # Based on https://stackoverflow.com/a/22045226/5497447
             iterable = iter(iterable)
             return iter(lambda: tuple(islice(iterable, size)), ())
 

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -981,6 +981,20 @@ def test_when_aggregation_method_is_changed_then_aggregated_result_is_correct(ag
     assert np.all(aggregated.values.ravel() == np.array(values_after_aggregation))
 
 
+@pytest.mark.parametrize("freq", ["D", "W", "M", "Q", "A", "Y", "H", "T", "min", "S", "30T", "2H", "17S"])
+def test_when_convert_frequency_called_then_categorical_columns_are_preserved(freq):
+    df_original = get_data_frame_with_variable_lengths({"B": 15, "A": 20}, freq=freq, covariates_names=["Y", "X"])
+    cat_columns = ["cat_1", "cat_2"]
+    for col in cat_columns:
+        df_original[col] = np.random.choice(["foo", "bar", "baz"], size=len(df_original))
+    # Select random rows & reset cached freq
+    df_irregular = df_original.iloc[[2, 5, 7, 10, 14, 15, 16, 33]]
+    df_irregular._cached_freq = None
+    df_regular = df_irregular.convert_frequency(freq=freq)
+    assert all(col in df_regular.columns for col in cat_columns)
+    assert df_regular.freq == pd.tseries.frequencies.to_offset(freq).freqstr
+
+
 @pytest.mark.parametrize("dtype", ["datetime64[ns]", "datetime64[us]", "datetime64[ms]", "datetime64[s]"])
 def test_when_timestamps_have_datetime64_type_then_tsdf_can_be_constructed(dtype):
     df = SAMPLE_DATAFRAME.copy()


### PR DESCRIPTION
*Description of changes:*
- `tsdf.convert_frequency` can be extremely slow for large datasets. In this PR, we parallelize resampling using joblib. 
- This results in a noticeable speedup. For example, for M4 Monthly dataset (48000 items):
  - Current sequential implementation based on `df.groupby(...).resample(...)` - `4m11s`.
  - This PR (32 cores, chunk_size=100) -`31s`.

Note that chunking critical for the speedup. If we don't use chunking, runtime for M4 Monthly goes up to `4m30s`, which is comparable to the sequential version.

I have considered [other methods](https://stackoverflow.com/questions/15799162/resampling-within-a-pandas-multiindex) for speeding up resampling, however:
 - `pd.Grouper` isn't applicable in case original data has irregular timestamps that are a subset of `date_range` (it's only appropriate for subsampling).
 - unstack/stack won't work in case items have different start-end dates.

The `convert_frequency` method is [extensively tested](https://github.com/autogluon/autogluon/blob/master/timeseries/tests/unittests/test_ts_dataset.py#L893-L981), so this change is low-risk addition for the v1.0 release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
