### PR TITLE
[core] Add async_timeout to requirements

### DIFF
--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -7,7 +7,6 @@ function setup_build_env {
     python3 -m pip install bandit
     python3 -m pip install packaging
     python3 -m pip install ruff
-    python3 -m pip install async-timeout
 }
 
 function setup_build_contrib_env {

--- a/core/setup.py
+++ b/core/setup.py
@@ -30,7 +30,6 @@ install_requires = (
         "requests",
         "matplotlib",
         "boto3",
-        "async-timeout",
         f"autogluon.common=={version}",
     ]
     if not ag.LITE_MODE
@@ -49,6 +48,7 @@ install_requires = (
 extras_require = {
     "ray": [
         "ray[default]>=2.6.3,<2.7",
+        "async-timeout",
     ],
     "raytune": [
         "ray[default,tune]>=2.6.3,<2.7",

--- a/core/setup.py
+++ b/core/setup.py
@@ -30,6 +30,7 @@ install_requires = (
         "requests",
         "matplotlib",
         "boto3",
+        "async-timeout",
         f"autogluon.common=={version}",
     ]
     if not ag.LITE_MODE

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -29,6 +29,7 @@ DEPENDENT_PACKAGES = {
     "torch": ">=2.0,<2.1",  # "<{N+1}" upper cap, sync with common/src/autogluon/common/utils/try_import.py
     "lightning": ">=2.0.0,<2.1",  # "<{N+1}" upper cap
     "pytorch_lightning": ">=2.0.0,<2.1",  # "<{N+1}" upper cap, capping `lightning` does not cap `pytorch_lightning`!
+    "async_timeout": ">=4.0,<5",  # Major version cap
 }
 if LITE_MODE:
     DEPENDENT_PACKAGES = {package: version for package, version in DEPENDENT_PACKAGES.items() if package not in ["psutil", "Pillow", "timm"]}


### PR DESCRIPTION
*Description of changes:*
- Ray fails on Python 3.11 if GPU is present. #3778 fixes this problem in our test environment, but the error seems to still be present outside of our test environment (e.g., if we install AG with `pip install autogluon` in a fresh Python 3.11 env). This PR fixes the problem by adding `async-timeout` to the `core[ray]` requirements.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
