### PR TITLE
[Feature][CI] Add Concurrency control to increase efficiency, save resources and bring down cost

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request_target:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.event.pull_request.head.sha }}
+  cancel-in-progress: true
+
 permissions:
   id-token: write
   pull-requests: write

--- a/.github/workflows/continuous_integration_multigpu.yaml
+++ b/.github/workflows/continuous_integration_multigpu.yaml
@@ -6,6 +6,10 @@ on:
     paths:
       - 'multimodal/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.event.pull_request.head.sha }}
+  cancel-in-progress: true
+
 permissions:
   id-token: write
   pull-requests: write


### PR DESCRIPTION
*Description of changes:*
This change adds concurrency control to our CI.
If a same PR has multiple commits within a short span of time then the older CI runs are cancelled and the latest one is only run. The same thing would happen for synchronization as well.
This would massively bring down the cost incurred by the AG Team for using AWS Batch for the CI.
It would also free up the vCPUs that are used unnecessarily for old runs, which we can then dedicate to new runs, thus increasing the capacity of our CI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
