### PR TITLE
[core] move transformers to setup_utils, bump dependency version

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -30,6 +30,8 @@ DEPENDENT_PACKAGES = {
     "lightning": ">=2.1,<2.2",  # Major version cap
     "pytorch_lightning": ">=2.1,<2.2",  # Major version cap, capping `lightning` does not cap `pytorch_lightning`!
     "async_timeout": ">=4.0,<5",  # Major version cap
+    "transformers[sentencepiece]": ">=4.36.0,<4.39.0",
+    "accelerate": ">=0.21.0,<0.22.0",
 }
 if LITE_MODE:
     DEPENDENT_PACKAGES = {package: version for package, version in DEPENDENT_PACKAGES.items() if package not in ["psutil", "Pillow", "timm"]}

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -30,7 +30,7 @@ DEPENDENT_PACKAGES = {
     "lightning": ">=2.1,<2.2",  # Major version cap
     "pytorch_lightning": ">=2.1,<2.2",  # Major version cap, capping `lightning` does not cap `pytorch_lightning`!
     "async_timeout": ">=4.0,<5",  # Major version cap
-    "transformers[sentencepiece]": ">=4.36.0,<4.39.0",
+    "transformers[sentencepiece]": ">=4.38.0,<4.39.0",
     "accelerate": ">=0.21.0,<0.22.0",
 }
 if LITE_MODE:

--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -29,12 +29,12 @@ install_requires = [
     "boto3",  # version range defined in `core/_setup_utils.py`
     "torch",  # version range defined in `core/_setup_utils.py`
     "lightning",  # version range defined in `core/_setup_utils.py`
+    "transformers[sentencepiece]",  # version range defined in `core/_setup_utils.py`
+    "accelerate",  # version range defined in `core/_setup_utils.py`
     "requests>=2.21,<3",
     "jsonschema>=4.14,<4.18",
     "seqeval>=1.2.2,<1.3.0",
     "evaluate>=0.4.0,<0.5.0",
-    "accelerate>=0.21.0,<0.22.0",
-    "transformers[sentencepiece]>=4.31.0,<4.32.0",
     "timm>=0.9.5,<0.10.0",
     "torchvision>=0.16.0,<0.17.0",
     "scikit-image>=0.19.1,<0.21.0",

--- a/multimodal/src/autogluon/multimodal/data/process_image.py
+++ b/multimodal/src/autogluon/multimodal/data/process_image.py
@@ -1,4 +1,3 @@
-import ast
 import logging
 import warnings
 from io import BytesIO
@@ -7,7 +6,6 @@ from typing import Callable, Dict, List, Optional, Union
 import numpy as np
 import PIL
 import torch
-from omegaconf import ListConfig
 from PIL import ImageFile
 from torch import nn
 from torchvision import transforms
@@ -21,19 +19,8 @@ try:
 except ImportError:
     BICUBIC = PIL.Image.BICUBIC
 
-from ..constants import (
-    AUTOMM,
-    CLIP,
-    CLIP_IMAGE_MEAN,
-    CLIP_IMAGE_STD,
-    COLUMN,
-    IMAGE,
-    IMAGE_BASE64_STR,
-    IMAGE_BYTEARRAY,
-    IMAGE_PATH,
-    IMAGE_VALID_NUM,
-    TIMM_IMAGE,
-)
+from ..constants import CLIP, COLUMN, IMAGE, IMAGE_BASE64_STR, IMAGE_BYTEARRAY, IMAGE_VALID_NUM, TIMM_IMAGE
+from ..models.clip import CLIPForImageText
 from ..models.timm_image import TimmAutoModelForImagePrediction
 from .collator import PadCollator, StackCollator
 from .utils import extract_value_from_config
@@ -101,9 +88,13 @@ class ImageProcessor:
         self.size = None
         self.mean = None
         self.std = None
+        if isinstance(model, CLIPForImageText):
+            config = model.model.vision_model.config
+        else:
+            config = model.config
 
         if model is not None:
-            self.size, self.mean, self.std = self.extract_default(model.config)
+            self.size, self.mean, self.std = self.extract_default(config)
             if isinstance(model, TimmAutoModelForImagePrediction):
                 if model.support_variable_input_size() and size is not None:
                     # We have detected that the model supports using an image size that is
@@ -112,7 +103,7 @@ class ImageProcessor:
                         logger.warning(
                             f"The provided image size={size} is smaller than the default size "
                             f"of the pretrained backbone, which is {self.size}. "
-                            f"Detailed configuration of the backbone is in {model.config}. "
+                            f"Detailed configuration of the backbone is in {config}. "
                             f"You may like to double check your configuration."
                         )
                     self.size = size
@@ -120,7 +111,7 @@ class ImageProcessor:
                 logger.warning(
                     f"The model does not support using an image size that is different from the default size. "
                     f"Provided image size={size}. Default size={self.size}. "
-                    f"Detailed model configuration={model.config}. We have ignored the provided image size."
+                    f"Detailed model configuration={config}. We have ignored the provided image size."
                 )
         if self.size is None:
             if size is not None:

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -55,11 +55,12 @@ extras_require = {
         "isort>=5.10",
         "black~=23.0",
     ],
+    "chronos-cpu": [  # for faster CPU inference in pretrained models
+        "optimum[onnxruntime,openvino,nncf]>=1.17,<1.18",
+    ],
 }
 
-extras_require["all"] = [
-    "optimum[openvino,onnxruntime,nncf]>=1.17,<1.18",  # for faster CPU inference in pretrained models
-]
+extras_require["all"] = list(set.union(*(set(extras_require[extra]) for extra in ["chronos-cpu"])))
 
 install_requires = ag.get_dependency_version_ranges(install_requires)
 

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -28,6 +28,8 @@ install_requires = [
     "torch",  # version range defined in `core/_setup_utils.py`
     "lightning",  # version range defined in `core/_setup_utils.py`
     "pytorch_lightning",  # version range defined in `core/_setup_utils.py`
+    "transformers[sentencepiece]",  # version range defined in `core/_setup_utils.py`
+    "accelerate",  # version range defined in `core/_setup_utils.py`
     "statsmodels>=0.13.0,<0.15",
     "gluonts>=0.14.0,<0.15",
     "networkx",  # version range defined in `core/_setup_utils.py`
@@ -55,7 +57,9 @@ extras_require = {
     ],
 }
 
-extras_require["all"] = []
+extras_require["all"] = [
+    "optimum[openvino,onnxruntime,nncf]>=1.17,<1.18",  # for faster CPU inference in pretrained models
+]
 
 install_requires = ag.get_dependency_version_ranges(install_requires)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Chronos implementation (cf #3978) requires `transformers>=4.36`. This PR moves transformers and accelerate version ranges to `_setup_utils.py` and bumps the version. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
