### PR TITLE
[AutoMM] Add support for loading pre-trained weights in ft_transformer

### DIFF
--- a/docs/tutorials/multimodal/advanced_topics/customization.ipynb
+++ b/docs/tutorials/multimodal/advanced_topics/customization.ipynb
@@ -1116,6 +1116,29 @@
    ]
   },
   {
+    "cell_type": "markdown",
+    "id": "9b29a7b",
+    "metadata": {},
+    "source": [
+     "### model.ft_transformer.checkpoint_name\n",
+     "\n",
+     "Provide a pre-trained weights to initialize ft_transformer backbone."
+    ]
+   },
+   {
+    "cell_type": "markdown",
+    "id": "6s39392",
+    "metadata": {},
+    "source": [
+     "```\n",
+     "# by default, AutoMM doesn't use pre-trained weights\n",
+     "predictor.fit(hyperparameters={\"model.ft_transformer.checkpoint_name\": None})\n",
+     "# initialize the ft_transformer backbone from the give checkpoint\n",
+     "predictor.fit(hyperparameters={\"model.ft_transformer.checkpoint_name\": 'my_checkpoint.ckpt'})\n",
+     "```"
+    ]
+   },
+  {
    "cell_type": "markdown",
    "id": "9b3d3a7b",
    "metadata": {},

--- a/docs/tutorials/multimodal/advanced_topics/customization.ipynb
+++ b/docs/tutorials/multimodal/advanced_topics/customization.ipynb
@@ -1122,7 +1122,7 @@
     "source": [
      "### model.ft_transformer.checkpoint_name\n",
      "\n",
-     "Provide a pre-trained weights to initialize ft_transformer backbone."
+     "Using local pre-trained weights or link to pre-trained weights to initialize ft_transformer backbone."
     ]
    },
    {
@@ -1133,8 +1133,10 @@
      "```\n",
      "# by default, AutoMM doesn't use pre-trained weights\n",
      "predictor.fit(hyperparameters={\"model.ft_transformer.checkpoint_name\": None})\n",
-     "# initialize the ft_transformer backbone from the give checkpoint\n",
+     "# initialize the ft_transformer backbone from local checkpoint\n",
      "predictor.fit(hyperparameters={\"model.ft_transformer.checkpoint_name\": 'my_checkpoint.ckpt'})\n",
+     "# initialize the ft_transformer backbone from url of checkpoint\n",
+     "predictor.fit(hyperparameters={\"model.ft_transformer.checkpoint_name\": 'https://automl-mm-bench.s3.amazonaws.com/ft_transformer_pretrained_ckpt/iter_2k.ckpt'})\n",
      "```"
     ]
    },

--- a/multimodal/src/autogluon/multimodal/configs/model/default.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/model/default.yaml
@@ -237,6 +237,7 @@ model:
     additive_attention: False # Whether to use lightweight additive attention, can be True, False or "auto"
     share_qv_weights: False # Whether to share weight for query and value, can be True, False or "auto"
     pooling_mode: "cls"
+    checkpoint_name: null
 
   sam:
     checkpoint_name: "facebook/sam-vit-huge"

--- a/multimodal/src/autogluon/multimodal/models/ft_transformer.py
+++ b/multimodal/src/autogluon/multimodal/models/ft_transformer.py
@@ -463,6 +463,7 @@ class FT_Transformer(nn.Module):
         share_qv_weights: Optional[bool] = False,
         pooling_mode: Optional[str] = "cls",
         checkpoint_name: str = None,
+        pretrained: bool = False,
     ) -> None:
         """
         Parameters
@@ -607,7 +608,7 @@ class FT_Transformer(nn.Module):
             self.categorical_adapter.apply(init_weights)
         self.head.apply(init_weights)
         # init transformer backbone from provided checkpoint
-        if checkpoint_name:
+        if pretrained and checkpoint_name:
             if "https://" in checkpoint_name or is_s3_url(checkpoint_name):
                 with tempfile.TemporaryDirectory() as tmpdirname:
                     checkpoint_path = os.path.join(tmpdirname, "./ft_transformer_pretrained.ckpt")

--- a/multimodal/src/autogluon/multimodal/models/ft_transformer.py
+++ b/multimodal/src/autogluon/multimodal/models/ft_transformer.py
@@ -604,7 +604,7 @@ class FT_Transformer(nn.Module):
         # init transformer backbone from provided checkpoint
         if checkpoint_name:
             ckpt = torch.load(checkpoint_name)
-            self.transformer.load_state_dict(ckpt['state_dict'])
+            self.transformer.load_state_dict(ckpt["state_dict"])
 
         self.name_to_id = self.get_layer_ids()
 

--- a/multimodal/src/autogluon/multimodal/models/ft_transformer.py
+++ b/multimodal/src/autogluon/multimodal/models/ft_transformer.py
@@ -3,6 +3,8 @@ from typing import List, Optional
 import torch
 from torch import Tensor, nn
 
+from autogluon.common.loaders._utils import download
+
 from ..constants import CATEGORICAL, FEATURES, LABEL, LOGITS, NUMERICAL
 from .custom_transformer import CLSToken, Custom_Transformer, _TokenInitialization
 from .utils import init_weights
@@ -603,7 +605,11 @@ class FT_Transformer(nn.Module):
         self.head.apply(init_weights)
         # init transformer backbone from provided checkpoint
         if checkpoint_name:
-            ckpt = torch.load(checkpoint_name)
+            if "https://" in checkpoint_name:
+                download(checkpoint_name, "./ft_transformer_pretrained.ckpt")
+                ckpt = torch.load("./ft_transformer_pretrained.ckpt")
+            else:
+                ckpt = torch.load(checkpoint_name)
             self.transformer.load_state_dict(ckpt["state_dict"])
 
         self.name_to_id = self.get_layer_ids()

--- a/multimodal/src/autogluon/multimodal/models/ft_transformer.py
+++ b/multimodal/src/autogluon/multimodal/models/ft_transformer.py
@@ -457,6 +457,7 @@ class FT_Transformer(nn.Module):
         additive_attention: Optional[bool] = False,
         share_qv_weights: Optional[bool] = False,
         pooling_mode: Optional[str] = "cls",
+        checkpoint_name: str = None,
     ) -> None:
         """
         Parameters
