### PR TITLE
[timeseries] Add support for categorical covariates

### DIFF
--- a/docs/tutorials/timeseries/forecasting-model-zoo.md
+++ b/docs/tutorials/timeseries/forecasting-model-zoo.md
@@ -280,25 +280,21 @@ Models not included in this table currently do not support any additional featur
    :header-rows: 1
    :stub-columns: 1
    :align: center
-   :widths: 40 15 15 15 15
+   :widths: 55 15 15 15
 
    * - Model
-     - Static features (continuous)
-     - Static features (categorical)
-     - Known covariates (continuous)
-     - Past covariates (continuous)
+     - Static features (continuous + categorical)
+     - Known covariates (continuous + categorical)
+     - Past covariates (continuous + categorical)
    * - :class:`~autogluon.timeseries.models.DirectTabularModel`
-     - ✅
      - ✅
      - ✅
      -
    * - :class:`~autogluon.timeseries.models.RecursiveTabularModel`
      - ✅
      - ✅
-     - ✅
      -
    * - :class:`~autogluon.timeseries.models.DeepARModel`
-     - ✅
      - ✅
      - ✅
      -
@@ -306,10 +302,8 @@ Models not included in this table currently do not support any additional featur
      - ✅
      - ✅
      - ✅
-     - ✅
    * - :class:`~autogluon.timeseries.models.WaveNetModel`
      - ✅
      - ✅
