### PR TITLE
Tabular: Fix dynamic_stacking on Windows

### DIFF
--- a/tabular/src/autogluon/tabular/models/fastainn/hyperparameters/searchspaces.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/hyperparameters/searchspaces.py
@@ -44,5 +44,5 @@ def get_searchspace_quantile():
     spaces = get_searchspace_regression()
 
     # residual threshold parameter in HuberPinballLoss
-    spaces.update({"alpha": Categorical(0.001, 0.01, 0.1, 1.0)})
+    spaces.update({"alpha": space.Categorical(0.001, 0.01, 0.1, 1.0)})
     return spaces

--- a/tabular/src/autogluon/tabular/models/tab_transformer/utils.py
+++ b/tabular/src/autogluon/tabular/models/tab_transformer/utils.py
@@ -3,6 +3,8 @@ import logging
 import torch
 from torch.utils.data import DataLoader, Dataset
 
+from autogluon.core.constants import REGRESSION
+
 from . import tab_transformer_encoder
 from .tab_transformer_encoder import NullEnc, WontEncodeError
 

--- a/tabular/src/autogluon/tabular/models/tabular_nn/compilers/onnx.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/compilers/onnx.py
@@ -321,13 +321,6 @@ class TabularNeuralNetTorchOnnxCompiler:
             OrdinalMergeRaresHandleUnknownEncoder,
         )
 
