### PR TITLE
[Fix] Using correct Python version on Windows runners for Platform tests

### DIFF
--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -1,17 +1,17 @@
 function setup_build_env {
-    python3 -m pip install --upgrade pip
-    python3 -m pip install tox
-    python3 -m pip install flake8
-    python3 -m pip install "black~=23.0"
-    python3 -m pip install isort>=5.10
-    python3 -m pip install bandit
-    python3 -m pip install packaging
-    python3 -m pip install ruff
+    python -m pip install --upgrade pip
+    python -m pip install tox
+    python -m pip install flake8
+    python -m pip install "black~=23.0"
+    python -m pip install isort>=5.10
+    python -m pip install bandit
+    python -m pip install packaging
+    python -m pip install ruff
 }
 
 function setup_build_contrib_env {
-    python3 -m pip install --upgrade pip
-    python3 -m pip install -r $(dirname "$0")/../../docs/requirements_doc.txt
+    python -m pip install --upgrade pip
+    python -m pip install -r $(dirname "$0")/../../docs/requirements_doc.txt
     export AG_DOCS=1
     export AUTOMM_TUTORIAL_MODE=1 # Disable progress bar in MultiModalPredictor
 }
@@ -24,20 +24,20 @@ function setup_benchmark_env {
 }
 
 function setup_hf_model_mirror {
-    pip3 install PyYAML
+    pip install PyYAML
     SUB_FOLDER="$1"
-    python3 $(dirname "$0")/setup_hf_model_mirror.py --model_list_file $(dirname "$0")/../../multimodal/tests/hf_model_list.yaml --sub_folder $SUB_FOLDER
+    python $(dirname "$0")/setup_hf_model_mirror.py --model_list_file $(dirname "$0")/../../multimodal/tests/hf_model_list.yaml --sub_folder $SUB_FOLDER
 }
 
 function install_local_packages {
     while(($#)) ; do
-        python3 -m pip install --upgrade -e $1
+        python -m pip install --upgrade -e $1
         shift
     done
 }
 
 function install_tabular {
-    python3 -m pip install --upgrade pygraphviz
+    python -m pip install --upgrade pygraphviz
     install_local_packages "tabular/$1"
 }
 
@@ -52,10 +52,10 @@ function install_multimodal_no_groundingdino {
     source $(dirname "$0")/setup_mmcv.sh
 
     # launch different process for each test to make sure memory is released
-    python3 -m pip install --upgrade pytest-xdist
+    python -m pip install --upgrade pytest-xdist
     install_local_packages "multimodal/$1"
     setup_mmcv
-    # python3 -m pip install --upgrade "mmocr<1.0"  # not compatible with mmcv 2.0
+    # python -m pip install --upgrade "mmocr<1.0"  # not compatible with mmcv 2.0
 }
 
 function install_multimodal {
@@ -63,10 +63,10 @@ function install_multimodal {
     source $(dirname "$0")/setup_groundingdino.sh
 
     # launch different process for each test to make sure memory is released
-    python3 -m pip install --upgrade pytest-xdist
+    python -m pip install --upgrade pytest-xdist
     install_local_packages "multimodal/$1"
     setup_mmcv
-    # python3 -m pip install --upgrade "mmocr<1.0"  # not compatible with mmcv 2.0
+    # python -m pip install --upgrade "mmocr<1.0"  # not compatible with mmcv 2.0
     setup_groundingdino
 }
 

--- a/.github/workflow_scripts/test_common.sh
+++ b/.github/workflow_scripts/test_common.sh
@@ -12,7 +12,7 @@ install_local_packages "common/[tests]"
 cd common/
 if [ -n "$ADDITIONAL_TEST_ARGS" ]
 then
-    python3 -m pytest --junitxml=results.xml --runslow "$ADDITIONAL_TEST_ARGS" tests
+    python -m pytest --junitxml=results.xml --runslow "$ADDITIONAL_TEST_ARGS" tests
 else
-    python3 -m pytest --junitxml=results.xml --runslow tests
+    python -m pytest --junitxml=results.xml --runslow tests
 fi

--- a/.github/workflow_scripts/test_core.sh
+++ b/.github/workflow_scripts/test_core.sh
@@ -13,10 +13,10 @@ cd core/
 if [ "$OSTYPE" == "msys" ]
 then
     # to skip certain tests on Windows platform
-    python3 -m pytest --junitxml=results.xml --runslow tests
+    python -m pytest --junitxml=results.xml --runslow tests
 elif [ -n "$ADDITIONAL_TEST_ARGS" ]
 then
-    python3 -m pytest --junitxml=results.xml --runslow --runplatform "$ADDITIONAL_TEST_ARGS" tests
+    python -m pytest --junitxml=results.xml --runslow --runplatform "$ADDITIONAL_TEST_ARGS" tests
 else
-    python3 -m pytest --junitxml=results.xml --runslow --runplatform tests
+    python -m pytest --junitxml=results.xml --runslow --runplatform tests
 fi

--- a/.github/workflow_scripts/test_eda.sh
+++ b/.github/workflow_scripts/test_eda.sh
@@ -11,10 +11,10 @@ export CUDA_VISIBLE_DEVICES=0
 install_local_packages "common/[tests]" "core/[all,tests]" "features/" "tabular/[all,tests]" "eda/[tests]"
 
 cd eda/
-python3 -m tox -e lint,typecheck,format,testenv
+python -m tox -e lint,typecheck,format,testenv
 if [ -n "$ADDITIONAL_TEST_ARGS" ]
 then
-    python3 -m pytest --junitxml=results.xml --runslow "$ADDITIONAL_TEST_ARGS" tests
+    python -m pytest --junitxml=results.xml --runslow "$ADDITIONAL_TEST_ARGS" tests
 else
-    python3 -m pytest --junitxml=results.xml --runslow tests
+    python -m pytest --junitxml=results.xml --runslow tests
 fi

--- a/.github/workflow_scripts/test_features.sh
+++ b/.github/workflow_scripts/test_features.sh
@@ -12,7 +12,7 @@ install_local_packages "common/[tests]" "features/"
 cd features/
 if [ -n "$ADDITIONAL_TEST_ARGS" ]
 then
-    python3 -m pytest --junitxml=results.xml --runslow "$ADDITIONAL_TEST_ARGS" tests
+    python -m pytest --junitxml=results.xml --runslow "$ADDITIONAL_TEST_ARGS" tests
 else
-    python3 -m pytest --junitxml=results.xml --runslow tests
+    python -m pytest --junitxml=results.xml --runslow tests
 fi

--- a/.github/workflow_scripts/test_multimodal.sh
+++ b/.github/workflow_scripts/test_multimodal.sh
@@ -14,8 +14,8 @@ function test_multimodal {
     cd multimodal/
     if [ -n "$ADDITIONAL_TEST_ARGS" ]
     then
-        python3 -m pytest --junitxml=results.xml --runslow "$ADDITIONAL_TEST_ARGS" tests/unittests/"$SUB_FOLDER"/
+        python -m pytest --junitxml=results.xml --runslow "$ADDITIONAL_TEST_ARGS" tests/unittests/"$SUB_FOLDER"/
     else
-        python3 -m pytest --junitxml=results.xml --runslow tests/unittests/"$SUB_FOLDER"/
+        python -m pytest --junitxml=results.xml --runslow tests/unittests/"$SUB_FOLDER"/
     fi   
 }

--- a/.github/workflow_scripts/test_tabular.sh
+++ b/.github/workflow_scripts/test_tabular.sh
@@ -28,7 +28,7 @@ fi
 cd tabular/
 if [ -n "$ADDITIONAL_TEST_ARGS" ]
 then
-    python3 -m pytest --junitxml=results.xml --runslow "$ADDITIONAL_TEST_ARGS" tests
+    python -m pytest --junitxml=results.xml --runslow "$ADDITIONAL_TEST_ARGS" tests
 else
-    python3 -m pytest --junitxml=results.xml --runslow tests
+    python -m pytest --junitxml=results.xml --runslow tests
 fi

--- a/.github/workflow_scripts/test_timeseries.sh
+++ b/.github/workflow_scripts/test_timeseries.sh
@@ -13,7 +13,7 @@ install_local_packages "common/[tests]" "core/[all,tests]" "features/" "tabular/
 cd timeseries/
 if [ -n "$ADDITIONAL_TEST_ARGS" ]
 then
-    python3 -m pytest --junitxml=results.xml --runslow "$ADDITIONAL_TEST_ARGS" tests
+    python -m pytest --junitxml=results.xml --runslow "$ADDITIONAL_TEST_ARGS" tests
 else
-    python3 -m pytest --junitxml=results.xml --runslow tests
+    python -m pytest --junitxml=results.xml --runslow tests
 fi


### PR DESCRIPTION
*Issue #:* https://github.com/autogluon/autogluon/issues/3807

(**NOTE**: This PR does not solve the issue linked above but just detects it, which was not the case earlier)

*Description of changes:*
This fix is to detect the error on Windows runners when we run platform tests. 
Currently the platform tests pass for Python 3.11 on Windows runners but this should not happen as AG installation should error out as `ray` does not support Python 3.11 on Windows (https://github.com/autogluon/autogluon/issues/3807#issuecomment-1851644976).

The platform tests pass on Github Windows runners because an incorrect version of python is used (3.9) when we use `python3` to install packages. Windows runners pick up the correct version only when we use `python` instead of `python3`.
This problem is not observed with other operating systems runners like `mac` and `ubuntu` and using either `python` or `python3` works.
Hence to correctly error out platform tests on windows we update all the scripts to use `python` rather than `python3`.
Link to test run of fix: https://github.com/prateekdesai04/autogluon/actions/runs/7280525259

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
