### PR TITLE
Fix Platform-Specific Test Failures in Tabular Module on Windows

### DIFF
--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -90,11 +90,12 @@ def _assert_predict_dict_identical_to_predict(predictor: TabularPredictor, data)
                 else:
                     model_pred = predictor.predict(data, model=m, as_pandas=as_pandas)
                 if as_pandas:
-                    if model_pred.dtype == "object":
-                        assert model_pred.equals(predict_dict[m])
-                    else:
-                        # pandas default int type on Windows is int64, while on Linux it is int32
+                    # pandas default int type on Windows is int64, while on Linux it is int32
+                    if model_pred.dtype in ["int64", "int32"]:
+                        assert predict_dict[m].dtype in ["int64", "int32"]
                         assert model_pred.astype("int64").equals(predict_dict[m].astype("int64"))
+                    else:
+                        assert model_pred.equals(predict_dict[m])
                 else:
                     assert np.array_equal(model_pred, predict_dict[m])
 

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -90,7 +90,11 @@ def _assert_predict_dict_identical_to_predict(predictor: TabularPredictor, data)
                 else:
                     model_pred = predictor.predict(data, model=m, as_pandas=as_pandas)
                 if as_pandas:
-                    assert model_pred.equals(predict_dict[m])
+                    if model_pred.dtype == "object":
+                        assert model_pred.equals(predict_dict[m])
+                    else:
+                        # pandas default int type on Windows is int64, while on Linux it is int32
+                        assert model_pred.astype("int64").equals(predict_dict[m].astype("int64"))
                 else:
                     assert np.array_equal(model_pred, predict_dict[m])
 


### PR DESCRIPTION
*Description:*

This pull request addresses a test failure observed on Windows environments within the tabular.The root cause of this issue has been identified as a discrepancy in pandas' default integer data type across different operating systems. Specifically, while pandas defaults to using `int64` on Windows, it utilizes `int32` on Linux platforms. This inconsistency leads to test failures when running platform-specific tests on Windows.

A detailed overview of the encountered test failure can be found here: [Test Failure Details](https://github.com/autogluon/autogluon/actions/runs/8570605165/job/23488891713).

*Changes Proposed:*

Implement a solution to ensure consistent behavior across platforms by explicitly managing the data type used in tests, thereby resolving the failure on Windows without affecting the functionality on other operating systems.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
