### PR TITLE
[timeseries] drop statsmodels, improve refit_every_n_windows

### DIFF
--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -30,7 +30,6 @@ install_requires = [
     "pytorch_lightning",  # version range defined in `core/_setup_utils.py`
     "transformers[sentencepiece]",  # version range defined in `core/_setup_utils.py`
     "accelerate",  # version range defined in `core/_setup_utils.py`
-    "statsmodels>=0.13.0,<0.15",
     "gluonts>=0.14.0,<0.14.4",  # 0.14.4 caps pandas<2.2
     "networkx",  # version range defined in `core/_setup_utils.py`
     # TODO: update statsforecast to v1.5.0 - resolve antlr4-python3-runtime dependency clash with multimodal

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -634,7 +634,7 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
             windows, where the number of validation windows is specified by `num_val_windows`. Note that in the
             default setting where `num_val_windows=1`, this argument has no effect.
 
-            If set to ``None``, model will only be fit once for the first validation window. By default,
+            If set to ``None``, models will only be fit once for the first (oldest) validation window. By default,
             `refit_every_n_windows=`, i.e., models will be refit for all validation windows.
         refit_full : bool, default = False
             If True, after training is complete, AutoGluon will attempt to re-train all models using all of training

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -635,7 +635,7 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
             default setting where `num_val_windows=1`, this argument has no effect.
 
             If set to ``None``, models will only be fit once for the first (oldest) validation window. By default,
-            `refit_every_n_windows=`, i.e., models will be refit for all validation windows.
+            `refit_every_n_windows=1`, i.e., all models will be refit for each validation windows.
         refit_full : bool, default = False
             If True, after training is complete, AutoGluon will attempt to re-train all models using all of training
             data (including the data initially reserved for validation). This argument has no effect if ``tuning_data``

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -631,7 +631,11 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
             This argument has no effect if ``tuning_data`` is provided.
         refit_every_n_windows: int or None, default = 1
             When performing cross validation, each model will be retrained every ``refit_every_n_windows`` validation
-            windows. If set to ``None``, model will only be fit once for the first validation window.
+            windows, where the number of validation windows is specified by `num_val_windows`. Note that in the
+            default setting where `num_val_windows=1`, this argument has no effect.
+
+            If set to ``None``, model will only be fit once for the first validation window. By default,
+            `refit_every_n_windows=`, i.e., models will be refit for all validation windows.
         refit_full : bool, default = False
             If True, after training is complete, AutoGluon will attempt to re-train all models using all of training
             data (including the data initially reserved for validation). This argument has no effect if ``tuning_data``
@@ -716,6 +720,12 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
 
         if num_val_windows == 0 and tuning_data is None:
             raise ValueError("Please set num_val_windows >= 1 or provide custom tuning_data")
+
+        if num_val_windows <= 1 and refit_every_n_windows > 1:
+            logger.warning(
+                f"\trefit_every_n_windows provided as {refit_every_n_windows} but num_val_windows is set to {num_val_windows}."
+                " Refit_every_n_windows will have no effect."
+            )
 
         if not skip_model_selection:
             train_data = self._filter_useless_train_data(

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -635,7 +635,7 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
             default setting where `num_val_windows=1`, this argument has no effect.
 
             If set to ``None``, models will only be fit once for the first (oldest) validation window. By default,
-            `refit_every_n_windows=1`, i.e., all models will be refit for each validation windows.
+            `refit_every_n_windows=1`, i.e., all models will be refit for each validation window.
         refit_full : bool, default = False
             If True, after training is complete, AutoGluon will attempt to re-train all models using all of training
             data (including the data initially reserved for validation). This argument has no effect if ``tuning_data``

--- a/timeseries/src/autogluon/timeseries/utils/warning_filters.py
+++ b/timeseries/src/autogluon/timeseries/utils/warning_filters.py
@@ -7,14 +7,12 @@ import re
 import sys
 import warnings
 
-from statsmodels.tools.sm_exceptions import ConvergenceWarning, ValueWarning
-
 __all__ = ["warning_filter", "disable_root_logger", "disable_tqdm"]
 
 
 @contextlib.contextmanager
 def warning_filter(all_warnings: bool = False):
-    categories = [RuntimeWarning, UserWarning, ConvergenceWarning, ValueWarning, FutureWarning]
+    categories = [RuntimeWarning, UserWarning, FutureWarning]
     if all_warnings:
         categories.append(Warning)
     with warnings.catch_warnings():


### PR DESCRIPTION
*Issue #, if available:*

#4062 

*Description of changes:*

Two housekeeping items
- Drop unused `statsmodels` dependency
- Improve docs and raise warning for `refit_every_n_windows`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
