### PR TITLE
Fix windows python 3.11 issue by removing ray

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -5,6 +5,8 @@ import importlib.util
 import os
 
 from setuptools import setup
+import sys
+import platform
 
 filepath = os.path.abspath(os.path.dirname(__file__))
 filepath_import = os.path.join(filepath, "..", "core", "src", "autogluon", "core", "_setup_utils.py")
@@ -45,18 +47,23 @@ install_requires = (
     ]
 )
 
-extras_require = {
-    "ray": [
-        "ray[default]>=2.6.3,<2.7",
-        "async-timeout",
-    ],
-    "raytune": [
-        "ray[default,tune]>=2.6.3,<2.7",
-        # TODO: consider alternatives as hyperopt is not actively maintained.
-        "hyperopt>=0.2.7,<0.2.8",  # This is needed for the bayes search to work.
-        # 'GPy>=1.10.0,<1.11.0'  # TODO: Enable this once PBT/PB2 are supported by ray lightning
-    ],
-}
+# Check for Windows and Python 3.11
+is_windows_and_py311 = platform.system().lower() == "windows" and sys.version_info.major == 3 and sys.version_info.minor == 11
+if not is_windows_and_py311:
+    extras_require = {
+        "ray": [
+            "ray[default]>=2.6.3,<2.7",
+        ],
+        "raytune": [
+            "ray[default,tune]>=2.6.3,<2.7",
+            # TODO: consider alternatives as hyperopt is not actively maintained.
+            "hyperopt>=0.2.7,<0.2.8",  # This is needed for the bayes search to work.
+            # 'GPy>=1.10.0,<1.11.0'  # TODO: Enable this once PBT/PB2 are supported by ray lightning
+        ],
+    }
+else:
+    # we don't install ray and raytune on Windows with Python 3.11 due to issue https://github.com/autogluon/autogluon/issues/3807
+    extras_require = {}
 
 tests_require = [
     "pytest",

--- a/core/setup.py
+++ b/core/setup.py
@@ -75,7 +75,8 @@ tests_require = [
 all_requires = []
 
 for extra_package in ["ray", "raytune"]:
-    all_requires += extras_require[extra_package]
+    if extra_package in extras_require:
+        all_requires += extras_require[extra_package]
 tests_require = list(set(tests_require))
 all_requires = list(set(all_requires))
 extras_require["tests"] = tests_require

--- a/core/setup.py
+++ b/core/setup.py
@@ -3,10 +3,10 @@
 # This code block is a HACK (!), but is necessary to avoid code duplication. Do NOT alter these lines.
 import importlib.util
 import os
+import platform
+import sys
 
 from setuptools import setup
-import sys
-import platform
 
 filepath = os.path.abspath(os.path.dirname(__file__))
 filepath_import = os.path.join(filepath, "..", "core", "src", "autogluon", "core", "_setup_utils.py")

--- a/core/setup.py
+++ b/core/setup.py
@@ -3,8 +3,6 @@
 # This code block is a HACK (!), but is necessary to avoid code duplication. Do NOT alter these lines.
 import importlib.util
 import os
-import platform
-import sys
 
 from setuptools import setup
 

--- a/core/setup.py
+++ b/core/setup.py
@@ -47,23 +47,20 @@ install_requires = (
     ]
 )
 
-# Check for Windows and Python 3.11
-is_windows_and_py311 = platform.system().lower() == "windows" and sys.version_info.major == 3 and sys.version_info.minor == 11
-if not is_windows_and_py311:
-    extras_require = {
+
+extras_require = {
         "ray": [
-            "ray[default]>=2.6.3,<2.7",
+            #TODO: remove this once ray release the support on windows and Python 3.11
+            "ray[default]>=2.6.3,<2.7; sys_platform != 'win32' or python_version < '3.11'",
         ],
         "raytune": [
-            "ray[default,tune]>=2.6.3,<2.7",
+            #TODO: remove this once ray release the support on windows and Python 3.11
+            "ray[default,tune]>=2.6.3,<2.7; sys_platform != 'win32' or python_version < '3.11'", 
             # TODO: consider alternatives as hyperopt is not actively maintained.
             "hyperopt>=0.2.7,<0.2.8",  # This is needed for the bayes search to work.
             # 'GPy>=1.10.0,<1.11.0'  # TODO: Enable this once PBT/PB2 are supported by ray lightning
         ],
     }
-else:
-    # we don't install ray and raytune on Windows with Python 3.11 due to issue https://github.com/autogluon/autogluon/issues/3807
-    extras_require = {}
 
 tests_require = [
     "pytest",

--- a/core/setup.py
+++ b/core/setup.py
@@ -49,18 +49,18 @@ install_requires = (
 
 
 extras_require = {
-        "ray": [
-            #TODO: remove this once ray release the support on windows and Python 3.11
-            "ray[default]>=2.6.3,<2.7; sys_platform != 'win32' or python_version < '3.11'",
-        ],
-        "raytune": [
-            #TODO: remove this once ray release the support on windows and Python 3.11
-            "ray[default,tune]>=2.6.3,<2.7; sys_platform != 'win32' or python_version < '3.11'", 
-            # TODO: consider alternatives as hyperopt is not actively maintained.
-            "hyperopt>=0.2.7,<0.2.8",  # This is needed for the bayes search to work.
-            # 'GPy>=1.10.0,<1.11.0'  # TODO: Enable this once PBT/PB2 are supported by ray lightning
-        ],
-    }
+    "ray": [
+        # TODO: remove this once ray release the support on windows and Python 3.11
+        "ray[default]>=2.6.3,<2.7; sys_platform != 'win32' or python_version < '3.11'",
+    ],
+    "raytune": [
+        # TODO: remove this once ray release the support on windows and Python 3.11
+        "ray[default,tune]>=2.6.3,<2.7; sys_platform != 'win32' or python_version < '3.11'",
+        # TODO: consider alternatives as hyperopt is not actively maintained.
+        "hyperopt>=0.2.7,<0.2.8",  # This is needed for the bayes search to work.
+        # 'GPy>=1.10.0,<1.11.0'  # TODO: Enable this once PBT/PB2 are supported by ray lightning
+    ],
+}
 
 tests_require = [
     "pytest",


### PR DESCRIPTION
*Issue #, if available:*

To fix AutoGluon installation [issue](https://github.com/autogluon/autogluon/issues/3807) on windows with Python 3.11

*Description of changes:*
Currently the workaround is not to install ray till ray release a version which support windows installation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
