### PR TITLE
[timeseries] use chronos test fixture in smoke tests

### DIFF
--- a/timeseries/tests/conftest.py
+++ b/timeseries/tests/conftest.py
@@ -35,8 +35,8 @@ def temp_model_path(tmp_path_factory):
 
 @pytest.fixture(scope="session")
 def hf_model_path(tmp_path_factory):
-    """Force HuggingFace to cache the model config once and reuse it from a temporary cache directory.
-    This prevents inflating HuggingFace download numbers as an HTTP request is sent every time
+    """Force Hugging Face to cache the model config once and reuse it from a temporary cache directory.
+    This prevents inflating Hugging Face download numbers as an HTTP request is sent every time
     ``ChronosPipeline.from_pretrained`` is called.
     """
     model_hub_id = "amazon/chronos-t5-tiny"
@@ -57,4 +57,7 @@ def hf_model_path(tmp_path_factory):
 
         yield str(snapshot_dir)
     except:
+        import warnings
+
+        warnings.warn("Could not cache Chronos for test session. Will call Hugging Face directly.")
         yield model_hub_id  # fallback to hub id if no snapshots found

--- a/timeseries/tests/smoketests/test_all_models.py
+++ b/timeseries/tests/smoketests/test_all_models.py
@@ -7,7 +7,6 @@ from pkg_resources import parse_version
 
 from autogluon.timeseries import TimeSeriesPredictor
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP, TimeSeriesDataFrame
-from autogluon.timeseries.models.presets import MODEL_TYPES
 from autogluon.timeseries.utils.datetime.seasonality import DEFAULT_SEASONALITIES
 
 TARGET_COLUMN = "custom_target"

--- a/timeseries/tests/smoketests/test_all_models.py
+++ b/timeseries/tests/smoketests/test_all_models.py
@@ -62,7 +62,7 @@ ALL_MODELS = {
     "ADIDA": DUMMY_MODEL_HPARAMS,
     "Average": DUMMY_MODEL_HPARAMS,
     "AutoCES": DUMMY_MODEL_HPARAMS,
-    "Chronos": {"model_path": "amazon/chronos-t5-tiny"},
+    "Chronos": {},
     "CrostonSBA": DUMMY_MODEL_HPARAMS,
     "DLinear": DUMMY_MODEL_HPARAMS,
     "DeepAR": DUMMY_MODEL_HPARAMS,
@@ -86,11 +86,28 @@ ALL_MODELS = {
 }
 
 
+# we wrap ALL_MODELS in a fixture in order to reuse the hf_model_path fixture, which
+# prevents polling Hugging Face during testing
+@pytest.fixture(scope="session")
+def all_model_hyperparams(hf_model_path):
+    return {
+        **ALL_MODELS,
+        "Chronos": {"model_path": hf_model_path},
+    }
+
+
 def assert_leaderboard_contains_all_models(leaderboard: pd.DataFrame, include_ensemble: bool = True):
-    expected_models = set(MODEL_TYPES[m](hyperparameters=kwargs).name for m, kwargs in ALL_MODELS.items())
+    expected_models = set(ALL_MODELS.keys())
     if include_ensemble:
         expected_models = expected_models.union({"WeightedEnsemble"})
-    failed_models = expected_models.difference(set(leaderboard["model"]))
+
+    failed_models = [
+        model
+        for model in expected_models
+        if not any(
+            fitted.startswith(model) for fitted in leaderboard["model"]  # Chronos appends more information to name
+        )
+    ]
     assert len(failed_models) == 0, f"Failed models: {failed_models}"
 
 
@@ -105,6 +122,7 @@ def test_all_models_can_handle_all_covariates(
     use_static_features_continuous,
     use_static_features_categorical,
     eval_metric,
+    all_model_hyperparams,
 ):
     prediction_length = 5
     train_data, test_data = generate_train_and_test_data(
@@ -123,7 +141,7 @@ def test_all_models_can_handle_all_covariates(
         known_covariates_names=known_covariates_names if len(known_covariates_names) > 0 else None,
         eval_metric=eval_metric,
     )
-    predictor.fit(train_data, hyperparameters=ALL_MODELS)
+    predictor.fit(train_data, hyperparameters=all_model_hyperparams)
     predictor.evaluate(test_data)
     leaderboard = predictor.leaderboard(test_data)
 
@@ -138,7 +156,7 @@ def test_all_models_can_handle_all_covariates(
 
 
 @pytest.mark.parametrize("freq", DEFAULT_SEASONALITIES.keys())
-def test_all_models_handle_all_pandas_frequencies(freq):
+def test_all_models_handle_all_pandas_frequencies(freq, all_model_hyperparams):
     if parse_version(pd.__version__) < parse_version("2.1") and freq == "SM":
         pytest.skip("'SM' frequency inference not supported by pandas < 2.1")
 
@@ -158,7 +176,7 @@ def test_all_models_handle_all_pandas_frequencies(freq):
         prediction_length=prediction_length,
         known_covariates_names=known_covariates_names if len(known_covariates_names) > 0 else None,
     )
-    predictor.fit(train_data, hyperparameters=ALL_MODELS)
+    predictor.fit(train_data, hyperparameters=all_model_hyperparams)
     predictor.evaluate(test_data)
     leaderboard = predictor.leaderboard(test_data)
 

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -43,7 +43,6 @@ def dummy_hyperparameters(hf_model_path):
     return {
         "epochs": 1,
         "num_batches_per_epoch": 1,
-        "maxiter": 1,
         "n_jobs": 1,
         "use_fallback_model": False,
         "model_path": hf_model_path,

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -35,19 +35,23 @@ TESTABLE_MODELS = (
     + [get_multi_window_deepar]
 )
 
-DUMMY_HYPERPARAMETERS = {
-    "epochs": 1,
-    "num_batches_per_epoch": 1,
-    "maxiter": 1,
-    "n_jobs": 1,
-    "use_fallback_model": False,
-    "model_path": "amazon/chronos-t5-tiny",
-}
 TESTABLE_PREDICTION_LENGTHS = [1, 5]
 
 
 @pytest.fixture(scope="module")
-def trained_models():
+def dummy_hyperparameters(hf_model_path):
+    return {
+        "epochs": 1,
+        "num_batches_per_epoch": 1,
+        "maxiter": 1,
+        "n_jobs": 1,
+        "use_fallback_model": False,
+        "model_path": hf_model_path,
+    }
+
+
+@pytest.fixture(scope="module")
+def trained_models(dummy_hyperparameters):
     models = {}
     model_paths = []
     for model_class, prediction_length in itertools.product(TESTABLE_MODELS, TESTABLE_PREDICTION_LENGTHS):
@@ -56,7 +60,7 @@ def trained_models():
             path=temp_model_path,
             freq="H",
             prediction_length=prediction_length,
-            hyperparameters=DUMMY_HYPERPARAMETERS,
+            hyperparameters=dummy_hyperparameters,
         )
 
         model.fit(train_data=DUMMY_TS_DATAFRAME)
@@ -148,12 +152,14 @@ def test_when_models_saved_then_they_can_be_loaded(model_class, trained_models, 
 @flaky
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="HPO tests lead to known issues in Windows platform tests")
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
-def test_given_hyperparameter_spaces_when_tune_called_then_tuning_output_correct(model_class, temp_model_path):
+def test_given_hyperparameter_spaces_when_tune_called_then_tuning_output_correct(
+    model_class, temp_model_path, dummy_hyperparameters
+):
     model = model_class(
         path=temp_model_path,
         freq="H",
         quantile_levels=[0.1, 0.9],
-        hyperparameters={**DUMMY_HYPERPARAMETERS, "epochs": space.Int(1, 3)},
+        hyperparameters={**dummy_hyperparameters, "epochs": space.Int(1, 3)},
     )
     if isinstance(model, MultiWindowBacktestingModel):
         val_data = None
@@ -198,14 +204,14 @@ def test_given_hyperparameter_spaces_to_init_when_fit_called_then_error_is_raise
     ],
 )
 def test_when_fit_called_then_models_train_and_returned_predictor_inference_has_mean_and_correct_quantiles(
-    model_class, quantile_levels, temp_model_path
+    model_class, quantile_levels, temp_model_path, dummy_hyperparameters
 ):
     model = model_class(
         path=temp_model_path,
         freq="H",
         prediction_length=3,
         quantile_levels=quantile_levels,
-        hyperparameters=DUMMY_HYPERPARAMETERS,
+        hyperparameters=dummy_hyperparameters,
     )
     model.fit(train_data=DUMMY_TS_DATAFRAME)
     predictions = model.predict(DUMMY_TS_DATAFRAME, quantile_levels=quantile_levels)
@@ -242,7 +248,7 @@ def test_when_fit_called_then_models_train_and_returned_predictor_inference_corr
 )
 @pytest.mark.parametrize("test_data_index", [["A", "B"], ["C", "D"], ["A"]])
 def test_when_fit_called_then_models_train_and_returned_predictor_inference_aligns_with_time(
-    model_class, test_data_index, temp_model_path
+    model_class, test_data_index, temp_model_path, dummy_hyperparameters
 ):
     prediction_length = 3
     train_data = get_data_frame_with_item_index(["A", "B"], data_length=10)
@@ -252,7 +258,7 @@ def test_when_fit_called_then_models_train_and_returned_predictor_inference_alig
         path=temp_model_path,
         freq="H",
         prediction_length=prediction_length,
-        hyperparameters=DUMMY_HYPERPARAMETERS,
+        hyperparameters=dummy_hyperparameters,
     )
 
     model.fit(train_data=train_data)
@@ -266,7 +272,9 @@ def test_when_fit_called_then_models_train_and_returned_predictor_inference_alig
 
 @pytest.mark.parametrize("freq", ["D", "H", "S", "M"])
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
-def test_when_predict_called_then_predicted_timestamps_align_with_time(model_class, freq, temp_model_path):
+def test_when_predict_called_then_predicted_timestamps_align_with_time(
+    model_class, freq, temp_model_path, dummy_hyperparameters
+):
     prediction_length = 4
     train_length = 20
     item_id = "A"
@@ -278,7 +286,7 @@ def test_when_predict_called_then_predicted_timestamps_align_with_time(model_cla
         path=temp_model_path,
         freq=train_data.freq,
         prediction_length=prediction_length,
-        hyperparameters=DUMMY_HYPERPARAMETERS,
+        hyperparameters=dummy_hyperparameters,
     )
 
     model.fit(train_data=train_data)
@@ -317,14 +325,14 @@ def test_when_predict_called_then_predicted_timestamps_align_with_time(model_cla
     ],
 )
 def test_when_predict_called_with_test_data_then_predictor_inference_correct(
-    model_class, temp_model_path, train_data, test_data
+    model_class, temp_model_path, train_data, test_data, dummy_hyperparameters
 ):
     prediction_length = 5
     model = model_class(
         path=temp_model_path,
         freq="H",
         prediction_length=prediction_length,
-        hyperparameters=DUMMY_HYPERPARAMETERS,
+        hyperparameters=dummy_hyperparameters,
     )
 
     model.fit(train_data=train_data)
@@ -362,13 +370,15 @@ def test_when_get_info_is_called_then_all_keys_are_present(model_class, predicti
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
-def test_when_median_not_in_quantile_levels_then_median_is_present_in_raw_predictions(model_class):
+def test_when_median_not_in_quantile_levels_then_median_is_present_in_raw_predictions(
+    model_class, dummy_hyperparameters
+):
     data = get_data_frame_with_item_index(["B", "A", "X", "C"])
     model = model_class(
         prediction_length=3,
         quantile_levels=[0.1, 0.15],
         freq=data.freq,
-        hyperparameters=DUMMY_HYPERPARAMETERS,
+        hyperparameters=dummy_hyperparameters,
     )
     if isinstance(model, MultiWindowBacktestingModel):
         # Median is present in the predictions of the base model, but not in the MultiWindowBacktestingModel wrapper
@@ -380,12 +390,14 @@ def test_when_median_not_in_quantile_levels_then_median_is_present_in_raw_predic
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
-def test_when_median_not_in_quantile_levels_then_median_is_dropped_at_prediction_time(model_class):
+def test_when_median_not_in_quantile_levels_then_median_is_dropped_at_prediction_time(
+    model_class, dummy_hyperparameters
+):
     model = model_class(
         prediction_length=3,
         quantile_levels=[0.1, 0.15],
         freq=DUMMY_TS_DATAFRAME.freq,
-        hyperparameters=DUMMY_HYPERPARAMETERS,
+        hyperparameters=dummy_hyperparameters,
     )
     assert model.must_drop_median
     model.fit(train_data=DUMMY_TS_DATAFRAME)
@@ -394,12 +406,12 @@ def test_when_median_not_in_quantile_levels_then_median_is_dropped_at_prediction
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
-def test_when_custom_metric_passed_to_model_then_model_can_score(model_class):
+def test_when_custom_metric_passed_to_model_then_model_can_score(model_class, dummy_hyperparameters):
     model = model_class(
         prediction_length=3,
         freq=DUMMY_TS_DATAFRAME.freq,
         quantile_levels=[0.1, 0.15],
-        hyperparameters=DUMMY_HYPERPARAMETERS,
+        hyperparameters=dummy_hyperparameters,
         eval_metric=CustomMetric(),
     )
     model.fit(train_data=DUMMY_TS_DATAFRAME)
@@ -408,11 +420,11 @@ def test_when_custom_metric_passed_to_model_then_model_can_score(model_class):
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
-def test_when_custom_metric_passed_to_model_then_model_can_hyperparameter_tune(model_class):
+def test_when_custom_metric_passed_to_model_then_model_can_hyperparameter_tune(model_class, dummy_hyperparameters):
     model = model_class(
         prediction_length=3,
         freq=DUMMY_TS_DATAFRAME.freq,
-        hyperparameters={**DUMMY_HYPERPARAMETERS, "epochs": space.Int(1, 3)},
+        hyperparameters={**dummy_hyperparameters, "epochs": space.Int(1, 3)},
         eval_metric=CustomMetric(),
     )
     backend = model._get_hpo_backend()
@@ -479,14 +491,16 @@ def test_given_searcher_when_ray_backend_used_in_hpo_then_correct_searcher_used(
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
-def test_when_data_contains_missing_values_then_model_can_fit_and_predict(temp_model_path, model_class):
+def test_when_data_contains_missing_values_then_model_can_fit_and_predict(
+    temp_model_path, model_class, dummy_hyperparameters
+):
     data = DUMMY_TS_DATAFRAME
     prediction_length = 5
     model = model_class(
         freq=data.freq,
         path=temp_model_path,
         prediction_length=prediction_length,
-        hyperparameters=DUMMY_HYPERPARAMETERS,
+        hyperparameters=dummy_hyperparameters,
     )
     model.fit(
         train_data=data,
@@ -497,9 +511,11 @@ def test_when_data_contains_missing_values_then_model_can_fit_and_predict(temp_m
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
-def test_when_fit_and_predict_called_then_train_val_and_test_data_is_preprocessed(temp_model_path, model_class):
+def test_when_fit_and_predict_called_then_train_val_and_test_data_is_preprocessed(
+    temp_model_path, model_class, dummy_hyperparameters
+):
     train_data = DUMMY_TS_DATAFRAME.copy()
-    model = model_class(freq=train_data.freq, path=temp_model_path, hyperparameters=DUMMY_HYPERPARAMETERS)
+    model = model_class(freq=train_data.freq, path=temp_model_path, hyperparameters=dummy_hyperparameters)
     preprocessed_data = train_data + 5.0
     if model._get_tags()["can_use_val_data"]:
         expected_val_data = preprocessed_data
@@ -523,7 +539,9 @@ def test_when_fit_and_predict_called_then_train_val_and_test_data_is_preprocesse
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
-def test_given_model_doesnt_support_nan_when_model_fits_then_nans_are_filled(temp_model_path, model_class):
+def test_given_model_doesnt_support_nan_when_model_fits_then_nans_are_filled(
+    temp_model_path, model_class, dummy_hyperparameters
+):
     data = get_data_frame_with_item_index(["B", "A", "C", "X"])
     data.iloc[[0, 1, 5, 10, 23, 26, 33, 60]] = float("nan")
     prediction_length = 5
@@ -531,7 +549,7 @@ def test_given_model_doesnt_support_nan_when_model_fits_then_nans_are_filled(tem
         freq=data.freq,
         path=temp_model_path,
         prediction_length=prediction_length,
-        hyperparameters=DUMMY_HYPERPARAMETERS,
+        hyperparameters=dummy_hyperparameters,
     )
 
     with mock.patch.object(model, "_fit") as mock_fit:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Previously time series smoke tests and model tests did not reuse the `hf_model_path` test fixture, leading to about ~250 downloads on Hugging Face for each CI run. This PR brings the number to about ~10~ 40. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
