### PR TITLE
[timeseries] Ensure that all metrics handle missing values in the target

### DIFF
--- a/timeseries/src/autogluon/timeseries/metrics/abstract.py
+++ b/timeseries/src/autogluon/timeseries/metrics/abstract.py
@@ -115,10 +115,10 @@ class TimeSeriesScorer:
         ----------
         data_future : TimeSeriesDataFrame
             Actual values of the time series during the forecast horizon (``prediction_length`` values for each time
-            series in the dataset). This data frame is guaranteed to have the same index as ``predictions``.
+            series in the dataset). Must have the same index as ``predictions``.
         predictions : TimeSeriesDataFrame
             Data frame with predictions for the forecast horizon. Contain columns "mean" (point forecast) and the
-            columns corresponding to each of the quantile levels.
+            columns corresponding to each of the quantile levels. Must have the same index as ``data_future``.
         target : str, default = "target"
             Name of the column in ``data_future`` that contains the target time series.
 

--- a/timeseries/src/autogluon/timeseries/metrics/abstract.py
+++ b/timeseries/src/autogluon/timeseries/metrics/abstract.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -159,9 +159,9 @@ class TimeSeriesScorer:
         return self.optimum - self.score(*args, **kwargs)
 
     @staticmethod
-    def _safemean(series: pd.Series) -> float:
-        """Compute mean of an pd.Series, ignoring inf, -inf and nan values."""
-        return np.nanmean(series.replace([np.inf, -np.inf], np.nan).values)
+    def _safemean(array: Union[np.ndarray, pd.Series]) -> float:
+        """Compute mean of a numpy array-like object, ignoring inf, -inf and nan values."""
+        return np.mean(array[np.isfinite(array)])
 
     @staticmethod
     def _get_point_forecast_score_inputs(

--- a/timeseries/src/autogluon/timeseries/metrics/abstract.py
+++ b/timeseries/src/autogluon/timeseries/metrics/abstract.py
@@ -76,6 +76,7 @@ class TimeSeriesScorer:
         data_past = data.slice_by_timestep(None, -prediction_length)
         data_future = data.slice_by_timestep(-prediction_length, None)
 
+        assert not predictions.isna().any().any(), "Predictions contain NaN values."
         assert (predictions.num_timesteps_per_item() == prediction_length).all()
         assert data_future.index.equals(predictions.index), "Prediction and data indices do not match."
 

--- a/timeseries/src/autogluon/timeseries/metrics/point.py
+++ b/timeseries/src/autogluon/timeseries/metrics/point.py
@@ -247,8 +247,11 @@ class MASE(TimeSeriesScorer):
             raise AssertionError("Call `save_past_metrics` before `compute_metric`")
 
         num_items = len(self._past_abs_seasonal_error)
-        mae_per_item = np.abs(y_true.values - y_pred.values).reshape([num_items, -1])  # [num_items, prediction_length]
-        return np.nanmean(mae_per_item / self._past_abs_seasonal_error.values[:, None])
+        # Reshape MAE values into [num_items, prediction_length] to normalize per item without groupby
+        mae_reshaped = np.abs(y_true.values - y_pred.values).reshape([num_items, -1])
+        # We assume that items are in the same order in both arrays because predictor sorts item_ids
+        mase_per_item = mae_reshaped / self._past_abs_seasonal_error.values[:, None]
+        return np.nanmean(mase_per_item)
 
 
 class RMSSE(TimeSeriesScorer):

--- a/timeseries/src/autogluon/timeseries/metrics/point.py
+++ b/timeseries/src/autogluon/timeseries/metrics/point.py
@@ -249,9 +249,8 @@ class MASE(TimeSeriesScorer):
         num_items = len(self._past_abs_seasonal_error)
         # Reshape MAE values into [num_items, prediction_length] to normalize per item without groupby
         mae_reshaped = np.abs(y_true.values - y_pred.values).reshape([num_items, -1])
-        # We assume that items are in the same order in both arrays because predictor sorts item_ids
-        mase_per_item = mae_reshaped / self._past_abs_seasonal_error.values[:, None]
-        return np.nanmean(mase_per_item)
+        # We assume that items are in the same order in both arrays because predictor sorts by item_id
+        return self._safemean(mae_reshaped / self._past_abs_seasonal_error.values[:, None])
 
 
 class RMSSE(TimeSeriesScorer):

--- a/timeseries/src/autogluon/timeseries/metrics/point.py
+++ b/timeseries/src/autogluon/timeseries/metrics/point.py
@@ -306,7 +306,7 @@ class RMSSE(TimeSeriesScorer):
         if self._past_squared_seasonal_error is None:
             raise AssertionError("Call `save_past_metrics` before `compute_metric`")
 
-        num_items = len(self._past_abs_seasonal_error)
+        num_items = len(self._past_squared_seasonal_error)
         # Reshape squared errors into [num_items, prediction_length] to normalize per item without groupby
         squared_errors = ((y_true.values - y_pred.values) ** 2.0).reshape([num_items, -1])
         # We assume that items are in the same order in both arrays because predictor sorts by item_id

--- a/timeseries/src/autogluon/timeseries/metrics/point.py
+++ b/timeseries/src/autogluon/timeseries/metrics/point.py
@@ -246,8 +246,9 @@ class MASE(TimeSeriesScorer):
         if self._past_abs_seasonal_error is None:
             raise AssertionError("Call `save_past_metrics` before `compute_metric`")
 
-        mae_per_item = (y_true - y_pred).abs().groupby(level=ITEMID, sort=False).mean()
-        return self._safemean(mae_per_item / self._past_abs_seasonal_error)
+        num_items = len(self._past_abs_seasonal_error)
+        mae_per_item = np.abs(y_true.values - y_pred.values).reshape([num_items, -1])  # [num_items, prediction_length]
+        return np.nanmean(mae_per_item / self._past_abs_seasonal_error.values[:, None])
 
 
 class RMSSE(TimeSeriesScorer):

--- a/timeseries/src/autogluon/timeseries/metrics/point.py
+++ b/timeseries/src/autogluon/timeseries/metrics/point.py
@@ -248,7 +248,6 @@ class MASE(TimeSeriesScorer):
         num_items = len(self._past_abs_seasonal_error)
         # Reshape abs errors into [num_items, prediction_length] to normalize per item without groupby
         abs_errors = np.abs(y_true.values - y_pred.values).reshape([num_items, -1])
-        # We assume that items are in the same order in both arrays because predictor sorts by item_id
         return self._safemean(abs_errors / self._past_abs_seasonal_error.values[:, None])
 
 
@@ -309,7 +308,6 @@ class RMSSE(TimeSeriesScorer):
         num_items = len(self._past_squared_seasonal_error)
         # Reshape squared errors into [num_items, prediction_length] to normalize per item without groupby
         squared_errors = ((y_true.values - y_pred.values) ** 2.0).reshape([num_items, -1])
-        # We assume that items are in the same order in both arrays because predictor sorts by item_id
         return np.sqrt(self._safemean(squared_errors / self._past_squared_seasonal_error.values[:, None]))
 
 

--- a/timeseries/src/autogluon/timeseries/metrics/quantile.py
+++ b/timeseries/src/autogluon/timeseries/metrics/quantile.py
@@ -41,8 +41,8 @@ class WQL(TimeSeriesScorer):
         values_pred = q_pred.values  # shape [N, len(quantile_levels)]
 
         return 2 * np.mean(
-            np.abs((values_true - values_pred) * ((values_true <= values_pred) - quantile_levels)).sum(axis=0)
-            / np.abs(values_true).sum()
+            np.nansum(np.abs((values_true - values_pred) * ((values_true <= values_pred) - quantile_levels)), axis=0)
+            / np.nansum(np.abs(values_true))
         )
 
 

--- a/timeseries/src/autogluon/timeseries/metrics/quantile.py
+++ b/timeseries/src/autogluon/timeseries/metrics/quantile.py
@@ -106,5 +106,4 @@ class SQL(TimeSeriesScorer):
         num_items = len(self._past_abs_seasonal_error)
         # Reshape quantile losses values into [num_items, prediction_length] to normalize per item without groupby
         quantile_losses = ql.reshape([num_items, -1])
-        # We assume that items are in the same order in both arrays because predictor sorts by item_id
         return 2 * self._safemean(quantile_losses / self._past_abs_seasonal_error.values[:, None])

--- a/timeseries/src/autogluon/timeseries/metrics/quantile.py
+++ b/timeseries/src/autogluon/timeseries/metrics/quantile.py
@@ -3,7 +3,7 @@ from typing import Optional
 import numpy as np
 import pandas as pd
 
-from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TimeSeriesDataFrame
+from autogluon.timeseries.dataset.ts_dataframe import TimeSeriesDataFrame
 
 from .abstract import TimeSeriesScorer
 from .utils import _in_sample_abs_seasonal_error
@@ -104,7 +104,7 @@ class SQL(TimeSeriesScorer):
 
         ql = np.abs((q_pred - values_true) * ((values_true <= q_pred) - quantile_levels)).mean(axis=1)
         num_items = len(self._past_abs_seasonal_error)
-        # Reshape QL values into [num_items, prediction_length] to normalize per item without groupby
-        ql_reshaped = ql.reshape([num_items, -1])
+        # Reshape quantile losses values into [num_items, prediction_length] to normalize per item without groupby
+        quantile_losses = ql.reshape([num_items, -1])
         # We assume that items are in the same order in both arrays because predictor sorts by item_id
-        return 2 * self._safemean(ql_reshaped / self._past_abs_seasonal_error.values[:, None])
+        return 2 * self._safemean(quantile_losses / self._past_abs_seasonal_error.values[:, None])

--- a/timeseries/tests/unittests/common.py
+++ b/timeseries/tests/unittests/common.py
@@ -199,7 +199,7 @@ class CustomMetric(TimeSeriesScorer):
 
 def get_prediction_for_df(data, prediction_length=5):
     forecast_index = get_forecast_horizon_index_ts_dataframe(data, prediction_length=prediction_length)
-    columns = ["mean", "0.1", "0.5", "0.9"]
+    columns = ["mean", "0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9"]
     return TimeSeriesDataFrame(
         pd.DataFrame(np.random.normal(size=[len(forecast_index), len(columns)]), index=forecast_index, columns=columns)
     )

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -1,4 +1,5 @@
 """Unit tests and utils common to all models"""
+
 import itertools
 import shutil
 import sys
@@ -112,8 +113,8 @@ def test_when_score_called_then_model_receives_truncated_data(model_class, predi
     with mock.patch.object(model, "predict") as patch_method:
         # Mock breaks the internals of the `score` method
         try:
-            _ = model.score(DUMMY_TS_DATAFRAME)
-        except AttributeError:
+            model.score(DUMMY_TS_DATAFRAME)
+        except AssertionError:
             pass
 
         (call_df,) = patch_method.call_args[0]

--- a/timeseries/tests/unittests/test_metrics.py
+++ b/timeseries/tests/unittests/test_metrics.py
@@ -312,8 +312,8 @@ def test_given_metric_is_optimized_by_median_when_model_predicts_then_median_is_
 def test_when_perfect_predictions_passed_to_metric_then_score_equals_optimum(metric_name):
     prediction_length = 5
     eval_metric = check_get_evaluation_metric(metric_name)
-    data = DUMMY_TS_DATAFRAME.copy()
-    predictions = data.slice_by_timestep(-prediction_length, None).rename(columns={"target": "mean"})
+    data = DUMMY_TS_DATAFRAME_WITH_MISSING.copy()
+    predictions = data.slice_by_timestep(-prediction_length, None).rename(columns={"target": "mean"}).fillna(0.0)
     for q in ["0.1", "0.4", "0.9"]:
         predictions[q] = predictions["mean"]
     score = eval_metric.score(data, predictions, prediction_length=prediction_length)
@@ -324,8 +324,8 @@ def test_when_perfect_predictions_passed_to_metric_then_score_equals_optimum(met
 def test_when_better_predictions_passed_to_metric_then_score_improves(metric_name):
     prediction_length = 5
     eval_metric = check_get_evaluation_metric(metric_name)
-    data = DUMMY_TS_DATAFRAME.copy()
-    predictions = data.slice_by_timestep(-prediction_length, None).rename(columns={"target": "mean"})
+    data = DUMMY_TS_DATAFRAME_WITH_MISSING.copy()
+    predictions = data.slice_by_timestep(-prediction_length, None).rename(columns={"target": "mean"}).fillna(0.0)
     for q in ["0.1", "0.4", "0.9"]:
         predictions[q] = predictions["mean"]
     good_score = eval_metric.score(data, predictions + 1, prediction_length=prediction_length)

--- a/timeseries/tests/unittests/test_metrics.py
+++ b/timeseries/tests/unittests/test_metrics.py
@@ -24,24 +24,29 @@ from autogluon.timeseries.metrics import AVAILABLE_METRICS, DEFAULT_METRIC_NAME,
 from autogluon.timeseries.metrics.utils import _in_sample_abs_seasonal_error, _in_sample_squared_seasonal_error
 from autogluon.timeseries.models.gluonts.abstract_gluonts import AbstractGluonTSModel
 
-from .common import DUMMY_TS_DATAFRAME, get_data_frame_with_item_index
+from .common import (
+    DUMMY_TS_DATAFRAME,
+    DUMMY_TS_DATAFRAME_WITH_MISSING,
+    get_data_frame_with_item_index,
+    get_prediction_for_df,
+)
 
 pytestmark = pytest.mark.filterwarnings("ignore")
 
 
-def get_ag_and_gts_metrics() -> List[Tuple[str, str, GluonTSMetric]]:
-    # Each entry is a tuple (ag_metric_name, gts_metric_name, gts_metric_object)
+def get_ag_and_gts_metrics() -> List[Tuple[str, GluonTSMetric]]:
+    # Each entry is a tuple (ag_metric_name, gts_metric_object)
     default_quantile_levels = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
     # Metric that have different names in AutoGluon and GluonTS
     ag_and_gts_metrics = [
-        ("WQL", "mean_weighted_sum_quantile_loss", MeanWeightedSumQuantileLoss(default_quantile_levels)),
-        ("SQL", "average_mean_scaled_quantile_loss", AverageMeanScaledQuantileLoss(default_quantile_levels)),
-        ("WAPE", "ND[mean]", ND("mean")),
+        ("WQL", MeanWeightedSumQuantileLoss(default_quantile_levels)),
+        ("SQL", AverageMeanScaledQuantileLoss(default_quantile_levels)),
+        ("WAPE", ND("mean")),
     ]
     # Metric that have same names in AutoGluon and GluonTS
     for point_metric_cls in [MAPE, SMAPE, MSE, RMSE, MASE, MAE]:
         name = str(point_metric_cls.__name__)
-        ag_and_gts_metrics.append((name, f"{name}[mean]", point_metric_cls("mean")))
+        ag_and_gts_metrics.append((name, point_metric_cls("mean")))
     return ag_and_gts_metrics
 
 
@@ -100,9 +105,7 @@ def to_gluonts_test_set(data, prediction_length):
     return test_template.generate_instances(prediction_length, windows=1)
 
 
-def check_gluonts_parity(
-    ag_metric_name, gts_metric_name, gts_metric, data, model, zero_forecast=False, equal_nan=False
-):
+def check_gluonts_parity(ag_metric_name, gts_metric, data, model, zero_forecast=False, equal_nan=False):
     data_train, data_test = data.train_test_split(model.prediction_length)
     forecast_df = model.predict(data_train)
     forecast_df["mean"] = forecast_df["0.5"]
@@ -126,26 +129,22 @@ def check_gluonts_parity(
     assert np.isclose(gts_value, ag_value, atol=1e-5, equal_nan=equal_nan)
 
 
-@pytest.mark.parametrize("ag_metric_name, gts_metric_name, gts_metric", AG_AND_GTS_METRICS)
-def test_when_metric_evaluated_then_output_equal_to_gluonts(
-    ag_metric_name, gts_metric_name, gts_metric, deepar_trained
-):
+@pytest.mark.parametrize("ag_metric_name, gts_metric", AG_AND_GTS_METRICS)
+def test_when_metric_evaluated_then_output_equal_to_gluonts(ag_metric_name, gts_metric, deepar_trained):
     check_gluonts_parity(
         ag_metric_name,
-        gts_metric_name,
         gts_metric,
         data=DUMMY_TS_DATAFRAME,
         model=deepar_trained,
     )
 
 
-@pytest.mark.parametrize("ag_metric_name, gts_metric_name, gts_metric", AG_AND_GTS_METRICS)
+@pytest.mark.parametrize("ag_metric_name, gts_metric", AG_AND_GTS_METRICS)
 def test_given_all_zero_data_when_metric_evaluated_then_output_equal_to_gluonts(
-    ag_metric_name, gts_metric_name, gts_metric, deepar_trained_zero_data
+    ag_metric_name, gts_metric, deepar_trained_zero_data
 ):
     check_gluonts_parity(
         ag_metric_name,
-        gts_metric_name,
         gts_metric,
         data=DUMMY_TS_DATAFRAME.copy() * 0,
         model=deepar_trained_zero_data,
@@ -153,18 +152,48 @@ def test_given_all_zero_data_when_metric_evaluated_then_output_equal_to_gluonts(
     )
 
 
-@pytest.mark.parametrize("ag_metric_name, gts_metric_name, gts_metric", AG_AND_GTS_METRICS)
+@pytest.mark.parametrize("ag_metric_name, gts_metric", AG_AND_GTS_METRICS)
 def test_given_zero_forecasts_when_metric_evaluated_then_output_equal_to_gluonts(
-    ag_metric_name, gts_metric_name, gts_metric, deepar_trained
+    ag_metric_name, gts_metric, deepar_trained
 ):
     check_gluonts_parity(
         ag_metric_name,
-        gts_metric_name,
         gts_metric,
         data=DUMMY_TS_DATAFRAME,
         model=deepar_trained,
         zero_forecast=True,
     )
+
+
+@pytest.mark.parametrize("ag_metric_name, gts_metric", AG_AND_GTS_METRICS)
+def test_given_missing_target_values_when_metric_evaluated_then_output_equal_to_gluonts(
+    ag_metric_name, gts_metric, deepar_trained
+):
+    check_gluonts_parity(
+        ag_metric_name,
+        gts_metric,
+        data=DUMMY_TS_DATAFRAME_WITH_MISSING,
+        model=deepar_trained,
+    )
+
+
+@pytest.mark.parametrize("metric_cls", AVAILABLE_METRICS.values())
+def test_given_missing_target_values_when_metric_evaluated_then_metric_is_not_nan(metric_cls):
+    prediction_length = 5
+    train, test = DUMMY_TS_DATAFRAME_WITH_MISSING.train_test_split(prediction_length)
+    predictions = get_prediction_for_df(train, prediction_length)
+    score = metric_cls()(data=test, predictions=predictions, prediction_length=prediction_length)
+    assert not pd.isna(score)
+
+
+@pytest.mark.parametrize("metric_cls", AVAILABLE_METRICS.values())
+def test_given_predictions_contain_nan_when_metric_evaluated_then_exception_is_raised(metric_cls):
+    prediction_length = 5
+    train, test = DUMMY_TS_DATAFRAME_WITH_MISSING.train_test_split(prediction_length)
+    predictions = get_prediction_for_df(train, prediction_length)
+    predictions.iloc[[3, 5]] = float("nan")
+    with pytest.raises(AssertionError, match="Predictions contain NaN values"):
+        metric_cls()(data=test, predictions=predictions, prediction_length=prediction_length)
 
 
 def test_available_metrics_have_coefficients():


### PR DESCRIPTION
*Issue #, if available:* #3886

*Description of changes:*
- Raise exception in `TimeSeriesScorer` if predictions contain NaN values
- Update implementation of WQL metric to handle NaN values in target column
- Update our implementation of MASE and SQL metrics to align with GluonTS in case missing values are present
  - As part of this update, we moved from `pandas + groupby` to `numpy + reshape`, which results in faster metric computations & lower fit time for WeightedEnsemble (for M4 Monthly with 48K time series, ensemble fit time decreases 200s -> 160s)
  - Update the RMSSE implementation to follow the same missing values handling logic
- Add new tests & update some old tests to use dataframes with missing values

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
