### PR TITLE
[timeseries] Ensure that Chronos respects time_limit during score_and_cache_oof

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -373,13 +373,14 @@ class AbstractTimeSeriesModel(AbstractModel):
         val_data: TimeSeriesDataFrame,
         store_val_score: bool = False,
         store_predict_time: bool = False,
+        **predict_kwargs,
     ) -> None:
         """Compute val_score, predict_time and cache out-of-fold (OOF) predictions."""
         past_data, known_covariates = val_data.get_model_inputs_for_scoring(
             prediction_length=self.prediction_length, known_covariates_names=self.metadata.known_covariates
         )
         predict_start_time = time.time()
-        oof_predictions = self.predict(past_data, known_covariates=known_covariates)
+        oof_predictions = self.predict(past_data, known_covariates=known_covariates, **predict_kwargs)
         self._oof_predictions = [oof_predictions]
         if store_predict_time:
             self.predict_time = time.time() - predict_start_time

--- a/timeseries/src/autogluon/timeseries/models/chronos/model.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/model.py
@@ -1,13 +1,11 @@
 import logging
 import os
-import time
 from typing import Any, Dict, Literal, Optional, Union
 
 import numpy as np
 import pandas as pd
 
 from autogluon.common.loaders import load_pkl
-from autogluon.core.utils.exceptions import TimeLimitExceeded
 from autogluon.timeseries.dataset.ts_dataframe import TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 from autogluon.timeseries.utils.forecast import get_forecast_horizon_index_ts_dataframe
@@ -53,48 +51,6 @@ MODEL_ALIASES = {
     "base": "amazon/chronos-t5-base",
     "large": "amazon/chronos-t5-large",
 }
-
-
-class ChronosInferenceDataset:
-    """A container for time series datasets that implements the ``torch.utils.data.Dataset`` interface"""
-
-    def __init__(
-        self,
-        target_df: TimeSeriesDataFrame,
-        context_length: int,
-        target_column: str = "target",
-        time_limit: Optional[float] = None,
-    ):
-        assert context_length > 0
-        self.context_length = context_length
-        self.target_array = target_df[target_column].to_numpy(dtype=np.float32)
-        self.freq = target_df.freq
-        self.creation_time = time.time()
-        self.time_limit = time_limit
-
-        # store pointer to start:end of each time series
-        cum_sizes = target_df.num_timesteps_per_item().values.cumsum()
-        self.indptr = np.append(0, cum_sizes).astype(np.int32)
-
-    def __len__(self):
-        return len(self.indptr) - 1  # noqa
-
-    def _get_context(self, a: np.ndarray, pad_value=np.nan):
-        a = a[-self.context_length :]
-        pad_size = self.context_length - len(a)
-        if pad_size > 0:
-            pad = np.full(shape=(pad_size,), fill_value=pad_value)
-            a = np.concatenate((pad, a))
-        return a
-
-    def __getitem__(self, idx) -> np.ndarray:
-        if self.time_limit is not None and time.time() - self.creation_time > self.time_limit:
-            raise TimeLimitExceeded
-
-        start_idx = self.indptr[idx]
-        end_idx = self.indptr[idx + 1]
-
-        return self._get_context(self.target_array[start_idx:end_idx])
 
 
 class ChronosModel(AbstractTimeSeriesModel):
@@ -306,20 +262,20 @@ class ChronosModel(AbstractTimeSeriesModel):
         num_workers: int = 0,
         time_limit: Optional[float] = None,
     ):
-        import torch
+        from .utils import ChronosInferenceDataLoader, ChronosInferenceDataset, timeout_callback
 
         chronos_dataset = ChronosInferenceDataset(
             target_df=data,
             target_column=self.target,
             context_length=context_length,
-            time_limit=time_limit,
         )
 
