### PR TITLE
[timeseries] Add support for categorical covariates

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -231,9 +231,6 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
         if static_features is not None:
             df = pd.merge(df, static_features, how="left", on=ITEMID, suffixes=(None, "_static_feat"))
 
-        # Convert float64 to float32 to reduce memory usage
-        float64_cols = list(df.select_dtypes(include="float64"))
-        df[float64_cols] = df[float64_cols].astype("float32")
         # We assume that df is sorted by 'unique_id' inside `TimeSeriesPredictor._check_and_prepare_data_frame`
         return df.rename(columns=column_name_mapping)
 

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -293,7 +293,7 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
             Preprocessed data in TimeSeriesDataFrame format.
         """
         df = self._to_data_frame(data, name=name)
-        df = df.astype({self.target: float})
+        df = df.astype({self.target: "float32"})
         # MultiIndex.is_monotonic_increasing checks if index is sorted by ["item_id", "timestamp"]
         if not df.index.is_monotonic_increasing:
             df = df.sort_index()

--- a/timeseries/src/autogluon/timeseries/utils/features.py
+++ b/timeseries/src/autogluon/timeseries/utils/features.py
@@ -68,8 +68,7 @@ class ContinuousAndCategoricalFeatureGenerator(PipelineFeatureGenerator):
 class TimeSeriesFeatureGenerator:
     """Takes care of preprocessing for static_features and past/known covariates.
 
-    Covariates are all converted to float dtype. Static features, if present, are all converted to categorical & float
-    dtypes.
+    All covariates & static features are converted into either float32 or categorical dtype.
     """
 
     def __init__(self, target: str, known_covariates_names: List[str], float_dtype: str = "float32"):

--- a/timeseries/src/autogluon/timeseries/utils/features.py
+++ b/timeseries/src/autogluon/timeseries/utils/features.py
@@ -32,7 +32,7 @@ class CovariateMetadata:
 class ContinuousAndCategoricalFeatureGenerator(PipelineFeatureGenerator):
     """Generates categorical and continuous features for time series models."""
 
-    def __init__(self, verbosity: int = 0, minimum_cat_count=2, **kwargs):
+    def __init__(self, verbosity: int = 0, minimum_cat_count=2, float_dtype: str = "float32", **kwargs):
         generators = [
             CategoryFeatureGenerator(minimum_cat_count=minimum_cat_count, fillna="mode"),
             IdentityFeatureGenerator(infer_features_in_args={"valid_raw_types": [R_INT, R_FLOAT]}),
@@ -46,11 +46,23 @@ class ContinuousAndCategoricalFeatureGenerator(PipelineFeatureGenerator):
             verbosity=verbosity,
             **kwargs,
         )
+        self.float_dtype = float_dtype
 
-    def fit_transform(self, X: pd.DataFrame, *args, **kwargs) -> pd.DataFrame:
+    def _convert_numerical_columns_to_float(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Convert the dtype of all numerical (float or int) columns to the given float dtype."""
+        numeric_columns = [col for col in df.columns if pd.api.types.is_numeric_dtype(df[col])]
+        return df.astype({col: self.float_dtype for col in numeric_columns})
+
+    def transform(self, X: pd.DataFrame, *args, **kwargs) -> pd.DataFrame:
         if isinstance(X, TimeSeriesDataFrame):
             X = pd.DataFrame(X)
-        return super().fit_transform(X, *args, **kwargs)
+        return self._convert_numerical_columns_to_float(super().transform(X, *args, **kwargs))
+
+    def fit_transform(self, X: pd.DataFrame, *args, **kwargs) -> pd.DataFrame:
+        # PipelineFeatureGenerator does not use transform() inside fit_transform(), so we need to override both methods
+        if isinstance(X, TimeSeriesDataFrame):
+            X = pd.DataFrame(X)
+        return self._convert_numerical_columns_to_float(super().fit_transform(X, *args, **kwargs))
 
 
 class TimeSeriesFeatureGenerator:
@@ -68,6 +80,7 @@ class TimeSeriesFeatureGenerator:
         self.past_covariates_names = []
         self.known_covariates_pipeline = ContinuousAndCategoricalFeatureGenerator()
         self.past_covariates_pipeline = ContinuousAndCategoricalFeatureGenerator()
+        # Cat features with cat_count=1 are fine in static_features since they are repeated for all time steps in a TS
         self.static_feature_pipeline = ContinuousAndCategoricalFeatureGenerator(minimum_cat_count=1)
         self.covariate_metadata: CovariateMetadata = None
 
@@ -83,49 +96,64 @@ class TimeSeriesFeatureGenerator:
             if column != self.target and column not in self.known_covariates_names:
                 self.past_covariates_names.append(column)
 
-        logger.info(f"\nTarget column: '{self.target}'\n")
+        self._check_required_columns_are_present(
+            data, required_column_names=self.required_column_names, data_frame_name="train_data"
+        )
+
+        logger.info("\nProvided data contains following columns:")
+        logger.info(f"\ttarget: '{self.target}'")
+
         if len(self.known_covariates_names) > 0:
             known_covariates_df = self.known_covariates_pipeline.fit_transform(data[self.known_covariates_names])
