### PR TITLE
handle binary classification for f1 metrics

### DIFF
--- a/multimodal/src/autogluon/multimodal/optimization/lit_module.py
+++ b/multimodal/src/autogluon/multimodal/optimization/lit_module.py
@@ -209,7 +209,12 @@ class LitModule(pl.LightningModule):
         label: torch.Tensor,
     ):
         if isinstance(
-            metric, (torchmetrics.classification.BinaryAUROC, torchmetrics.classification.BinaryAveragePrecision)
+            metric,
+            (
+                torchmetrics.classification.BinaryAUROC,
+                torchmetrics.classification.BinaryAveragePrecision,
+                torchmetrics.classification.BinaryF1Score,
+            ),
         ):
             prob = F.softmax(logits.float(), dim=1)
             metric.update(preds=prob[:, 1], target=label)  # only for binary classification


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/autogluon/autogluon/issues/3414

*Description of changes:*
This PR fixes the bug when using `f1`, `f1_macro`, `f1_micro` for binary classification problems.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
