### PR TITLE
[timeseries] Add option to keep lightning_logs after training

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -393,6 +393,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         self._check_fit_params()
         # update auxiliary parameters
         init_args = self._get_estimator_init_args()
+        keep_lightning_logs = init_args.pop("keep_lightning_logs", False)
         callbacks = self._get_callbacks(
             time_limit=time_limit,
             early_stopping_patience=None if val_data is None else init_args["early_stopping_patience"],
@@ -411,7 +412,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
                 self.gts_predictor.batch_size = init_args["predict_batch_size"]
 
         lightning_logs_dir = Path(self.path) / "lightning_logs"
-        if lightning_logs_dir.exists() and lightning_logs_dir.is_dir():
+        if not keep_lightning_logs and lightning_logs_dir.exists() and lightning_logs_dir.is_dir():
             logger.debug(f"Removing lightning_logs directory {lightning_logs_dir}")
             shutil.rmtree(lightning_logs_dir)
 

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -1,6 +1,7 @@
 """
 Module including wrappers for PyTorch implementations of models in GluonTS
 """
+
 import logging
 from typing import Any, Dict, Type
 
@@ -78,6 +79,8 @@ class DeepARModel(AbstractGluonTSModel):
         Optional keyword arguments passed to ``lightning.Trainer``.
     early_stopping_patience : int or None, default = 20
         Early stop training if the validation loss doesn't improve for this many epochs.
+    keep_lightning_logs : bool, default = False
+        If True, ``lightning_logs`` directory will NOT be removed after the model finished training.
     """
 
     supports_known_covariates = True
@@ -131,6 +134,8 @@ class SimpleFeedForwardModel(AbstractGluonTSModel):
         Optional keyword arguments passed to ``lightning.Trainer``.
     early_stopping_patience : int or None, default = 20
         Early stop training if the validation loss doesn't improve for this many epochs.
+    keep_lightning_logs : bool, default = False
+        If True, ``lightning_logs`` directory will NOT be removed after the model finished training.
     """
 
     def _get_estimator_class(self) -> Type[GluonTSEstimator]:
@@ -188,6 +193,8 @@ class TemporalFusionTransformerModel(AbstractGluonTSModel):
         Optional keyword arguments passed to ``lightning.Trainer``.
     early_stopping_patience : int or None, default = 20
         Early stop training if the validation loss doesn't improve for this many epochs.
+    keep_lightning_logs : bool, default = False
+        If True, ``lightning_logs`` directory will NOT be removed after the model finished training.
     """
 
     supports_known_covariates = True
@@ -254,6 +261,8 @@ class DLinearModel(AbstractGluonTSModel):
         Early stop training if the validation loss doesn't improve for this many epochs.
     weight_decay : float, default = 1e-8
         Weight decay regularization parameter.
+    keep_lightning_logs : bool, default = False
+        If True, ``lightning_logs`` directory will NOT be removed after the model finished training.
     """
 
     @property
@@ -306,6 +315,8 @@ class PatchTSTModel(AbstractGluonTSModel):
         Learning rate used during training
     weight_decay : float, default = 1e-8
         Weight decay regularization parameter.
+    keep_lightning_logs : bool, default = False
+        If True, ``lightning_logs`` directory will NOT be removed after the model finished training.
     """
 
     @property
@@ -377,6 +388,8 @@ class WaveNetModel(AbstractGluonTSModel):
         Early stop training if the validation loss doesn't improve for this many epochs.
     weight_decay : float, default = 1e-8
         Weight decay regularization parameter.
+    keep_lightning_logs : bool, default = False
+        If True, ``lightning_logs`` directory will NOT be removed after the model finished training.
     """
 
     supports_known_covariates = True

--- a/timeseries/tests/unittests/models/test_gluonts.py
+++ b/timeseries/tests/unittests/models/test_gluonts.py
@@ -312,10 +312,17 @@ def test_when_custom_trainer_kwargs_given_then_trainer_receives_them():
         assert received_trainer_kwargs[k] == v
 
 
-@pytest.mark.parametrize("model_class", TESTABLE_MODELS)
+def test_when_model_finishes_training_then_logs_are_removed(temp_model_path):
+    model = TemporalFusionTransformerModel(
+        freq=DUMMY_TS_DATAFRAME.freq, path=temp_model_path, hyperparameters=DUMMY_HYPERPARAMETERS
+    )
+    model.fit(train_data=DUMMY_TS_DATAFRAME)
+    assert not (Path(model.path) / "lightning_logs").exists()
+
+
 @pytest.mark.parametrize("keep_lightning_logs", [True, False])
-def test_when_keep_lightning_logs_set_then_logs_are_not_removed(keep_lightning_logs, temp_model_path, model_class):
-    model = model_class(
+def test_when_keep_lightning_logs_set_then_logs_are_not_removed(keep_lightning_logs, temp_model_path):
+    model = DeepARModel(
         freq=DUMMY_TS_DATAFRAME.freq,
         path=temp_model_path,
         hyperparameters={"keep_lightning_logs": keep_lightning_logs, **DUMMY_HYPERPARAMETERS},

--- a/timeseries/tests/unittests/models/test_gluonts.py
+++ b/timeseries/tests/unittests/models/test_gluonts.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest import mock
 
 import numpy as np
@@ -309,3 +310,15 @@ def test_when_custom_trainer_kwargs_given_then_trainer_receives_them():
     received_trainer_kwargs = catch_trainer_kwargs(model)
     for k, v in trainer_kwargs.items():
         assert received_trainer_kwargs[k] == v
+
+
+@pytest.mark.parametrize("model_class", TESTABLE_MODELS)
+@pytest.mark.parametrize("keep_lightning_logs", [True, False])
+def test_when_keep_lightning_logs_set_then_logs_are_not_removed(keep_lightning_logs, temp_model_path, model_class):
+    model = model_class(
+        freq=DUMMY_TS_DATAFRAME.freq,
+        path=temp_model_path,
+        hyperparameters={"keep_lightning_logs": keep_lightning_logs, **DUMMY_HYPERPARAMETERS},
+    )
+    model.fit(train_data=DUMMY_TS_DATAFRAME)
+    assert (Path(model.path) / "lightning_logs").exists() == keep_lightning_logs


### PR DESCRIPTION
*Issue #, if available:* Fixes #3853

*Description of changes:*
- Add hyperparameter `keep_lightning_logs` to GluonTS models. If set to `True`, `lightning_logs` directory won't be removed after training.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
