### PR TITLE
[timeseries] Add option to skip model selection if only 1 model is trained

### DIFF
--- a/timeseries/src/autogluon/timeseries/configs/presets_configs.py
+++ b/timeseries/src/autogluon/timeseries/configs/presets_configs.py
@@ -1,4 +1,5 @@
 """Preset configurations for autogluon.timeseries Predictors"""
+
 from autogluon.timeseries.models.presets import get_default_hps
 
 # TODO: change default HPO settings when other HPO strategies (e.g., Ray tune) are available
@@ -11,18 +12,23 @@ TIMESERIES_PRESETS_CONFIGS = dict(
     fast_training={"hyperparameters": "very_light"},
     chronos_tiny={
         "hyperparameters": {"Chronos": {"model_path": "tiny"}},
+        "skip_model_selection": True,
     },
     chronos_mini={
         "hyperparameters": {"Chronos": {"model_path": "mini"}},
+        "skip_model_selection": True,
     },
     chronos_small={
         "hyperparameters": {"Chronos": {"model_path": "small"}},
+        "skip_model_selection": True,
     },
     chronos_base={
         "hyperparameters": {"Chronos": {"model_path": "base"}},
+        "skip_model_selection": True,
     },
     chronos_large={
         "hyperparameters": {"Chronos": {"model_path": "large", "batch_size": 8}},
+        "skip_model_selection": True,
     },
     chronos_ensemble={
         "hyperparameters": {

--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -97,6 +97,7 @@ class TimeSeriesLearner(AbstractLearner):
                 target=self.target,
                 quantile_levels=self.quantile_levels,
                 verbosity=kwargs.get("verbosity", 2),
+                skip_model_selection=kwargs.get("skip_model_selection", False),
                 enable_ensemble=kwargs.get("enable_ensemble", True),
                 metadata=self.feature_generator.covariate_metadata,
                 val_splitter=val_splitter,

--- a/timeseries/src/autogluon/timeseries/trainer/auto_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/auto_trainer.py
@@ -27,7 +27,8 @@ class AutoTimeSeriesTrainer(AbstractTimeSeriesTrainer):
             target=self.target,
             metadata=self.metadata,
             excluded_model_types=kwargs.get("excluded_model_types"),
-            multi_window=multi_window,
+            # if skip_model_selection = True, we skip backtesting
+            multi_window=multi_window and not self.skip_model_selection,
         )
 
     def fit(

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -397,6 +397,17 @@ def test_when_target_included_in_known_covariates_then_exception_is_raised(temp_
         )
 
 
+EXPECTED_FIT_SUMMARY_KEYS = [
+    "model_types",
+    "model_performance",
+    "model_best",
+    "model_paths",
+    "model_fit_times",
+    "model_pred_times",
+    "model_hyperparams",
+    "leaderboard",
+]
+
 @pytest.mark.parametrize(
     "hyperparameters, num_models",
     [
@@ -409,18 +420,8 @@ def test_when_fit_summary_is_called_then_all_keys_and_models_are_included(
 ):
     predictor = TimeSeriesPredictor(path=temp_model_path)
     predictor.fit(DUMMY_TS_DATAFRAME, hyperparameters=hyperparameters)
-    expected_keys = [
-        "model_types",
-        "model_performance",
-        "model_best",
-        "model_paths",
-        "model_fit_times",
-        "model_pred_times",
-        "model_hyperparams",
-        "leaderboard",
-    ]
     fit_summary = predictor.fit_summary()
-    for key in expected_keys:
+    for key in EXPECTED_FIT_SUMMARY_KEYS:
         assert key in fit_summary
         # All keys except model_best return a dict with results per model
         if key != "model_best":
@@ -1238,3 +1239,52 @@ def test_when_not_all_quantile_forecasts_available_then_predictor_can_plot(selec
 def test_when_predictions_for_plot_have_incorrect_format_then_exception_is_raised(predictions):
     with pytest.raises(ValueError, match="predictions must be a TimeSeriesDataFrame"):
         TimeSeriesPredictor().plot(DUMMY_TS_DATAFRAME, predictions=predictions)
+
+
+def test_given_skip_model_selection_when_multiple_models_provided_then_exception_is_raised(temp_model_path):
+    with pytest.raises(ValueError, match="a single model must be provided"):
+        TimeSeriesPredictor(path=temp_model_path).fit(
+            DUMMY_TS_DATAFRAME, skip_model_selection=True, hyperparameters={"Naive": {}, "SeasonalNaive": {}}
+        )
+
+
+def test_given_skip_model_selection_when_search_space_provided_then_exception_is_raised(temp_model_path):
+    with pytest.raises(ValueError, match="should contain no search spaces"):
+        TimeSeriesPredictor(path=temp_model_path).fit(
+            DUMMY_TS_DATAFRAME,
+            skip_model_selection=True,
+            hyperparameters={"SeasonalNaive": {"seasonal_period": space.Categorical(1, 2)}},
+            hyperparameter_tune_kwargs="auto",
+        )
+
+
+@pytest.mark.parametrize("hyperparameters", [{"RecursiveTabular": {}}, {"Chronos": {"model_path": "tiny"}}])
+@pytest.mark.parametrize("tuning_data", [None, DUMMY_TS_DATAFRAME])
+def test_given_skip_model_selection_then_predictor_can_fit_predict(temp_model_path, hyperparameters, tuning_data):
+    predictor = TimeSeriesPredictor(prediction_length=10, path=temp_model_path).fit(
+        DUMMY_TS_DATAFRAME, tuning_data=tuning_data, skip_model_selection=True, hyperparameters=hyperparameters
+    )
+    predictions = predictor.predict(DUMMY_TS_DATAFRAME)
+    assert all(predictions.item_ids == DUMMY_TS_DATAFRAME.item_ids)
+
+
+@pytest.mark.parametrize("hyperparameters", [{"RecursiveTabular": {}}, {"Chronos": {"model_path": "tiny"}}])
+def test_given_skip_model_selection_then_all_predictor_methods_work(temp_model_path, hyperparameters):
+    predictor = TimeSeriesPredictor(prediction_length=10, path=temp_model_path).fit(
+        DUMMY_TS_DATAFRAME, skip_model_selection=True, hyperparameters=hyperparameters
+    )
+
+    assert predictor.model_best is not None
+    assert isinstance(predictor.leaderboard(DUMMY_TS_DATAFRAME), pd.DataFrame)
+
+    info = predictor.info()
+    for key in EXPECTED_INFO_KEYS:
+        assert key in info
+    assert len(info["model_info"]) == 1
+
+    fit_summary = predictor.fit_summary()
+    for key in EXPECTED_FIT_SUMMARY_KEYS:
+        assert key in fit_summary
+        # All keys except model_best return a dict with results per model
+        if key != "model_best":
+            assert len(fit_summary[key]) == 1

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -408,6 +408,7 @@ EXPECTED_FIT_SUMMARY_KEYS = [
     "leaderboard",
 ]
 
+
 @pytest.mark.parametrize(
     "hyperparameters, num_models",
     [

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -1,4 +1,5 @@
 """Unit tests for trainers"""
+
 import copy
 import shutil
 import sys
@@ -585,3 +586,14 @@ def test_given_no_models_trained_during_fit_then_empty_leaderboard_returned(use_
     leaderboard = trainer.leaderboard(data=test_data)
     assert all(c in leaderboard.columns for c in expected_columns)
     assert len(leaderboard) == 0
+
+
+@pytest.mark.parametrize("skip_model_selection", [True, False])
+def test_given_skip_model_selection_when_trainer_fits_then_val_score_is_not_computed(
+    temp_model_path, skip_model_selection
+):
+    trainer = AutoTimeSeriesTrainer(path=temp_model_path, skip_model_selection=skip_model_selection)
+    trainer.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}})
+
+    model = trainer.load_model("Naive")
+    assert (model.val_score is None) == skip_model_selection


### PR DESCRIPTION
*Description of changes:*
- Add kwarg `skip_model_selection` to `TimeSeriesPredictor.fit`. It can be used if only a single model is to be trained. If set to True, model will skip computing the validation score, thereby reducing the overall fit time.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