-            logger.info("Inferred types of known_covariates:")
-            known_covariates_cat, known_covariates_real = self._detect_and_log_column_types(
-                known_covariates_df, original_column_names=self.known_covariates_names
-            )
+            logger.info("\tknown_covariates:")
+            known_covariates_cat, known_covariates_real = self._detect_and_log_column_types(known_covariates_df)
+            self.known_covariates_names = self.known_covariates_pipeline.features_in
         else:
             known_covariates_cat = []
             known_covariates_real = []
 
         if len(self.past_covariates_names) > 0:
             past_covariates_df = self.past_covariates_pipeline.fit_transform(data[self.past_covariates_names])
-            logger.info("Inferred types of past_covariates")
-            past_covariates_cat, past_covariates_real = self._detect_and_log_column_types(
-                past_covariates_df, original_column_names=self.past_covariates_names
-            )
+            logger.info("\tpast_covariates:")
+            past_covariates_cat, past_covariates_real = self._detect_and_log_column_types(past_covariates_df)
+            self.past_covariates_names = self.past_covariates_pipeline.features_in
         else:
             past_covariates_cat = []
             past_covariates_real = []
 
+        ignored_covariates = data.columns.difference(
+            [self.target] + self.known_covariates_names + self.past_covariates_names
+        )
+
         if data.static_features is not None:
             static_features_df = self.static_feature_pipeline.fit_transform(data.static_features)
-            logger.info("Inferred types of static_features:")
-            static_features_cat, static_features_real = self._detect_and_log_column_types(
-                static_features_df, original_column_names=data.static_features.columns
-            )
+            logger.info("\tstatic_features:")
+            static_features_cat, static_features_real = self._detect_and_log_column_types(static_features_df)
+            ignored_static_features = data.static_features.columns.difference(self.static_feature_pipeline.features_in)
         else:
             static_features_cat = []
             static_features_real = []
+            ignored_static_features = []
+
+        if len(ignored_covariates) > 0 or len(ignored_static_features) > 0:
+            logger.info(f"\nAutoGluon will ignore following non-numeric/non-informative columns:")
+            if len(ignored_covariates) > 0:
+                logger.info(f"\tignored covariates:      {list(ignored_covariates)}")
+            if len(ignored_static_features) > 0:
+                logger.info(f"\tignored static_features: {list(ignored_static_features)}")
 
         if len(data.columns) > 1 or data.static_features is not None:
             logger.info(
-                "To learn how to fix incorrectly inferred types, please see documentation for TimeSeriesPredictor.fit "
+                "\nTo learn how to fix incorrectly inferred types, please see documentation for TimeSeriesPredictor.fit"
             )
 
         self.covariate_metadata = CovariateMetadata(
+            known_covariates_cat=known_covariates_cat,
+            known_covariates_real=known_covariates_real,
+            past_covariates_cat=past_covariates_cat,
+            past_covariates_real=past_covariates_real,
             static_features_cat=static_features_cat,
             static_features_real=static_features_real,
-            known_covariates_real=known_covariates_real,
-            past_covariates_real=past_covariates_real,
-            known_covariates_cat=known_covariates_cat,
-            past_covariates_cat=past_covariates_cat,
         )
         self._is_fit = True
 
@@ -153,12 +181,10 @@ class TimeSeriesFeatureGenerator:
             if data.static_features is None:
                 raise ValueError(f"Provided {data_frame_name} must contain static_features")
             static_features = self.static_feature_pipeline.transform(data.static_features)
-            static_features = self._convert_numerical_features_to_float(static_features)
         else:
             static_features = None
 
