### PR TITLE
[timeseries] fix random seed, reset seed for every model

### DIFF
--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -170,13 +170,19 @@ class TimeSeriesLearner(AbstractLearner):
         known_covariates: Optional[TimeSeriesDataFrame] = None,
         model: Optional[Union[str, AbstractTimeSeriesModel]] = None,
         use_cache: bool = True,
+        random_seed: Optional[int] = None,
         **kwargs,
     ) -> TimeSeriesDataFrame:
         data = self.feature_generator.transform(data)
         known_covariates = self.feature_generator.transform_future_known_covariates(known_covariates)
         known_covariates = self._align_covariates_with_forecast_index(known_covariates=known_covariates, data=data)
         return self.load_trainer().predict(
-            data=data, known_covariates=known_covariates, model=model, use_cache=use_cache, **kwargs
+            data=data,
+            known_covariates=known_covariates,
+            model=model,
+            use_cache=use_cache,
+            random_seed=random_seed,
+            **kwargs,
         )
 
     def score(

--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -77,6 +77,7 @@ class TimeSeriesLearner(AbstractLearner):
         time_limit: Optional[int] = None,
         val_splitter: Optional[AbstractWindowSplitter] = None,
         refit_every_n_windows: Optional[int] = 1,
+        random_seed: Optional[int] = None,
         **kwargs,
     ) -> None:
         self._time_limit = time_limit
@@ -122,6 +123,7 @@ class TimeSeriesLearner(AbstractLearner):
             hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
             excluded_model_types=kwargs.get("excluded_model_types"),
             time_limit=time_limit,
+            random_seed=random_seed,
         )
 
         self._time_fit_training = time.time() - time_start

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -708,9 +708,6 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
             prediction_length=self.prediction_length, num_val_windows=num_val_windows, val_step_size=val_step_size
         )
 
-        if random_seed is not None:
-            seed_everything(random_seed)
-
         time_left = None if time_limit is None else time_limit - (time.time() - time_start)
         self._learner.fit(
             train_data=train_data,
@@ -723,6 +720,7 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
             val_splitter=val_splitter,
             refit_every_n_windows=refit_every_n_windows,
             enable_ensemble=enable_ensemble,
+            random_seed=random_seed,
         )
         if refit_full:
             if tuning_data is None:
@@ -807,14 +805,18 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
         B       2020-03-04    17.1
                 2020-03-05     8.3
         """
-        if random_seed is not None:
-            seed_everything(random_seed)
         # Don't use data.item_ids in case data is not a TimeSeriesDataFrame
         original_item_id_order = data.reset_index()[ITEMID].unique()
         data = self._check_and_prepare_data_frame(data)
         if known_covariates is not None:
             known_covariates = self._to_data_frame(known_covariates)
-        predictions = self._learner.predict(data, known_covariates=known_covariates, model=model, use_cache=use_cache)
+        predictions = self._learner.predict(
+            data,
+            known_covariates=known_covariates,
+            model=model,
+            use_cache=use_cache,
+            random_seed=random_seed,
+        )
         return predictions.reindex(original_item_id_order, level=ITEMID)
 
     def evaluate(

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -11,7 +11,7 @@ import pandas as pd
 from autogluon.common.utils.deprecated_utils import Deprecated
 from autogluon.common.utils.log_utils import add_log_to_file, set_logger_verbosity
 from autogluon.common.utils.system_info import get_ag_system_info
-from autogluon.common.utils.utils import check_saved_predictor_version, seed_everything, setup_outputdir
+from autogluon.common.utils.utils import check_saved_predictor_version, setup_outputdir
 from autogluon.core.utils.decorators import apply_presets
 from autogluon.core.utils.loaders import load_pkl, load_str
 from autogluon.core.utils.savers import save_pkl, save_str

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -806,6 +806,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         known_covariates: Optional[TimeSeriesDataFrame] = None,
         model: Optional[Union[str, AbstractTimeSeriesModel]] = None,
         use_cache: bool = True,
+        random_seed: Optional[int] = None,
         **kwargs,
     ) -> TimeSeriesDataFrame:
         model_name = self._get_model_for_prediction(model)
@@ -814,7 +815,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
             data=data,
             known_covariates=known_covariates,
             use_cache=use_cache,
-            random_seed=kwargs.get("random_seed"),
+            random_seed=random_seed,
         )
         return model_pred_dict[model_name]
 

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 from tqdm import tqdm
 
-from autogluon.common.utils.utils import hash_pandas_df
+from autogluon.common.utils.utils import hash_pandas_df, seed_everything
 from autogluon.core.models import AbstractModel
 from autogluon.core.utils.exceptions import TimeLimitExceeded
 from autogluon.core.utils.loaders import load_pkl
@@ -529,6 +529,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         hyperparameter_tune_kwargs: Optional[Union[str, dict]] = None,
         excluded_model_types: Optional[List[str]] = None,
         time_limit: Optional[float] = None,
+        random_seed: Optional[int] = None,
     ) -> List[str]:
         logger.info(f"\nStarting training. Start time is {time.strftime('%Y-%m-%d %H:%M:%S')}")
 
@@ -573,6 +574,9 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
                 if time_left <= 0:
                     logger.info(f"Stopping training due to lack of time remaining. Time left: {time_left:.1f} seconds")
                     break
+
+            if random_seed is not None:
+                seed_everything(random_seed)
 
             if contains_searchspace(model.get_user_params()):
                 fit_log_message = f"Hyperparameter tuning model {model.name}. "
@@ -806,7 +810,11 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
     ) -> TimeSeriesDataFrame:
         model_name = self._get_model_for_prediction(model)
         model_pred_dict = self.get_model_pred_dict(
-            model_names=[model_name], data=data, known_covariates=known_covariates, use_cache=use_cache
+            model_names=[model_name],
+            data=data,
+            known_covariates=known_covariates,
+            use_cache=use_cache,
+            random_seed=kwargs.get("random_seed"),
         )
         return model_pred_dict[model_name]
 
@@ -901,6 +909,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         record_pred_time: bool = False,
         raise_exception_if_failed: bool = True,
         use_cache: bool = True,
+        random_seed: Optional[int] = None,
     ) -> Union[Dict[str, TimeSeriesDataFrame], Tuple[Dict[str, TimeSeriesDataFrame], Dict[str, float]]]:
         """Return a dictionary with predictions of all models for the given dataset.
 
@@ -940,6 +949,8 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         failed_models = []
         for model_name in model_set:
             if model_name not in model_pred_dict:
+                if random_seed is not None:
+                    seed_everything(random_seed)
                 try:
                     predict_start_time = time.time()
                     model_pred_dict[model_name] = self._predict_model(

--- a/timeseries/src/autogluon/timeseries/trainer/auto_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/auto_trainer.py
@@ -38,6 +38,7 @@ class AutoTimeSeriesTrainer(AbstractTimeSeriesTrainer):
         hyperparameter_tune_kwargs: Optional[Union[str, Dict]] = None,
         excluded_model_types: Optional[List[str]] = None,
         time_limit: Optional[float] = None,
+        random_seed: Optional[int] = None,
     ):
         """
         Fit a set of timeseries models specified by the `hyperparameters`
@@ -59,6 +60,8 @@ class AutoTimeSeriesTrainer(AbstractTimeSeriesTrainer):
             Names of models that should not be trained, even if listed in `hyperparameters`.
         time_limit
             Time limit for training
+        random_seed
+            Random seed that will be set to each model during training
         """
         self._train_multi(
             train_data,
@@ -67,4 +70,5 @@ class AutoTimeSeriesTrainer(AbstractTimeSeriesTrainer):
             hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
             excluded_model_types=excluded_model_types,
             time_limit=time_limit,
+            random_seed=random_seed,
         )

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -14,6 +14,7 @@ import pytest
 
 from autogluon.common import space
 from autogluon.common.utils.log_utils import verbosity2loglevel
