### PR TITLE
[timeseries] Fix refit_full bug

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -359,6 +359,9 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
             predictions[str(q)] = predictions["mean"] + norm.ppf(q) * std_per_timestep.to_numpy()
         return predictions
 
+    def _more_tags(self) -> dict:
+        return {"can_refit_full": True}
+
 
 class DirectTabularModel(AbstractMLForecastModel):
     """Predict all future time series values simultaneously using TabularPredictor from AutoGluon-Tabular.

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -1091,11 +1091,13 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
 
         valid_model_set = []
         for name in model_names:
-            if name in self.model_refit_map and self.model_refit_map[model] in existing_models:
+            if name in self.model_refit_map and self.model_refit_map[name] in existing_models:
                 logger.info(
                     f"Model '{name}' already has a refit _FULL model: "
-                    f"'{self.model_refit_map[model]}', skipping refit...",
+                    f"'{self.model_refit_map[name]}', skipping refit..."
                 )
+            elif name in self.model_refit_map.values():
+                logger.debug(f"Model '{name}' is a refit _FULL model, skipping refit...")
             else:
                 valid_model_set.append(name)
 

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -341,7 +341,6 @@ def test_when_trainer_fit_and_deleted_then_oof_predictions_can_be_loaded(temp_mo
         hyperparameters={
             "Naive": {},
             "ETS": {},
-            "AutoETS": {"n_jobs": 1},
             "DirectTabular": {"tabular_hyperparameters": {"GBM": {}}},
             "DeepAR": {"epochs": 1, "num_batches_per_epoch": 1},
         },
@@ -400,9 +399,9 @@ def trained_and_refit_trainers():
             train_data=DUMMY_TS_DATAFRAME,
             hyperparameters={
                 "Naive": {},
-                "ETS": {"maxiter": 1},
+                "Theta": {},
                 "DeepAR": {"epochs": 1, "num_batches_per_epoch": 1},
-                "DirectTabular": {"tabular_hyperparameters": {"GBM": {}}},
+                "DirectTabular": {},
                 "RecursiveTabular": {},
             },
         )
@@ -423,6 +422,14 @@ def test_when_refit_full_called_then_all_models_are_retrained(trained_and_refit_
     expected_refit_full_dict = {name: name + ag.constants.REFIT_FULL_SUFFIX for name in trainer.get_model_names()}
     assert dict_equal_primitive(refit_trainer.model_refit_map, expected_refit_full_dict)
     assert len(leaderboard_refit) == len(leaderboard_initial) + len(expected_refit_full_dict)
+
+
+def test_when_refit_full_called_multiple_times_then_no_new_models_are_trained(trained_and_refit_trainers):
+    _, refit_trainer = trained_and_refit_trainers
+    model_names_refit = refit_trainer.get_model_names()
+    refit_trainer.refit_full("all")
+    model_names_second_refit = refit_trainer.get_model_names()
+    assert set(model_names_refit) == set(model_names_second_refit)
 
 
 def test_when_refit_full_called_then_all_models_can_predict(trained_and_refit_trainers):


### PR DESCRIPTION
*Issue #, if available:* #3814

*Description of changes:*
- Fix bugs when calling `predictor.refit_full()` multiple times
- Add test that verifies correctness of repeated calls to `refit_full()`
- Add `can_refit_full` tag to `DirectTabular` and `RecursiveTabular` models that was incorrectly removed in v1.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