-        data = self._convert_numerical_features_to_float(pd.concat(dfs, axis=1))
-        return TimeSeriesDataFrame(data, static_features=static_features)
+        return TimeSeriesDataFrame(pd.concat(dfs, axis=1), static_features=static_features)
 
     def transform_future_known_covariates(
         self, known_covariates: Optional[TimeSeriesDataFrame]
@@ -169,9 +195,7 @@ class TimeSeriesFeatureGenerator:
             self._check_required_columns_are_present(
                 known_covariates, required_column_names=self.known_covariates_names, data_frame_name="known_covariates"
             )
-            return TimeSeriesDataFrame(
-                self._convert_numerical_features_to_float(self.known_covariates_pipeline.transform(known_covariates))
-            )
+            return TimeSeriesDataFrame(self.known_covariates_pipeline.transform(known_covariates))
         else:
             return None
 
@@ -180,30 +204,19 @@ class TimeSeriesFeatureGenerator:
         return self.transform(data, data_frame_name=data_frame_name)
 
     @staticmethod
-    def _detect_and_log_column_types(
-        transformed_df: pd.DataFrame, original_column_names: List[str]
-    ) -> Tuple[List[str], List[str]]:
-        """Return names of categorical and real-valued columns, and log the inferred column types."""
+    def _detect_and_log_column_types(transformed_df: pd.DataFrame) -> Tuple[List[str], List[str]]:
+        """Log & return names of categorical and real-valued columns in the DataFrame."""
         cat_column_names = []
         real_column_names = []
-        ignored_columns = pd.Index(original_column_names).difference(transformed_df.columns).tolist()
         for column_name, column_dtype in transformed_df.dtypes.items():
             if isinstance(column_dtype, pd.CategoricalDtype):
                 cat_column_names.append(column_name)
             elif pd.api.types.is_numeric_dtype(column_dtype):
                 real_column_names.append(column_name)
 
-        logger.info(f"\tcategorical:        {reprlib.repr(cat_column_names)}")
-        logger.info(f"\tcontinuous (float): {reprlib.repr(real_column_names)}")
-        if len(ignored_columns) > 0:
-            logger.info(f"\tignored:            {reprlib.repr(ignored_columns)}")
+        logger.info(f"\t\tcategorical:        {reprlib.repr(cat_column_names)}")
+        logger.info(f"\t\tcontinuous (float): {reprlib.repr(real_column_names)}")
         return cat_column_names, real_column_names
-
-    def _convert_numerical_features_to_float(self, df: pd.DataFrame) -> pd.DataFrame:
-        """In-place convert the dtype of all numerical (float or int) columns to the given float dtype."""
-        numeric_columns = [col for col in df.columns if pd.api.types.is_numeric_dtype(df[col])]
-        df[numeric_columns] = df[numeric_columns].astype(self.float_dtype)
-        return df
 
     @staticmethod
     def _check_required_columns_are_present(

--- a/timeseries/src/autogluon/timeseries/utils/features.py
+++ b/timeseries/src/autogluon/timeseries/utils/features.py
@@ -2,9 +2,7 @@ import logging
 import reprlib
 from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
-from autogluon.common.features.feature_metadata import FeatureMetadata
 
-import numpy as np
 import pandas as pd
 
 from autogluon.common.features.types import R_FLOAT, R_INT
@@ -15,7 +13,6 @@ from autogluon.features.generators import (
     PipelineFeatureGenerator,
 )
 from autogluon.timeseries import TimeSeriesDataFrame
-from pandas import DataFrame
 
 logger = logging.getLogger(__name__)
 
@@ -35,9 +32,9 @@ class CovariateMetadata:
 class ContinuousAndCategoricalFeatureGenerator(PipelineFeatureGenerator):
     """Generates categorical and continuous features for time series models."""
 
-    def __init__(self, verbosity: int = 0, **kwargs):
+    def __init__(self, verbosity: int = 0, minimum_cat_count=2, **kwargs):
         generators = [
-            CategoryFeatureGenerator(minimum_cat_count=1, fillna="mode"),
+            CategoryFeatureGenerator(minimum_cat_count=minimum_cat_count, fillna="mode"),
             IdentityFeatureGenerator(infer_features_in_args={"valid_raw_types": [R_INT, R_FLOAT]}),
         ]
         super().__init__(
@@ -63,49 +60,20 @@ class TimeSeriesFeatureGenerator:
     dtypes.
     """
 
-    def __init__(self, target: str, known_covariates_names: List[str]):
+    def __init__(self, target: str, known_covariates_names: List[str], float_dtype: str = "float32"):
         self.target = target
+        self.float_dtype = float_dtype
         self._is_fit = False
         self.known_covariates_names = list(known_covariates_names)
         self.past_covariates_names = []
         self.known_covariates_pipeline = ContinuousAndCategoricalFeatureGenerator()
         self.past_covariates_pipeline = ContinuousAndCategoricalFeatureGenerator()
-        self.static_feature_pipeline = ContinuousAndCategoricalFeatureGenerator()
+        self.static_feature_pipeline = ContinuousAndCategoricalFeatureGenerator(minimum_cat_count=1)
         self.covariate_metadata: CovariateMetadata = None
 
     @property
     def required_column_names(self) -> List[str]:
         return [self.target] + list(self.known_covariates_names) + list(self.past_covariates_names)
-
-    @staticmethod
-    def _detect_inferred_types(
-        transformed_df: pd.DataFrame, original_column_names: List[str]
-    ) -> Tuple[List[str], List[str]]:
-        """Return names of categorical and real-valued columns, and log the inferred column types."""
-        cat_column_names = []
-        real_column_names = []
-        unused_columns = transformed_df.columns.difference(original_column_names)
-        for column_name, column_dtype in transformed_df.dtypes.items():
-            if pd.api.types.is_categorical_dtype(column_dtype):
-                cat_column_names.append(column_name)
-            elif pd.api.types.is_numeric_dtype(column_dtype):
-                real_column_names.append(column_name)
-            else:
-                unused_columns.append(column_name)
-
-        logger.info("Inferred types of {name}:")
-        logger.info(f"\tcategorical:        {cat_column_names}")
-        logger.info(f"\tcontinuous (float): {real_column_names}")
-        if len(unused_columns) > 0:
-            logger.info(f"\t\tremoved (uninformative columns): {unused_columns}")
-        return cat_column_names, real_column_names
-
-    @staticmethod
-    def _convert_numerical_features_to_float(df: pd.DataFrame, float_dtype=np.float64) -> pd.DataFrame:
-        """In-place convert the dtype of all numerical (float or int) columns to the given float dtype."""
-        numeric_columns = [col for col in df.columns if pd.api.types.is_numeric_dtype(df[col])]
-        df[numeric_columns] = df[numeric_columns].astype(float_dtype)
-        return df
 
     def fit(self, data: TimeSeriesDataFrame) -> None:
         assert not self._is_fit, f"{self.__class__.__name__} has already been fit"
@@ -115,10 +83,9 @@ class TimeSeriesFeatureGenerator:
             if column != self.target and column not in self.known_covariates_names:
                 self.past_covariates_names.append(column)
 
-        logger.info("\nProvided dataset contains following columns:")
-        logger.info(f"\ntarget:           '{self.target}'")
+        logger.info(f"\nTarget column: '{self.target}'\n")
         if len(self.known_covariates_names) > 0:
-            logger.info(f"\nknown covariates: {self.known_covariates_names}")
+            logger.info("Inferred types of known_covariates:")
             known_covariates_df = self.known_covariates_pipeline.fit_transform(data[self.known_covariates_names])
             known_covariates_cat, known_covariates_real = self._detect_inferred_types(
                 known_covariates_df, original_column_names=self.known_covariates_names
@@ -128,7 +95,7 @@ class TimeSeriesFeatureGenerator:
             known_covariates_real = []
 
         if len(self.past_covariates_names) > 0:
-            logger.info(f"\npast covariates:  {self.past_covariates_names}")
+            logger.info("Inferred types of past_covariates")
             past_covariates_df = self.past_covariates_pipeline.fit_transform(data[self.past_covariates_names])
             past_covariates_cat, past_covariates_real = self._detect_inferred_types(
                 past_covariates_df, original_column_names=self.past_covariates_names
@@ -138,7 +105,7 @@ class TimeSeriesFeatureGenerator:
             past_covariates_real = []
 
         if data.static_features is not None:
-            logger.info(f"\tstatic features:  {data.static_features.columns.to_list()}")
+            logger.info("Inferred types of static_features:")
             static_features_df = self.static_feature_pipeline.fit_transform(data.static_features)
             static_features_cat, static_features_real = self._detect_inferred_types(
                 static_features_df, original_column_names=data.static_features.columns
@@ -162,20 +129,6 @@ class TimeSeriesFeatureGenerator:
         )
         self._is_fit = True
 
-    @staticmethod
-    def _check_and_prepare_covariates(
-        data: TimeSeriesDataFrame,
-        required_column_names: List[str],
-        data_frame_name: str,
-    ) -> TimeSeriesDataFrame:
-        """Select the required columns from the data frame."""
-        missing_columns = pd.Index(required_column_names).difference(data.columns)
-        if len(missing_columns) > 0:
-            raise ValueError(
-                f"{len(missing_columns)} columns are missing from {data_frame_name}: {reprlib.repr(missing_columns.to_list())}"
-            )
-        return data[required_column_names]
-
     def transform(self, data: TimeSeriesDataFrame, data_frame_name: str = "data") -> TimeSeriesDataFrame:
         """Transform static features and past/known covariates.
 
@@ -185,30 +138,27 @@ class TimeSeriesFeatureGenerator:
         If some columns are missing or are incompatible, an exception will be raised.
         """
         assert self._is_fit, f"{self.__class__.__name__} has not been fit yet"
-        # Avoid modifying inplace
-        data = data.copy(deep=False)
-        data = self._check_and_prepare_covariates(
+        self._check_required_columns_are_present(
             data, required_column_names=self.required_column_names, data_frame_name=data_frame_name
         )
+        dfs = [data[[self.target]]]
 
         if len(self.known_covariates_names) > 0:
-            data[self.known_covariates_names] = self.known_covariates_pipeline.transform(
-                data[self.known_covariates_names]
-            )
+            dfs.append(self.known_covariates_pipeline.transform(data[self.known_covariates_names]))
+
         if len(self.past_covariates_names) > 0:
-            data[self.past_covariates_names] = self.past_covariates_pipeline.transform(
-                data[self.past_covariates_names]
-            )
+            dfs.append(self.past_covariates_pipeline.transform(data[self.past_covariates_names]))
 
         if self.static_feature_pipeline.is_fit():
             if data.static_features is None:
                 raise ValueError(f"Provided {data_frame_name} must contain static_features")
             static_features = self.static_feature_pipeline.transform(data.static_features)
-            data.static_features = self._convert_numerical_features_to_float(static_features)
+            static_features = self._convert_numerical_features_to_float(static_features)
         else:
-            data.static_features = None
+            static_features = None
 
-        return data
+        data = self._convert_numerical_features_to_float(pd.concat(dfs, axis=1))
+        return TimeSeriesDataFrame(data, static_features=static_features)
 
     def transform_future_known_covariates(
         self, known_covariates: Optional[TimeSeriesDataFrame]
@@ -216,15 +166,51 @@ class TimeSeriesFeatureGenerator:
         assert self._is_fit, f"{self.__class__.__name__} has not been fit yet"
         if len(self.known_covariates_names) > 0:
             assert known_covariates is not None, "known_covariates must be provided at prediction time"
-            known_covariates = self._check_and_prepare_covariates(
-                known_covariates,
-                required_column_names=self.known_covariates_names,
-                data_frame_name="known_covariates",
+            self._check_required_columns_are_present(
+                known_covariates, required_column_names=self.known_covariates_names, data_frame_name="known_covariates"
             )
-            return self.known_covariates_pipeline.transform(known_covariates)
+            return TimeSeriesDataFrame(
+                self._convert_numerical_features_to_float(self.known_covariates_pipeline.transform(known_covariates))
+            )
         else:
             return None
 
     def fit_transform(self, data: TimeSeriesDataFrame, data_frame_name: str = "data") -> TimeSeriesDataFrame:
         self.fit(data)
         return self.transform(data, data_frame_name=data_frame_name)
+
+    @staticmethod
+    def _detect_inferred_types(
+        transformed_df: pd.DataFrame, original_column_names: List[str]
+    ) -> Tuple[List[str], List[str]]:
+        """Return names of categorical and real-valued columns, and log the inferred column types."""
+        cat_column_names = []
+        real_column_names = []
+        unused_columns = pd.Index(original_column_names).difference(transformed_df.columns).tolist()
+        for column_name, column_dtype in transformed_df.dtypes.items():
+            if isinstance(column_dtype, pd.CategoricalDtype):
+                cat_column_names.append(column_name)
+            elif pd.api.types.is_numeric_dtype(column_dtype):
+                real_column_names.append(column_name)
+
+        logger.info(f"\tcategorical:        {reprlib.repr(cat_column_names)}")
+        logger.info(f"\tcontinuous (float): {reprlib.repr(real_column_names)}")
+        if len(unused_columns) > 0:
+            logger.info(f"\tignored:            {reprlib.repr(unused_columns)}")
+        return cat_column_names, real_column_names
+
+    def _convert_numerical_features_to_float(self, df: pd.DataFrame) -> pd.DataFrame:
+        """In-place convert the dtype of all numerical (float or int) columns to the given float dtype."""
+        numeric_columns = [col for col in df.columns if pd.api.types.is_numeric_dtype(df[col])]
+        df[numeric_columns] = df[numeric_columns].astype(self.float_dtype)
+        return df
+
+    @staticmethod
+    def _check_required_columns_are_present(
+        data: TimeSeriesDataFrame, required_column_names: List[str], data_frame_name: str
+    ) -> None:
+        missing_columns = pd.Index(required_column_names).difference(data.columns)
+        if len(missing_columns) > 0:
+            raise ValueError(
+                f"{len(missing_columns)} columns are missing from {data_frame_name}: {reprlib.repr(missing_columns.to_list())}"
+            )

--- a/timeseries/src/autogluon/timeseries/utils/features.py
+++ b/timeseries/src/autogluon/timeseries/utils/features.py
@@ -136,7 +136,7 @@ class TimeSeriesFeatureGenerator:
             ignored_static_features = []
 
         if len(ignored_covariates) > 0 or len(ignored_static_features) > 0:
-            logger.info(f"\nAutoGluon will ignore following non-numeric/non-informative columns:")
+            logger.info("\nAutoGluon will ignore following non-numeric/non-informative columns:")
             if len(ignored_covariates) > 0:
                 logger.info(f"\tignored covariates:      {list(ignored_covariates)}")
             if len(ignored_static_features) > 0:

--- a/timeseries/tests/unittests/models/test_gluonts.py
+++ b/timeseries/tests/unittests/models/test_gluonts.py
@@ -130,7 +130,7 @@ def test_when_static_features_present_then_they_are_passed_to_dataset(model_clas
             feat_static_cat = call_kwargs["feat_static_cat"]
             feat_static_real = call_kwargs["feat_static_real"]
             assert (feat_static_cat.dtypes == "category").all()
-            assert (feat_static_real.dtypes == "float").all()
+            assert (feat_static_real.dtypes == "float32").all()
 
 
 @pytest.mark.parametrize("model_class", MODELS_WITH_STATIC_FEATURES)
@@ -197,7 +197,7 @@ def test_when_known_covariates_present_then_they_are_passed_to_dataset(model_cla
         finally:
             call_kwargs = patch_dataset.call_args[1]
             feat_dynamic_real = call_kwargs["feat_dynamic_real"]
-            assert (feat_dynamic_real.dtypes == "float").all()
+            assert (feat_dynamic_real.dtypes == "float32").all()
 
 
 @pytest.mark.parametrize("model_class", MODELS_WITH_KNOWN_COVARIATES)

--- a/timeseries/tests/unittests/test_features.py
+++ b/timeseries/tests/unittests/test_features.py
@@ -7,18 +7,28 @@ from autogluon.timeseries.utils.features import TimeSeriesFeatureGenerator
 from .common import DATAFRAME_WITH_STATIC, get_data_frame_with_variable_lengths
 
 
-@pytest.mark.parametrize("known_covariates_names", [["known_1", "known_2"], []])
-@pytest.mark.parametrize("past_covariates_names", [["past_1", "past_2", "past_3"], []])
-@pytest.mark.parametrize("static_features_cat", [["cat_1"], []])
-@pytest.mark.parametrize("static_features_real", [["real_1", "real_3"], []])
+@pytest.mark.parametrize("known_covariates_cat", [["known_cat_1"], []])
+@pytest.mark.parametrize("known_covariates_real", [["known_real_1", "known_real_2"], []])
+@pytest.mark.parametrize("past_covariates_cat", [["past_cat_1", "past_cat_2"], []])
+@pytest.mark.parametrize("past_covariates_real", [["past_real_1"], []])
+@pytest.mark.parametrize("static_features_cat", [["static_cat_1"], []])
+@pytest.mark.parametrize("static_features_real", [["static_real_1", "static_real_2"], []])
 def test_when_covariates_present_in_data_then_they_are_included_in_metadata(
-    known_covariates_names, past_covariates_names, static_features_cat, static_features_real
+    known_covariates_cat,
+    known_covariates_real,
+    past_covariates_cat,
+    past_covariates_real,
+    static_features_cat,
+    static_features_real,
 ):
+    known_covariates_names = known_covariates_cat + known_covariates_real
     feat_generator = TimeSeriesFeatureGenerator(target="target", known_covariates_names=known_covariates_names)
     item_id_to_length = {1: 10, 5: 20, 2: 30}
-    data = get_data_frame_with_variable_lengths(
-        item_id_to_length, covariates_names=known_covariates_names + past_covariates_names
-    )
+    data = get_data_frame_with_variable_lengths(item_id_to_length)
+    for col in known_covariates_cat + past_covariates_cat:
+        data[col] = np.random.choice(["foo", "bar", "baz"], size=len(data))
+    for col in known_covariates_real + past_covariates_real:
+        data[col] = np.random.normal(size=len(data))
     if static_features_cat or static_features_real:
         cat_dict = {k: np.random.choice(["foo", "bar"], size=len(item_id_to_length)) for k in static_features_cat}
         real_dict = {k: np.random.normal(size=len(item_id_to_length)) for k in static_features_real}
@@ -26,8 +36,10 @@ def test_when_covariates_present_in_data_then_they_are_included_in_metadata(
     feat_generator.fit(data)
     metadata = feat_generator.covariate_metadata
 
-    assert metadata.known_covariates_real == known_covariates_names
-    assert metadata.past_covariates_real == past_covariates_names
+    assert metadata.known_covariates_cat == known_covariates_cat
+    assert metadata.known_covariates_real == known_covariates_real
+    assert metadata.past_covariates_cat == past_covariates_cat
+    assert metadata.past_covariates_real == past_covariates_real
     assert metadata.static_features_cat == static_features_cat
     assert metadata.static_features_real == static_features_real
 

--- a/timeseries/tests/unittests/test_features.py
+++ b/timeseries/tests/unittests/test_features.py
@@ -2,9 +2,42 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from typing import Dict, List, Optional
+
 from autogluon.timeseries.utils.features import TimeSeriesFeatureGenerator
 
-from .common import DATAFRAME_WITH_STATIC, get_data_frame_with_variable_lengths
+from .common import get_data_frame_with_variable_lengths
+
+
+ITEM_ID_TO_LENGTH = {1: 10, 5: 20, 2: 30}
+
+
+def get_data_frame_with_covariates(
+    item_id_to_length: Dict[str, int] = ITEM_ID_TO_LENGTH,
+    target: str = "target",
+    covariates_cat: Optional[List[str]] = None,
+    covariates_real: Optional[List[str]] = None,
+    static_features_cat: Optional[List[str]] = None,
+    static_features_real: Optional[List[str]] = None,
+):
+    data = get_data_frame_with_variable_lengths(item_id_to_length)
+    data.rename(columns={"target": target}, inplace=True)
+    if covariates_cat:
+        for col in covariates_cat:
+            data[col] = np.random.choice(["foo", "bar", "baz"], size=len(data))
+    if covariates_real:
+        for col in covariates_real:
+            data[col] = np.random.rand(len(data))
+    if static_features_cat or static_features_real:
+        static_dict = {}
+        if static_features_cat:
+            for col in static_features_cat:
+                static_dict[col] = np.random.choice(["cat", "dog", "cow"], size=data.num_items)
+        if static_features_real:
+            for col in static_features_real:
+                static_dict[col] = np.random.rand(data.num_items)
+        data.static_features = pd.DataFrame(static_dict, index=data.item_ids)
+    return data
 
 
 @pytest.mark.parametrize("known_covariates_cat", [["known_cat_1"], []])
@@ -23,16 +56,12 @@ def test_when_covariates_present_in_data_then_they_are_included_in_metadata(
 ):
     known_covariates_names = known_covariates_cat + known_covariates_real
     feat_generator = TimeSeriesFeatureGenerator(target="target", known_covariates_names=known_covariates_names)
-    item_id_to_length = {1: 10, 5: 20, 2: 30}
-    data = get_data_frame_with_variable_lengths(item_id_to_length)
-    for col in known_covariates_cat + past_covariates_cat:
-        data[col] = np.random.choice(["foo", "bar", "baz"], size=len(data))
-    for col in known_covariates_real + past_covariates_real:
-        data[col] = np.random.normal(size=len(data))
-    if static_features_cat or static_features_real:
-        cat_dict = {k: np.random.choice(["foo", "bar"], size=len(item_id_to_length)) for k in static_features_cat}
-        real_dict = {k: np.random.normal(size=len(item_id_to_length)) for k in static_features_real}
-        data.static_features = pd.DataFrame({**cat_dict, **real_dict}, index=data.item_ids)
+    data = get_data_frame_with_covariates(
+        covariates_cat=known_covariates_cat + past_covariates_cat,
+        covariates_real=known_covariates_real + past_covariates_real,
+        static_features_cat=static_features_cat,
+        static_features_real=static_features_real,
+    )
     feat_generator.fit(data)
     metadata = feat_generator.covariate_metadata
 
@@ -44,10 +73,66 @@ def test_when_covariates_present_in_data_then_they_are_included_in_metadata(
     assert metadata.static_features_real == static_features_real
 
 
-def test_given_duplicate_static_features_then_generator_can_fit_transform():
-    feat_generator = TimeSeriesFeatureGenerator(target="target", known_covariates_names=[])
-    data = DATAFRAME_WITH_STATIC.copy()
-    data.static_features["feat5"] = data.static_features["feat1"]
+def test_when_transform_applied_then_numeric_features_are_converted_to_float32():
+    data = get_data_frame_with_covariates(covariates_cat=["cov_cat"], static_features_cat=["static_cat"])
+
+    data["int1"] = np.random.randint(0, 100, size=len(data), dtype=np.int32)
+    data["int2"] = np.random.randint(0, 100, size=len(data), dtype=np.int64)
+    data["float1"] = np.random.rand(len(data)).astype(np.float32)
+    data["float2"] = np.random.rand(len(data)).astype(np.float64)
+
+    data.static_features["int1_s"] = np.random.randint(0, 100, size=data.num_items, dtype=np.int32)
+    data.static_features["int2_s"] = np.random.randint(0, 100, size=data.num_items, dtype=np.int64)
+    data.static_features["float1_s"] = np.random.rand(data.num_items).astype(np.float32)
+    data.static_features["float2_s"] = np.random.rand(data.num_items).astype(np.float64)
+
+    feat_generator = TimeSeriesFeatureGenerator(target="target", known_covariates_names=["int1", "float2"])
+    data_transformed = feat_generator.fit_transform(data)
+    for col in ["int1", "int2", "float1", "float2"]:
+        assert isinstance(data_transformed[col].dtype, np.dtypes.Float32DType)
+    for col in ["int1_s", "int2_s", "float1_s", "float2_s"]:
+        assert isinstance(data_transformed.static_features[col].dtype, np.dtypes.Float32DType)
+
+
+def test_when_duplicate_columns_provided_during_fit_then_they_are_removed():
+    data = get_data_frame_with_covariates(covariates_cat=["known", "past"], static_features_real=["static"])
+    data["known_duplicate"] = data["known"]
+    data["past_duplicate"] = data["past"]
+    data.static_features["static_duplicate"] = data.static_features["static"]
+    feat_generator = TimeSeriesFeatureGenerator(target="target", known_covariates_names=["known", "known_duplicate"])
+    data_transformed = feat_generator.fit_transform(data)
+    assert "known_duplicate" not in data_transformed.columns
+    assert "past_duplicate" not in data_transformed.columns
+    assert "static_duplicate" not in data_transformed.static_features.columns
+
+
+def test_when_duplicate_columns_provided_during_fit_then_they_can_be_omitted_during_transform():
+    data = get_data_frame_with_covariates(covariates_cat=["known", "past"], static_features_real=["static"])
+    data_with_duplicates = data.copy()
+    data_with_duplicates["known_duplicate"] = data_with_duplicates["known"]
+    data_with_duplicates["past_duplicate"] = data_with_duplicates["past"]
+    data_with_duplicates.static_features["static_duplicate"] = data.static_features["static"]
+    feat_generator = TimeSeriesFeatureGenerator(target="target", known_covariates_names=["known", "known_duplicate"])
+    feat_generator.fit(data_with_duplicates)
+    feat_generator.transform(data)
+
+
+def test_when_known_covariates_have_non_numeric_non_cat_dtypes_then_they_can_be_omitted_at_predict_time():
+    data = get_data_frame_with_covariates(covariates_real=["past"])
+    data["known"] = pd.date_range(start="2020-01-01", freq="D", periods=len(data))
+    feat_generator = TimeSeriesFeatureGenerator(target="target", known_covariates_names=["known"])
     feat_generator.fit(data)
-    out = feat_generator.transform(data)
-    assert isinstance(out.static_features, pd.DataFrame)
+    feat_generator.transform_future_known_covariates(None)
+
+
+def test_when_bool_columns_provided_then_they_are_converted_to_cat():
+    data = get_data_frame_with_covariates(covariates_cat=["known", "past"], static_features_real=["static"])
+    data["known_bool"] = np.random.randint(0, 1, size=len(data)).astype(bool)
+    data["past_bool"] = np.random.randint(0, 1, size=len(data)).astype(bool)
+    data.static_features["static_bool"] = np.random.randint(0, 1, size=data.num_items).astype(bool)
+    feat_generator = TimeSeriesFeatureGenerator(target="target", known_covariates_names=["known", "known_bool"])
+
+    data_transformed = feat_generator.fit_transform(data)
+    assert isinstance(data_transformed["known_bool"].dtype, pd.CategoricalDtype)
+    assert isinstance(data_transformed["past_bool"].dtype, pd.CategoricalDtype)
+    assert isinstance(data_transformed.static_features["static_bool"].dtype, pd.CategoricalDtype)

--- a/timeseries/tests/unittests/test_features.py
+++ b/timeseries/tests/unittests/test_features.py
@@ -1,13 +1,12 @@
+from typing import Dict, List, Optional
+
 import numpy as np
 import pandas as pd
 import pytest
 
-from typing import Dict, List, Optional
-
 from autogluon.timeseries.utils.features import TimeSeriesFeatureGenerator
 
 from .common import get_data_frame_with_variable_lengths
-
 
 ITEM_ID_TO_LENGTH = {1: 10, 5: 20, 2: 30}
 

--- a/timeseries/tests/unittests/test_learner.py
+++ b/timeseries/tests/unittests/test_learner.py
@@ -243,9 +243,9 @@ def test_when_static_features_are_preprocessed_then_dtypes_are_correct(temp_mode
     )
     learner = TimeSeriesLearner(path_context=temp_model_path)
     train_data_processed = learner.feature_generator.fit_transform(train_data)
-    assert train_data_processed.static_features["f1"].dtype == np.float64
+    assert train_data_processed.static_features["f1"].dtype == np.float32
     assert train_data_processed.static_features["f2"].dtype == "category"
-    assert train_data_processed.static_features["f3"].dtype == np.float64
+    assert train_data_processed.static_features["f3"].dtype == np.float32
 
 
 def test_when_train_data_has_static_feat_but_pred_data_has_no_static_feat_then_exception_is_raised(temp_model_path):

--- a/timeseries/tests/unittests/test_learner.py
+++ b/timeseries/tests/unittests/test_learner.py
@@ -272,14 +272,6 @@ def test_given_expected_known_covariates_missing_from_train_data_when_learner_fi
         learner.fit(train_data=train_data, hyperparameters=HYPERPARAMETERS_DUMMY)
 
 
-def test_given_known_covariates_have_non_numeric_dtypes_when_learner_fits_then_exception_is_raised(temp_model_path):
-    learner = TimeSeriesLearner(path_context=temp_model_path, known_covariates_names=["Y", "Z", "X"])
-    train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, covariates_names=["X", "Z", "Y"])
-    train_data["Y"] = np.random.choice(["foo", "bar", "baz"], size=len(train_data)).astype("O")
-    with pytest.raises(ValueError, match="must all have numeric \(float or int\) dtypes"):
-        learner.fit(train_data=train_data, hyperparameters=HYPERPARAMETERS_DUMMY)
-
-
 def test_given_expected_known_covariates_missing_from_data_when_learner_predicts_then_exception_is_raised(
     temp_model_path,
 ):


### PR DESCRIPTION
*Description of changes:*
- Add support for known and past **categorical** covariates to `autogluon.timeseries.utils.features.TimeSeriesFeatureGenerator`.
- Improve log messages about the inferred column types
- Convert all continuous covariates, features, and target to float32

Example log for a dataset with various covariates:
```
Provided data contains following columns:
        target: 'target'
        known_covariates:
                categorical:        ['feat1']
                continuous (float): ['feat3']
        past_covariates:
                categorical:        ['feat2', 'feat_bool']
                continuous (float): ['feat4']
        static_features:
                categorical:        ['a', 'c']
                continuous (float): ['b']

AutoGluon will ignore following non-numeric/non-informative columns:
        ignored covariates:      ['feat_dt', 'feat_repeat']
        ignored static_features: ['d']

To learn how to fix incorrectly inferred types, please see documentation for TimeSeriesPredictor.fit
```

To do in a later PR:
- [ ] Pass the categorical covariates to models that support them
- [ ] Add discussion of categorical covariates to the documentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
