### PR TITLE
[Timeseries] Fix platform tests failing on Ubuntu and MacOS for Python 3.8

### DIFF
--- a/timeseries/tests/smoketests/test_all_models.py
+++ b/timeseries/tests/smoketests/test_all_models.py
@@ -138,6 +138,7 @@ def test_all_models_can_handle_all_covariates(
 
 
 @pytest.mark.parametrize("freq", DEFAULT_SEASONALITIES.keys())
+@pytest.mark.skipif(parse_version(pd.__version__) < parse_version("2.1"), reason="Skipping test for pandas < 2.1")
 def test_all_models_handle_all_pandas_frequencies(freq):
     if parse_version(pd.__version__) < parse_version("2.1") and freq == "SM":
         pytest.skip("'SM' frequency inference not supported by pandas < 2.1")

--- a/timeseries/tests/unittests/models/test_local.py
+++ b/timeseries/tests/unittests/models/test_local.py
@@ -1,5 +1,5 @@
-import sys
 import logging
+import sys
 from typing import Dict
 
 import numpy as np

--- a/timeseries/tests/unittests/models/test_local.py
+++ b/timeseries/tests/unittests/models/test_local.py
@@ -1,3 +1,4 @@
+import sys
 import logging
 from typing import Dict
 
@@ -357,6 +358,7 @@ def test_when_conformalized_model_called_then_nonconformity_score_values_correct
 @pytest.mark.parametrize("model_class", NONSEASONAL_TESTABLE_MODELS)
 @pytest.mark.parametrize("prediction_length", [1, 3, 10])
 @pytest.mark.parametrize("positive_only", [True, False])
+@pytest.mark.skipif(sys.version_info[:2] == (3, 8), reason="np.dtypes not available in Python 3.8")
 def test_when_intermittent_models_fit_then_values_are_lower_bounded(
     model_class, prediction_length, positive_only, temp_model_path
 ):

--- a/timeseries/tests/unittests/test_features.py
+++ b/timeseries/tests/unittests/test_features.py
@@ -78,7 +78,7 @@ def test_when_covariates_present_in_data_then_they_are_included_in_metadata(
     assert metadata.static_features_real == static_features_real
 
 
-@pytest.mark.skipif(sys.version_info <= (3, 8), reason="np.dtypes not available in Python 3.8")
+@pytest.mark.skipif(sys.version_info[:2] == (3, 8), reason="np.dtypes not available in Python 3.8")
 def test_when_transform_applied_then_numeric_features_are_converted_to_float32():
     data = get_data_frame_with_covariates(covariates_cat=["cov_cat"], static_features_cat=["static_cat"])
 


### PR DESCRIPTION
*Description of changes:*
Fixes failure of timeseries platform tests on Ubuntu and MacOS for Python 3.8
This PR is similar to https://github.com/autogluon/autogluon/pull/4040.
Link to platform tests (passing for Python 3.8): https://github.com/prateekdesai04/autogluon/actions/runs/8576700048

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
