### PR TITLE
[timeseries] Preprocess real-valued features for neural network models

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -313,8 +313,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
             assert "past" in self._real_column_transformers, "Preprocessing pipeline must be fit first"
             data[columns] = self._real_column_transformers["past"].transform(data[columns])
 
-        # TODO: self.supports_static_features
-        if len(self.metadata.static_features_real) > 0:
+        if self.supports_static_features and len(self.metadata.static_features_real) > 0:
             columns = self.metadata.static_features_real
             if is_train:
                 self._real_column_transformers["static"] = self._get_transformer_for_columns(

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -16,8 +16,8 @@ from gluonts.model.estimator import Estimator as GluonTSEstimator
 from gluonts.model.forecast import Forecast, QuantileForecast, SampleForecast
 from gluonts.model.predictor import Predictor as GluonTSPredictor
 from pandas.tseries.frequencies import to_offset
-from sklearn.preprocessing import StandardScaler, QuantileTransformer
 from sklearn.compose import ColumnTransformer
+from sklearn.preprocessing import QuantileTransformer, StandardScaler
 
 from autogluon.common.loaders import load_pkl
 from autogluon.core.hpo.constants import RAY_BACKEND

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -357,7 +357,8 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         self, known_covariates: Optional[TimeSeriesDataFrame]
     ) -> Optional[TimeSeriesDataFrame]:
         columns = self.metadata.known_covariates_real
-        if len(columns) > 0:
+        if self.supports_known_covariates and len(columns) > 0:
+            assert "known" in self._real_column_transformers, "Preprocessing pipeline must be fit first"
             known_covariates[columns] = self._real_column_transformers["known"].transform(known_covariates[columns])
         return known_covariates
 

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -303,12 +303,14 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
             columns = self.metadata.known_covariates_real
             if is_train:
                 self._real_column_transformers["known"] = self._get_transformer_for_columns(data, columns=columns)
+            assert "known" in self._real_column_transformers, "Preprocessing pipeline must be fit first"
             data[columns] = self._real_column_transformers["known"].transform(data[columns])
 
         if self.supports_past_covariates and len(self.metadata.past_covariates_real) > 0:
             columns = self.metadata.past_covariates_real
             if is_train:
                 self._real_column_transformers["past"] = self._get_transformer_for_columns(data, columns=columns)
+            assert "past" in self._real_column_transformers, "Preprocessing pipeline must be fit first"
             data[columns] = self._real_column_transformers["past"].transform(data[columns])
 
         # TODO: self.supports_static_features
@@ -318,13 +320,14 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
                 self._real_column_transformers["static"] = self._get_transformer_for_columns(
                     data.static_features, columns=columns
                 )
+            assert "static" in self._real_column_transformers, "Preprocessing pipeline must be fit first"
             data.static_features[columns] = self._real_column_transformers["static"].transform(
                 data.static_features[columns]
             )
         return data
 
     def _get_transformer_for_columns(self, df: pd.DataFrame, columns: List[str]) -> Dict[str, str]:
-        """Ignore bool features, use QuantileTransform for skewed features, and use StandardScaler for the rest.
+        """Passthrough bool features, use QuantileTransform for skewed features, and use StandardScaler for the rest.
 
         The preprocessing logic is similar to the TORCH_NN model from Tabular.
         """

--- a/timeseries/tests/unittests/models/test_gluonts.py
+++ b/timeseries/tests/unittests/models/test_gluonts.py
@@ -372,8 +372,7 @@ def test_given_features_present_when_model_is_fit_then_feature_transformer_is_pr
     else:
         assert "past" not in model._real_column_transformers
 
-    # TODO: Add check for model.supports_static_features after rebasing on feature importance
-    if len(static_features_real) > 0:
+    if len(static_features_real) > 0 and model.supports_static_features:
         assert len(model._real_column_transformers["static"].feature_names_in_) > 0
     else:
         assert "static" not in model._real_column_transformers


### PR DESCRIPTION
*Description of changes:*
- Preprocess real-valued columns in known, past & static covariates for GluonTS models. We use the same logic as used by `TORCH_NN` model in AG-Tabular:
  - Boolean features are kept as-is
  - Skewed features (skewness > 0.99) are transformed with `QuantileTransform`
  - Remaining features are transformed with `StandardScaler`

To do:
- [x] Add tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
