### PR TITLE
Optionally use Poppler/Pdf2Image for PDF Image Conversion

### DIFF
--- a/docs/tutorials/multimodal/document_prediction/pdf_classification.ipynb
+++ b/docs/tutorials/multimodal/document_prediction/pdf_classification.ipynb
@@ -19,19 +19,36 @@
     "Using AutoMM, you can handle and build machine learning models on PDF documents just like working on other modalities such as text and images, without bothering about PDFs processing. \n",
     "In this tutorial, we will introduce how to classify PDF documents automatically with AutoMM using document foundation models. Let’s get started!\n",
     "\n",
-    "Install AutoGluon MultiModal with extra dependency PyMuPDF:"
+    "Install AutoGluon MultiModal with either pdf2image or PyMuPDF:\n",
+    "\n",
+    "WARNING: pdf2image requires poppler-utils to be installed on the os. PyMuPDF is pure Python but is licensed under GNU AFFERO GPL 3.0.\n",
+    "\n",
+    "https://poppler.freedesktop.org for source\n",
+    "\n",
+    "https://github.com/oschwartz10612/poppler-windows for Windows release (make sure to add the bin/ folder to PATH after installing)\n",
+    "\n",
+    "brew install poppler for Mac"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install autogluon.multimodal[pdf2image]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "!pip install autogluon.multimodal[PyMuPDF]"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "attachments": {},

--- a/docs/tutorials/multimodal/document_prediction/pdf_classification.ipynb
+++ b/docs/tutorials/multimodal/document_prediction/pdf_classification.ipynb
@@ -19,26 +19,11 @@
     "Using AutoMM, you can handle and build machine learning models on PDF documents just like working on other modalities such as text and images, without bothering about PDFs processing. \n",
     "In this tutorial, we will introduce how to classify PDF documents automatically with AutoMM using document foundation models. Let’s get started!\n",
     "\n",
-    "Install AutoGluon MultiModal with either pdf2image or PyMuPDF:\n",
+    "For document processing, AutoGluon requires poppler to be installed. Check https://poppler.freedesktop.org for source \n",
     "\n",
-    "WARNING: pdf2image requires poppler-utils to be installed on the os. PyMuPDF is pure Python but is licensed under GNU AFFERO GPL 3.0 which doesn't come with AutoGluon\n",
+    "https://github.com/oschwartz10612/poppler-windows for Windows release (make sure to add the bin/ folder to PATH after installing) \n",
     "\n",
-    "https://poppler.freedesktop.org for source\n",
-    "\n",
-    "https://github.com/oschwartz10612/poppler-windows for Windows release (make sure to add the bin/ folder to PATH after installing)\n",
-    "\n",
-    "brew install poppler for Mac"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "!pip install PyMuPDF"
+    "`brew install poppler` for Mac"
    ]
   },
   {

--- a/docs/tutorials/multimodal/document_prediction/pdf_classification.ipynb
+++ b/docs/tutorials/multimodal/document_prediction/pdf_classification.ipynb
@@ -21,7 +21,7 @@
     "\n",
     "Install AutoGluon MultiModal with either pdf2image or PyMuPDF:\n",
     "\n",
-    "WARNING: pdf2image requires poppler-utils to be installed on the os. PyMuPDF is pure Python but is licensed under GNU AFFERO GPL 3.0.\n",
+    "WARNING: pdf2image requires poppler-utils to be installed on the os. PyMuPDF is pure Python but is licensed under GNU AFFERO GPL 3.0 which doesn't come with AutoGluon\n",
     "\n",
     "https://poppler.freedesktop.org for source\n",
     "\n",
@@ -33,21 +33,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install autogluon.multimodal[pdf2image]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
-    "!pip install autogluon.multimodal[PyMuPDF]"
+    "!pip install PyMuPDF"
    ]
   },
   {
@@ -254,8 +245,14 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "agt",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "name": "python",
+   "version": "3.10.14"
   },
   "orig_nbformat": 4
  },

--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -54,6 +54,7 @@ install_requires = [
     "tensorboard>=2.9,<3",
     "pytesseract>=0.3.9,<0.3.11",
     "nvidia-ml-py3==7.352.0",
+    "pdf2image>=1.17.0,<1.19",
 ]
 
 install_requires = ag.get_dependency_version_ranges(install_requires)
@@ -68,19 +69,7 @@ tests_require = [
     "tensorrt>=8.6.0,<8.6.2;platform_system=='Linux' and python_version<'3.11'",
 ]
 
-extras_require = {
-    "PyMuPDF": [
-        "PyMuPDF<=1.21.1",
-    ],
-    "pdf2image": [
-        "pdf2image<=1.17.0",
-    ],
-}
-
-for test_package in ["PyMuPDF", "pdf2image"]:
-    tests_require += extras_require[test_package]
-
-extras_require["tests"] = tests_require
+extras_require = {"tests": tests_require}
 
 
 if __name__ == "__main__":

--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -71,10 +71,13 @@ tests_require = [
 extras_require = {
     "PyMuPDF": [
         "PyMuPDF<=1.21.1",
-    ]
+    ],
+    "pdf2image": [
+        "pdf2image<=1.17.0",
+    ],
 }
 
-for test_package in ["PyMuPDF"]:
+for test_package in ["PyMuPDF", "pdf2image"]:
     tests_require += extras_require[test_package]
 
 extras_require["tests"] = tests_require

--- a/multimodal/src/autogluon/multimodal/data/process_document.py
+++ b/multimodal/src/autogluon/multimodal/data/process_document.py
@@ -1,15 +1,15 @@
+import importlib.util
 import logging
 import os
+import re
+import shutil
+import subprocess
 import warnings
 from io import BytesIO
 from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import PIL
