### PR TITLE
[timeseries] Limit number of GluonTS validation batches

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -283,6 +283,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         init_args = self._get_estimator_init_args()
 
         default_trainer_kwargs = {
+            "limit_val_batches": 3,
             "max_epochs": init_args["max_epochs"],
             "callbacks": init_args["callbacks"],
             "enable_progress_bar": False,


### PR DESCRIPTION
*Description of changes:*
- Ensure that # of validation batches is still limited in case `Cached` issue is fixed in GluonTS v0.14.x.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
