### PR TITLE
[timeseries] Fix path and device bugs

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -204,7 +204,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
             model = load_pkl.load(path=os.path.join(path, cls.model_file_name), verbose=verbose)
             if reset_paths:
                 model.set_contexts(path)
-            model.gts_predictor = PyTorchPredictor.deserialize(Path(path) / cls.gluonts_model_path)
+            model.gts_predictor = PyTorchPredictor.deserialize(Path(path) / cls.gluonts_model_path, device="auto")
         return model
 
     def _get_hpo_backend(self):

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -1197,7 +1197,7 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
     def plot(
         self,
         data: Union[TimeSeriesDataFrame, pd.DataFrame, Path, str],
-        predictions: Optional[Union[TimeSeriesDataFrame, pd.DataFrame, Path, str]] = None,
+        predictions: Optional[TimeSeriesDataFrame] = None,
         quantile_levels: Optional[List[float]] = None,
         item_ids: Optional[List[Union[str, int]]] = None,
         max_num_item_ids: int = 8,

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -522,15 +522,17 @@ def test_given_data_is_in_dataframe_format_then_predictor_works(temp_model_path)
     assert isinstance(predictions, TimeSeriesDataFrame)
 
 
-def test_given_data_is_in_str_format_then_predictor_works(temp_model_path):
+@pytest.mark.parametrize("path_format", [str, Path])
+def test_given_data_is_in_str_format_then_predictor_works(temp_model_path, path_format):
     df = pd.DataFrame(DUMMY_TS_DATAFRAME.reset_index())
     with tempfile.NamedTemporaryFile("w") as data_path:
+        data_path = path_format(str(data_path))
         df.to_csv(data_path, index=False)
         predictor = TimeSeriesPredictor(path=temp_model_path)
-        predictor.fit(df, hyperparameters={"Naive": {}})
-        predictor.leaderboard(df)
-        predictor.evaluate(df)
-        predictions = predictor.predict(df)
+        predictor.fit(data_path, hyperparameters={"Naive": {}})
+        predictor.leaderboard(data_path)
+        predictor.evaluate(data_path)
+        predictions = predictor.predict(data_path)
         assert isinstance(predictions, TimeSeriesDataFrame)
 
 


### PR DESCRIPTION
*Description of changes:*
- Fix a bug, where GluonTS models trained on GPU could not be loaded on a CPU-only machine
- Fix a bug, where passing path to data as a `str` raised an exception
  - Fix the respective test that was supposed to catch this bug
- Allow passing the path to data as a `pathlib.Path` when using `TimeSeriesPredictor`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
