### PR TITLE
[FIX] Imporve Error Handling and Init for Ray for Memory Save Sub-fits in Dynamic Stacking 

### DIFF
--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1283,8 +1283,9 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             try:
                 _ds_ray = try_import_ray()
                 if not _ds_ray.is_initialized():
-                    _ds_ray.init(address="auto", logging_level=logging.ERROR, log_to_driver=False)
-            except:
+                    _ds_ray.init(logging_level=logging.ERROR, log_to_driver=False)
+            except Exception as e:
+                warnings.warn(f"Failed to use ray for memory safe fits. Falling back to normal fit. Error: {repr(e)}", stacklevel=2)
                 _ds_ray = None
 
             if _ds_ray is not None:


### PR DESCRIPTION
While searching for another issue, I realized that the current implementation of memory-safe fits will not do memory-safe fits in the edge case where Ray was never initialized on the current system (e.g., in a fresh container).

Due to using `address="auto"`, this would fail and then be silently handled by except without informing the user. 
This PR is a short, straightforward fix for this and provides a warning now if save memory fits should have been used but were not. 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
