### PR TITLE
[AutoMM][CI] Capping scikit-learn to avoid HPO test failure

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -19,7 +19,7 @@ DEPENDENT_PACKAGES = {
     "boto3": ">=1.10,<2",  # <2 because unlikely to introduce breaking changes in minor releases. >=1.10 because 1.10 is 3 years old, no need to support older
     "numpy": ">=1.21,<1.29",  # "<{N+3}" upper cap, where N is the latest released minor version, assuming no warnings using N
     "pandas": ">=2.0.0,<2.2.0",  # "<{N+1}" upper cap
-    "scikit-learn": ">=1.3.0,<1.4.1",  # "<{N+2}" upper cap
+    "scikit-learn": ">=1.3.0,<1.4.1",  # "<{N+1}" upper cap, capping to micro version as AutoMM HPO tests fail on upgrading to higher verison 
     "scipy": ">=1.5.4,<1.13",  # "<{N+2}" upper cap
     "psutil": ">=5.7.3,<6",  # Major version cap
     "s3fs": ">=2023.1,<2025",  # Yearly cap

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -19,7 +19,7 @@ DEPENDENT_PACKAGES = {
     "boto3": ">=1.10,<2",  # <2 because unlikely to introduce breaking changes in minor releases. >=1.10 because 1.10 is 3 years old, no need to support older
     "numpy": ">=1.21,<1.29",  # "<{N+3}" upper cap, where N is the latest released minor version, assuming no warnings using N
     "pandas": ">=2.0.0,<2.2.0",  # "<{N+1}" upper cap
-    "scikit-learn": ">=1.3.0,<1.4.1",  # "<{N+1}" upper cap, capping to micro version as AutoMM HPO tests fail on upgrading to higher verison
+    "scikit-learn": ">=1.3.0,<1.4.1",  # "<{N+1}" upper cap, capping to micro version as AutoMM HPO tests fail on upgrading to higher version
     "scipy": ">=1.5.4,<1.13",  # "<{N+2}" upper cap
     "psutil": ">=5.7.3,<6",  # Major version cap
     "s3fs": ">=2023.1,<2025",  # Yearly cap

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -19,7 +19,7 @@ DEPENDENT_PACKAGES = {
     "boto3": ">=1.10,<2",  # <2 because unlikely to introduce breaking changes in minor releases. >=1.10 because 1.10 is 3 years old, no need to support older
     "numpy": ">=1.21,<1.29",  # "<{N+3}" upper cap, where N is the latest released minor version, assuming no warnings using N
     "pandas": ">=2.0.0,<2.2.0",  # "<{N+1}" upper cap
-    "scikit-learn": ">=1.3.0,<1.4.1",  # "<{N+1}" upper cap, capping to micro version as AutoMM HPO tests fail on upgrading to higher verison 
+    "scikit-learn": ">=1.3.0,<1.4.1",  # "<{N+1}" upper cap, capping to micro version as AutoMM HPO tests fail on upgrading to higher verison
     "scipy": ">=1.5.4,<1.13",  # "<{N+2}" upper cap
     "psutil": ">=5.7.3,<6",  # Major version cap
     "s3fs": ">=2023.1,<2025",  # Yearly cap
@@ -120,11 +120,7 @@ def default_setup_args(*, version, submodule):
         zip_safe=True,
         include_package_data=True,
         python_requires=PYTHON_REQUIRES,
-        package_data={
-            AUTOGLUON: [
-                "LICENSE",
-            ]
-        },
+        package_data={AUTOGLUON: ["LICENSE"]},
         classifiers=[
             development_status,
             "Intended Audience :: Education",

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -19,7 +19,7 @@ DEPENDENT_PACKAGES = {
     "boto3": ">=1.10,<2",  # <2 because unlikely to introduce breaking changes in minor releases. >=1.10 because 1.10 is 3 years old, no need to support older
     "numpy": ">=1.21,<1.29",  # "<{N+3}" upper cap, where N is the latest released minor version, assuming no warnings using N
     "pandas": ">=2.0.0,<2.2.0",  # "<{N+1}" upper cap
-    "scikit-learn": ">=1.3.0,<1.5",  # "<{N+2}" upper cap
+    "scikit-learn": ">=1.3.0,<1.4.1",  # "<{N+2}" upper cap
     "scipy": ">=1.5.4,<1.13",  # "<{N+2}" upper cap
     "psutil": ">=5.7.3,<6",  # Major version cap
     "s3fs": ">=2023.1,<2025",  # Yearly cap


### PR DESCRIPTION
*Description of changes:*
Recently `scikit-learn` released a new version 1.4.1.post1 on 16th Feb 2024.
This release somehow interferes with Ray and causes a failure of all tests under `test_hpo.py`.
The fix for now is to cap the version of `scikit-learn` that is installed until further investigation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
