### PR TITLE
[AutoMM] Fix a bug of CLIP model's image feature normalization.

### DIFF
--- a/multimodal/src/autogluon/multimodal/models/clip.py
+++ b/multimodal/src/autogluon/multimodal/models/clip.py
@@ -153,7 +153,7 @@ class CLIPForImageText(nn.Module):
             image_features = image_features.reshape((b, n, -1)) * image_masks[:, :, None]  # (b, n, num_features)
 
             # normalized features
-            image_features = image_features / image_features.norm(dim=-1, keepdim=True)
+            image_features = image_features / torch.clamp(image_features.norm(dim=-1, keepdim=True), min=1e-6)
 
             # collect image features by image column names
             image_column_features, image_column_feature_masks = get_column_features(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fix the bug which results in returning a tensor with NaN values when image data is absent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