-        return torch.utils.data.DataLoader(
+        return ChronosInferenceDataLoader(
             chronos_dataset,
             batch_size=self.batch_size,
             shuffle=False,
             num_workers=num_workers,
+            on_batch=timeout_callback(seconds=time_limit),
         )
 
     def _predict(

--- a/timeseries/src/autogluon/timeseries/models/chronos/model.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/model.py
@@ -346,6 +346,7 @@ class ChronosModel(AbstractTimeSeriesModel):
         **predict_kwargs,
     ) -> None:
         # All computation happens during inference, so we provide the time_limit at prediction time
+        # TODO: Once custom predict_kwargs is allowed, make sure that `time_limit` is not among the keys
         super().score_and_cache_oof(
             val_data, store_val_score, store_predict_time, time_limit=self.time_limit, **predict_kwargs
         )

--- a/timeseries/src/autogluon/timeseries/models/chronos/utils.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/utils.py
@@ -1,0 +1,66 @@
+import time
+from typing import Callable
+
+import numpy as np
+import torch
+
+from autogluon.core.utils.exceptions import TimeLimitExceeded
+from autogluon.timeseries.dataset.ts_dataframe import TimeSeriesDataFrame
+
+
+class ChronosInferenceDataset:
+    """A container for time series datasets that implements the ``torch.utils.data.Dataset`` interface"""
+
+    def __init__(
+        self,
+        target_df: TimeSeriesDataFrame,
+        context_length: int,
+        target_column: str = "target",
+    ):
+        assert context_length > 0
+        self.context_length = context_length
+        self.target_array = target_df[target_column].to_numpy(dtype=np.float32)
+        self.freq = target_df.freq
+
+        # store pointer to start:end of each time series
+        cum_sizes = target_df.num_timesteps_per_item().values.cumsum()
+        self.indptr = np.append(0, cum_sizes).astype(np.int32)
+
+    def __len__(self):
+        return len(self.indptr) - 1  # noqa
+
+    def _get_context(self, a: np.ndarray, pad_value=np.nan):
+        a = a[-self.context_length :]
+        pad_size = self.context_length - len(a)
+        if pad_size > 0:
+            pad = np.full(shape=(pad_size,), fill_value=pad_value)
+            a = np.concatenate((pad, a))
+        return a
+
+    def __getitem__(self, idx) -> np.ndarray:
+        start_idx = self.indptr[idx]
+        end_idx = self.indptr[idx + 1]
+
+        return self._get_context(self.target_array[start_idx:end_idx])
+
+
+class ChronosInferenceDataLoader(torch.utils.data.DataLoader):
+    def __init__(self, *args, **kwargs):
+        self.callback: Callable = kwargs.pop("on_batch", lambda: None)
+        super().__init__(*args, **kwargs)
+
+    def __iter__(self):
+        for item in super().__iter__():
+            yield item
+            self.callback()
+
+
+def timeout_callback(seconds: float) -> Callable:
+    """Return a callback object that raises an exception if time limit is exceeded."""
+    start_time = time.time()
+
+    def callback() -> None:
+        if time.time() - start_time > seconds:
+            raise TimeLimitExceeded
+
+    return callback

--- a/timeseries/src/autogluon/timeseries/models/chronos/utils.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/utils.py
@@ -1,5 +1,5 @@
 import time
-from typing import Callable
+from typing import Callable, Optional
 
 import numpy as np
 import torch
@@ -55,12 +55,12 @@ class ChronosInferenceDataLoader(torch.utils.data.DataLoader):
             self.callback()
 
 
-def timeout_callback(seconds: float) -> Callable:
+def timeout_callback(seconds: Optional[float]) -> Callable:
     """Return a callback object that raises an exception if time limit is exceeded."""
     start_time = time.time()
 
     def callback() -> None:
-        if time.time() - start_time > seconds:
+        if seconds is not None and time.time() - start_time > seconds:
             raise TimeLimitExceeded
 
     return callback

--- a/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
+++ b/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
@@ -189,6 +189,7 @@ class MultiWindowBacktestingModel(AbstractTimeSeriesModel):
         val_data: TimeSeriesDataFrame,
         store_val_score: bool = False,
         store_predict_time: bool = False,
+        **predict_kwargs,
     ) -> None:
         # self.val_score, self.predict_time, self._oof_predictions already saved during _fit()
         assert self._oof_predictions is not None

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -580,3 +580,14 @@ def test_when_model_created_then_model_has_all_required_tags(temp_model_path, mo
     for tag in EXPECTED_MODEL_TAGS:
         assert tag in model_tags
     assert len(model_tags) == len(EXPECTED_MODEL_TAGS)
+
+
+@pytest.mark.parametrize("model_class", CHRONOS_TESTABLE_MODELS + LOCAL_TESTABLE_MODELS)
+def test_when_inference_only_model_scores_oof_then_time_limit_is_passed_to_predict(model_class):
+    data = DUMMY_TS_DATAFRAME
+    model = model_class(freq=data.freq, hyperparameters=DUMMY_HYPERPARAMETERS)
+    time_limit = 94.4
+    model.fit(train_data=data, time_limit=time_limit)
+    with mock.patch.object(model, "_predict") as mock_predict:
+        model.score_and_cache_oof(data)
+        assert mock_predict.call_args[1]["time_limit"] == time_limit

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -583,9 +583,9 @@ def test_when_model_created_then_model_has_all_required_tags(temp_model_path, mo
 
 
 @pytest.mark.parametrize("model_class", CHRONOS_TESTABLE_MODELS + LOCAL_TESTABLE_MODELS)
-def test_when_inference_only_model_scores_oof_then_time_limit_is_passed_to_predict(model_class):
+def test_when_inference_only_model_scores_oof_then_time_limit_is_passed_to_predict(model_class, dummy_hyperparameters):
     data = DUMMY_TS_DATAFRAME
-    model = model_class(freq=data.freq, hyperparameters=DUMMY_HYPERPARAMETERS)
+    model = model_class(freq=data.freq, hyperparameters=dummy_hyperparameters)
     time_limit = 94.4
     model.fit(train_data=data, time_limit=time_limit)
     with mock.patch.object(model, "_predict") as mock_predict:


### PR DESCRIPTION
*Description of changes:*
- Ensure that Chronos does not have an extremely long inference time during model selection (e.g., if huge dataset is provided on bad hardware) by adding a callback to the Chronos dataloader that checks if the time_limit is not exceeded
- Unify design of inference time limits between local models & Chronos


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
