### PR TITLE
[timeseries] enable logging to file, clean up set_logger_verbosity calls

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -227,11 +227,6 @@ class AbstractTimeSeriesModel(AbstractModel):
         verbosity : int, default = 2
             Verbosity levels range from 0 to 4 and control how much information is printed.
             Higher levels correspond to more detailed print statements (you can set verbosity = 0 to suppress warnings).
-            verbosity 4: logs every training iteration, and logs the most detailed information.
-            verbosity 3: logs training iterations periodically, and logs more detailed information.
-            verbosity 2: logs only important information.
-            verbosity 1: logs only warnings and exceptions.
-            verbosity 0: logs only exceptions.
         **kwargs :
             Any additional fit arguments a model supports.
 
@@ -427,7 +422,6 @@ class AbstractTimeSeriesModel(AbstractModel):
         hpo_executor: HpoExecutor,
         **kwargs,
     ):
-        # verbosity = kwargs.get('verbosity', 2)
         time_start = time.time()
         logger.debug(f"\tStarting AbstractTimeSeriesModel hyperparameter tuning for {self.name}")
         search_space = self._get_search_space()

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -9,7 +9,6 @@ import pandas as pd
 from sklearn.base import BaseEstimator
 
 import autogluon.core as ag
-from autogluon.common.utils.log_utils import set_logger_verbosity
 from autogluon.tabular import TabularPredictor
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP, TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
@@ -249,7 +248,6 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
         from mlforecast import MLForecast
 
         self._check_fit_params()
-        set_logger_verbosity(verbosity, logger=logger)
         fit_start_time = time.time()
         # TabularEstimator is passed to MLForecast later to include tuning_data
         model_params = self._get_model_params()

--- a/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
+++ b/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
@@ -6,7 +6,6 @@ from typing import Dict, List, Optional
 import numpy as np
 
 import autogluon.core as ag
-from autogluon.common.utils.log_utils import set_logger_verbosity
 from autogluon.core.models.greedy_ensemble.ensemble_selection import EnsembleSelection
 from autogluon.timeseries import TimeSeriesDataFrame
 from autogluon.timeseries.metrics import TimeSeriesScorer
@@ -112,10 +111,8 @@ class TimeSeriesGreedyEnsemble(AbstractTimeSeriesEnsembleModel):
         predictions_per_window: Dict[str, List[TimeSeriesDataFrame]],
         data_per_window: List[TimeSeriesDataFrame],
         time_limit: Optional[int] = None,
-        verbosity: int = 2,
         **kwargs,
     ):
-        set_logger_verbosity(verbosity, logger=logger)
         if self.eval_metric_seasonal_period is None:
             self.eval_metric_seasonal_period = get_seasonality(self.freq)
         ensemble_selection = TimeSeriesEnsembleSelection(

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -18,7 +18,6 @@ from gluonts.model.predictor import Predictor as GluonTSPredictor
 from pandas.tseries.frequencies import to_offset
 
 from autogluon.common.loaders import load_pkl
-from autogluon.common.utils.log_utils import set_logger_verbosity
 from autogluon.core.hpo.constants import RAY_BACKEND
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP, TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
@@ -383,7 +382,6 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
             if "lightning" in logger_name:
                 pl_logger = logging.getLogger(logger_name)
                 pl_logger.setLevel(logging.ERROR if verbosity <= 3 else logging.INFO)
-        set_logger_verbosity(verbosity, logger=logger)
         gts_logger.setLevel(logging.ERROR if verbosity <= 3 else logging.INFO)
 
         if verbosity > 3:

--- a/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
+++ b/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
@@ -8,7 +8,6 @@ import pandas as pd
 from joblib import Parallel, delayed
 from scipy.stats import norm
 
-from autogluon.common.utils.log_utils import set_logger_verbosity
 from autogluon.core.utils.exceptions import TimeLimitExceeded
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
@@ -87,9 +86,8 @@ class AbstractLocalModel(AbstractTimeSeriesModel):
         self._seasonal_period: Optional[int] = None
         self.time_limit: Optional[float] = None
 
-    def _fit(self, train_data: TimeSeriesDataFrame, time_limit: Optional[int] = None, verbosity: int = 2, **kwargs):
+    def _fit(self, train_data: TimeSeriesDataFrame, time_limit: Optional[int] = None, **kwargs):
         self._check_fit_params()
-        set_logger_verbosity(verbosity, logger=logger)
 
         if time_limit is not None and time_limit < self.init_time_in_seconds:
             raise TimeLimitExceeded

--- a/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
+++ b/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
@@ -9,7 +9,6 @@ from typing import Dict, Optional, Type, Union
 import numpy as np
 
 import autogluon.core as ag
-from autogluon.common.utils.log_utils import set_logger_verbosity
 from autogluon.timeseries.dataset.ts_dataframe import TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 from autogluon.timeseries.models.local.abstract_local_model import AbstractLocalModel
@@ -82,9 +81,6 @@ class MultiWindowBacktestingModel(AbstractTimeSeriesModel):
     ):
         # TODO: use incremental training for GluonTS models?
         # TODO: implement parallel fitting similar to ParallelLocalFoldFittingStrategy in tabular?
