### PR TITLE
Fix HPO crash in memory check

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -15,6 +15,7 @@ import numpy as np
 import pandas as pd
 
 from autogluon.common.features.feature_metadata import FeatureMetadata
+from autogluon.common.space import Space
 from autogluon.common.utils.distribute_utils import DistributedContext
 from autogluon.common.utils.lite import disable_if_lite_mode
 from autogluon.common.utils.log_utils import DuplicateFilter
@@ -1945,9 +1946,27 @@ class AbstractModel:
         else:
             return dict()
 
-    def _get_model_params(self) -> dict:
-        """Gets params that are passed to the inner model."""
-        return self._get_params()
+    def _get_model_params(self, convert_search_spaces_to_default: bool = False) -> dict:
+        """
+        Gets params that are passed to the inner model.
+
+        Parameters
+        ----------
+        convert_search_spaces_to_default: bool, default = False
+            If True, search spaces are converted to the default value.
+            This is useful when having to estimate memory usage estimates prior to doing hyperparameter tuning.
+
+        Returns
+        -------
+        params: dict
+            Dictionary of model hyperparameters.
+        """
+        params = self._get_params()
+        if convert_search_spaces_to_default:
+            for param, val in params.items():
+                if isinstance(val, Space):
+                    params[param] = val.default
+        return params
 
     # TODO: Add documentation for valid args for each model. Currently only `early_stop`
     def _ag_params(self) -> set:

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -78,7 +78,7 @@ class CatBoostModel(AbstractModel):
         data_mem_usage = get_approximate_df_mem_usage(X).sum()
         data_mem_usage_bytes = data_mem_usage * 5 + data_mem_usage / 4 * num_classes  # TODO: Extremely crude approximation, can be vastly improved
 
-        params = self._get_model_params()
+        params = self._get_model_params(convert_search_spaces_to_default=True)
         border_count = params.get("border_count", 254)
         depth = params.get("depth", 6)
         # Formula based on manual testing, aligns with LightGBM histogram sizes

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -79,7 +79,7 @@ class LGBModel(AbstractModel):
         data_mem_usage = get_approximate_df_mem_usage(X).sum()
         data_mem_usage_bytes = data_mem_usage * 5 + data_mem_usage / 4 * num_classes  # TODO: Extremely crude approximation, can be vastly improved
 
-        params = self._get_model_params()
+        params = self._get_model_params(convert_search_spaces_to_default=True)
         max_bins = params.get("max_bins", 255)
         num_leaves = params.get("num_leaves", 31)
         # Memory usage of histogram based on https://github.com/microsoft/LightGBM/issues/562#issuecomment-304524592

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -208,7 +208,7 @@ class XGBoostModel(AbstractModel):
         data_mem_usage = get_approximate_df_mem_usage(X).sum()
         data_mem_usage_bytes = data_mem_usage * 7 + data_mem_usage / 4 * num_classes  # TODO: Extremely crude approximation, can be vastly improved
 
-        params = self._get_model_params()
+        params = self._get_model_params(convert_search_spaces_to_default=True)
         max_bin = params.get("max_bin", 256)
         max_depth = params.get("max_depth", 6)
         # Formula based on manual testing, aligns with LightGBM histogram sizes


### PR DESCRIPTION
*Issue #, if available:*
Resolves #3928 

*Description of changes:*
- Fixes crash during HPO if the user specified in their search space a hyperparameter which is used to estimate memory usage of a model. Now we use the default value within the search space for the memory check.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
