### PR TITLE
[timeseries] add persist logic to TimeSeriesPredictor

### DIFF
--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -251,7 +251,7 @@ class TimeSeriesLearner(AbstractLearner):
         list_of_models : List[str]
             List of models removed from memory
         """
-        unpersisted_models = self.trainer.unpersist()
+        unpersisted_models = self.load_trainer().unpersist()
         self.trainer = None
         return unpersisted_models
 

--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -228,5 +228,14 @@ class TimeSeriesLearner(AbstractLearner):
         learner_info.pop("random_state", None)
         return learner_info
 
+    def persist_trainer(self, models="all", with_ancestors=False, **kwargs) -> list:
+        """Loads models and trainer in memory so that they don't have to be loaded during predictions"""
+        self.trainer = self.load_trainer()
+        self.trainer.persist(models, with_ancestors=with_ancestors)
+
+    def unpersist_trainer(self):
+        self.trainer.unpersist()
+        self.trainer = None
+
     def refit_full(self, model: str = "all") -> Dict[str, str]:
         return self.load_trainer().refit_full(model=model)

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -415,12 +415,12 @@ class AbstractTimeSeriesModel(AbstractModel):
         hpo_executor.register_resources(self, k_fold=1, **kwargs)
         return self._hyperparameter_tune(hpo_executor=hpo_executor, **kwargs)
 
-    def persist(self) -> None:
+    def persist(self) -> "AbstractTimeSeriesModel":
         """Ask the model to persist its assets in memory, i.e., to predict with low latency. In practice
         this is used for pretrained models that have to lazy-load model parameters to device memory at
         prediction time.
         """