-        verbosity = kwargs.get("verbosity", 2)
-        set_logger_verbosity(verbosity, logger=logger)
-
         if val_data is not None:
             raise ValueError(f"val_data should not be passed to {self.name}.fit()")
         if val_splitter is None:

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -128,7 +128,7 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
         debug messages from AutoGluon and all logging in dependencies (GluonTS, PyTorch Lightning, AutoGluon-Tabular, etc.)
     log_to_file: bool, default = True
         Whether to save the logs into a file for later reference
-    log_file_path: str, default = "auto"
+    log_file_path: Union[str, Path], default = "auto"
         File path to save the logs.
         If auto, logs will be saved under `predictor_path/logs/predictor_log.txt`.
         Will be ignored if `log_to_file` is set to False
@@ -157,7 +157,7 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
         path: Optional[Union[str, Path]] = None,
         verbosity: int = 2,
         log_to_file: bool = True,
-        log_file_path: str = "auto",
+        log_file_path: Union[str, Path] = "auto",
         quantile_levels: Optional[List[float]] = None,
         cache_predictions: bool = True,
         learner_type: Optional[Type[AbstractLearner]] = None,
@@ -239,7 +239,7 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
     def _trainer(self) -> AbstractTimeSeriesTrainer:
         return self._learner.load_trainer()  # noqa
 
-    def _setup_log_to_file(self, log_to_file, log_file_path):
+    def _setup_log_to_file(self, log_to_file: bool, log_file_path: Union[str, Path]) -> None:
         if log_to_file:
             if log_file_path == "auto":
                 log_file_path = os.path.join(self.path, "logs", self._predictor_log_file_name)

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -12,7 +12,6 @@ import numpy as np
 import pandas as pd
 from tqdm import tqdm
 
-from autogluon.common.utils.log_utils import set_logger_verbosity
 from autogluon.common.utils.utils import hash_pandas_df
 from autogluon.core.models import AbstractModel
 from autogluon.core.utils.exceptions import TimeLimitExceeded
@@ -275,7 +274,6 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         self.ensemble_model_type = TimeSeriesGreedyEnsemble
 
         self.verbosity = verbosity
-        set_logger_verbosity(self.verbosity, logger=logger)
 
         # Dict of normal model -> FULL model. FULL models are produced by
         # self.refit_single_full() and self.refit_full().
@@ -688,9 +686,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
             quantile_levels=self.quantile_levels,
             metadata=self.metadata,
         )
-        ensemble.fit_ensemble(
-            model_preds, data_per_window=data_per_window, time_limit=time_limit, verbosity=self.verbosity
-        )
+        ensemble.fit_ensemble(model_preds, data_per_window=data_per_window, time_limit=time_limit)
         ensemble.fit_time = time.time() - time_start
 
         predict_time = 0

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -12,13 +12,12 @@ import pandas as pd
 import pytest
 
 from autogluon.common import space
+from autogluon.common.utils.log_utils import verbosity2loglevel
 from autogluon.timeseries.dataset import TimeSeriesDataFrame
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP
 from autogluon.timeseries.metrics import DEFAULT_METRIC_NAME
 from autogluon.timeseries.models import DeepARModel, SimpleFeedForwardModel
 from autogluon.timeseries.predictor import TimeSeriesPredictor
-
-from autogluon.common.utils.log_utils import verbosity2loglevel
 
 from .common import DUMMY_TS_DATAFRAME, CustomMetric, get_data_frame_with_variable_lengths
 

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -1029,6 +1029,18 @@ def test_when_log_file_set_then_predictor_logs_to_custom_file(temp_model_path):
     assert "Naive" in log_text
 
 
+def test_when_log_file_set_with_pathlib_then_predictor_logs_to_custom_file(temp_model_path):
+    predictor = TimeSeriesPredictor(path=temp_model_path, log_to_file=True, log_file_path=Path(".") / "custom_log.txt")
+    predictor.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}})
+    log_path = Path(".") / "custom_log.txt"
+    assert Path.exists(log_path)
+
+    # check if the log contains text
+    with open(log_path, "r") as f:
+        log_text = f.read()
+    assert "Naive" in log_text
+
+
 def test_when_log_to_file_set_to_false_then_predictor_does_not_log_to_file(temp_model_path):
     predictor = TimeSeriesPredictor(path=temp_model_path, log_to_file=False)
     predictor.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}})


### PR DESCRIPTION
*Issue #, if available:*

#3766 

*Description of changes:*

- Enable logging to file, including a custom log file name following the API of `TabularPredictor`.
- Clean up unused verbosity arguments and set_logger_verbosity calls throughout the library. 

Note: Previously, timeseries model objects (`AbstractTimeSeriesModel`) had their own verbosity levels provided in the call to `fit`, which was propagated from the Trainer `fit` call to individual models. While this created clutter, it also afforded the flexibility of models potentially using the verbosity level to set dependency log output levels (e.g., GluonTS). We keep this as is: GluonTS models still receive `verbosity` as a fit argument.

However, logger verbosity is now only controlled by the Predictor, which sets the verbosity (either during init or fit) to the `autogluon.timeseries` parent logger, which is inherited by all `logging.getLogger(__name__)` calls in the timeseries module. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