-     - ✅
-     - 
+     -
 ```

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -3,7 +3,7 @@ import os
 import re
 import time
 from contextlib import nullcontext
-from typing import Any, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from autogluon.common import space
 from autogluon.common.loaders import load_pkl

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -296,6 +296,7 @@ class AbstractTimeSeriesModel(AbstractModel):
             of input items.
         """
         data = self.preprocess(data, is_train=False)
+        known_covariates = self.preprocess_known_covariates(known_covariates)
         predictions = self._predict(data=data, known_covariates=known_covariates, **kwargs)
         logger.debug(f"Predicting with model {self.name}")
         # "0.5" might be missing from the quantiles if self is a wrapper (MultiWindowBacktestingModel or ensemble)
@@ -358,7 +359,7 @@ class AbstractTimeSeriesModel(AbstractModel):
             time steps of each time series.
         """
         past_data, known_covariates = data.get_model_inputs_for_scoring(
-            prediction_length=self.prediction_length, known_covariates_names=self.metadata.known_covariates_real
+            prediction_length=self.prediction_length, known_covariates_names=self.metadata.known_covariates
         )
         predictions = self.predict(past_data, known_covariates=known_covariates)
         return self._score_with_predictions(data=data, predictions=predictions, metric=metric)
@@ -371,7 +372,7 @@ class AbstractTimeSeriesModel(AbstractModel):
     ) -> None:
         """Compute val_score, predict_time and cache out-of-fold (OOF) predictions."""
         past_data, known_covariates = val_data.get_model_inputs_for_scoring(
-            prediction_length=self.prediction_length, known_covariates_names=self.metadata.known_covariates_real
+            prediction_length=self.prediction_length, known_covariates_names=self.metadata.known_covariates
         )
         predict_start_time = time.time()
         oof_predictions = self.predict(past_data, known_covariates=known_covariates)
@@ -494,8 +495,13 @@ class AbstractTimeSeriesModel(AbstractModel):
 
         return hpo_models, analysis
 
-    def preprocess(self, data: TimeSeriesDataFrame, is_train: bool = False, **kwargs) -> Any:
+    def preprocess(self, data: TimeSeriesDataFrame, is_train: bool = False, **kwargs) -> TimeSeriesDataFrame:
         return data
+
+    def preprocess_known_covariates(
+        self, known_covariates: Optional[TimeSeriesDataFrame]
+    ) -> Optional[TimeSeriesDataFrame]:
+        return known_covariates
 
     def get_memory_size(self, **kwargs) -> Optional[int]:
         return None

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -242,7 +242,7 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
         Each row contains unique_id, ds, y, and (optionally) known covariates & static features.
         """
         # TODO: Add support for past_covariates
-        selected_columns = self.metadata.known_covariates_real.copy()
+        selected_columns = self.metadata.known_covariates.copy()
         column_name_mapping = {ITEMID: MLF_ITEMID, TIMESTAMP: MLF_TIMESTAMP}
         if include_target:
             selected_columns += [self.target]

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -188,7 +188,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         self._ohe_generator_known: Optional[OneHotEncoder] = None
         self._ohe_generator_past: Optional[OneHotEncoder] = None
         self.callbacks = []
-        # Following attributes may be overriden during fit() based on train_data & model parameters
+        # Following attributes may be overridden during fit() based on train_data & model parameters
         self.num_feat_static_cat = 0
         self.num_feat_static_real = 0
         self.num_feat_dynamic_cat = 0

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -57,7 +57,7 @@ class SimpleGluonTSDataset(GluonTSDataset):
         assert target_df is not None
         assert target_df.freq, "Initializing GluonTS data sets without freq is not allowed"
         # Convert TimeSeriesDataFrame to pd.Series for faster processing
-        self.target_array = self._astype(target_df[target_column], dtype=np.float32)
+        self.target_array = target_df[target_column].to_numpy(np.float32)
         self.feat_static_cat = self._astype(feat_static_cat, dtype=np.int64)
         self.feat_static_real = self._astype(feat_static_real, dtype=np.float32)
         self.feat_dynamic_cat = self._astype(feat_dynamic_cat, dtype=np.int64)

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -19,6 +19,9 @@ from pandas.tseries.frequencies import to_offset
 
 from autogluon.common.loaders import load_pkl
 from autogluon.core.hpo.constants import RAY_BACKEND
+from autogluon.tabular.models.tabular_nn.utils.categorical_encoders import (
+    OneHotMergeRaresHandleUnknownEncoder as OneHotEncoder,
+)
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP, TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 from autogluon.timeseries.utils.datetime import norm_freq_str
@@ -42,21 +45,25 @@ class SimpleGluonTSDataset(GluonTSDataset):
         self,
         target_df: TimeSeriesDataFrame,
         target_column: str = "target",
-        feat_static_cat: Optional[pd.DataFrame] = None,
-        feat_static_real: Optional[pd.DataFrame] = None,
-        feat_dynamic_real: Optional[pd.DataFrame] = None,
-        past_feat_dynamic_real: Optional[pd.DataFrame] = None,
+        feat_static_cat: Optional[np.ndarray] = None,
+        feat_static_real: Optional[np.ndarray] = None,
+        feat_dynamic_cat: Optional[np.ndarray] = None,
+        feat_dynamic_real: Optional[np.ndarray] = None,
+        past_feat_dynamic_cat: Optional[np.ndarray] = None,
+        past_feat_dynamic_real: Optional[np.ndarray] = None,
         includes_future: bool = False,
         prediction_length: int = None,
     ):
         assert target_df is not None
         assert target_df.freq, "Initializing GluonTS data sets without freq is not allowed"
         # Convert TimeSeriesDataFrame to pd.Series for faster processing
-        self.target_array = self._to_array(target_df[target_column], dtype=np.float32)
-        self.feat_static_cat = self._to_array(feat_static_cat, dtype=np.int64)
-        self.feat_static_real = self._to_array(feat_static_real, dtype=np.float32)
-        self.feat_dynamic_real = self._to_array(feat_dynamic_real, dtype=np.float32)
-        self.past_feat_dynamic_real = self._to_array(past_feat_dynamic_real, dtype=np.float32)
+        self.target_array = self._astype(target_df[target_column], dtype=np.float32)
+        self.feat_static_cat = self._astype(feat_static_cat, dtype=np.int64)
+        self.feat_static_real = self._astype(feat_static_real, dtype=np.float32)
+        self.feat_dynamic_cat = self._astype(feat_dynamic_cat, dtype=np.int64)
+        self.feat_dynamic_real = self._astype(feat_dynamic_real, dtype=np.float32)
+        self.past_feat_dynamic_cat = self._astype(past_feat_dynamic_cat, dtype=np.int64)
+        self.past_feat_dynamic_real = self._astype(past_feat_dynamic_real, dtype=np.float32)
         self.freq = self._to_gluonts_freq(target_df.freq)
 
         # Necessary to compute indptr for known_covariates at prediction time
@@ -73,11 +80,11 @@ class SimpleGluonTSDataset(GluonTSDataset):
         assert len(self.item_ids) == len(self.start_timestamps)
 
     @staticmethod
-    def _to_array(df: Optional[pd.DataFrame], dtype: np.dtype) -> Optional[np.ndarray]:
-        if df is None:
+    def _astype(array: Optional[np.ndarray], dtype: np.dtype) -> Optional[np.ndarray]:
+        if array is None:
             return None
         else:
-            return df.to_numpy(dtype=dtype)
+            return array.astype(dtype=dtype)
 
     @staticmethod
     def _to_gluonts_freq(freq: str) -> str:
@@ -111,12 +118,18 @@ class SimpleGluonTSDataset(GluonTSDataset):
                 ts[FieldName.FEAT_STATIC_CAT] = self.feat_static_cat[j]
             if self.feat_static_real is not None:
                 ts[FieldName.FEAT_STATIC_REAL] = self.feat_static_real[j]
+            if self.past_feat_dynamic_cat is not None:
+                ts[FieldName.PAST_FEAT_DYNAMIC_CAT] = self.past_feat_dynamic_cat[start_idx:end_idx].T
             if self.past_feat_dynamic_real is not None:
                 ts[FieldName.PAST_FEAT_DYNAMIC_REAL] = self.past_feat_dynamic_real[start_idx:end_idx].T
+
+            # Dynamic features that may extend into the future
+            if self.includes_future:
+                start_idx = start_idx + j * self.prediction_length
+                end_idx = end_idx + (j + 1) * self.prediction_length
+            if self.feat_dynamic_cat is not None:
+                ts[FieldName.FEAT_DYNAMIC_CAT] = self.feat_dynamic_cat[start_idx:end_idx].T
             if self.feat_dynamic_real is not None:
-                if self.includes_future:
-                    start_idx = start_idx + j * self.prediction_length
-                    end_idx = end_idx + (j + 1) * self.prediction_length
                 ts[FieldName.FEAT_DYNAMIC_REAL] = self.feat_dynamic_real[start_idx:end_idx].T
             yield ts
 
@@ -150,6 +163,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
     default_num_samples: int = 250
     supports_known_covariates: bool = False
     supports_past_covariates: bool = False
+    supports_cat_covariates: bool = False
 
     def __init__(
         self,
@@ -171,12 +185,19 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
             **kwargs,
         )
         self.gts_predictor: Optional[GluonTSPredictor] = None
+        self._ohe_generator_known: Optional[OneHotEncoder] = None
+        self._ohe_generator_past: Optional[OneHotEncoder] = None
         self.callbacks = []
+        # Following attributes may be overriden during fit() based on train_data & model parameters
         self.num_feat_static_cat = 0
         self.num_feat_static_real = 0
+        self.num_feat_dynamic_cat = 0
         self.num_feat_dynamic_real = 0
+        self.num_past_feat_dynamic_cat = 0
         self.num_past_feat_dynamic_real = 0
         self.feat_static_cat_cardinality: List[int] = []
+        self.feat_dynamic_cat_cardinality: List[int] = []
+        self.past_feat_dynamic_cat_cardinality: List[int] = []
         self.negative_data = True
 
     def save(self, path: str = None, verbose: bool = True) -> str:
@@ -210,37 +231,63 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
     def _get_hpo_backend(self):
         return RAY_BACKEND
 
-    def _deferred_init_params_aux(self, **kwargs) -> None:
-        """Update GluonTS specific parameters with information available
-        only at training time.
-        """
-        if "dataset" in kwargs:
-            ds = kwargs.get("dataset")
-            self.freq = ds.freq or self.freq
-            if not self.freq:
-                raise ValueError(
-                    "Dataset frequency not provided in the dataset, fit arguments or "
-                    "during initialization. Please provide a `freq` string to `fit`."
-                )
+    def _deferred_init_params_aux(self, dataset: TimeSeriesDataFrame) -> None:
+        """Update GluonTS specific parameters with information available only at training time."""
+        self.freq = dataset.freq or self.freq
+        if not self.freq:
+            raise ValueError(
+                "Dataset frequency not provided in the dataset, fit arguments or "
+                "during initialization. Please provide a `freq` string to `fit`."
+            )
 
-            model_params = self._get_model_params()
-            disable_static_features = model_params.get("disable_static_features", False)
-            if not disable_static_features:
-                self.num_feat_static_cat = len(self.metadata.static_features_cat)
-                self.num_feat_static_real = len(self.metadata.static_features_real)
-                if self.num_feat_static_cat > 0:
-                    feat_static_cat = ds.static_features[self.metadata.static_features_cat]
-                    self.feat_static_cat_cardinality = feat_static_cat.nunique().tolist()
-            disable_known_covariates = model_params.get("disable_known_covariates", False)
-            if not disable_known_covariates and self.supports_known_covariates:
-                self.num_feat_dynamic_real = len(self.metadata.known_covariates_real)
-            disable_past_covariates = model_params.get("disable_past_covariates", False)
-            if not disable_past_covariates and self.supports_past_covariates:
-                self.num_past_feat_dynamic_real = len(self.metadata.past_covariates_real)
-            self.negative_data = (ds[self.target] < 0).any()
+        model_params = self._get_model_params()
+        disable_static_features = model_params.get("disable_static_features", False)
+        if not disable_static_features:
+            self.num_feat_static_cat = len(self.metadata.static_features_cat)
+            self.num_feat_static_real = len(self.metadata.static_features_real)
+            if self.num_feat_static_cat > 0:
+                feat_static_cat = dataset.static_features[self.metadata.static_features_cat]
+                self.feat_static_cat_cardinality = feat_static_cat.nunique().tolist()
 
-        if "callbacks" in kwargs:
-            self.callbacks += kwargs["callbacks"]
+        disable_known_covariates = model_params.get("disable_known_covariates", False)
+        if not disable_known_covariates and self.supports_known_covariates:
+            self.num_feat_dynamic_cat = len(self.metadata.known_covariates_cat)
+            self.num_feat_dynamic_real = len(self.metadata.known_covariates_real)
+            if self.num_feat_dynamic_cat > 0:
+                feat_dynamic_cat = dataset[self.metadata.known_covariates_cat]
+                if self.supports_cat_covariates:
+                    self.feat_static_cat_cardinality = feat_dynamic_cat.nunique().tolist()
+                else:
+                    # If model doesn't support categorical covariates, convert them to real via one hot encoding
+                    self._ohe_generator_known = OneHotEncoder(
+                        max_levels=model_params.get("max_cat_cardinality", 100),
+                        sparse=False,
+                    )
+                    feat_dynamic_cat_ohe = self._ohe_generator_known.fit_transform(pd.DataFrame(feat_dynamic_cat))
+                    self.num_feat_dynamic_cat = 0
+                    self.num_feat_dynamic_real += feat_dynamic_cat_ohe.shape[1]
+
+        disable_past_covariates = model_params.get("disable_past_covariates", False)
+        if not disable_past_covariates and self.supports_past_covariates:
+            self.num_past_feat_dynamic_cat = len(self.metadata.past_covariates_cat)
+            self.num_past_feat_dynamic_real = len(self.metadata.past_covariates_real)
+            if self.num_past_feat_dynamic_cat > 0:
+                past_feat_dynamic_cat = dataset[self.metadata.past_covariates_cat]
+                if self.supports_cat_covariates:
+                    self.past_feat_static_cat_cardinality = past_feat_dynamic_cat.nunique().tolist()
+                else:
+                    # If model doesn't support categorical covariates, convert them to real via one hot encoding
+                    self._ohe_generator_past = OneHotEncoder(
+                        max_levels=model_params.get("max_cat_cardinality", 100),
+                        sparse=False,
+                    )
+                    past_feat_dynamic_cat_ohe = self._ohe_generator_past.fit_transform(
+                        pd.DataFrame(past_feat_dynamic_cat)
+                    )
+                    self.num_past_feat_dynamic_cat = 0
+                    self.num_past_feat_dynamic_real += past_feat_dynamic_cat_ohe.shape[1]
+
+        self.negative_data = (dataset[self.target] < 0).any()
 
     @property
     def default_context_length(self) -> int:
@@ -322,42 +369,76 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         if time_series_df is not None:
             # TODO: Preprocess real-valued features with StdScaler?
             if self.num_feat_static_cat > 0:
-                feat_static_cat = time_series_df.static_features[self.metadata.static_features_cat]
+                feat_static_cat = time_series_df.static_features[self.metadata.static_features_cat].to_numpy()
             else:
                 feat_static_cat = None
 
             if self.num_feat_static_real > 0:
-                feat_static_real = time_series_df.static_features[self.metadata.static_features_real]
+                feat_static_real = time_series_df.static_features[self.metadata.static_features_real].to_numpy()
             else:
                 feat_static_real = None
 
+            expected_known_covariates_len = len(time_series_df) + self.prediction_length * time_series_df.num_items
+            # Convert TSDF -> DF to avoid overhead / input validation
+            df = pd.DataFrame(time_series_df)
+            if known_covariates is not None:
+                known_covariates = pd.DataFrame(known_covariates)
+            if self.num_feat_dynamic_cat > 0:
+                feat_dynamic_cat = df[self.metadata.known_covariates_cat].to_numpy()
+                if known_covariates is not None:
+                    feat_dynamic_cat = np.concatenate(
+                        [feat_dynamic_cat, known_covariates[self.metadata.known_covariates_cat].to_numpy()]
+                    )
+                    assert len(feat_dynamic_cat) == expected_known_covariates_len
+            else:
+                feat_dynamic_cat = None
+
             if self.num_feat_dynamic_real > 0:
-                # Convert TSDF -> DF to avoid overhead / input validation
-                feat_dynamic_real = pd.DataFrame(time_series_df[self.metadata.known_covariates_real])
+                feat_dynamic_real = df[self.metadata.known_covariates_real]
                 # Append future values of known covariates
                 if known_covariates is not None:
-                    feat_dynamic_real = pd.concat([feat_dynamic_real, known_covariates], axis=0)
-                    expected_length = len(time_series_df) + self.prediction_length * time_series_df.num_items
-                    if len(feat_dynamic_real) != expected_length:
-                        raise ValueError(
-                            f"known_covariates must contain values for the next prediction_length = "
-                            f"{self.prediction_length} time steps in each time series."
+                    feat_dynamic_real = np.concatenate(
+                        [feat_dynamic_real, known_covariates[self.metadata.known_covariates_real].to_numpy()]
+                    )
+                    assert len(feat_dynamic_real) == expected_known_covariates_len
+                # Categorical covariates are one-hot-encoded as real
+                if self._ohe_generator_known is not None:
+                    feat_dynamic_cat_ohe = self._ohe_generator_known.transform(df[self.metadata.known_covariates_cat])
+                    if known_covariates is not None:
+                        future_dynamic_cat_ohe = self._ohe_generator_known.transform(
+                            known_covariates[self.metadata.known_covariates_cat]
                         )
+                        feat_dynamic_cat_ohe = np.concatenate([feat_dynamic_cat_ohe, future_dynamic_cat_ohe])
+                        assert len(feat_dynamic_cat_ohe) == expected_known_covariates_len
+                    feat_dynamic_real = np.concatenate([feat_dynamic_real, feat_dynamic_cat_ohe], axis=1)
             else:
                 feat_dynamic_real = None
 
+            if self.num_past_feat_dynamic_cat > 0:
+                past_feat_dynamic_cat = df[self.metadata.past_covariates_cat].to_numpy()
+            else:
+                past_feat_dynamic_cat = None
+
             if self.num_past_feat_dynamic_real > 0:
-                # Convert TSDF -> DF to avoid overhead / input validation
-                past_feat_dynamic_real = pd.DataFrame(time_series_df[self.metadata.past_covariates_real])
+                past_feat_dynamic_real = df[self.metadata.past_covariates_real].to_numpy()
+                if self._ohe_generator_past is not None:
+                    past_feat_dynamic_cat_ohe = self._ohe_generator_past.transform(
+                        df[self.metadata.past_covariates_cat]
+                    )
+                    past_feat_dynamic_real = np.concatenate(
+                        [past_feat_dynamic_real, past_feat_dynamic_cat_ohe], axis=1
+                    )
             else:
                 past_feat_dynamic_real = None
 
             return SimpleGluonTSDataset(
-                target_df=time_series_df,
+                target_df=time_series_df[[self.target]],
                 target_column=self.target,
                 feat_static_cat=feat_static_cat,
                 feat_static_real=feat_static_real,
+                feat_dynamic_cat=feat_dynamic_cat,
                 feat_dynamic_real=feat_dynamic_real,
+                past_feat_dynamic_cat=past_feat_dynamic_cat,
                 past_feat_dynamic_real=past_feat_dynamic_real,
                 includes_future=known_covariates is not None,
                 prediction_length=self.prediction_length,
@@ -392,11 +473,11 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         # update auxiliary parameters
         init_args = self._get_estimator_init_args()
         keep_lightning_logs = init_args.pop("keep_lightning_logs", False)
-        callbacks = self._get_callbacks(
+        self.callbacks = self._get_callbacks(
             time_limit=time_limit,
             early_stopping_patience=None if val_data is None else init_args["early_stopping_patience"],
         )
-        self._deferred_init_params_aux(dataset=train_data, callbacks=callbacks)
+        self._deferred_init_params_aux(train_data)
 
         estimator = self._get_estimator()
         with warning_filter(), disable_root_logger(), gluonts.core.settings.let(gluonts.env.env, use_tqdm=False):

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -84,7 +84,7 @@ class SimpleGluonTSDataset(GluonTSDataset):
         if array is None:
             return None
         else:
-            return array.astype(dtype=dtype)
+            return array.astype(dtype)
 
     @staticmethod
     def _to_gluonts_freq(freq: str) -> str:
@@ -256,12 +256,13 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
             if self.num_feat_dynamic_cat > 0:
                 feat_dynamic_cat = dataset[self.metadata.known_covariates_cat]
                 if self.supports_cat_covariates:
-                    self.feat_static_cat_cardinality = feat_dynamic_cat.nunique().tolist()
+                    self.feat_dynamic_cat_cardinality = feat_dynamic_cat.nunique().tolist()
                 else:
                     # If model doesn't support categorical covariates, convert them to real via one hot encoding
                     self._ohe_generator_known = OneHotEncoder(
                         max_levels=model_params.get("max_cat_cardinality", 100),
                         sparse=False,
+                        dtype="float32",
                     )
                     feat_dynamic_cat_ohe = self._ohe_generator_known.fit_transform(pd.DataFrame(feat_dynamic_cat))
                     self.num_feat_dynamic_cat = 0
@@ -274,12 +275,13 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
             if self.num_past_feat_dynamic_cat > 0:
                 past_feat_dynamic_cat = dataset[self.metadata.past_covariates_cat]
                 if self.supports_cat_covariates:
-                    self.past_feat_static_cat_cardinality = past_feat_dynamic_cat.nunique().tolist()
+                    self.past_feat_dynamic_cat_cardinality = past_feat_dynamic_cat.nunique().tolist()
                 else:
                     # If model doesn't support categorical covariates, convert them to real via one hot encoding
                     self._ohe_generator_past = OneHotEncoder(
                         max_levels=model_params.get("max_cat_cardinality", 100),
                         sparse=False,
+                        dtype="float32",
                     )
                     past_feat_dynamic_cat_ohe = self._ohe_generator_past.fit_transform(
                         pd.DataFrame(past_feat_dynamic_cat)
@@ -394,7 +396,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
                 feat_dynamic_cat = None
 
             if self.num_feat_dynamic_real > 0:
-                feat_dynamic_real = df[self.metadata.known_covariates_real]
+                feat_dynamic_real = df[self.metadata.known_covariates_real].to_numpy()
                 # Append future values of known covariates
                 if known_covariates is not None:
                     feat_dynamic_real = np.concatenate(

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -199,6 +199,7 @@ class TemporalFusionTransformerModel(AbstractGluonTSModel):
 
     supports_known_covariates = True
     supports_past_covariates = True
+    supports_cat_covariates = True
 
     @property
     def default_context_length(self) -> int:
@@ -219,6 +220,7 @@ class TemporalFusionTransformerModel(AbstractGluonTSModel):
             init_kwargs["static_dims"] = [self.num_feat_static_real]
         if len(self.feat_static_cat_cardinality):
             init_kwargs["static_cardinalities"] = self.feat_static_cat_cardinality
+
         init_kwargs.setdefault("time_features", get_time_features_for_frequency(self.freq))
         return init_kwargs
 

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -220,6 +220,10 @@ class TemporalFusionTransformerModel(AbstractGluonTSModel):
             init_kwargs["static_dims"] = [self.num_feat_static_real]
         if len(self.feat_static_cat_cardinality):
             init_kwargs["static_cardinalities"] = self.feat_static_cat_cardinality
+        if len(self.feat_dynamic_cat_cardinality):
+            init_kwargs["dynamic_cardinalities"] = self.feat_dynamic_cat_cardinality
+        if len(self.past_feat_dynamic_cat_cardinality):
+            init_kwargs["past_dynamic_cardinalities"] = self.past_feat_dynamic_cat_cardinality
 
         init_kwargs.setdefault("time_features", get_time_features_for_frequency(self.freq))
         return init_kwargs

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -61,6 +61,8 @@ class DeepARModel(AbstractGluonTSModel):
     embedding_dimension : int, optional
         Dimension of the embeddings for categorical features
         (if None, defaults to [min(50, (cat+1)//2) for cat in cardinality])
+    max_cat_cardinality : int, default = 100
+        Maximum number of dimensions to use when one-hot-encoding categorical known_covariates.
     distr_output : gluonts.torch.distributions.DistributionOutput, default = StudentTOutput()
         Distribution to use to evaluate observations and sample predictions
     scaling: bool, default = True
@@ -378,6 +380,8 @@ class WaveNetModel(AbstractGluonTSModel):
         If True, logarithm of the scale of the past data will be used as an additional static feature.
     negative_data : bool, default = True
         Flag indicating whether the time series take negative values.
+    max_cat_cardinality : int, default = 100
+        Maximum number of dimensions to use when one-hot-encoding categorical known_covariates.
     max_epochs : int, default = 100
         Number of epochs the model will be trained for
     batch_size : int, default = 64

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -1227,7 +1227,7 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
         }
 
         past_data, known_covariates = test_data.get_model_inputs_for_scoring(
-            prediction_length=self.prediction_length, known_covariates_names=trainer.metadata.known_covariates_real
+            prediction_length=self.prediction_length, known_covariates_names=trainer.metadata.known_covariates
         )
         pred_proba_dict_test: Dict[str, TimeSeriesDataFrame] = trainer.get_model_pred_dict(
             base_models, data=past_data, known_covariates=known_covariates

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -763,7 +763,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
 
         if data is not None:
             past_data, known_covariates = data.get_model_inputs_for_scoring(
-                prediction_length=self.prediction_length, known_covariates_names=self.metadata.known_covariates_real
+                prediction_length=self.prediction_length, known_covariates_names=self.metadata.known_covariates
             )
             logger.info(
                 "Additional data provided, testing on additional data. Resulting leaderboard "
@@ -923,7 +923,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         use_cache: bool = True,
     ) -> Dict[str, float]:
         past_data, known_covariates = data.get_model_inputs_for_scoring(
-            prediction_length=self.prediction_length, known_covariates_names=self.metadata.known_covariates_real
+            prediction_length=self.prediction_length, known_covariates_names=self.metadata.known_covariates
         )
         predictions = self.predict(data=past_data, known_covariates=known_covariates, model=model, use_cache=use_cache)
         if not isinstance(metrics, list):  # a single metric is provided

--- a/timeseries/tests/smoketests/test_all_models.py
+++ b/timeseries/tests/smoketests/test_all_models.py
@@ -32,10 +32,10 @@ def generate_train_and_test_data(
         index = pd.MultiIndex.from_product([(item_id,), timestamps], names=[ITEMID, TIMESTAMP])
         columns = {TARGET_COLUMN: np.random.normal(size=length)}
         if use_known_covariates:
-            columns["known_A"] = np.random.randint(0, 10, size=length)
+            columns["known_A"] = np.random.choice(["foo", "bar", "baz"], size=length)
             columns["known_B"] = np.random.normal(size=length)
         if use_past_covariates:
-            columns["past_A"] = np.random.randint(0, 10, size=length)
+            columns["past_A"] = np.random.choice(["foo", "bar", "baz"], size=length)
             columns["past_B"] = np.random.normal(size=length)
             columns["past_C"] = np.random.normal(size=length)
         df_per_item.append(pd.DataFrame(columns, index=index))
@@ -45,7 +45,7 @@ def generate_train_and_test_data(
     if use_static_features_categorical or use_static_features_continuous:
         static_columns = {}
         if use_static_features_categorical:
-            static_columns["static_A"] = np.random.choice(["foo", "bar", "bazz"], size=len(ITEM_IDS))
+            static_columns["static_A"] = np.random.choice(["foo", "bar", "baz"], size=len(ITEM_IDS))
         if use_static_features_continuous:
             static_columns["static_B"] = np.random.normal(size=len(ITEM_IDS))
         static_df = pd.DataFrame(static_columns, index=ITEM_IDS)

--- a/timeseries/tests/unittests/common.py
+++ b/timeseries/tests/unittests/common.py
@@ -138,8 +138,11 @@ def get_data_frame_with_variable_lengths(
     df.freq  # compute _cached_freq
     df.static_features = static_features
     if covariates_names is not None:
-        for name in covariates_names:
-            df[name] = np.random.normal(size=len(df))
+        for i, name in enumerate(covariates_names):
+            if i % 2:
+                df[name] = np.random.normal(size=len(df))
+            else:
+                df[name] = np.random.choice(["foo", "bar"], size=len(df))
     return df
 
 

--- a/timeseries/tests/unittests/common.py
+++ b/timeseries/tests/unittests/common.py
@@ -139,6 +139,7 @@ def get_data_frame_with_variable_lengths(
     df.static_features = static_features
     if covariates_names is not None:
         for i, name in enumerate(covariates_names):
+            # Make every second feature categorical
             if i % 2:
                 df[name] = np.random.normal(size=len(df))
             else:

--- a/timeseries/tests/unittests/test_learner.py
+++ b/timeseries/tests/unittests/test_learner.py
@@ -302,7 +302,7 @@ def test_given_extra_covariates_are_present_in_dataframe_when_learner_predicts_t
     train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, covariates_names=["Y", "X"])
     learner.fit(train_data=train_data, hyperparameters=HYPERPARAMETERS_DUMMY)
 
-    data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, covariates_names=["Z", "Y", "X"])
+    data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, covariates_names=["Y", "X", "Z"])
     pred_data = data.slice_by_timestep(None, -prediction_length)
     known_covariates = data.slice_by_timestep(-prediction_length, None).drop("target", axis=1)
     with mock.patch("autogluon.timeseries.trainer.auto_trainer.AutoTimeSeriesTrainer.predict") as mock_predict:


### PR DESCRIPTION
*Description of changes:*
- Add support for categorical covariates for all MLForecast + GluonTS models
  - For GluonTS models that only support real-valued covariates, we one-hot-encode the categorical covariates

To do:
- [x] Extend tests for GluonTS models with different covariates combinations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