-        return None
+        return self
 
     def _hyperparameter_tune(
         self,

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -415,6 +415,13 @@ class AbstractTimeSeriesModel(AbstractModel):
         hpo_executor.register_resources(self, k_fold=1, **kwargs)
         return self._hyperparameter_tune(hpo_executor=hpo_executor, **kwargs)
 
+    def persist(self) -> None:
+        """Ask the model to persist its assets in memory, i.e., to predict with low latency. In practice
+        this is used for pretrained models that have to lazy-load model parameters to device memory at
+        prediction time.
+        """
+        return None
+
     def _hyperparameter_tune(
         self,
         train_data: TimeSeriesDataFrame,

--- a/timeseries/src/autogluon/timeseries/models/chronos/model.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/model.py
@@ -234,6 +234,9 @@ class ChronosModel(AbstractTimeSeriesModel):
 
         self.model_pipeline = pipeline
 
+    def persist(self) -> None:
+        self.load_model_pipeline(context_length=self.context_length or self.maximum_context_length)
+
     def _fit(
         self,
         train_data: TimeSeriesDataFrame,
@@ -283,8 +286,9 @@ class ChronosModel(AbstractTimeSeriesModel):
         with warning_filter(all_warnings=True):
             import torch
 
-            # load model pipeline to device memory
-            self.load_model_pipeline(context_length=context_length)
+            if self.model_pipeline is None:
+                # load model pipeline to device memory
+                self.load_model_pipeline(context_length=context_length)
 
             self.model_pipeline.model.eval()
             with torch.inference_mode():

--- a/timeseries/src/autogluon/timeseries/models/chronos/model.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/model.py
@@ -234,8 +234,9 @@ class ChronosModel(AbstractTimeSeriesModel):
 
         self.model_pipeline = pipeline
 
-    def persist(self) -> None:
+    def persist(self) -> "ChronosModel":
         self.load_model_pipeline(context_length=self.context_length or self.maximum_context_length)
+        return self
 
     def _fit(
         self,

--- a/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
+++ b/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
@@ -212,6 +212,11 @@ class MultiWindowBacktestingModel(AbstractTimeSeriesModel):
             most_recent_model.save()
         return save_path
 
+    def persist(self):
+        if self.most_recent_model is None:
+            raise ValueError(f"{self.name} must be fit before persisting")
+        self.most_recent_model.persist()
+
     @classmethod
     def load(
         cls, path: str, reset_paths: bool = True, load_oof: bool = False, verbose: bool = True

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -653,6 +653,7 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
         verbosity : int, optional
             If provided, overrides the ``verbosity`` value used when creating the ``TimeSeriesPredictor``. See
             documentation for :class:`~autogluon.timeseries.TimeSeriesPredictor` for more details.
+
         """
         time_start = time.time()
         if self._learner.is_fit:

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -5,7 +5,7 @@ import os
 import pprint
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union
 
 import numpy as np
 import pandas as pd
@@ -983,37 +983,46 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
                 return self._trainer.model_best
         return self._trainer.get_model_best()
 
-    def persist(self, models="best", with_ancestors=True) -> List[str]:
+    def persist(
+        self, models: Union[Literal["all", "best"], List[str]] = "best", with_ancestors: bool = True
+    ) -> List[str]:
         """Persist models in memory for reduced inference latency. This is particularly important if the models are being used for online
         inference where low latency is critical. If models are not persisted in memory, they are loaded from disk every time they are
-        asked to make predictions.
+        asked to make predictions. This is especially cumbersome for large deep learning based models which have to be loaded into
+        accelerator (e.g., GPU) memory each time.
 
         Parameters
         ----------
         models : list of str or str, default = 'best'
             Model names of models to persist.
             If 'best' then the model with the highest validation score is persisted (this is the model used for prediction by default).
-            If 'all' then all models are persisted.
-            Valid models are listed in this `predictor` by calling `predictor.model_names()`.
+            If 'all' then all models are persisted. Valid models are listed in this `predictor` by calling `predictor.model_names()`.
         with_ancestors : bool, default = True
             If True, all ancestor models of the provided models will also be persisted.
-            If False, stacker models will not have the models they depend on persisted unless those models were specified in `models`.
+            If False, ensemble models will not have the models they depend on persisted unless those models were specified in `models`.
             This will slow down inference as the ancestor models will still need to be loaded from disk for each predict call.
-            Only relevant for stacker models.
+            Only relevant for ensemble models.
 
         Returns
         -------
-        List of persisted model names.
+        list_of_models : List[str]
+            List of persisted model names.
         """
         return self._learner.persist_trainer(models=models, with_ancestors=with_ancestors)
 
-    def unpersist(self) -> None:
-        """Unpersist models in memory for reduced memory usage.
-        If models are not persisted in memory, they are loaded from disk every time they are asked to make predictions.
+    def unpersist(self) -> List[str]:
+        """Unpersist models in memory for reduced memory usage. If models are not persisted in memory, they are loaded from
+        disk every time they are asked to make predictions.
+
         Note: Another way to reset the predictor and unpersist models is to reload the predictor from disk
-        via `predictor = TabularPredictor.load(predictor.path)`.
+        via `predictor = TimeSeriesPredictor.load(predictor.path)`.
+
+        Returns
+        -------
+        list_of_models : List[str]
+            List of unpersisted model names.
         """
-        self._learner.unpersist_trainer()
+        return self._learner.unpersist_trainer()
 
     def leaderboard(
         self,

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -71,21 +71,6 @@ class SimpleAbstractTrainer:
             results[model] = self.model_graph.nodes[model][attribute]
         return results
 
-    def get_model_best(self) -> str:
-        """Return the name of the best model by model performance on the validation set."""
-        models = self.get_model_names()
-        if not models:
-            raise ValueError("Trainer has no fit models that can predict.")
-        if len(models) == 1:
-            return models[0]
-        model_performances = self.get_models_attribute_dict(attribute="val_score")
-        performances_list = [(m, model_performances[m]) for m in models if model_performances[m] is not None]
-
-        if not performances_list:
-            raise ValueError("No fitted models have validation scores computed.")
-
-        return max(performances_list, key=lambda i: i[1])[0]
-
     def get_model_attribute(self, model: Union[str, AbstractModel], attribute: str):
         """Get a member attribute for given model from the `model_graph`."""
         if not isinstance(model, str):
@@ -218,6 +203,9 @@ class SimpleAbstractTrainer:
         save_pkl.save(path=os.path.join(self.path, self.trainer_info_name), object=info)
         save_json.save(path=os.path.join(self.path, self.trainer_info_json_name), obj=info)
         return info
+
+    def get_model_best(self, *args, **kwargs) -> AbstractModel:
+        raise NotImplementedError
 
     def get_info(self, include_model_info: bool = False) -> Dict[str, Any]:
         num_models_trained = len(self.get_model_names())
@@ -389,11 +377,52 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
 
         return levels
 
+    def get_model_best(self) -> str:
+        """Return the name of the best model by model performance on the validation set."""
+        models = self.get_model_names()
+        if not models:
+            raise ValueError("Trainer has no fit models that can predict.")
+        if len(models) == 1:
+            return models[0]
+        model_performances = self.get_models_attribute_dict(attribute="val_score")
+        model_levels = self._get_model_levels()
+        performances_list = [
+            (m, model_performances[m], model_levels.get(m, 0)) for m in models if model_performances[m] is not None
+        ]
+
+        if not performances_list:
+            raise ValueError("No fitted models have validation scores computed.")
+
+        # rank models in terms of validation score. if two models have the same validation score,
+        # rank them by their level in the model graph (lower level models are preferred).
+        return max(performances_list, key=lambda i: (i[1], -i[2]))[0]
+
     def get_model_names(self, level: Optional[int] = None, **kwargs) -> List[str]:
         """Get model names that are registered in the model graph"""
         if level is not None:
             return list(node for node, l in self._get_model_levels().items() if l == level)  # noqa: E741
         return list(self.model_graph.nodes)
+
+    # TODO: the following two methods are copied from tabular's AbstractTrainer.
+    def get_minimum_model_set(self, model, include_self=True) -> list:
+        """Gets the minimum set of models that the provided model depends on, including itself
+        Returns a list of model names
+        """
+        if not isinstance(model, str):
+            model = model.name
+        minimum_model_set = list(nx.bfs_tree(self.model_graph, model, reverse=True))
+        if not include_self:
+            minimum_model_set = [m for m in minimum_model_set if m != model]
+        return minimum_model_set
+
+    def get_minimum_models_set(self, models: list) -> list:
+        """Gets the minimum set of models that the provided models depend on, including themselves
+        Returns a list of model names
+        """
+        models_set = set()
+        for model in models:
+            models_set = models_set.union(self.get_minimum_model_set(model))
+        return list(models_set)
 
     def _train_single(
         self,
@@ -796,6 +825,39 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         df.reset_index(drop=True, inplace=True)
 
         return df[explicit_column_order]
+
+    def persist(self, model_names="all", with_ancestors=False, **kwargs) -> List[str]:
+        if model_names == "all":
+            model_names = self.get_model_names()
+        elif model_names == "best":
+            model_names = [self.get_model_best()]
+        if not isinstance(model_names, list):
+            raise ValueError(f"model_names must be a list of model names. Invalid value: {model_names}")
+        if with_ancestors:
+            model_names = self.get_minimum_models_set(model_names)
+        model_names_already_persisted = [model_name for model_name in model_names if model_name in self.models]
+        model_names = [model_name for model_name in model_names if model_name not in model_names_already_persisted]
+
+        models = []
+        for model_name in model_names:
+            model = self.load_model(model_name)
+            model.persist()
+            self.models[model.name] = model
+            models.append(model)
+
+        return model_names
+
+    def unpersist(self, model_names="all") -> list:
+        if model_names == "all":
+            model_names = list(self.models.keys())
+        if not isinstance(model_names, list):
+            raise ValueError(f"model_names must be a list of model names. Invalid value: {model_names}")
+        unpersisted_models = []
+        for model in model_names:
+            if model in self.models:
+                self.models.pop(model)
+                unpersisted_models.append(model)
+        return unpersisted_models
 
     def _get_model_for_prediction(self, model: Optional[Union[str, AbstractTimeSeriesModel]] = None) -> str:
         """Given an optional identifier or model object, return the name of the model with which to predict.

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -1293,3 +1293,57 @@ def test_given_skip_model_selection_then_all_predictor_methods_work(temp_model_p
         # All keys except model_best return a dict with results per model
         if key != "model_best":
             assert len(fit_summary[key]) == 1
+
+
+@pytest.mark.parametrize("hyperparameters", [{"Naive": {}}, {"SeasonalNaive": {}}, {"Naive": {}, "SeasonalNaive": {}}])
+def test_when_persist_called_then_at_least_one_model_persisted(temp_model_path, hyperparameters):
+    predictor = TimeSeriesPredictor(path=temp_model_path).fit(
+        DUMMY_TS_DATAFRAME,
+        hyperparameters=hyperparameters,
+        enable_ensemble=False,
+    )
+    predictor.persist()
+
+    assert len(predictor._learner.trainer.models) > 0
+
+
+@pytest.mark.parametrize("hyperparameters", [{"Naive": {}}, {"SeasonalNaive": {}}, {"Naive": {}, "SeasonalNaive": {}}])
+def test_when_predictor_saved_loaded_and_persist_called_then_at_least_one_model_persisted(
+    temp_model_path, hyperparameters
+):
+    predictor = TimeSeriesPredictor(path=temp_model_path).fit(
+        DUMMY_TS_DATAFRAME,
+        hyperparameters=hyperparameters,
+        enable_ensemble=False,
+    )
+    path = predictor.path
+    predictor.save()
+    predictor = TimeSeriesPredictor.load(path)
+    predictor.persist()
+
+    assert len(predictor._learner.trainer.models) > 0
+
+
+@pytest.mark.parametrize("hyperparameters", [{"Naive": {}}, {"SeasonalNaive": {}}, {"Naive": {}, "SeasonalNaive": {}}])
+def test_when_persist_not_called_then_no_models_persisted(temp_model_path, hyperparameters):
+    predictor = TimeSeriesPredictor(path=temp_model_path).fit(
+        DUMMY_TS_DATAFRAME,
+        hyperparameters=hyperparameters,
+        enable_ensemble=False,
+    )
+
+    assert len(predictor._learner.trainer.models) == 0
+
+
+@pytest.mark.parametrize("hyperparameters", [{"Naive": {}}, {"SeasonalNaive": {}}, {"Naive": {}, "SeasonalNaive": {}}])
+def test_when_predictor_saved_loaded_and_persist_not_called_then_no_models_persisted(temp_model_path, hyperparameters):
+    predictor = TimeSeriesPredictor(path=temp_model_path).fit(
+        DUMMY_TS_DATAFRAME,
+        hyperparameters=hyperparameters,
+        enable_ensemble=False,
+    )
+    path = predictor.path
+    predictor.save()
+    predictor = TimeSeriesPredictor.load(path)
+
+    assert len(predictor._learner.load_trainer().models) == 0

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -20,6 +20,7 @@ from autogluon.timeseries.dataset import TimeSeriesDataFrame
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP
 from autogluon.timeseries.metrics import DEFAULT_METRIC_NAME
 from autogluon.timeseries.models import DeepARModel, SimpleFeedForwardModel
+from autogluon.timeseries.models.ensemble.greedy_ensemble import TimeSeriesGreedyEnsemble
 from autogluon.timeseries.predictor import TimeSeriesPredictor
 
 from .common import (
@@ -1366,4 +1367,174 @@ def test_when_predictor_persisted_saved_loaded_and_persist_not_called_then_no_mo
     predictor.save()
     predictor = TimeSeriesPredictor.load(path)
 
+    assert len(predictor._learner.load_trainer().models) == 0
+
+
+@pytest.mark.parametrize("hyperparameters", [{"Naive": {}}, {"SeasonalNaive": {}}, {"Naive": {}, "SeasonalNaive": {}}])
+def test_when_persist_called_then_persisted_models_names_are_returned(temp_model_path, hyperparameters):
+    predictor = TimeSeriesPredictor(path=temp_model_path).fit(
+        DUMMY_TS_DATAFRAME,
+        hyperparameters=hyperparameters,
+        enable_ensemble=False,
+    )
+    persisted_models = predictor.persist()
+
+    assert set(persisted_models).issubset(set(hyperparameters.keys()))
+
+
+@pytest.mark.parametrize("hyperparameters", [{"Naive": {}}, {"SeasonalNaive": {}}, {"Naive": {}, "SeasonalNaive": {}}])
+def test_when_persist_and_unpersisted_called_then_persisted_and_unpersisted_models_names_are_returned(
+    temp_model_path, hyperparameters
+):
+    predictor = TimeSeriesPredictor(path=temp_model_path).fit(
+        DUMMY_TS_DATAFRAME,
+        hyperparameters=hyperparameters,
+        enable_ensemble=False,
+    )
+    persisted_models = predictor.persist()
+
+    assert set(persisted_models).issubset(set(hyperparameters.keys()))
+
+    unpersisted_models = predictor.unpersist()
+
+    assert set(unpersisted_models) == set(persisted_models)
+    assert len(predictor._learner.load_trainer().models) == 0
+
+
+def _add_ensemble_to_predictor(predictor, hyperparameters, make_best_model=True):
+    trainer = predictor._learner.load_trainer()
+
+    # Manually add ensemble to ensure that both models have non-zero weight
+    ensemble = TimeSeriesGreedyEnsemble(name="WeightedEnsemble", path=trainer.path)
+    ensemble.model_to_weight = {k: 1 / len(hyperparameters) for k in hyperparameters.keys()}
+    if make_best_model:
+        ensemble.val_score = 0  # make the ensemble the best model
+
+    trainer._add_model(model=ensemble, base_models=hyperparameters.keys())
+    trainer.save_model(model=ensemble)
+    predictor._learner.save()
+
+    return predictor
+
+
+@pytest.mark.parametrize("hyperparameters", [{"Naive": {}}, {"SeasonalNaive": {}}])
+def test_given_single_model_with_ensemble_when_predictor_persisted_then_only_one_model_persisted(
+    temp_model_path, hyperparameters
+):
+    predictor = TimeSeriesPredictor(path=temp_model_path).fit(
+        DUMMY_TS_DATAFRAME,
+        hyperparameters=hyperparameters,
+        enable_ensemble=False,
+    )
+    predictor = _add_ensemble_to_predictor(predictor, hyperparameters, make_best_model=False)
+
+    predictor.persist()
+    assert len(predictor._learner.load_trainer().models) == 1
+
+    predictor.unpersist()
+    assert len(predictor._learner.load_trainer().models) == 0
+
+
+@pytest.mark.parametrize(
+    "hyperparameters",
+    [
+        {"Naive": {}, "SeasonalNaive": {}},
+        {"Naive": {}, "DeepAR": {"max_epochs": 1}},
+    ],
+)
+def test_given_multiple_models_with_ensemble_when_predictor_all_persisted_then_all_models_persisted(
+    temp_model_path, hyperparameters
+):
+    predictor = TimeSeriesPredictor(path=temp_model_path).fit(
+        DUMMY_TS_DATAFRAME,
+        hyperparameters=hyperparameters,
+        enable_ensemble=False,
+    )
+    predictor = _add_ensemble_to_predictor(predictor, hyperparameters)
+
+    print(predictor._learner.load_trainer().get_model_names())
+    persisted_models = predictor.persist("all")
+    assert len(predictor._learner.load_trainer().models) == len(hyperparameters) + 1
+    assert any(m == "WeightedEnsemble" for m in persisted_models)
+
+    predictor.unpersist()
+    assert len(predictor._learner.load_trainer().models) == 0
+
+
+def test_given_multiple_models_with_ensemble_when_predictor_persisted_then_ensemble_and_dependencies_persisted(
+    temp_model_path,
+):
+    hyperparameters = {"Naive": {}, "SeasonalNaive": {}}
+    predictor = TimeSeriesPredictor(path=temp_model_path).fit(
+        DUMMY_TS_DATAFRAME,
+        hyperparameters=hyperparameters,
+        enable_ensemble=False,
+    )
+    predictor = _add_ensemble_to_predictor(predictor, hyperparameters)
+
+    persisted_models = predictor.persist()
+    assert len(predictor._learner.load_trainer().models) == len(hyperparameters) + 1
+    assert any(m == "WeightedEnsemble" for m in persisted_models)
+
+    predictor.unpersist()
+    assert len(predictor._learner.load_trainer().models) == 0
+
+
+@pytest.mark.parametrize("with_ancestors", [True, False])
+def test_given_multiple_models_with_ensemble_when_ensemble_persisted_then_persist_obeys_with_ancestors(
+    temp_model_path, with_ancestors
+):
+    hyperparameters = {"Naive": {}, "SeasonalNaive": {}}
+    predictor = TimeSeriesPredictor(path=temp_model_path).fit(
+        DUMMY_TS_DATAFRAME,
+        hyperparameters=hyperparameters,
+        enable_ensemble=False,
+    )
+    predictor = _add_ensemble_to_predictor(predictor, hyperparameters)
+
+    persisted_models = predictor.persist(with_ancestors=with_ancestors)
+    assert len(predictor._learner.load_trainer().models) == 1 + (2 if with_ancestors else 0)
+    assert any(m == "WeightedEnsemble" for m in persisted_models)
+
+    predictor.unpersist()
+    assert len(predictor._learner.load_trainer().models) == 0
+
+
+def test_given_multiple_models_with_ensemble_when_predictor_persisted_saved_loaded_then_ensemble_and_dependencies_persisted(
+    temp_model_path,
+):
+    hyperparameters = {"Naive": {}, "SeasonalNaive": {}}
+    predictor = TimeSeriesPredictor(path=temp_model_path).fit(
+        DUMMY_TS_DATAFRAME,
+        hyperparameters=hyperparameters,
+        enable_ensemble=False,
+    )
+    predictor = _add_ensemble_to_predictor(predictor, hyperparameters)
+    predictor.save()
+
+    path = predictor.path
+    predictor = TimeSeriesPredictor.load(path)
+
+    persisted_models = predictor.persist()
+    assert len(predictor._learner.load_trainer().models) == len(hyperparameters) + 1
+    assert any(m == "WeightedEnsemble" for m in persisted_models)
+
+    predictor.unpersist()
+    assert len(predictor._learner.load_trainer().models) == 0
+
+
+def test_given_multiple_models_with_ensemble_when_single_model_persisted_then_single_model_persisted(temp_model_path):
+    hyperparameters = {"Naive": {}, "SeasonalNaive": {}}
+    predictor = TimeSeriesPredictor(path=temp_model_path).fit(
+        DUMMY_TS_DATAFRAME,
+        hyperparameters=hyperparameters,
+        enable_ensemble=False,
+    )
+    predictor = _add_ensemble_to_predictor(predictor, hyperparameters)
+
+    persisted_models = predictor.persist(["Naive"])
+    assert len(predictor._learner.load_trainer().models) == 1
+    assert persisted_models[0] == "Naive"
+
+    predictor.unpersist()
     assert len(predictor._learner.load_trainer().models) == 0

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -1347,3 +1347,23 @@ def test_when_predictor_saved_loaded_and_persist_not_called_then_no_models_persi
     predictor = TimeSeriesPredictor.load(path)
 
     assert len(predictor._learner.load_trainer().models) == 0
+
+
+@pytest.mark.parametrize("hyperparameters", [{"Naive": {}}, {"SeasonalNaive": {}}, {"Naive": {}, "SeasonalNaive": {}}])
+def test_when_predictor_persisted_saved_loaded_and_persist_not_called_then_no_models_persisted(
+    temp_model_path, hyperparameters
+):
+    predictor = TimeSeriesPredictor(path=temp_model_path).fit(
+        DUMMY_TS_DATAFRAME,
+        hyperparameters=hyperparameters,
+        enable_ensemble=False,
+    )
+    path = predictor.path
+    predictor.persist()
+
+    assert len(predictor._learner.load_trainer().models) > 0
+
+    predictor.save()
+    predictor = TimeSeriesPredictor.load(path)
+
+    assert len(predictor._learner.load_trainer().models) == 0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds methods to `persist` predictor, learner, trainer and model objects, bringing the ability to persist models in memory like in `TabularPredictor`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