-import shutil
-import re
-import subprocess
-import importlib.util
 import pytesseract
 import torch
 from nptyping import NDArray

--- a/multimodal/src/autogluon/multimodal/data/process_document.py
+++ b/multimodal/src/autogluon/multimodal/data/process_document.py
@@ -281,7 +281,11 @@ class DocumentProcessor:
                 if feature_modalities[per_col_name] == DOCUMENT_PDF:
                     # Check if poppler-utils and pdf2image is installed. If so, use to convert image to PDF.
                     # (preferable to fitz for image conversion due to licensing)
-                    if shutil.which("pdftoppm") and shutil.which("pdfimages") and importlib.util.find_spec("pdf2image"):
+                    if (
+                        shutil.which("pdftoppm")
+                        and shutil.which("pdfimages")
+                        and importlib.util.find_spec("pdf2image")
+                    ):
                         import pdf2image
 
                         def get_dpi_poppler(path: str, default: int = 300) -> int:
@@ -313,16 +317,16 @@ class DocumentProcessor:
 
                         dpi = get_dpi_poppler(per_col_image_features[0])
                         doc_image = pdf2image.convert_from_path(per_col_image_features[0], dpi=dpi)[0]
-                    # else:
-                    #     import fitz
+                    else:
+                        import fitz
 
-                    #     # Load the pdf file.
-                    #     pdf_doc = fitz.open(per_col_image_features[0])
-                    #     first_page = pdf_doc.load_page(0)
-                    #     pix = first_page.get_pixmap(matrix=fitz.Matrix(1, 1))
-                    #     # Convert pdf into PIL images.
-                    #     with PIL.Image.frombytes(image_mode, [pix.width, pix.height], pix.samples) as doc_image:
-                    #         doc_image = doc_image.convert(image_mode)
+                        # Load the pdf file.
+                        pdf_doc = fitz.open(per_col_image_features[0])
+                        first_page = pdf_doc.load_page(0)
+                        pix = first_page.get_pixmap(matrix=fitz.Matrix(1, 1))
+                        # Convert pdf into PIL images.
+                        with PIL.Image.frombytes(image_mode, [pix.width, pix.height], pix.samples) as doc_image:
+                            doc_image = doc_image.convert(image_mode)
 
                     words, normalized_word_boxes = self.get_ocr_features(per_col_image_features[0], doc_image)
                 else:

--- a/multimodal/src/autogluon/multimodal/data/process_document.py
+++ b/multimodal/src/autogluon/multimodal/data/process_document.py
@@ -279,56 +279,15 @@ class DocumentProcessor:
             try:
                 # Process PDF documents.
                 if feature_modalities[per_col_name] == DOCUMENT_PDF:
-                    # Check if poppler-utils and pdf2image is installed. If so, use to convert image to PDF.
-                    # (preferable to fitz for image conversion due to licensing)
-                    if (
-                        shutil.which("pdftoppm")
-                        and shutil.which("pdfimages")
-                        and importlib.util.find_spec("pdf2image")
-                    ):
-                        import pdf2image
+                    from pdf2image import convert_from_path
 
-                        def get_dpi_poppler(path: str, default: int = 300) -> int:
-                            # Command setup for pdfimages -list to get dpi for the first page
-                            cmd = ["pdfimages", "-list", path]
-                            try:
-                                # Execute the command and capture the output
-                                result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-                                if result.returncode != 0:
-                                    logger.warning(
-                                        f"Failed to capture dpi for {path}: {result.stderr}, using default={default}"
-                                    )
-                                    return default
-
-                                # Process the output lines to find dpi
-                                lines = result.stdout.splitlines()
-                                for line in lines:
-                                    if "image" in line:
-                                        cols = re.split(r"\s+", line.strip())
-                                        if len(cols) >= 14:
-                                            dpi = (float(cols[12]) + float(cols[13])) / 2
-                                            return int(dpi)
-                            except Exception as e:
-                                logger.warning(f"Failed to capture dpi for {path}: {e}, using default={default}")
-                                return default
-                            else:
-                                logger.warning(f"Failed to capture dpi for {path}, using default={default}")
-                                return default
-
-                        dpi = get_dpi_poppler(per_col_image_features[0])
-                        doc_image = pdf2image.convert_from_path(per_col_image_features[0], dpi=dpi)[0]
+                    # Convert PDF to PIL images.
+                    doc_images = convert_from_path(per_col_image_features[0])
+                    if doc_images:
+                        doc_image = doc_images[0].convert(image_mode)
+                        words, normalized_word_boxes = self.get_ocr_features(per_col_image_features[0], doc_image)
                     else:
-                        import fitz
-
-                        # Load the pdf file.
-                        pdf_doc = fitz.open(per_col_image_features[0])
-                        first_page = pdf_doc.load_page(0)
-                        pix = first_page.get_pixmap(matrix=fitz.Matrix(1, 1))
-                        # Convert pdf into PIL images.
-                        with PIL.Image.frombytes(image_mode, [pix.width, pix.height], pix.samples) as doc_image:
-                            doc_image = doc_image.convert(image_mode)
-
-                    words, normalized_word_boxes = self.get_ocr_features(per_col_image_features[0], doc_image)
+                        raise ValueError("Failed to convert PDF to images.")
                 else:
                     # Process document image.
                     with PIL.Image.open(per_col_image_features[0]) as doc_image:


### PR DESCRIPTION
*Issue #, if available:*
[3800](https://github.com/autogluon/autogluon/issues/3800)

*Description of changes:*
Check if poppler is installed and in PATH. If so, get the DPI and convert the PDF with pdf2image.
Adds an optional dependency pdf2image, which can be installed in place of PyMuPDF.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
