### PR TITLE
Tabular: Refactor and fix `fit_pseudolabel` logic

### DIFF
--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -20,6 +20,7 @@ from autogluon.common.utils.try_import import try_import_ray
 
 from ...constants import MULTICLASS, QUANTILE, REFIT_FULL_SUFFIX, REGRESSION, SOFTCLASS
 from ...hpo.exceptions import EmptySearchSpace
+from ...pseudolabeling.pseudolabeling import assert_pseudo_column_match
 from ...utils.exceptions import TimeLimitExceeded
 from ...utils.loaders import load_pkl
 from ...utils.savers import save_pkl
@@ -144,12 +145,12 @@ class BaggedEnsembleModel(AbstractModel):
     def is_valid_oof(self):
         return self.is_fit() and (self._child_oof or self._bagged_mode)
 
-    def predict_proba_oof(self, **kwargs):
+    def predict_proba_oof(self, **kwargs) -> np.array:
         # TODO: Require is_valid == True (add option param to ignore is_valid)
         return self._predict_proba_oof(self._oof_pred_proba, self._oof_pred_model_repeats)
 
     @staticmethod
-    def _predict_proba_oof(oof_pred_proba, oof_pred_model_repeats, return_type=np.float32):
+    def _predict_proba_oof(oof_pred_proba, oof_pred_model_repeats, return_type=np.float32) -> np.array:
         oof_pred_model_repeats_without_0 = np.where(oof_pred_model_repeats == 0, 1, oof_pred_model_repeats)
         if oof_pred_proba.ndim == 2:
             oof_pred_model_repeats_without_0 = oof_pred_model_repeats_without_0[:, None]
@@ -254,7 +255,16 @@ class BaggedEnsembleModel(AbstractModel):
 
         save_bag_folds = self.params.get("save_bag_folds", True)
         if k_fold == 1:
-            self._fit_single(X=X, y=y, model_base=model_base, use_child_oof=use_child_oof, skip_oof=_skip_oof, **kwargs)
+            self._fit_single(
+                X=X,
+                y=y,
+                X_pseudo=X_pseudo,
+                y_pseudo=y_pseudo,
+                model_base=model_base,
+                use_child_oof=use_child_oof,
+                skip_oof=_skip_oof,
+                **kwargs,
+            )
             return self
         else:
             refit_folds = self.params.get("refit_folds", False)
@@ -463,7 +473,7 @@ class BaggedEnsembleModel(AbstractModel):
             sample_weight = sample_weight[valid_indices]
         return self.score_with_y_pred_proba(y=y, y_pred_proba=y_pred_proba, sample_weight=sample_weight)
 
-    def _fit_single(self, X, y, model_base, use_child_oof, time_limit=None, skip_oof=False, **kwargs):
+    def _fit_single(self, X, y, model_base, use_child_oof, time_limit=None, skip_oof=False, X_pseudo=None, y_pseudo=None, **kwargs):
         if self.is_fit():
             raise AssertionError("Model is already fit.")
         if self._n_repeats != 0:
@@ -471,7 +481,20 @@ class BaggedEnsembleModel(AbstractModel):
         model_base.name = f"{model_base.name}S1F1"
         model_base.set_contexts(path_context=os.path.join(self.path, model_base.name))
         time_start_fit = time.time()
-        model_base.fit(X=X, y=y, time_limit=time_limit, **kwargs)
+
+        is_pseudo = X_pseudo is not None and y_pseudo is not None
+        # FIXME: This can lead to poor performance. Probably not bugged, but rather all pseudolabels can come from the same class...
+        #  Consider pseudolabelling to respect the original distribution
+        if is_pseudo:
+            # FIXME: Consider use_child_oof with pseudo labels! Need to keep track of indices
+            logger.log(15, f"{len(X_pseudo)} extra rows of pseudolabeled data added to training set for {self.name}")
+            assert_pseudo_column_match(X=X, X_pseudo=X_pseudo)
+            X_fit = pd.concat([X, X_pseudo], axis=0, ignore_index=True)
+            y_fit = pd.concat([y, y_pseudo], axis=0, ignore_index=True)
+        else:
+            X_fit = X
+            y_fit = y
+        model_base.fit(X=X_fit, y=y_fit, time_limit=time_limit, **kwargs)
         model_base.fit_time = time.time() - time_start_fit
         model_base.predict_time = None
         if not skip_oof:
@@ -507,7 +530,9 @@ class BaggedEnsembleModel(AbstractModel):
                 )
                 time_start_predict = time.time()
                 if model_base._get_tags().get("valid_oof", False):
-                    self._oof_pred_proba = model_base.predict_proba_oof(X=X, y=y)
+                    # For models with the ability to produce their own OOF, such as RandomForest OOB and KNN-LOO,
+                    # we get their OOF predictions on the full data, then limit to the original training data.
+                    self._oof_pred_proba = model_base.predict_proba_oof(X=X_fit, y=y_fit)[:len(X)]
                 else:
                     logger.warning(
                         "\tWARNING: `use_child_oof` was specified but child model does not have a dedicated `predict_proba_oof` method. This model may have heavily overfit validation scores."

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -532,7 +532,7 @@ class BaggedEnsembleModel(AbstractModel):
                 if model_base._get_tags().get("valid_oof", False):
                     # For models with the ability to produce their own OOF, such as RandomForest OOB and KNN-LOO,
                     # we get their OOF predictions on the full data, then limit to the original training data.
-                    self._oof_pred_proba = model_base.predict_proba_oof(X=X_fit, y=y_fit)[:len(X)]
+                    self._oof_pred_proba = model_base.predict_proba_oof(X=X_fit, y=y_fit)[: len(X)]
                 else:
                     logger.warning(
                         "\tWARNING: `use_child_oof` was specified but child model does not have a dedicated `predict_proba_oof` method. This model may have heavily overfit validation scores."

--- a/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
+++ b/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
@@ -17,6 +17,7 @@ from autogluon.common.utils.resource_utils import ResourceManager
 from autogluon.common.utils.s3_utils import download_s3_folder, s3_path_to_bucket_prefix, upload_s3_folder
 from autogluon.common.utils.try_import import try_import_ray
 
+from ...pseudolabeling.pseudolabeling import assert_pseudo_column_match
 from ...ray.resources_calculator import ResourceCalculatorFactory
 from ...utils.exceptions import NotEnoughCudaMemoryError, NotEnoughMemoryError, TimeLimitExceeded
 from ..abstract.abstract_model import AbstractModel
@@ -338,6 +339,7 @@ class SequentialLocalFoldFittingStrategy(FoldFittingStrategy):
 
         if is_pseudo:
             logger.log(15, f"{len(self.X_pseudo)} extra rows of pseudolabeled data added to training set for {fold_model.name}")
+            assert_pseudo_column_match(X=X_fold, X_pseudo=self.X_pseudo)
             X_fold = pd.concat([X_fold, self.X_pseudo], axis=0, ignore_index=True)
             y_fold = pd.concat([y_fold, self.y_pseudo], axis=0, ignore_index=True)
 

--- a/core/src/autogluon/core/pseudolabeling/pseudolabeling.py
+++ b/core/src/autogluon/core/pseudolabeling/pseudolabeling.py
@@ -237,3 +237,25 @@ def filter_ensemble_classification(predictor, unlabeled_data: pd.DataFrame, lead
     test_pseudo_indices = sample_bins_uniformly(y_pred_proba=y_pred_proba_ensemble, df_indexes=pseudo_indexes)
 
     return test_pseudo_indices[test_pseudo_indices], y_pred_proba_ensemble, y_pred_ensemble
+
+
+def assert_pseudo_column_match(X: pd.DataFrame, X_pseudo: pd.DataFrame):
+    """
+    Raises an AssertionError if X and X_pseudo don't share the same columns.
+    Useful to call prior to concatenating the data together to avoid unexpected behavior.
+
+    Parameters
+    ----------
+    X: pd.DataFrame
+        The original training data
+    X_pseudo: pd.DataFrame
+        Additional training data with pseudo-labelled targets
+    """
+    if set(X.columns) != set(X_pseudo.columns):
+        X_unique_cols = sorted(set(X.columns).difference(X_pseudo.columns))
+        X_pseudo_unique_cols = sorted(set(X_pseudo.columns).difference(X.columns))
+        raise AssertionError(
+            f"X and X_pseudo columns are mismatched!\n"
+            f"\tUnexpected Columns in X_pseudo: {X_pseudo_unique_cols}\n"
+            f"\t   Missing Columns in X_pseudo: {X_unique_cols}"
+        )

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -46,6 +46,7 @@ from ..models import (
     StackerEnsembleModel,
     WeightedEnsembleModel,
 )
+from ..pseudolabeling.pseudolabeling import assert_pseudo_column_match
 from ..utils import (
     compute_permutation_feature_importance,
     compute_weighted_metric,
@@ -1245,7 +1246,7 @@ class AbstractTrainer:
 
     # You must have previously called fit() with cache_data=True
     # Fits _FULL versions of specified models, but does NOT link them (_FULL stackers will still use normal models as input)
-    def refit_single_full(self, X=None, y=None, X_val=None, y_val=None, X_unlabeled=None, models=None) -> List[str]:
+    def refit_single_full(self, X=None, y=None, X_val=None, y_val=None, X_unlabeled=None, models=None, **kwargs) -> List[str]:
         if X is None:
             X = self.load_X()
         if X_val is None:
@@ -1323,6 +1324,7 @@ class AbstractTrainer:
                         n_repeats=1,
                         ensemble_type=type(model),
                         refit_full=True,
+                        **kwargs,
                     )
                 if len(models_trained) == 1:
                     model_refit_map[model_name] = models_trained[0]
@@ -1347,7 +1349,7 @@ class AbstractTrainer:
     # Fits _FULL models and links them in the stack so _FULL models only use other _FULL models as input during stacking
     # If model is specified, will fit all _FULL models that are ancestors of the provided model, automatically linking them.
     # If no model is specified, all models are refit and linked appropriately.
-    def refit_ensemble_full(self, model: str | List[str] = "all") -> dict:
+    def refit_ensemble_full(self, model: str | List[str] = "all", **kwargs) -> dict:
         if model == "all":
             ensemble_set = self.get_model_names()
         elif isinstance(model, list):
@@ -1365,7 +1367,7 @@ class AbstractTrainer:
             else:
                 ensemble_set_valid.append(model)
         if ensemble_set_valid:
-            models_trained_full = self.refit_single_full(models=ensemble_set_valid)
+            models_trained_full = self.refit_single_full(models=ensemble_set_valid, **kwargs)
         else:
             models_trained_full = []
 
@@ -1807,6 +1809,7 @@ class AbstractTrainer:
             # Bagged model does validation on the fit level where as single models do it separately. Hence this if statement
             # is required
             if not isinstance(model, BaggedEnsembleModel) and X_pseudo is not None and y_pseudo is not None and X_pseudo.columns.equals(X.columns):
+                assert_pseudo_column_match(X=X, X_pseudo=X_pseudo)
                 X_w_pseudo = pd.concat([X, X_pseudo])
                 y_w_pseudo = pd.concat([y, y_pseudo])
                 model_fit_kwargs.pop("X_pseudo")
@@ -1814,6 +1817,11 @@ class AbstractTrainer:
                 logger.log(15, f"{len(X_pseudo)} extra rows of pseudolabeled data added to training set for {model.name}")
                 model = self._train_single(X_w_pseudo, y_w_pseudo, model, X_val, y_val, **model_fit_kwargs)
             else:
+                if level > 1:
+                    if X_pseudo is not None and y_pseudo is not None:
+                        logger.log(15, f'Dropping pseudo in stacking layer due to missing out-of-fold predictions')
+                    model_fit_kwargs.pop("X_pseudo", None)
+                    model_fit_kwargs.pop("y_pseudo", None)
                 model = self._train_single(X, y, model, X_val, y_val, total_resources=total_resources, **model_fit_kwargs)
 
             fit_end_time = time.time()

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -1819,7 +1819,7 @@ class AbstractTrainer:
             else:
                 if level > 1:
                     if X_pseudo is not None and y_pseudo is not None:
-                        logger.log(15, f'Dropping pseudo in stacking layer due to missing out-of-fold predictions')
+                        logger.log(15, f"Dropping pseudo in stacking layer due to missing out-of-fold predictions")
                     model_fit_kwargs.pop("X_pseudo", None)
                     model_fit_kwargs.pop("y_pseudo", None)
                 model = self._train_single(X, y, model, X_val, y_val, total_resources=total_resources, **model_fit_kwargs)

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -446,8 +446,8 @@ class AbstractTabularLearner(AbstractLearner):
     # Fits _FULL models and links them in the stack so _FULL models only use other _FULL models as input during stacking
     # If model is specified, will fit all _FULL models that are ancestors of the provided model, automatically linking them.
     # If no model is specified, all models are refit and linked appropriately.
-    def refit_ensemble_full(self, model: str | List[str] = "all"):
-        return self.load_trainer().refit_ensemble_full(model=model)
+    def refit_ensemble_full(self, model: str | List[str] = "all", **kwargs):
+        return self.load_trainer().refit_ensemble_full(model=model, **kwargs)
 
     def fit_transform_features(self, X, y=None, **kwargs):
         if self.label in X:

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1718,9 +1718,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             logger.log(20, f"Beginning iteration {iter_print} of pseudolabeling out of max {max_iter}")
 
             if len(test_pseudo_idxes_true) < 1:
-                logger.log(
-                    20, f"Could not confidently assign pseudolabels for any of the provided rows in iteration {iter_print}. Done with pseudolabeling..."
-                )
+                logger.log(20, f"Could not confidently assign pseudolabels for any of the provided rows in iteration {iter_print}. Done with pseudolabeling...")
                 break
             else:
                 logger.log(

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -306,7 +306,18 @@ def test_advanced_functionality():
     predictor.delete_models(models_to_keep=[])  # Test that dry-run doesn't delete models
     assert len(predictor.model_names()) == num_models * 2
     predictor.predict(data=test_data)
-    predictor.delete_models(models_to_keep=[], dry_run=False)  # Test that dry-run deletes models
+
+    # Test refit_full with train_data_extra argument
+    refit_full_models = list(predictor.model_refit_map().values())
+    predictor.delete_models(models_to_delete=refit_full_models, dry_run=False)
+    assert len(predictor.model_names()) == num_models
+    assert predictor.model_refit_map() == dict()
+    predictor.refit_full(train_data_extra=test_data)  # train_data_extra argument
+    assert len(predictor.model_names()) == num_models * 2
+    assert len(predictor.model_refit_map()) == num_models
+    predictor.predict(data=test_data)
+
+    predictor.delete_models(models_to_keep=[], dry_run=False)  # Test that dry_run=False deletes models
     assert len(predictor.model_names()) == 0
     assert len(predictor.leaderboard()) == 0
     assert len(predictor.leaderboard(extra_info=True)) == 0


### PR DESCRIPTION
*Issue #, if available:*
Resolves #3897
 
*Description of changes:*
- [x] Fixed refit_full not using pseudo-labels
- [x] Fixes incorrect pseudo-labelling logic when applied to multi-layer stacking during fit (NaNs in pred columns, now we drop pseudo-labelled data in stack layers)
- [x] Fixed transductive learning not producing the correct transductive predictions as output (should now be much stronger)
- [x] Fixed transductive learning with refit_full not working as intended
- [x] Allow post-fit refit_full call to use pseudo-labels
- [x] Address remaining FIXME comments
- [x] Add documentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
