### PR TITLE
Ignore pandas downcast warning

### DIFF
--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import logging
+import warnings
 import time
 from builtins import classmethod
 from functools import partial
@@ -197,7 +198,10 @@ class NNFastAiTabularModel(AbstractModel):
             column_fills = {k: self.columns_fills[k] for k in columns_to_fill}
             if column_fills:
                 # TODO: pandas==1.5.3 fillna is 10x+ slower than pandas==1.3.5 with large column count
-                df = df.fillna(column_fills, inplace=False, downcast=False)
+                # TODO: Remove warning later as a follow up to https://github.com/autogluon/autogluon/pull/3734
+                with warnings.catch_warnings():
+                    warnings.simplefilter(action="ignore", category=FutureWarning)
+                    df = df.fillna(column_fills, inplace=False, downcast=False)
             else:
                 df = df.copy()
         else:

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import copy
 import logging
-import warnings
 import time
+import warnings
 from builtins import classmethod
 from functools import partial
 from pathlib import Path


### PR DESCRIPTION
*Issue #, if available:*
Autogluon 1.0 emits the following warning since pandas 2.2 [depreacated downcast arg](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.fillna.html) in `pd.fillna`.
```
autogluon/tabular/models/fastainn/tabular_nn_fastai.py:200: FutureWarning: The 'downcast' keyword in fillna is deprecated and will be removed in a future version. Use res.infer_objects(copy=False) to infer non-object dtype, or pd.to_numeric with the 'downcast' keyword to downcast numeric results.
```

It was partially resolved in #3734 

*Description of changes:*
This PR also adds the warning filter to tabular_nn_fastai.py.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
