### PR TITLE
[Tabular] Removing scikit-learn upgrade cap and handling failures in DecisionTreeRegressor

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -19,7 +19,7 @@ DEPENDENT_PACKAGES = {
     "boto3": ">=1.10,<2",  # <2 because unlikely to introduce breaking changes in minor releases. >=1.10 because 1.10 is 3 years old, no need to support older
     "numpy": ">=1.21,<1.29",  # "<{N+3}" upper cap, where N is the latest released minor version, assuming no warnings using N
     "pandas": ">=2.0.0,<2.2.0",  # "<{N+1}" upper cap
-    "scikit-learn": ">=1.3.0,<1.4",  # "<{N+1}" upper cap, Note: this is temporary and will be addressed in future PRs
+    "scikit-learn": ">=1.3.0,<1.5",  # "<{N+2}" upper cap
     "scipy": ">=1.5.4,<1.13",  # "<{N+2}" upper cap
     "psutil": ">=5.7.3,<6",  # Major version cap
     "s3fs": ">=2023.1,<2025",  # Yearly cap

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -19,7 +19,7 @@ DEPENDENT_PACKAGES = {
     "boto3": ">=1.10,<2",  # <2 because unlikely to introduce breaking changes in minor releases. >=1.10 because 1.10 is 3 years old, no need to support older
     "numpy": ">=1.21,<1.29",  # "<{N+3}" upper cap, where N is the latest released minor version, assuming no warnings using N
     "pandas": ">=2.0.0,<2.2.0",  # "<{N+1}" upper cap
-    "scikit-learn": ">=1.3.0,<1.5",  # "<{N+2}" upper cap
+    "scikit-learn": ">=1.3.0,<1.4",  # "<{N+1}" upper cap, Note: this is temporary and will be addressed in future PRs
     "scipy": ">=1.5.4,<1.13",  # "<{N+2}" upper cap
     "psutil": ">=5.7.3,<6",  # Major version cap
     "s3fs": ">=2023.1,<2025",  # Yearly cap

--- a/features/src/autogluon/features/generators/one_hot_encoder.py
+++ b/features/src/autogluon/features/generators/one_hot_encoder.py
@@ -127,7 +127,7 @@ class OneHotEncoderFeatureGenerator(AbstractFeatureGenerator):
         super().__init__(**kwargs)
         self.max_levels = max_levels
         self.sparse = sparse
-        self._ohe = OneHotEncoder(dtype=dtype, sparse=self.sparse, handle_unknown="ignore", drop=drop)
+        self._ohe = OneHotEncoder(dtype=dtype, sparse_output=self.sparse, handle_unknown="ignore", drop=drop)
         self._ohe_columns = None
         self._cat_feat_gen = None
 

--- a/tabular/src/autogluon/tabular/models/rf/rf_quantile.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_quantile.py
@@ -510,6 +510,10 @@ class BaseForestQuantileRegressor(ForestRegressor):
                 bootstrap_indices = np.arange(len(y))
 
             est_weights = np.bincount(bootstrap_indices, minlength=len(y))
+            # FIXME: When updating from scikit-learn 1.3.2 to 1.4.0, BaseTreeQuantileRegressor.fit is not called
+            # Re-calculating y_train_ and y_train_leaves_ to resolve this issue
+            est.y_train_ = y
+            est.y_train_leaves_ = est.tree_.apply(X)
             y_train_leaves = est.y_train_leaves_
             # Normalize the bootstrap weights such that the total weight of each leaf sums up to 1
             # Relabel leaves starting from zero in order to efficiently count the total sum per leaf with bincount

--- a/tabular/src/autogluon/tabular/models/rf/rf_quantile.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_quantile.py
@@ -510,7 +510,7 @@ class BaseForestQuantileRegressor(ForestRegressor):
                 bootstrap_indices = np.arange(len(y))
 
             est_weights = np.bincount(bootstrap_indices, minlength=len(y))
-            y_train_leaves = est.tree_.apply(X)
+            y_train_leaves = est.y_train_leaves_
             # Normalize the bootstrap weights such that the total weight of each leaf sums up to 1
             # Relabel leaves starting from zero in order to efficiently count the total sum per leaf with bincount
             leaves_starting_from_zero = np.unique(y_train_leaves, return_inverse=True)[1]

--- a/tabular/src/autogluon/tabular/models/rf/rf_quantile.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_quantile.py
@@ -510,7 +510,7 @@ class BaseForestQuantileRegressor(ForestRegressor):
                 bootstrap_indices = np.arange(len(y))
 
             est_weights = np.bincount(bootstrap_indices, minlength=len(y))
-            y_train_leaves = est.y_train_leaves_
+            y_train_leaves = est.tree_.apply(X)
             # Normalize the bootstrap weights such that the total weight of each leaf sums up to 1
             # Relabel leaves starting from zero in order to efficiently count the total sum per leaf with bincount
             leaves_starting_from_zero = np.unique(y_train_leaves, return_inverse=True)[1]


### PR DESCRIPTION
*Issue #, if available:* A follow-up PR on https://github.com/autogluon/autogluon/pull/3872

*Description of changes:* This PR handles the failures that are produced as a result of upgrading to `scikit-learn 1.4.0`.
Currently, the way we fix this is re-calculate `y_train_` and `y_train_leaves_` in DecisionTreeRegressor and make the object similar to what it was when we were using `scikit-learn 1.3.2`. This might be updated if we find a better fix in the future.
Link to detailed discussion about the issue: https://github.com/autogluon/autogluon/pull/3872#discussion_r1462653449

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
