### PR TITLE
fix issue 3899, call self.save after update _time_fit_training, add t…

### DIFF
--- a/full_install.bat
+++ b/full_install.bat
@@ -1,0 +1,9 @@
+
+python -m pip install -e common/[tests]
+python -m pip install -e core/[all,tests]
+python -m pip install -e features/
+python -m pip install -e tabular/[all,tests]
+python -m pip install -e multimodal/[tests]
+python -m pip install -e timeseries/[all,tests]
+python -m pip install -e eda/
+python -m pip install -e autogluon/

--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -123,7 +123,6 @@ class TimeSeriesLearner(AbstractLearner):
             excluded_model_types=kwargs.get("excluded_model_types"),
             time_limit=time_limit,
         )
-        self.save_trainer(trainer=self.trainer)
 
         self._time_fit_training = time.time() - time_start
         self.save()

--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -126,6 +126,7 @@ class TimeSeriesLearner(AbstractLearner):
         self.save_trainer(trainer=self.trainer)
 
         self._time_fit_training = time.time() - time_start
+        self.save()
 
     def _align_covariates_with_forecast_index(
         self,

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -411,6 +411,18 @@ def test_when_fit_summary_is_called_then_all_keys_and_models_are_included(
             assert len(fit_summary[key]) == num_models
 
 
+EXPECTED_INFO_KEYS = [
+    "path",
+    "version",
+    "time_fit_training",
+    "time_limit",
+    "best_model",
+    "best_model_score_val",
+    "num_models_trained",
+    "model_info",
+]
+
+
 @pytest.mark.parametrize(
     "hyperparameters, num_models",
     [
@@ -421,21 +433,24 @@ def test_when_fit_summary_is_called_then_all_keys_and_models_are_included(
 def test_when_info_is_called_then_all_keys_and_models_are_included(temp_model_path, hyperparameters, num_models):
     predictor = TimeSeriesPredictor(path=temp_model_path)
     predictor.fit(DUMMY_TS_DATAFRAME, hyperparameters=hyperparameters)
-    expected_keys = [
-        "path",
-        "version",
-        "time_fit_training",
-        "time_limit",
-        "best_model",
-        "best_model_score_val",
-        "num_models_trained",
-        "model_info",
-    ]
     info = predictor.info()
-    for key in expected_keys:
+    for key in EXPECTED_INFO_KEYS:
         assert key in info
 
     assert len(info["model_info"]) == num_models
+
+
+def test_when_predictor_is_loaded_then_info_works(temp_model_path):
+    predictor = TimeSeriesPredictor(path=temp_model_path, prediction_length=2)
+    predictor.fit(train_data=DUMMY_TS_DATAFRAME, hyperparameters=DUMMY_HYPERPARAMETERS)
+    predictor.save()
+    del predictor
+    predictor = TimeSeriesPredictor.load(temp_model_path)
+    info = predictor.info()
+    for key in EXPECTED_INFO_KEYS:
+        assert key in info
+
+    assert len(info["model_info"]) == len(DUMMY_HYPERPARAMETERS)
 
 
 def test_when_train_data_contains_nans_then_predictor_can_fit(temp_model_path):
@@ -497,16 +512,6 @@ def test_given_data_is_in_dataframe_format_then_predictor_works(temp_model_path)
     predictor.evaluate(df)
     predictions = predictor.predict(df)
     assert isinstance(predictions, TimeSeriesDataFrame)
-
-def test_load_predictor_then_info_works(temp_model_path):
-    predictor = TimeSeriesPredictor(path=temp_model_path, prediction_length=2)
-    predictor.fit(
-        train_data=DUMMY_TS_DATAFRAME
-    )
-    predictor.save()
-    del predictor    
-    predictor = TimeSeriesPredictor.load(temp_model_path)
-    predictor.info()
 
 
 def test_given_data_is_in_str_format_then_predictor_works(temp_model_path):

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -498,6 +498,16 @@ def test_given_data_is_in_dataframe_format_then_predictor_works(temp_model_path)
     predictions = predictor.predict(df)
     assert isinstance(predictions, TimeSeriesDataFrame)
 
+def test_load_predictor_then_info_works(temp_model_path):
+    predictor = TimeSeriesPredictor(path=temp_model_path, prediction_length=2)
+    predictor.fit(
+        train_data=DUMMY_TS_DATAFRAME
+    )
+    predictor.save()
+    del predictor    
+    predictor = TimeSeriesPredictor.load(temp_model_path)
+    predictor.info()
+
 
 def test_given_data_is_in_str_format_then_predictor_works(temp_model_path):
     df = pd.DataFrame(DUMMY_TS_DATAFRAME.reset_index())

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -450,7 +450,7 @@ def test_when_predictor_is_loaded_then_info_works(temp_model_path):
     for key in EXPECTED_INFO_KEYS:
         assert key in info
 
-    assert len(info["model_info"]) == len(DUMMY_HYPERPARAMETERS)
+    assert len(info["model_info"]) == len(DUMMY_HYPERPARAMETERS) + 1  # + 1 for ensemble
 
 
 def test_when_train_data_contains_nans_then_predictor_can_fit(temp_model_path):


### PR DESCRIPTION
fix issue #3899 TimeSeriesPredictor.info raises exception when called after calling TimeSeriesPredictor.load 

*Issue #3899 :*

*Description of changes:*
|file|changes|
|--|-----|
|timeseries/src/autogluon/timeseries/learner.py | call self.save() after update self._time_fit_training|
|timeseries/tests/unittests/test_predictor.py | add test_load_predictor_then_info_works to cover issue #3899 |
|full_install.bat | copied from full_install.sh to facilitate installation in Windows|


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