+from autogluon.common.utils.utils import seed_everything
 from autogluon.timeseries.dataset import TimeSeriesDataFrame
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP
 from autogluon.timeseries.metrics import DEFAULT_METRIC_NAME
@@ -1097,13 +1098,17 @@ def test_when_predictor_fit_with_verbosity_then_verbosity_overridden_and_propaga
 
 
 @pytest.mark.parametrize("random_seed", [123, 1, 42])
-def test_when_predictor_fit_with_random_seed_then_random_seed_set_for_all_models(temp_model_path, random_seed):
+def test_when_predictor_fit_with_random_seed_then_torch_seed_set_for_all_models(temp_model_path, random_seed):
     predictor = TimeSeriesPredictor(path=temp_model_path)
 
     import torch
 
     def train_save_side_effect(self, *args, **kwargs):
         assert torch.get_rng_state().numpy()[0] == random_seed
+
+        # mess with the seed
+        seed_everything(66)
+
         return "mock_model"
 
     with mock.patch("autogluon.timeseries.trainer.AbstractTimeSeriesTrainer._train_and_save") as mock_train_save:
@@ -1113,7 +1118,7 @@ def test_when_predictor_fit_with_random_seed_then_random_seed_set_for_all_models
             hyperparameters={
                 "SeasonalNaive": {},
                 "RecursiveTabular": {
-                    "tabular_hyperparameters": {"NN_TORCH": {"proc.impute_strategy": "constant"}},
+                    "tabular_hyperparameters": {"NN_TORCH": {"proc.impute_strategy": "constant", "num_epochs": 1}},
                 },
                 "TemporalFusionTransformer": {"epochs": 1},
                 "DeepAR": {"epochs": 1},
@@ -1124,8 +1129,8 @@ def test_when_predictor_fit_with_random_seed_then_random_seed_set_for_all_models
         assert mock_train_save.call_count == 4
 
 
-@pytest.mark.parametrize("random_seed", [123, 1, 42])
-def test_when_predictor_predict_called_with_random_seed_then_random_seed_set_for_all_models(
+@pytest.mark.parametrize("random_seed", [123, 42])
+def test_when_predictor_predict_called_with_random_seed_then_torch_seed_set_for_all_predictions(
     temp_model_path, random_seed
 ):
     predictor = TimeSeriesPredictor(path=temp_model_path)

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -2,7 +2,6 @@
 import copy
 import logging
 import math
-import os
 import sys
 import tempfile
 from pathlib import Path

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -2,6 +2,7 @@
 import copy
 import logging
 import math
+import os
 import sys
 import tempfile
 from pathlib import Path
@@ -1034,26 +1035,32 @@ def test_when_log_to_file_set_then_predictor_logs_to_file(temp_model_path):
 
 def test_when_log_file_set_then_predictor_logs_to_custom_file(temp_model_path):
     predictor = TimeSeriesPredictor(path=temp_model_path, log_to_file=True, log_file_path="custom_log.txt")
-    predictor.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}})
     log_path = Path(".") / "custom_log.txt"
-    assert Path.exists(log_path)
+    try:
+        predictor.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}})
+        assert Path.exists(log_path)
 
-    # check if the log contains text
-    with open(log_path, "r") as f:
-        log_text = f.read()
-    assert "Naive" in log_text
+        # check if the log contains text
+        with open(log_path, "r") as f:
+            log_text = f.read()
+        assert "Naive" in log_text
+    finally:
+        log_path.unlink(missing_ok=True)
 
 
 def test_when_log_file_set_with_pathlib_then_predictor_logs_to_custom_file(temp_model_path):
     predictor = TimeSeriesPredictor(path=temp_model_path, log_to_file=True, log_file_path=Path(".") / "custom_log.txt")
-    predictor.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}})
     log_path = Path(".") / "custom_log.txt"
