### PR TITLE
DOC: Mention quadratic_kappa metric in eval_metric docs

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -85,9 +85,9 @@ class AbstractModel:
         If `eval_metric = None`, it is automatically chosen based on `problem_type`.
         Defaults to 'accuracy' for binary and multiclass classification and 'root_mean_squared_error' for regression.
         Otherwise, options for classification:
-            ['accuracy', 'balanced_accuracy', 'f1', 'f1_macro', 'f1_micro', 'f1_weighted',
-            'roc_auc', 'roc_auc_ovo_macro', 'average_precision', 'precision', 'precision_macro', 'precision_micro',
-            'precision_weighted', 'recall', 'recall_macro', 'recall_micro', 'recall_weighted', 'log_loss', 'pac_score']
+            ['accuracy', 'balanced_accuracy', 'f1', 'f1_macro', 'f1_micro', 'f1_weighted', 'roc_auc', 'roc_auc_ovo_macro',
+            'average_precision', 'precision', 'precision_macro', 'precision_micro', 'precision_weighted', 'recall',
+            'recall_macro', 'recall_micro', 'recall_weighted', 'log_loss', 'pac_score', 'quadratic_kappa']
         Options for regression:
             ['root_mean_squared_error', 'mean_squared_error', 'mean_absolute_error', 'median_absolute_error', 'r2']
         Options for quantile regression:


### PR DESCRIPTION
*Issue #, if available:*
Quadratic Kappa is an important evaluation metric used in lots of kaggle competitions. This was added in https://github.com/autogluon/autogluon/pull/1104 but the documentation [doesn't](https://auto.gluon.ai/stable/api/autogluon.tabular.TabularPredictor.html#autogluon-tabular-tabularpredictor) mention its availability as one of the `eval_metric` options inside AutoGluon.

*Description of changes:*
Add `quadratic_kappa` to the doc list of `eval_metric` options for classification.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
