### PR TITLE
[timeseries] Fix logger messages if series are all NaN

### DIFF
--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -759,10 +759,10 @@ class TimeSeriesDataFrame(pd.DataFrame, TimeSeriesDataFrameDeprecatedMixin):
                 2019-02-07     4.0
 
         """
-        if not self.index.is_monotonic_increasing:
-            logger.warning(
-                "Trying to fill missing values in an unsorted dataframe. "
-                "It is highly recommended to call `ts_df.sort_index()` before calling `ts_df.fill_missing_values()`"
+        if self.freq is None:
+            raise ValueError(
+                "Please make sure that all time series have a regular index before calling `fill_missing_values`"
+                "(for example, using the `convert_frequency` method)."
             )
 
         # Convert to pd.DataFrame for faster processing

--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -759,10 +759,10 @@ class TimeSeriesDataFrame(pd.DataFrame, TimeSeriesDataFrameDeprecatedMixin):
                 2019-02-07     4.0
 
         """
-        if self.freq is None:
-            raise ValueError(
-                "Please make sure that all time series have a regular index before calling `fill_missing_values`"
-                "(for example, using the `convert_frequency` method)."
+        if not self.index.is_monotonic_increasing:
+            logger.warning(
+                "Trying to fill missing values in an unsorted dataframe. "
+                "It is highly recommended to call `ts_df.sort_index()` before calling `ts_df.fill_missing_values()`"
             )
 
         # Convert to pd.DataFrame for faster processing

--- a/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
+++ b/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
@@ -185,9 +185,9 @@ class AbstractLocalModel(AbstractTimeSeriesModel):
         if end_time is not None and time.time() >= end_time:
             raise TimeLimitExceeded
 
+        model_failed = False
         if time_series.isna().all():
             result = self._dummy_forecast.copy()
-            model_failed = True
         else:
             try:
                 result = self._predict_with_local_model(
@@ -196,7 +196,6 @@ class AbstractLocalModel(AbstractTimeSeriesModel):
                 )
                 if not np.isfinite(result.values).all():
                     raise RuntimeError("Forecast contains NaN or Inf values.")
-                model_failed = False
             except Exception:
                 if self.use_fallback_model:
                     result = seasonal_naive_forecast(


### PR DESCRIPTION
*Description of changes:*
- Avoid printing the following error message when dummy forecast is used for all-NaN series
```
Warning: SeasonalNaive/W0 failed for 1 time series (50%). Fallback model SeasonalNaive was used for these time series
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
