### PR TITLE
[timeseries] Fix long path name issue on Windows for Chronos

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/chronos/model.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/model.py
@@ -182,7 +182,7 @@ class ChronosModel(AbstractTimeSeriesModel):
             self.context_length = self.maximum_context_length
 
         # we truncate the name to avoid long path errors on Windows
-        model_path_safe = model_path_input.replace("/", "__").replace(os.path.sep, "__")[-50:]
+        model_path_safe = str(model_path_input).replace("/", "__").replace(os.path.sep, "__")[-50:]
         name = (name if name is not None else "Chronos") + f"[{model_path_safe}]"
 
         super().__init__(

--- a/timeseries/src/autogluon/timeseries/models/chronos/model.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/model.py
@@ -181,7 +181,8 @@ class ChronosModel(AbstractTimeSeriesModel):
             )
             self.context_length = self.maximum_context_length
 
-        model_path_safe = str.replace(model_path_input, "/", "__")
+        # we truncate the name to avoid long path errors on Windows
+        model_path_safe = model_path_input.replace("/", "__").replace(os.path.sep, "__")[-50:]
         name = (name if name is not None else "Chronos") + f"[{model_path_safe}]"
 
         super().__init__(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Previously, models saved to long local pathnames caused test failures due to Windows' MAX_PATH. Our path names are now safe for both Windows' `os.path.sep` and also truncates the names of models loaded locally to increase readability and avoid MAX_PATH issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
