### PR TITLE
Upgrade Dependency Ranges for 1.1

### DIFF
--- a/common/src/autogluon/common/utils/try_import.py
+++ b/common/src/autogluon/common/utils/try_import.py
@@ -175,10 +175,10 @@ def try_import_vowpalwabbit():
 
         vowpalwabbit_version = parse_version(vowpalwabbit.__version__)
         assert vowpalwabbit_version >= parse_version("9.0.0") and vowpalwabbit_version < parse_version(
-            "9.9.0"
-        ), f"Currently, we only support vowpalwabbit version >=9.0 and <9.9. Found vowpalwabbit version: {vowpalwabbit_version}"
+            "9.10.0"
+        ), f"Currently, we only support vowpalwabbit version >=9.0 and <9.10. Found vowpalwabbit version: {vowpalwabbit_version}"
     except ImportError:
-        raise ImportError("`import vowpalwabbit` failed.\n" "A quick tip is to install via `pip install vowpalwabbit>=9,<9.9")
+        raise ImportError("`import vowpalwabbit` failed.\n" "A quick tip is to install via `pip install vowpalwabbit>=9,<9.10")
 
 
 def try_import_fasttext():

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -18,7 +18,7 @@ PYTHON_REQUIRES = ">=3.8, <3.12"
 DEPENDENT_PACKAGES = {
     "boto3": ">=1.10,<2",  # <2 because unlikely to introduce breaking changes in minor releases. >=1.10 because 1.10 is 3 years old, no need to support older
     "numpy": ">=1.21,<1.29",  # "<{N+3}" upper cap, where N is the latest released minor version, assuming no warnings using N
-    "pandas": ">=2.0.0,<2.2.0",  # "<{N+1}" upper cap
+    "pandas": ">=2.0.0,<2.3.0",  # "<{N+1}" upper cap
     "scikit-learn": ">=1.3.0,<1.4.1",  # "<{N+1}" upper cap, capping to micro version as AutoMM HPO tests fail on upgrading to higher version
     "scipy": ">=1.5.4,<1.13",  # "<{N+2}" upper cap
     "psutil": ">=5.7.3,<6",  # Major version cap

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -18,7 +18,7 @@ PYTHON_REQUIRES = ">=3.8, <3.12"
 DEPENDENT_PACKAGES = {
     "boto3": ">=1.10,<2",  # <2 because unlikely to introduce breaking changes in minor releases. >=1.10 because 1.10 is 3 years old, no need to support older
     "numpy": ">=1.21,<1.29",  # "<{N+3}" upper cap, where N is the latest released minor version, assuming no warnings using N
-    "pandas": ">=2.0.0,<2.3.0",  # "<{N+1}" upper cap
+    "pandas": ">=2.0.0,<2.2.0",  # "<{N+1}" upper cap
     "scikit-learn": ">=1.3.0,<1.4.1",  # "<{N+1}" upper cap, capping to micro version as AutoMM HPO tests fail on upgrading to higher version
     "scipy": ">=1.5.4,<1.13",  # "<{N+2}" upper cap
     "psutil": ">=5.7.3,<6",  # Major version cap

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -59,7 +59,7 @@ extras_require = {
         f"{ag.PACKAGE_NAME}.core[all]=={version}",
     ],
     "skex": [
-        "scikit-learn-intelex>=2023.0,<2024.1",  # <{N+1} upper cap, where N is the latest released minor version
+        "scikit-learn-intelex>=2023.0,<2024.3",  # <{N+1} upper cap, where N is the latest released minor version
     ],
     "imodels": [
         "imodels>=1.3.10,<1.4.0",  # 1.3.8/1.3.9 either remove/renamed attribute `complexity_` causing failures. https://github.com/csinva/imodels/issues/147
@@ -67,16 +67,16 @@ extras_require = {
     "vowpalwabbit": [
         # FIXME: 9.5+ causes VW to save an empty model which always predicts 0. Confirmed on MacOS (Intel CPU). Unknown how to fix.
         # No vowpalwabbit wheel for python 3.11 or above yet
-        "vowpalwabbit>=9,<9.9; python_version < '3.11'",
+        "vowpalwabbit>=9,<9.10; python_version < '3.11'",
     ],
     "skl2onnx": [
-        "skl2onnx>=1.15.0,<1.16.0",
+        "skl2onnx>=1.15.0,<1.17.0",
         # For macOS, there isn't a onnxruntime-gpu package installed with skl2onnx.
         # Therefore, we install onnxruntime explicitly here just for macOS.
-        "onnxruntime>=1.15.0,<1.16.0",
+        "onnxruntime>=1.15.0,<1.18.0",
     ]
     if sys.platform == "darwin"
-    else ["skl2onnx>=1.15.0,<1.16.0", "onnxruntime-gpu>=1.15.0,<1.16.0"],
+    else ["skl2onnx>=1.15.0,<1.17.0", "onnxruntime-gpu>=1.15.0,<1.18.0"],
 }
 
 # TODO: v1.0: Rename `all` to `core`, make `all` contain everything.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Upgrade Dependency Ranges for 1.1
- Update pandas to 2.2.x has been moved to a future PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
