### PR TITLE
[timeseries] Raise ValueError if duplicate feature names are provided for feature importance

### DIFF
--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -250,8 +250,8 @@ class TimeSeriesLearner(AbstractLearner):
                     raise ValueError(f"Feature {fn} not found in covariate metadata or the dataset.")
 
         if len(set(features)) < len(features):
-            logger.warning(
-                "Duplicate feature names provided to compute feature importance. This will lead to unexpected behavior. "
+            raise ValueError(
+                "Duplicate feature names provided to compute feature importance. "
                 "Please provide unique feature names across both static features and covariates."
             )
 


### PR DESCRIPTION
*Description of changes:*
- If there are duplicate column names in static features & covariates, `predictor.feature_importance()` will fail 100% of the time with an uninformative error message. This PR raises an informative exception in this case.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
