### PR TITLE
[timeseries] Fix windows platform tests logfile permission error

### DIFF
--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -1088,7 +1088,13 @@ def test_when_log_file_set_then_predictor_logs_to_custom_file(temp_model_path):
             log_text = f.read()
         assert "Naive" in log_text
     finally:
-        log_path.unlink(missing_ok=True)
+        try:
+            log_path.unlink(missing_ok=True)
+        except PermissionError:
+            # Windows won't allow to clean up the directory if logs are saved to it;
+            # Permission Error: The process can't access the file since it is being used by another process
+            # skip deletion
+            pass
 
 
 def test_when_log_file_set_with_pathlib_then_predictor_logs_to_custom_file(temp_model_path):
@@ -1103,7 +1109,13 @@ def test_when_log_file_set_with_pathlib_then_predictor_logs_to_custom_file(temp_
             log_text = f.read()
         assert "Naive" in log_text
     finally:
-        log_path.unlink(missing_ok=True)
+        try:
+            log_path.unlink(missing_ok=True)
+        except PermissionError:
+            # Windows won't allow to clean up the directory if logs are saved to it;
+            # Permission Error: The process can't access the file since it is being used by another process
+            # skip deletion
+            pass
 
 
 def test_when_log_to_file_set_to_false_then_predictor_does_not_log_to_file(temp_model_path):


### PR DESCRIPTION
*Issue #, if available:*
[Windows platform tests](https://github.com/autogluon/autogluon/actions/runs/8539963097/job/23395948812) for `timeseries` are failing due to a permission error on removing a logfile that is being used by another process.

*Description of changes:*
This was introduced due to changes made in #3934 specifically these two lines were added to clean up the test directory (see comment: https://github.com/autogluon/autogluon/pull/3934/files#r1495459186). So this is a test specific fix for windows, and we skip removing the custom_log file in windows tests.:
https://github.com/autogluon/autogluon/blob/4de305651abe621aeab92d4a950cfc6fc1f6c3b9/timeseries/tests/unittests/test_predictor.py#L1090-L1091

Thanks @shchur for helping setup the machine and sharing some context on the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
