### PR TITLE
[timeseries] Fix platform tests failing for Python 3.8 because of old numpy version

### DIFF
--- a/timeseries/tests/unittests/test_features.py
+++ b/timeseries/tests/unittests/test_features.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Optional
 import numpy as np
 import pandas as pd
 import pytest
+import sys
 
 from autogluon.timeseries.utils.features import TimeSeriesFeatureGenerator
 
@@ -72,6 +73,7 @@ def test_when_covariates_present_in_data_then_they_are_included_in_metadata(
     assert metadata.static_features_real == static_features_real
 
 
+@pytest.mark.skipif(sys.version_info <= (3, 8), reason="np.dtypes not available in Python 3.8")
 def test_when_transform_applied_then_numeric_features_are_converted_to_float32():
     data = get_data_frame_with_covariates(covariates_cat=["cov_cat"], static_features_cat=["static_cat"])
 


### PR DESCRIPTION
*Description of changes:*
- Fix platform tests failing for Python 3.8 because numpy v1.24 gets installed on Python 3.8 envs


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
