### PR TITLE
[timeseries] add RMSLE to metrics

### DIFF
--- a/docs/tutorials/timeseries/forecasting-metrics.md
+++ b/docs/tutorials/timeseries/forecasting-metrics.md
@@ -50,6 +50,7 @@ Currently, AutoGluon supports following evaluation metrics:
    MASE
    MSE
    RMSE
+   RMSLE
    RMSSE
    SMAPE
    WAPE
@@ -128,6 +129,10 @@ If your goal is to predict the **mean** (expected value), you should use `MSE`, 
      - 
      - ✅
      - mean
+   * - :class:`~autogluon.timeseries.metrics.RMSLE`
+     - 
+     - 
+     -
    * - :class:`~autogluon.timeseries.metrics.RMSSE`
      - 
      - 
@@ -172,6 +177,10 @@ We use the following notation in mathematical definitions of point forecast metr
 
 ```{eval-rst}
 .. autoclass:: RMSE
+```
+
+```{eval-rst}
+.. autoclass:: RMSLE
 ```
 
 ```{eval-rst}

--- a/timeseries/src/autogluon/timeseries/metrics/__init__.py
+++ b/timeseries/src/autogluon/timeseries/metrics/__init__.py
@@ -2,7 +2,7 @@ from pprint import pformat
 from typing import Type, Union
 
 from .abstract import TimeSeriesScorer
-from .point import MAE, MAPE, MASE, MSE, RMSE, RMSSE, SMAPE, WAPE
+from .point import MAE, MAPE, MASE, MSE, RMSE, RMSLE, RMSSE, SMAPE, WAPE
 from .quantile import SQL, WQL
 
 __all__ = [
@@ -12,6 +12,7 @@ __all__ = [
     "SMAPE",
     "MSE",
     "RMSE",
+    "RMSLE",
     "RMSSE",
     "SQL",
     "WAPE",
@@ -25,6 +26,7 @@ AVAILABLE_METRICS = {
     "MAPE": MAPE,
     "SMAPE": SMAPE,
     "RMSE": RMSE,
+    "RMSLE": RMSLE,
     "RMSSE": RMSSE,
     "WAPE": WAPE,
     "SQL": SQL,

--- a/timeseries/src/autogluon/timeseries/metrics/point.py
+++ b/timeseries/src/autogluon/timeseries/metrics/point.py
@@ -336,3 +336,23 @@ class RMSLE(TimeSeriesScorer):
         y_pred = np.clip(y_pred, a_min=0.0, a_max=None)
 
         return np.sqrt(np.power(np.log1p(y_pred) - np.log1p(y_true), 2).mean())
+
+    def __call__(
+        self,
+        data: TimeSeriesDataFrame,
+        predictions: TimeSeriesDataFrame,
+        prediction_length: int = 1,
+        target: str = "target",
+        seasonal_period: Optional[int] = None,
+        **kwargs,
+    ) -> float:
+        if (data[target] < 0).any():
+            raise ValueError(f"{self.name} cannot be used if target time series contains negative values!")
+        return super().__call__(
+            data=data,
+            predictions=predictions,
+            prediction_length=prediction_length,
+            target=target,
+            seasonal_period=seasonal_period,
+            **kwargs,
+        )

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -94,6 +94,7 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
         - ``"MASE"``: mean absolute scaled error
         - ``"MSE"``: mean squared error
         - ``"RMSE"``: root mean squared error
+        - ``"RMSLE"``: root mean squared logarithmic error
         - ``"RMSSE"``: root mean squared scaled error
         - ``"SMAPE"``: "symmetric" mean absolute percentage error
         - ``"WAPE"``: weighted absolute percentage error

--- a/timeseries/tests/unittests/test_metrics.py
+++ b/timeseries/tests/unittests/test_metrics.py
@@ -238,6 +238,35 @@ def test_RMSSE(prediction_length, seasonal_period, expected_result):
     assert ag_value == expected_result
 
 
+@pytest.mark.parametrize(
+    "prediction_length, expected_result",
+    [
+        (3, 1.03952774131806),
+        (4, 1.11754262032011),
+        (5, 1.17302207173233),
+        (6, 1.21497832991862),
+    ],
+)
+def test_RMSLE(prediction_length, expected_result):
+    data = get_data_frame_with_item_index(
+        ["1"],
+        start_date="2022-01-01 00:00:00",
+        data_length=2 * prediction_length,
+        columns=["target"],
+        data_generation="sequential",
+    )
+    predictions = get_data_frame_with_item_index(
+        ["1"],
+        start_date=str(pd.Timestamp("2022-01-01 00:00:00") + pd.to_timedelta(prediction_length, unit="H")),
+        data_length=prediction_length,
+        columns=["mean"],
+        data_generation="sequential",
+    )
+    metric = check_get_evaluation_metric("RMSLE")
+    ag_value = metric.sign * metric(data, predictions, prediction_length=prediction_length)
+    assert np.isclose(ag_value, expected_result, atol=1e-5)
+
+
 @pytest.mark.parametrize("metric_name", AVAILABLE_METRICS)
 def test_given_metric_is_optimized_by_median_when_model_predicts_then_median_is_pasted_to_mean_forecast(metric_name):
     eval_metric = check_get_evaluation_metric(metric_name)


### PR DESCRIPTION
*Issue #, if available:*

#3878

*Description of changes:*

RMSLE is a forecast error metric popular with some Kaggle competitions, that is specifically insensitive to effects of scale and trends and has an asymmetric penalty for overprediction. For example, the "getting started" Sales Prediction competition uses RMSLE. This PR includes RMSLE to AG-TS.

Discussion points: 
- [x] the current implementation "clips" predictions to 0. This may not be an assumption we would like to make. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
