### PR TITLE
[FIX] Avoid `chdir_to_trial_dir` causing silent `DeprecationWarning` Error

### DIFF
--- a/core/src/autogluon/core/hpo/executors.py
+++ b/core/src/autogluon/core/hpo/executors.py
@@ -396,9 +396,9 @@ class RayHpoExecutor(HpoExecutor):
         trainable_is_parallel
             Whether the trainable itself will use ray to run parallel job or not.
         tune_config_kwargs
-            Additional args being passed to tune.TuneConfig https://docs.ray.io/en/latest/ray-air/package-ref.html#ray.tune.tune_config.TuneConfig
+            Additional args being passed to tune.TuneConfig https://docs.ray.io/en/latest/tune/api/doc/ray.tune.TuneConfig.html#ray-tune-tuneconfig
         run_config_kwargs
-            Additional args being passed to air.RunConfig https://docs.ray.io/en/latest/ray-air/package-ref.html#ray.air.config.RunConfig
+            Additional args being passed to air.RunConfig https://docs.ray.io/en/latest/train/api/doc/ray.train.RunConfig.html#ray.train.RunConfig
         """
         from .ray_hpo import RayTuneAdapterFactory, run
 

--- a/core/src/autogluon/core/hpo/ray_hpo.py
+++ b/core/src/autogluon/core/hpo/ray_hpo.py
@@ -206,9 +206,9 @@ def run(
     verbose
         0 = silent, 1 = only status updates, 2 = status and brief trial results, 3 = status and detailed trial results.
     tune_config_kwargs
-        Additional args being passed to tune.TuneConfig https://docs.ray.io/en/latest/ray-air/package-ref.html#ray.tune.tune_config.TuneConfig
+        Additional args being passed to tune.TuneConfig  https://docs.ray.io/en/latest/tune/api/doc/ray.tune.TuneConfig.html#ray-tune-tuneconfig
     run_config_kwargs
-        Additional args being passed to air.RunConfig https://docs.ray.io/en/latest/ray-air/package-ref.html#ray.air.config.RunConfig
+        Additional args being passed to air.RunConfig https://docs.ray.io/en/latest/train/api/doc/ray.train.RunConfig.html#ray.train.RunConfig
     """
     assert mode in [MIN, MAX], f"mode {mode} is not a valid option. Options are {[MIN, MAX]}"
     if isinstance(hyperparameter_tune_kwargs, str):

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -1541,7 +1541,7 @@ class AbstractModel:
             minimum_cpu_per_trial=minimum_resources.get("num_cpus", 1),
             minimum_gpu_per_trial=minimum_resources.get("num_gpus", 0),
             model_estimate_memory_usage=model_estimate_memory_usage,
-            adapter_type="tabular"
+            adapter_type="tabular",
         )
 
         hpo_results = hpo_executor.get_hpo_results(

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -1393,7 +1393,7 @@ class BaggedEnsembleModel(AbstractModel):
             minimum_gpu_per_trial=minimum_gpu_per_fold,
             model_estimate_memory_usage=None,  # Not needed as we've already calculated it above
             adapter_type="tabular",
-            trainable_is_parallel=True
+            trainable_is_parallel=True,
         )
 
         hpo_results = hpo_executor.get_hpo_results(

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -1381,6 +1381,10 @@ class BaggedEnsembleModel(AbstractModel):
         minimum_cpu_per_fold = minimum_resources_per_fold.get("num_cpus", 1)
         minimum_gpu_per_fold = minimum_resources_per_fold.get("num_gpus", 0)
 
+        # This explicitly tells ray.Tune to not change the working directory
+        # to the trial directory, giving access to paths relative to
+        # the original working directory.
+        os.environ["RAY_CHDIR_TO_TRIAL_DIR"] = "0"
         hpo_executor.execute(
             model_trial=model_trial,
             train_fn_kwargs=train_fn_kwargs,
@@ -1389,8 +1393,7 @@ class BaggedEnsembleModel(AbstractModel):
             minimum_gpu_per_trial=minimum_gpu_per_fold,
             model_estimate_memory_usage=None,  # Not needed as we've already calculated it above
             adapter_type="tabular",
-            trainable_is_parallel=True,
-            tune_config_kwargs={"chdir_to_trial_dir": False},
+            trainable_is_parallel=True
         )
 
         hpo_results = hpo_executor.get_hpo_results(


### PR DESCRIPTION
*Issue #, if available:*
Fixes #4075 

*Description of changes:*
Use the environment variable `RAY_CHDIR_TO_TRIAL_DIR` instead of the argument `chdir_to_trial_dir`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