@@ -594,12 +595,17 @@ class FT_Transformer(nn.Module):
             initialization="uniform",
         )
 
-        # init weights
+        # init tokenizer and head weights
         if self.numerical_feature_tokenizer:
             self.numerical_adapter.apply(init_weights)
         if self.categorical_feature_tokenizer:
             self.categorical_adapter.apply(init_weights)
         self.head.apply(init_weights)
+        # init transformer backbone from provided checkpoint
+        if checkpoint_name:
+            ckpt = torch.load(checkpoint_name)
+            self.transformer.load_state_dict(ckpt['state_dict'])
+
         self.name_to_id = self.get_layer_ids()
 
     @property

--- a/multimodal/src/autogluon/multimodal/models/utils.py
+++ b/multimodal/src/autogluon/multimodal/models/utils.py
@@ -237,8 +237,11 @@ def group_param_names(
     # split blocks at the first level
     children_prefix = []
     for n in selected_names:
-        child_name = n[len(model_prefix) + 1 :].split(".")[0]
-        child_prefix = f"{model_prefix}.{child_name}"
+        if model_prefix is not None:
+            child_name = n[len(model_prefix) + 1 :].split(".")[0]
+            child_prefix = f"{model_prefix}.{child_name}"
+        else:
+            child_prefix = n.split(".")[0]
         if child_prefix not in children_prefix:
             children_prefix.append(child_prefix)
 

--- a/multimodal/src/autogluon/multimodal/utils/model.py
+++ b/multimodal/src/autogluon/multimodal/utils/model.py
@@ -372,6 +372,7 @@ def create_model(
             additive_attention=OmegaConf.select(model_config, "additive_attention", default=False),
             share_qv_weights=OmegaConf.select(model_config, "share_qv_weights", default=False),
             pooling_mode=OmegaConf.select(model_config, "pooling_mode", default="cls"),
+            checkpoint_name=model_config.checkpoint_name,
         )
     elif model_name.lower().startswith(SAM):
         model = SAMForSemanticSegmentation(

--- a/multimodal/src/autogluon/multimodal/utils/model.py
+++ b/multimodal/src/autogluon/multimodal/utils/model.py
@@ -373,6 +373,7 @@ def create_model(
             share_qv_weights=OmegaConf.select(model_config, "share_qv_weights", default=False),
             pooling_mode=OmegaConf.select(model_config, "pooling_mode", default="cls"),
             checkpoint_name=model_config.checkpoint_name,
+            pretrained=pretrained,
         )
     elif model_name.lower().startswith(SAM):
         model = SAMForSemanticSegmentation(

--- a/multimodal/tests/unittests/predictor/test_predictor.py
+++ b/multimodal/tests/unittests/predictor/test_predictor.py
@@ -9,7 +9,6 @@ import pytest
 from omegaconf import OmegaConf
 from torch import nn
 
-from autogluon.common.loaders._utils import download
 from autogluon.multimodal import MultiModalPredictor
 from autogluon.multimodal.constants import (
     BEST,

--- a/multimodal/tests/unittests/predictor/test_predictor.py
+++ b/multimodal/tests/unittests/predictor/test_predictor.py
@@ -679,8 +679,6 @@ def test_load_ckpt():
 
 
 def test_fttransformer_load_ckpt():
-    download("https://automl-mm-bench.s3.amazonaws.com/ft_transformer_pretrained_ckpt/iter_2k.ckpt", "./")
-
     dataset = ALL_DATASETS["petfinder"]
     metric_name = dataset.metric
 
@@ -691,7 +689,7 @@ def test_fttransformer_load_ckpt():
     )
     hyperparameters = {
         "model.names": ["ft_transformer"],
-        "model.ft_transformer.checkpoint_name": "./iter_2k.ckpt",
+        "model.ft_transformer.checkpoint_name": "https://automl-mm-bench.s3.amazonaws.com/ft_transformer_pretrained_ckpt/iter_2k.ckpt",
         "data.categorical.convert_to_text": False,  # ensure the categorical model is used.
         "data.numerical.convert_to_text": False,  # ensure the numerical model is used.
     }

--- a/multimodal/tests/unittests/predictor/test_predictor.py
+++ b/multimodal/tests/unittests/predictor/test_predictor.py
@@ -679,7 +679,7 @@ def test_load_ckpt():
 
 
 def test_fttransformer_load_ckpt():
-    download("s3://automl-mm-bench/ft_transformer_pretrained_ckpt/iter_2k.ckpt", "./")
+    download("https://automl-mm-bench.s3.amazonaws.com/ft_transformer_pretrained_ckpt/iter_2k.ckpt", "./")
 
     dataset = ALL_DATASETS["petfinder"]
     metric_name = dataset.metric


### PR DESCRIPTION
*Issue #, if available:*
Resolves #3847

*Description of changes:*
- Add `checkpoint_name` argument in ft_transformer so that users could load pre-trained ft_transformer weights.
- Fixed a bug in setting `layer_id` when `model_prefix` is `None`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
