### PR TITLE
[timeseries] Add scale feature and normalize covariates for MLForecast models

### DIFF
--- a/timeseries/tests/unittests/models/test_mlforecast.py
+++ b/timeseries/tests/unittests/models/test_mlforecast.py
@@ -49,7 +49,7 @@ def test_when_covariates_and_features_present_then_train_and_val_dfs_have_correc
     )
     # Initialize model._target_lags and model._date_features from freq
     model.fit(train_data=data, time_limit=3)
-    train_df, val_df = model._generate_train_val_dfs(data)
+    train_df, val_df = model._generate_train_val_dfs(model._add_scale_as_static_feature(data))
     expected_num_features = (
         len(lags)
         + len(known_covariates_names)

--- a/timeseries/tests/unittests/models/test_mlforecast.py
+++ b/timeseries/tests/unittests/models/test_mlforecast.py
@@ -53,9 +53,11 @@ def test_when_covariates_and_features_present_then_train_and_val_dfs_have_correc
     expected_num_features = (
         len(lags)
         + len(known_covariates_names)
+        + len(model.metadata.known_covariates_real)  # item-normalized version of each real covariate
         + len(static_features_names)
         + len(model._date_features)
         + 2  # target, item_id
+        + 2  # mean/scale of the target
     )
     # sum(differences) rows  dropped per item, prediction_length rows are reserved for validation
     expected_num_train_rows = len(data) - (sum(differences) + model.prediction_length) * data.num_items


### PR DESCRIPTION
*Description of changes:*
- Some lightweight feature engineering for MLForecast-based models:
  - Add two static features, encoding mean & std of the target time series for each item
  - For each continuous real-valued covariate, add a copy of this covariate that is mean-abs-scaled per item


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
