### PR TITLE
[timeseries] Fix prediction failing if context contains < 3 observations

### DIFF
--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -759,18 +759,18 @@ class TimeSeriesDataFrame(pd.DataFrame, TimeSeriesDataFrameDeprecatedMixin):
                 2019-02-07     4.0
 
         """
-        if self.freq is None:
-            raise ValueError(
-                "Please make sure that all time series have a regular index before calling `fill_missing_values`"
-                "(for example, using the `convert_frequency` method)."
-            )
-
         # Convert to pd.DataFrame for faster processing
         df = pd.DataFrame(self)
 
         # Skip filling if there are no NaNs
         if not df.isna().any(axis=None):
             return self
+
+        if not self.index.is_monotonic_increasing:
+            logger.warning(
+                "Trying to fill missing values in an unsorted dataframe. "
+                "It is highly recommended to call `ts_df.sort_index()` before calling `ts_df.fill_missing_values()`"
+            )
 
         grouped_df = df.groupby(level=ITEMID, sort=False, group_keys=False)
         if method == "auto":

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -497,7 +497,7 @@ class DirectTabularModel(AbstractMLForecastModel):
         if known_covariates is not None:
             data_future = known_covariates.copy()
         else:
-            future_index = get_forecast_horizon_index_ts_dataframe(data, self.prediction_length)
+            future_index = get_forecast_horizon_index_ts_dataframe(data, self.prediction_length, freq=self.freq)
             data_future = pd.DataFrame(columns=[self.target], index=future_index, dtype="float32")
         # MLForecast raises exception of target contains NaN. We use inf as placeholder, replace them by NaN afterwards
         data_future[self.target] = float("inf")
@@ -630,7 +630,7 @@ class RecursiveTabularModel(AbstractMLForecastModel):
         if self._max_ts_length is not None:
             new_df = self._shorten_all_series(new_df, self._max_ts_length)
         if known_covariates is None:
-            future_index = get_forecast_horizon_index_ts_dataframe(data, self.prediction_length)
+            future_index = get_forecast_horizon_index_ts_dataframe(data, self.prediction_length, freq=self.freq)
             known_covariates = pd.DataFrame(columns=[self.target], index=future_index, dtype="float32")
         X_df = self._to_mlforecast_df(known_covariates, data.static_features, include_target=False)
         # If both covariates & static features are missing, set X_df = None to avoid exception from MLForecast

--- a/timeseries/src/autogluon/timeseries/models/chronos/model.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/model.py
@@ -330,7 +330,7 @@ class ChronosModel(AbstractTimeSeriesModel):
         df = pd.DataFrame(
             np.concatenate([mean, quantiles], axis=1),
             columns=["mean"] + [str(q) for q in self.quantile_levels],
-            index=get_forecast_horizon_index_ts_dataframe(data, self.prediction_length),
+            index=get_forecast_horizon_index_ts_dataframe(data, self.prediction_length, freq=self.freq),
         )
 
         return TimeSeriesDataFrame(df)

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -46,6 +46,7 @@ class SimpleGluonTSDataset(GluonTSDataset):
     def __init__(
         self,
         target_df: TimeSeriesDataFrame,
+        freq: str,
         target_column: str = "target",
         feat_static_cat: Optional[np.ndarray] = None,
         feat_static_real: Optional[np.ndarray] = None,
@@ -57,7 +58,6 @@ class SimpleGluonTSDataset(GluonTSDataset):
         prediction_length: int = None,
     ):
         assert target_df is not None
-        assert target_df.freq, "Initializing GluonTS data sets without freq is not allowed"
         # Convert TimeSeriesDataFrame to pd.Series for faster processing
         self.target_array = target_df[target_column].to_numpy(np.float32)
         self.feat_static_cat = self._astype(feat_static_cat, dtype=np.int64)
@@ -66,7 +66,7 @@ class SimpleGluonTSDataset(GluonTSDataset):
         self.feat_dynamic_real = self._astype(feat_dynamic_real, dtype=np.float32)
         self.past_feat_dynamic_cat = self._astype(past_feat_dynamic_cat, dtype=np.int64)
         self.past_feat_dynamic_real = self._astype(past_feat_dynamic_real, dtype=np.float32)
-        self.freq = self._to_gluonts_freq(target_df.freq)
+        self.freq = self._to_gluonts_freq(freq)
 
         # Necessary to compute indptr for known_covariates at prediction time
         self.includes_future = includes_future
@@ -234,13 +234,6 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
 
     def _deferred_init_params_aux(self, dataset: TimeSeriesDataFrame) -> None:
         """Update GluonTS specific parameters with information available only at training time."""
-        self.freq = dataset.freq or self.freq
-        if not self.freq:
-            raise ValueError(
-                "Dataset frequency not provided in the dataset, fit arguments or "
-                "during initialization. Please provide a `freq` string to `fit`."
-            )
-
         model_params = self._get_model_params()
         disable_static_features = model_params.get("disable_static_features", False)
         if not disable_static_features:
@@ -502,6 +495,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
 
             return SimpleGluonTSDataset(
                 target_df=time_series_df[[self.target]],
+                freq=self.freq,
                 target_column=self.target,
                 feat_static_cat=feat_static_cat,
                 feat_static_real=feat_static_real,

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -592,7 +592,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
             predicted_targets = self._predict_gluonts_forecasts(data, known_covariates=known_covariates, **kwargs)
             df = self._gluonts_forecasts_to_data_frame(
                 predicted_targets,
-                forecast_index=get_forecast_horizon_index_ts_dataframe(data, self.prediction_length),
+                forecast_index=get_forecast_horizon_index_ts_dataframe(data, self.prediction_length, freq=self.freq),
             )
         return df
 

--- a/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
+++ b/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
@@ -166,7 +166,7 @@ class AbstractLocalModel(AbstractTimeSeriesModel):
                 f"({fraction_failed_models:.1%}). Fallback model SeasonalNaive was used for these time series."
             )
         predictions_df = pd.concat([pred for pred, _ in predictions_with_flags])
-        predictions_df.index = get_forecast_horizon_index_ts_dataframe(data, self.prediction_length)
+        predictions_df.index = get_forecast_horizon_index_ts_dataframe(data, self.prediction_length, freq=self.freq)
         return TimeSeriesDataFrame(predictions_df)
 
     def score_and_cache_oof(

--- a/timeseries/src/autogluon/timeseries/utils/forecast.py
+++ b/timeseries/src/autogluon/timeseries/utils/forecast.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -15,7 +16,9 @@ def get_forecast_horizon_index_single_time_series(
 
 
 def get_forecast_horizon_index_ts_dataframe(
-    ts_dataframe: TimeSeriesDataFrame, prediction_length: int
+    ts_dataframe: TimeSeriesDataFrame,
+    prediction_length: int,
+    freq: Optional[str] = None,
 ) -> pd.MultiIndex:
     """For each item in the dataframe, get timestamps for the next prediction_length many time steps into the future.
 
