### PR TITLE
[timeseries] Fix timeseries platform tests on ubuntu/mac with Python 3.8

### DIFF
--- a/timeseries/tests/smoketests/test_all_models.py
+++ b/timeseries/tests/smoketests/test_all_models.py
@@ -140,7 +140,7 @@ def test_all_models_can_handle_all_covariates(
 @pytest.mark.parametrize("freq", DEFAULT_SEASONALITIES.keys())
 def test_all_models_handle_all_pandas_frequencies(freq):
     if parse_version(pd.__version__) < parse_version("2.1") and freq in ["SM", "B", "BH"]:
-        pytest.skip("'SM' frequency inference not supported by pandas < 2.1")
+        pytest.skip(f"'{freq}' frequency inference not supported by pandas < 2.1")
 
     prediction_length = 5
 

--- a/timeseries/tests/smoketests/test_all_models.py
+++ b/timeseries/tests/smoketests/test_all_models.py
@@ -139,7 +139,7 @@ def test_all_models_can_handle_all_covariates(
 
 @pytest.mark.parametrize("freq", DEFAULT_SEASONALITIES.keys())
 def test_all_models_handle_all_pandas_frequencies(freq):
-    if parse_version(pd.__version__) < parse_version("2.1") and freq == "SM":
+    if parse_version(pd.__version__) < parse_version("2.1") and freq in ["SM", "B", "BH"]:
         pytest.skip("'SM' frequency inference not supported by pandas < 2.1")
 
     prediction_length = 5

--- a/timeseries/tests/unittests/models/test_local.py
+++ b/timeseries/tests/unittests/models/test_local.py
@@ -362,7 +362,7 @@ def test_when_intermittent_models_fit_then_values_are_lower_bounded(
 ):
     data = DUMMY_VARIABLE_LENGTH_TS_DATAFRAME
     if positive_only:
-        data = data.clip(0, None)
+        data[data < 0] = 0.0
     else:
         # make sure there are some negative values
         for c in data.columns:

--- a/timeseries/tests/unittests/test_features.py
+++ b/timeseries/tests/unittests/test_features.py
@@ -78,7 +78,7 @@ def test_when_covariates_present_in_data_then_they_are_included_in_metadata(
     assert metadata.static_features_real == static_features_real
 
 
-@pytest.mark.skipif(sys.version_info <= (3, 8), reason="np.dtypes not available in Python 3.8")
+@pytest.mark.skipif(sys.version_info[:2] <= (3, 8), reason="np.dtypes not available in Python 3.8")
 def test_when_transform_applied_then_numeric_features_are_converted_to_float32():
     data = get_data_frame_with_covariates(covariates_cat=["cov_cat"], static_features_cat=["static_cat"])
 


### PR DESCRIPTION
*Description of changes:*
- Supersedes #4049 
- Fix failing tests caused by capped `numpy` / `pandas` versions available for Python 3.8


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
