### PR TITLE
[timeseries] fix predictor tests temporary path issue

### DIFF
--- a/timeseries/tests/conftest.py
+++ b/timeseries/tests/conftest.py
@@ -1,5 +1,4 @@
-import shutil
-import tempfile
+from uuid import uuid4
 
 import pytest
 
@@ -28,13 +27,7 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_slow)
 
 
-@pytest.fixture(scope="function")
-def temp_model_path():
-    """Pytest fixture to save as model paths that clean up after themselves"""
-    td = tempfile.mkdtemp()
-    yield td
-    try:
-        shutil.rmtree(td)
-    except PermissionError:
-        # Windows won't allow to clean up the directory if logs are saved to it; skip deletion
-        pass
+@pytest.fixture()
+def temp_model_path(tmp_path_factory):
+    fn = tmp_path_factory.mktemp(str(uuid4())[:6])
+    return str(fn)

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -4,9 +4,9 @@ import copy
 import logging
 import math
 import sys
-import tempfile
 from pathlib import Path
 from unittest import mock
+from uuid import uuid4
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -533,17 +533,21 @@ def test_given_data_is_in_dataframe_format_then_predictor_works(temp_model_path)
 
 
 @pytest.mark.parametrize("path_format", [str, Path])
-def test_given_data_is_in_str_format_then_predictor_works(temp_model_path, path_format):
+def test_given_data_is_in_str_format_then_predictor_works(temp_model_path, tmp_path, path_format):
     df = pd.DataFrame(DUMMY_TS_DATAFRAME.reset_index())
-    with tempfile.NamedTemporaryFile("w") as data_path:
-        data_path = path_format(str(data_path))
-        df.to_csv(data_path, index=False)
-        predictor = TimeSeriesPredictor(path=temp_model_path)
-        predictor.fit(data_path, hyperparameters={"Naive": {}})
-        predictor.leaderboard(data_path)
-        predictor.evaluate(data_path)
-        predictions = predictor.predict(data_path)
-        assert isinstance(predictions, TimeSeriesDataFrame)
+
+    tmp_path_subdir = tmp_path / str(uuid4())[:4]
+    data_path = path_format(str(tmp_path_subdir))
+
+    df.to_csv(data_path, index=False)
+
+    predictor = TimeSeriesPredictor(path=temp_model_path)
+    predictor.fit(data_path, hyperparameters={"Naive": {}})
+    predictor.leaderboard(data_path)
+    predictor.evaluate(data_path)
+    predictions = predictor.predict(data_path)
+
+    assert isinstance(predictions, TimeSeriesDataFrame)
 
 
 @pytest.mark.parametrize("rename_columns", [{TIMESTAMP: "custom_timestamp"}, {ITEMID: "custom_item_id"}])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes a bug that causes a FileNotFoundError from ray using the current temporary path fixture in predictor tests. This PR replaces predictor path fixtures with the pytest fixtures.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