-    assert Path.exists(log_path)
+    try:
+        predictor.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}})
+        assert Path.exists(log_path)
 
-    # check if the log contains text
-    with open(log_path, "r") as f:
-        log_text = f.read()
-    assert "Naive" in log_text
+        # check if the log contains text
+        with open(log_path, "r") as f:
+            log_text = f.read()
+        assert "Naive" in log_text
+    finally:
+        log_path.unlink(missing_ok=True)
 
 
 def test_when_log_to_file_set_to_false_then_predictor_does_not_log_to_file(temp_model_path):
@@ -1087,3 +1094,62 @@ def test_when_predictor_fit_with_verbosity_then_verbosity_overridden_and_propaga
     for suffix in logger_suffixes:
         level = logging.getLogger(f"autogluon.timeseries.{suffix}").getEffectiveLevel()
         assert level == verbosity2loglevel(verbosity)
+
+
+@pytest.mark.parametrize("random_seed", [123, 1, 42])
+def test_when_predictor_fit_with_random_seed_then_random_seed_set_for_all_models(temp_model_path, random_seed):
+    predictor = TimeSeriesPredictor(path=temp_model_path)
+
+    import torch
+
+    def train_save_side_effect(self, *args, **kwargs):
+        assert torch.get_rng_state().numpy()[0] == random_seed
+        return "mock_model"
+
+    with mock.patch("autogluon.timeseries.trainer.AbstractTimeSeriesTrainer._train_and_save") as mock_train_save:
+        mock_train_save.side_effect = train_save_side_effect
+        predictor.fit(
+            DUMMY_TS_DATAFRAME,
+            hyperparameters={
+                "SeasonalNaive": {},
+                "RecursiveTabular": {
+                    "tabular_hyperparameters": {"NN_TORCH": {"proc.impute_strategy": "constant"}},
+                },
+                "TemporalFusionTransformer": {"epochs": 1},
+                "DeepAR": {"epochs": 1},
+            },
+            random_seed=random_seed,
+            enable_ensemble=False,
+        )
+        assert mock_train_save.call_count == 4
+
+
+@pytest.mark.parametrize("random_seed", [123, 1, 42])
+def test_when_predictor_predict_called_with_random_seed_then_random_seed_set_for_all_models(
+    temp_model_path, random_seed
+):
+    predictor = TimeSeriesPredictor(path=temp_model_path)
+
+    predictor.fit(
+        DUMMY_TS_DATAFRAME,
+        hyperparameters={
+            "SeasonalNaive": {},
+            "DeepAR": {"epochs": 1},
+        },
+        random_seed=random_seed,
+        enable_ensemble=False,
+    )
+
+    import torch
+
+    def predict_model_side_effect(*args, **kwargs):
+        assert torch.get_rng_state().numpy()[0] == random_seed
+        return DUMMY_TS_DATAFRAME
+
+    with mock.patch("autogluon.timeseries.trainer.AbstractTimeSeriesTrainer._predict_model") as mock_predict_model:
+        mock_predict_model.side_effect = predict_model_side_effect
+        try:
+            predictor.predict(DUMMY_TS_DATAFRAME, random_seed=random_seed)
+        except RuntimeError:
+            pass
+        assert mock_predict_model.call_count == 1


### PR DESCRIPTION
*Issue #, if available:*

#3896 
#3923

*Description of changes:*

Previously, `seed_everything` was called once at the beginning of `TimeSeriesPredictor` `fit` and `predict` methods which led to two undesirable side effects:
- if any of the models reset the seeds in their internal logic, they could effectively cancel the `random_seed` provided by the user. This was done, e.g., in `RecursiveTabular`'s `NN_TORCH` affecting `high_quality` presets.
- The fitting order of models could affect the outcomes of individual models. i.e., the random state at the beginning of each model depended on previous models.

With this change, we propagate the random seed to the learner and trainer both at training and prediction time. We set the seed again, per model, when fitting single models or predicting with single models.

Also fixes a minor issue in predictor unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
