### PR TITLE
Update conf.py copyright to reflect current year

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,7 +5,7 @@ sys.path = ['.', '..'] + sys.path
 
 project = 'AutoGluon'
 release = '1.0.1'
-copyright = '2023, All authors. Licensed under Apache 2.0.'
+copyright = '2024, All authors. Licensed under Apache 2.0.'
 author = 'AutoGluon contributors'
 
 extensions = [


### PR DESCRIPTION
**This change ensures the copyright information in conf.py accurately displays the current year (2024).**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