@@ -26,7 +29,9 @@ def get_forecast_horizon_index_ts_dataframe(
     last = ts_dataframe.reset_index()[[ITEMID, TIMESTAMP]].groupby(by=ITEMID, sort=False, as_index=False).last()
     item_ids = np.repeat(last[ITEMID], prediction_length)
 
-    offset = pd.tseries.frequencies.to_offset(ts_dataframe.freq)
+    if freq is None:
+        freq = ts_dataframe.freq
+    offset = pd.tseries.frequencies.to_offset(freq)
     last_ts = pd.DatetimeIndex(last[TIMESTAMP])
     # Non-vectorized offsets like BusinessDay may produce a PerformanceWarning - we filter them
     with warnings.catch_warnings():

--- a/timeseries/tests/unittests/models/test_gluonts.py
+++ b/timeseries/tests/unittests/models/test_gluonts.py
@@ -268,7 +268,10 @@ def test_when_static_and_dynamic_covariates_present_then_model_trains_normally(m
 
 @pytest.mark.parametrize("predict_batch_size", [30, 200])
 def test_given_custom_predict_batch_size_then_predictor_uses_correct_batch_size(predict_batch_size):
-    model = PatchTSTModel(hyperparameters={"predict_batch_size": predict_batch_size, **DUMMY_HYPERPARAMETERS})
+    model = PatchTSTModel(
+        hyperparameters={"predict_batch_size": predict_batch_size, **DUMMY_HYPERPARAMETERS},
+        freq=DUMMY_TS_DATAFRAME.freq,
+    )
     model.fit(train_data=DUMMY_TS_DATAFRAME)
     assert model.gts_predictor.batch_size == predict_batch_size
 
@@ -287,7 +290,10 @@ def test_when_custom_callbacks_passed_via_trainer_kwargs_then_trainer_receives_t
     from lightning.pytorch.callbacks import RichModelSummary
 
     callback = RichModelSummary()
-    model = DLinearModel(hyperparameters={"trainer_kwargs": {"callbacks": [callback]}, **DUMMY_HYPERPARAMETERS})
+    model = DLinearModel(
+        hyperparameters={"trainer_kwargs": {"callbacks": [callback]}, **DUMMY_HYPERPARAMETERS},
+        freq=DUMMY_TS_DATAFRAME.freq,
+    )
     received_trainer_kwargs = catch_trainer_kwargs(model)
     assert any(isinstance(cb, RichModelSummary) for cb in received_trainer_kwargs["callbacks"])
 
@@ -296,7 +302,10 @@ def test_when_early_stopping_patience_provided_then_early_stopping_callback_crea
     from lightning.pytorch.callbacks import EarlyStopping
 
     patience = 7
-    model = SimpleFeedForwardModel(hyperparameters={"early_stopping_patience": patience, **DUMMY_HYPERPARAMETERS})
+    model = SimpleFeedForwardModel(
+        hyperparameters={"early_stopping_patience": patience, **DUMMY_HYPERPARAMETERS},
+        freq=DUMMY_TS_DATAFRAME.freq,
+    )
     received_trainer_kwargs = catch_trainer_kwargs(model)
     es_callbacks = [cb for cb in received_trainer_kwargs["callbacks"] if isinstance(cb, EarlyStopping)]
     assert len(es_callbacks) == 1
@@ -314,7 +323,10 @@ def test_when_early_stopping_patience_is_none_then_early_stopping_callback_not_c
 
 def test_when_custom_trainer_kwargs_given_then_trainer_receives_them():
     trainer_kwargs = {"max_epochs": 5, "limit_train_batches": 100}
-    model = PatchTSTModel(hyperparameters={"trainer_kwargs": trainer_kwargs, **DUMMY_HYPERPARAMETERS})
+    model = PatchTSTModel(
+        hyperparameters={"trainer_kwargs": trainer_kwargs, **DUMMY_HYPERPARAMETERS},
+        freq=DUMMY_TS_DATAFRAME.freq,
+    )
     received_trainer_kwargs = catch_trainer_kwargs(model)
     for k, v in trainer_kwargs.items():
         assert received_trainer_kwargs[k] == v

--- a/timeseries/tests/unittests/models/test_gluonts.py
+++ b/timeseries/tests/unittests/models/test_gluonts.py
@@ -315,7 +315,10 @@ def test_when_early_stopping_patience_provided_then_early_stopping_callback_crea
 def test_when_early_stopping_patience_is_none_then_early_stopping_callback_not_created():
     from lightning.pytorch.callbacks import EarlyStopping
 
-    model = SimpleFeedForwardModel(hyperparameters={"early_stopping_patience": None, **DUMMY_HYPERPARAMETERS})
+    model = SimpleFeedForwardModel(
+        hyperparameters={"early_stopping_patience": None, **DUMMY_HYPERPARAMETERS},
+        freq=DUMMY_TS_DATAFRAME.freq,
+    )
     received_trainer_kwargs = catch_trainer_kwargs(model)
     es_callbacks = [cb for cb in received_trainer_kwargs["callbacks"] if isinstance(cb, EarlyStopping)]
     assert len(es_callbacks) == 0

--- a/timeseries/tests/unittests/models/test_local.py
+++ b/timeseries/tests/unittests/models/test_local.py
@@ -179,7 +179,9 @@ def failing_predict(*args, **kwargs):
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
 def test_when_fallback_model_disabled_and_model_fails_then_exception_is_raised(temp_model_path, model_class):
-    model = model_class(temp_model_path, hyperparameters={"use_fallback_model": False, "n_jobs": 1})
+    model = model_class(
+        path=temp_model_path, hyperparameters={"use_fallback_model": False, "n_jobs": 1}, freq=DUMMY_TS_DATAFRAME.freq
+    )
     model.fit(train_data=DUMMY_TS_DATAFRAME)
     model._predict_with_local_model = failing_predict
     with pytest.raises(RuntimeError, match="Custom error message"):
@@ -188,7 +190,9 @@ def test_when_fallback_model_disabled_and_model_fails_then_exception_is_raised(t
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
 def test_when_fallback_model_enabled_and_model_fails_then_no_exception_is_raised(temp_model_path, model_class):
-    model = model_class(temp_model_path, hyperparameters={"use_fallback_model": True, "n_jobs": 1})
+    model = model_class(
+        path=temp_model_path, hyperparameters={"use_fallback_model": True, "n_jobs": 1}, freq=DUMMY_TS_DATAFRAME.freq
+    )
     model.fit(train_data=DUMMY_TS_DATAFRAME)
     model._predict_with_local_model = failing_predict
     predictions = model.predict(DUMMY_TS_DATAFRAME)


### PR DESCRIPTION
*Description of changes:*
- Many models currently rely on `data.freq` of the data passed to `model.predict(data)` when generating the forecast. It may happen that some time series in `data` passed to `predict` contain just a single observation. In this case, `freq` inference is impossible and the model fails.
- With this PR, we
  1. Rely on `self.freq` attribute of the model instead of `data.freq` whenever frequency is required
  2. Make sure that `data.fill_missing_values()` works even no `freq` is available (as this is too strong of a requirement for this method)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
