### PR TITLE
Fix the path matching logics in tabular conftest.py to accommodate windows

### DIFF
--- a/tabular/tests/conftest.py
+++ b/tabular/tests/conftest.py
@@ -51,10 +51,15 @@ def pytest_collection_modifyitems(config, items):
         for marker in custom_markers:
             if marker in item.keywords:
                 item.add_marker(custom_markers[marker])
+
+    # Normalize the file paths and use a consistent comparison method
+    normalized_path = lambda p: os.path.normpath(str(p))
+    resource_allocation_path = normalized_path("tests/unittests/resource_allocation")
+
     # Reordering logic to ensure tests under ./unittests/resource_allocation run last
     # TODO: Fix this once resource_allocation tests are robost enough to run with other tests without ordering issues
-    resource_allocation_tests = [item for item in items if "unittests/resource_allocation" in str(item.fspath)]
-    other_tests = [item for item in items if "unittests/resource_allocation" not in str(item.fspath)]
+    resource_allocation_tests = [item for item in items if resource_allocation_path in normalized_path(item.fspath)]
+    other_tests = [item for item in items if resource_allocation_path not in normalized_path(item.fspath)]
 
     items.clear()
     items.extend(other_tests)


### PR DESCRIPTION
*Issue #, if available:*
Fix the path matching logics in tabular conftest.py to accommodate windows


*Description of changes:*
On windows machine, the path matching logics failed due to directory separator used is not consistent

Adding link to working platform tests: https://github.com/autogluon/autogluon/actions/runs/8546584824


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
