### PR TITLE
[timeseries] Use different random seed for each model

### DIFF
--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -613,7 +613,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
                     break
 
             if random_seed is not None:
-                seed_everything(random_seed)
+                seed_everything(random_seed + i)
 
             if contains_searchspace(model.get_user_params()):
                 fit_log_message = f"Hyperparameter tuning model {model.name}. "

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -1154,38 +1154,6 @@ def test_when_predictor_fit_with_verbosity_then_verbosity_overridden_and_propaga
         assert level == verbosity2loglevel(verbosity)
 
 
-@pytest.mark.parametrize("random_seed", [123, 1, 42])
-def test_when_predictor_fit_with_random_seed_then_torch_seed_set_for_all_models(temp_model_path, random_seed):
-    predictor = TimeSeriesPredictor(path=temp_model_path)
-
-    import torch
-
-    def train_save_side_effect(self, *args, **kwargs):
-        assert torch.get_rng_state().numpy()[0] == random_seed
-
-        # mess with the seed
-        seed_everything(66)
-
-        return "mock_model"
-
-    with mock.patch("autogluon.timeseries.trainer.AbstractTimeSeriesTrainer._train_and_save") as mock_train_save:
-        mock_train_save.side_effect = train_save_side_effect
-        predictor.fit(
-            DUMMY_TS_DATAFRAME,
-            hyperparameters={
-                "SeasonalNaive": {},
-                "RecursiveTabular": {
-                    "tabular_hyperparameters": {"NN_TORCH": {"proc.impute_strategy": "constant", "num_epochs": 1}},
-                },
-                "TemporalFusionTransformer": {"epochs": 1},
-                "DeepAR": {"epochs": 1},
-            },
-            random_seed=random_seed,
-            enable_ensemble=False,
-        )
-        assert mock_train_save.call_count == 4
-
-
 @pytest.mark.parametrize("random_seed", [123, 42])
 def test_when_predictor_predict_called_with_random_seed_then_torch_seed_set_for_all_predictions(
     temp_model_path, random_seed

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -15,7 +15,6 @@ import pytest
 
 from autogluon.common import space
 from autogluon.common.utils.log_utils import verbosity2loglevel
-from autogluon.common.utils.utils import seed_everything
 from autogluon.timeseries.dataset import TimeSeriesDataFrame
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP
 from autogluon.timeseries.metrics import DEFAULT_METRIC_NAME


### PR DESCRIPTION
*Description of changes:*
- Increment the random seed used to train each consecutive model by 1. This fixes a weird regression for GluonTS models: when we use the same seed for all GluonTS models, their performance becomes correlated and sometimes leads to an overall performance regression. This likely happens because, when the seed is fixed, the GluonTS dataloaders returns batches in the same order.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
