### PR TITLE
Fix get_precision_context

### DIFF
--- a/multimodal/src/autogluon/multimodal/utils/environment.py
+++ b/multimodal/src/autogluon/multimodal/utils/environment.py
@@ -238,15 +238,14 @@ def get_precision_context(precision: Union[int, str], device_type: Optional[str]
     -------
     A precision context manager.
     """
-    if precision == 32:
+    precision = infer_precision(num_gpus=1, precision=precision, as_torch=True)
+    if precision == torch.float32:
         assert torch.get_default_dtype() == torch.float32
         return contextlib.nullcontext()
-    elif precision in [16, "16", "16-mixed", "bf16", "bf16-mixed"]:
-        return torch.autocast(device_type=device_type, dtype=torch.bfloat16 if "bf16" in precision else torch.half)
-    elif precision == 64:
+    elif precision == torch.float64:
         return double_precision_context()
     else:
-        raise ValueError(f"Unknown precision: {precision}")
+        return torch.autocast(device_type=device_type, dtype=precision)
 
 
 def check_if_packages_installed(problem_type: str = None, package_names: List[str] = None):


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Avoid crash when model `config.yaml` contains integer `precision: 16`


```pytb
File "/usr/share/python3/app/lib/python3.11/site-packages/autogluon/multimodal/predictor.py", line 644, in predict_proba
    return self._learner.predict_proba(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/python3/app/lib/python3.11/site-packages/autogluon/multimodal/learners/base.py", line 2000, in predict_proba
    outputs = self.predict_per_run(
              ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/python3/app/lib/python3.11/site-packages/autogluon/multimodal/learners/base.py", line 1724, in predict_per_run
    outputs = self.realtime_predict(
              ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/python3/app/lib/python3.11/site-packages/autogluon/multimodal/learners/base.py", line 1631, in realtime_predict
    output = self.predict_batch(
             ^^^^^^^^^^^^^^^^^^^
  File "/usr/share/python3/app/lib/python3.11/site-packages/autogluon/multimodal/utils/inference.py", line 180, in predict_batch
    precision_context = get_precision_context(precision=precision, device_type=device_type)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/python3/app/lib/python3.11/site-packages/autogluon/multimodal/utils/environment.py", line 245, in get_precision_context
    return torch.autocast(device_type=device_type, dtype=torch.bfloat16 if "bf16" in precision else torch.half)
                                                                           ^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'int' is not iterable

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
