### PR TITLE
[timeseries] Fix platform tests failing on Windows

### DIFF
--- a/timeseries/tests/conftest.py
+++ b/timeseries/tests/conftest.py
@@ -33,4 +33,8 @@ def temp_model_path():
     """Pytest fixture to save as model paths that clean up after themselves"""
     td = tempfile.mkdtemp()
     yield td
-    shutil.rmtree(td)
+    try:
+        shutil.rmtree(td)
+    except PermissionError:
+        # Windows won't allow to clean up the directory if logs are saved to it; skip deletion
+        pass


### PR DESCRIPTION
*Description of changes:*
- Skip deleting directory created by` temp_model_path` on Windows if logs are saved to it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
