### PR TITLE
[timeseries] Fix incorrect scaling used by MLForecast models

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -106,18 +106,20 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
             if data.isna().any(axis=None):
                 data[self.target] = data[self.target].fillna(value=self._train_target_median)
 
-        for col in self.metadata.known_covariates_real:
-            # Normalize non-boolean features using mean_abs scaling
-            if not data[col].isin([0, 1]).all():
-                covariate_scales = data[col].abs().groupby(level=ITEMID, sort=False).mean()
+        with pd.option_context("mode.chained_assignment", None):
+            pd.options.mode.chained_assignment
+            for col in self.metadata.known_covariates_real:
+                # Normalize non-boolean features using mean_abs scaling
+                if not data[col].isin([0, 1]).all():
+                    covariate_scales = data[col].abs().groupby(level=ITEMID, sort=False).mean()
 
-                scaled_col = f"__scaled_{col}"
-                data[scaled_col] = data[col] / covariate_scales
-                if known_covariates is not None:
-                    known_covariates[scaled_col] = known_covariates[col] / covariate_scales
+                    scaled_col = f"__scaled_{col}"
+                    data[scaled_col] = data[col] / covariate_scales
+                    if known_covariates is not None:
+                        known_covariates[scaled_col] = known_covariates[col] / covariate_scales
 
-                if is_train:
-                    self._extra_covariates_columns.append(scaled_col)
+                    if is_train:
+                        self._extra_covariates_columns.append(scaled_col)
 
         return data, known_covariates
 

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -107,7 +107,6 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
                 data[self.target] = data[self.target].fillna(value=self._train_target_median)
 
         with pd.option_context("mode.chained_assignment", None):
-            pd.options.mode.chained_assignment
             for col in self.metadata.known_covariates_real:
                 # Normalize non-boolean features using mean_abs scaling
                 if not data[col].isin([0, 1]).all():

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -326,7 +326,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
                 data.static_features[columns] = self._real_column_transformers["static"].transform(
                     data.static_features[columns]
                 )
-        return data
+        return data, known_covariates
 
     def _get_transformer_for_columns(self, df: pd.DataFrame, columns: List[str]) -> Dict[str, str]:
         """Passthrough bool features, use QuantileTransform for skewed features, and use StandardScaler for the rest.

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -3,7 +3,7 @@ import os
 import shutil
 from datetime import timedelta
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterator, List, Literal, Optional, Type, Union
+from typing import Any, Callable, Dict, Iterator, List, Literal, Optional, Tuple, Type, Union
 
 import gluonts
 import gluonts.core.settings
@@ -289,7 +289,13 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
     def default_context_length(self) -> int:
         return min(512, max(10, 2 * self.prediction_length))
 
-    def preprocess(self, data: TimeSeriesDataFrame, is_train: bool = False, **kwargs) -> TimeSeriesDataFrame:
+    def preprocess(
+        self,
+        data: TimeSeriesDataFrame,
+        known_covariates: Optional[TimeSeriesDataFrame] = None,
+        is_train: bool = False,
+        **kwargs,
+    ) -> Tuple[TimeSeriesDataFrame, Optional[TimeSeriesDataFrame]]:
         # Copy data to avoid SettingWithCopyWarning from pandas
         data = data.copy()
         if self.supports_known_covariates and len(self.metadata.known_covariates_real) > 0:
@@ -298,6 +304,11 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
                 self._real_column_transformers["known"] = self._get_transformer_for_columns(data, columns=columns)
             assert "known" in self._real_column_transformers, "Preprocessing pipeline must be fit first"
             data[columns] = self._real_column_transformers["known"].transform(data[columns])
+
+            if known_covariates is not None:
+                known_covariates[columns] = self._real_column_transformers["known"].transform(
+                    known_covariates[columns]
+                )
 
         if self.supports_past_covariates and len(self.metadata.past_covariates_real) > 0:
             columns = self.metadata.past_covariates_real
@@ -345,15 +356,6 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         with warning_filter():
             column_transformer = ColumnTransformer(transformers=transformers, remainder="passthrough").fit(df[columns])
         return column_transformer
-
-    def preprocess_known_covariates(
-        self, known_covariates: Optional[TimeSeriesDataFrame]
-    ) -> Optional[TimeSeriesDataFrame]:
-        columns = self.metadata.known_covariates_real
-        if self.supports_known_covariates and len(columns) > 0:
-            assert "known" in self._real_column_transformers, "Preprocessing pipeline must be fit first"
-            known_covariates[columns] = self._real_column_transformers["known"].transform(known_covariates[columns])
-        return known_covariates
 
     def _get_model_params(self) -> dict:
         """Gets params that are passed to the inner model."""

--- a/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
+++ b/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
@@ -87,10 +87,16 @@ class AbstractLocalModel(AbstractTimeSeriesModel):
         self.time_limit: Optional[float] = None
         self._dummy_forecast: Optional[pd.DataFrame] = None
 
-    def preprocess(self, data: TimeSeriesDataFrame, is_train: bool = False, **kwargs) -> Any:
+    def preprocess(
+        self,
+        data: TimeSeriesDataFrame,
+        known_covariates: Optional[TimeSeriesDataFrame] = None,
+        is_train: bool = False,
+        **kwargs,
+    ) -> Tuple[TimeSeriesDataFrame, Optional[TimeSeriesDataFrame]]:
         if not self._get_tags()["allow_nan"]:
             data = data.fill_missing_values()
-        return data
+        return data, known_covariates
 
     def _fit(self, train_data: TimeSeriesDataFrame, time_limit: Optional[int] = None, **kwargs):
         self._check_fit_params()


### PR DESCRIPTION
*Description of changes:*
- The covariate scaling logic introduced in #4069 had a mistake - we used a different for past & future data. This could result in a pathological case: when `prediction_length=1`, scaled covariates will just become equal to 1. This PR fixes this problem and uses the same scale for computed on past data when scaling the covariates. To implement the above change, we merge the `preprocess` & `preprocess_known_covariates` methods into one.
- Use `pd.option_context` to silence pandas `SettingWithCopyWarning` instead of unnecessary copies.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
