### PR TITLE
[CI Fix][Tabular]Disable dynamic stacking for pseudolabeling

### DIFF
--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -655,6 +655,7 @@ def test_pseudolabeling():
         num_bag_folds=2,
         num_bag_sets=1,
         ag_args_ensemble=dict(fold_fitting_strategy="sequential_local"),
+        dynamic_stacking=False,
     )
     for idx in range(len(datasets)):
         dataset = datasets[idx]


### PR DESCRIPTION
*Description of changes:*
**_test_tabular.py:test_pseduolabeling.py_** fails as there is a deadlock due to Ray.
refer issue for more info: https://github.com/autogluon/autogluon/issues/3870
This PR fixes a test showing this behavior by disabling dynamic stacking, which in turn fixes the CI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