-        # BIG HACK!
-        # It is required to take raw_name instead of onnx_name for inputs.
-        # TODO: Remove this hack after upgrading skl2onnx to >1.13
-        # See https://github.com/onnx/sklearn-onnx/pull/938
-        if int(skl2onnx.__version__.split(".")[1]) <= 13:
-            skl2onnx.common.utils.get_column_index = skl2onnx_common_utils_get_column_index
-
         update_registered_converter(
             QuantileTransformer,
             "SklearnQuantileTransformer",
@@ -379,62 +372,3 @@ class TabularNeuralNetTorchOnnxCompiler:
 
         onnx_bytes = onnx.load(os.path.join(path, "model.onnx"))
         return TabularNeuralNetTorchOnnxTransformer(model=onnx_bytes)
-
-
-# It is required to take raw_name instead of onnx_name for inputs.
-# TODO: Remove this hack after upgrading skl2onnx to >1.13
-# See https://github.com/onnx/sklearn-onnx/pull/938
-def skl2onnx_common_utils_get_column_index(i, inputs):
-    """
-    Returns a tuples (variable index, column index in that variable).
-    The function has two different behaviours, one when *i* (column index)
-    is an integer, another one when *i* is a string (column name).
-    If *i* is a string, the function looks for input name with
-    this name and returns (index, 0).
-    If *i* is an integer, let's assume first we have two inputs
-    *I0 = FloatTensorType([None, 2])* and *I1 = FloatTensorType([None, 3])*,
-    in this case, here are the results:
-
-    ::
-
-        get_column_index(0, inputs) -> (0, 0)
-        get_column_index(1, inputs) -> (0, 1)
-        get_column_index(2, inputs) -> (1, 0)
-        get_column_index(3, inputs) -> (1, 1)
-        get_column_index(4, inputs) -> (1, 2)
-    """
-    from skl2onnx.common.data_types import TensorType
-
-    if isinstance(i, int):
-        if i == 0:
-            # Useful shortcut, skips the case when end is None
-            # (unknown dimension)
-            return 0, 0
-        vi = 0
-        pos = 0
-        end = inputs[0].type.shape[1] if isinstance(inputs[0].type, TensorType) else 1
-        if end is None:
-            raise RuntimeError("Cannot extract a specific column {0} when " "one input ('{1}') has unknown " "dimension.".format(i, inputs[0]))
-        while True:
-            if pos <= i < end:
-                return (vi, i - pos)
-            vi += 1
-            pos = end
-            if vi >= len(inputs):
-                raise RuntimeError("Input {} (i={}, end={}) is not available in\n{}".format(vi, i, end, pprint.pformat(inputs)))
-            rel_end = inputs[vi].type.shape[1] if isinstance(inputs[vi].type, TensorType) else 1
-            if rel_end is None:
-                raise RuntimeError("Cannot extract a specific column {0} when " "one input ('{1}') has unknown " "dimension.".format(i, inputs[vi]))
-            end += rel_end
-    else:
-        for ind, inp in enumerate(inputs):
-            if inp.raw_name == i:
-                return ind, 0
-        raise RuntimeError(
-            "Unable to find column name %r among names %r. "
-            "Make sure the input names specified with parameter "
-            "initial_types fits the column names specified in the "
-            "pipeline to convert. This may happen because a "
-            "ColumnTransformer follows a transformer without "
-            "any mapped converter in a pipeline." % (i, [n.raw_name for n in inputs])
-        )

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -8,8 +8,8 @@ import os
 import pprint
 import shutil
 import time
-from typing import Any, Dict, List, Optional, Tuple, Union
 import warnings
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import networkx as nx
 import numpy as np

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1137,7 +1137,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         time_start = time.time()
         time_limit_og = ag_fit_kwargs["time_limit"]
         org_num_stack_levels = ag_fit_kwargs["num_stack_levels"]
-        ds_fit_context = self._learner.path_context_og + os.path.sep + "ds_sub_fit"
+        ds_fit_context = os.path.join(self._learner.path_context_og, "ds_sub_fit")
         logger.info(
             "Detecting stacked overfitting by sub-fitting AutoGluon on the input data. "
             "That is, copies of AutoGluon will be sub-fit on subset(s) of the data. "
@@ -1175,11 +1175,11 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         # -- Validation Method
         if validation_procedure == "holdout":
             if holdout_data is None:
-                ds_fit_kwargs.update(dict(holdout_frac=holdout_frac, ds_fit_context=ds_fit_context + os.path.sep + "sub_fit_ho"))
+                ds_fit_kwargs.update(dict(holdout_frac=holdout_frac, ds_fit_context=os.path.join(ds_fit_context, "sub_fit_ho")))
                 logger.info(f"Starting holdout-based sub-fit for dynamic stacking. Context path is: {ds_fit_kwargs['ds_fit_context']}.")
             else:
                 _, holdout_data, _ = self._validate_fit_data(train_data=X, tuning_data=holdout_data)
-                ds_fit_kwargs["ds_fit_context"] = ds_fit_context + os.path.sep + "sub_fit_custom_ho"
+                ds_fit_kwargs["ds_fit_context"] = os.path.join(ds_fit_context, "sub_fit_custom_ho")
                 logger.info(
                     f"Starting holdout-based sub-fit for dynamic stacking with custom validation data. Context path is: {ds_fit_kwargs['ds_fit_context']}."
                 )
@@ -1219,7 +1219,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
                     dict(
                         train_indices=train_indices,
                         val_indices=val_indices,
-                        ds_fit_context=ds_fit_context + os.path.sep + f"sub_fit_{split_index}",
+                        ds_fit_context=os.path.join(ds_fit_context, f"sub_fit_{split_index}"),
                     )
                 )
                 logger.info(

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -9,6 +9,7 @@ import pprint
 import shutil
 import time
 from typing import Any, Dict, List, Optional, Tuple, Union
+import warnings
 
 import networkx as nx
 import numpy as np
@@ -1136,7 +1137,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         time_start = time.time()
         time_limit_og = ag_fit_kwargs["time_limit"]
         org_num_stack_levels = ag_fit_kwargs["num_stack_levels"]
-        ds_fit_context = self._learner.path_context_og + "/ds_sub_fit"
+        ds_fit_context = self._learner.path_context_og + os.path.sep + "ds_sub_fit"
         logger.info(
             "Detecting stacked overfitting by sub-fitting AutoGluon on the input data. "
             "That is, copies of AutoGluon will be sub-fit on subset(s) of the data. "
@@ -1174,11 +1175,11 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         # -- Validation Method
         if validation_procedure == "holdout":
             if holdout_data is None:
-                ds_fit_kwargs.update(dict(holdout_frac=holdout_frac, ds_fit_context=ds_fit_context + "/sub_fit_ho"))
+                ds_fit_kwargs.update(dict(holdout_frac=holdout_frac, ds_fit_context=ds_fit_context + os.path.sep + "sub_fit_ho"))
                 logger.info(f"Starting holdout-based sub-fit for dynamic stacking. Context path is: {ds_fit_kwargs['ds_fit_context']}.")
             else:
                 _, holdout_data, _ = self._validate_fit_data(train_data=X, tuning_data=holdout_data)
-                ds_fit_kwargs["ds_fit_context"] = ds_fit_context + "/sub_fit_custom_ho"
+                ds_fit_kwargs["ds_fit_context"] = ds_fit_context + os.path.sep + "sub_fit_custom_ho"
                 logger.info(
                     f"Starting holdout-based sub-fit for dynamic stacking with custom validation data. Context path is: {ds_fit_kwargs['ds_fit_context']}."
                 )
@@ -1218,7 +1219,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
                     dict(
                         train_indices=train_indices,
                         val_indices=val_indices,
-                        ds_fit_context=ds_fit_context + f"/sub_fit_{split_index}",
+                        ds_fit_context=ds_fit_context + os.path.sep + f"sub_fit_{split_index}",
                     )
                 )
                 logger.info(


### PR DESCRIPTION
*Issue #, if available:*

Resolves #3884
Related: #3882

*Description of changes:*

- Fixes paths to use `os.path.sep` instead of `/` in dynamic stacking to avoid errors on Windows.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
