### PR TITLE
[eda] added positive class parameters and autodetection

### DIFF
--- a/eda/setup.py
+++ b/eda/setup.py
@@ -29,9 +29,9 @@ install_requires = [
     'phik>=0.12.2,<0.13',
     'seaborn>=0.12.0,<0.13',
     'ipywidgets>=7.7.1,<9.0',  # min versions guidance: 7.7.1 collab/kaggle
-    'shap>=0.41,<0.42',
+    'shap>=0.44,<0.45',
     'yellowbrick>=1.5,<1.6',
-    'pyod>=1.0,<1.1',
+    'pyod>=1.1,<1.2',
     'suod>=0.0.8,<0.1',
     'ipython>7.16,<8.13',  # IPython 8.13+ supports Python 3.9 and above; Python 3.7 is supported with IPython >7.16
     f'autogluon.core=={version}',

--- a/eda/src/autogluon/eda/auto/simple.py
+++ b/eda/src/autogluon/eda/auto/simple.py
@@ -1090,6 +1090,7 @@ def explain_rows(
     train_data: pd.DataFrame,
     model: TabularPredictor,
     rows: pd.DataFrame,
+    positive_class: Optional = None,
     display_rows: bool = False,
     plot: Optional[str] = "force",
     baseline_sample: int = 100,
@@ -1113,6 +1114,10 @@ def explain_rows(
         trained AutoGluon predictor
     rows: pd.DataFrame,
         rows to explain
+    positive_class: Optional
+        Optionally specify positive class to explain; if not provided, the value will be autodetected.
+        For binary it's derived from `model.positive_class`.
+        For multiclass it's the last column in prediction probabilities.
     display_rows: bool, default = False
         if `True` then display the row before the explanation chart
     plot: Optional[str], default = 'force'
@@ -1180,7 +1185,7 @@ def explain_rows(
         train_data=train_data[model.original_features],
         model=model,
         return_state=return_state,
-        anlz_facets=[ShapAnalysis(rows, baseline_sample=baseline_sample, **fit_args)],  # type: ignore
+        anlz_facets=[ShapAnalysis(rows, positive_class=positive_class, baseline_sample=baseline_sample, **fit_args)],  # type: ignore
         viz_facets=viz_facets,  # type: ignore
     )
 


### PR DESCRIPTION
*Issue #, if available:* #3497

*Description of changes:*
- Added positive class selection - see #3497
- binary classification will use `model.positive_class`
- multiclass uses the last column in prediction probabilities
```python
auto.explain_rows(
    train_data=df_train,
    model=state.model,
    display_rows=True,
    return_state=True,
    positive_class='banana', # specify positive class
    rows=state.model_evaluation.highest_error[:1]
)
```

- Libraries updates: bumped versions for shap and pyod; updated changed shap API calls.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
