### PR TITLE
[tabular] Add secondary_decision_thresholds to calibrate_decision_threshold

### DIFF
--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -3836,7 +3836,8 @@ class AbstractTrainer:
         metric: str | Scorer | None = None,
         model: str = "best",
         weights=None,
-        decision_thresholds: int | List[float] = 50,
+        decision_thresholds: int | List[float] = 25,
+        secondary_decision_thresholds: int | None = 19,
         verbose: bool = True,
         **kwargs,
     ) -> float:
@@ -3895,6 +3896,7 @@ class AbstractTrainer:
             y_pred_proba=y_pred_proba,
             metric=lambda y, y_pred: self._score_with_y_pred(y=y, y_pred=y_pred, weights=weights, metric=metric),
             decision_thresholds=decision_thresholds,
+            secondary_decision_thresholds=secondary_decision_thresholds,
             metric_name=metric.name,
             verbose=verbose,
             **kwargs,

--- a/core/tests/unittests/calibrate/test_decision_threshold.py
+++ b/core/tests/unittests/calibrate/test_decision_threshold.py
@@ -35,15 +35,24 @@ def test_calibrate_decision_threshold():
         y=y,
         y_pred_proba=y_pred_proba,
         metric=f1,
+        decision_thresholds=50,
+        secondary_decision_thresholds=None,
     )
     assert decision_threshold == 0.24
 
     decision_threshold = calibrate_decision_threshold(
         y=y,
         y_pred_proba=y_pred_proba,
+        metric=f1,
+    )
+    assert decision_threshold == 0.249
+
+    decision_threshold = calibrate_decision_threshold(
+        y=y,
+        y_pred_proba=y_pred_proba,
         metric=balanced_accuracy,
     )
-    assert decision_threshold == 0.24
+    assert decision_threshold == 0.249
 
     decision_threshold = calibrate_decision_threshold(
         y=y,
@@ -70,6 +79,7 @@ def test_calibrate_decision_threshold_select_closer_to_0_5():
         y_pred_proba=y_pred_proba,
         metric=balanced_accuracy,
         decision_thresholds=[0.5, 0.244, 0.247],
+        secondary_decision_thresholds=None,
     )
     assert decision_threshold == 0.247
 
@@ -78,6 +88,7 @@ def test_calibrate_decision_threshold_select_closer_to_0_5():
         y_pred_proba=y_pred_proba,
         metric=balanced_accuracy,
         decision_thresholds=[0.5, 0.247, 0.244],
+        secondary_decision_thresholds=None,
     )
     assert decision_threshold == 0.247
 
@@ -115,4 +126,36 @@ def test_calibrate_decision_threshold_out_of_bounds():
             y_pred_proba=y_pred_proba,
             metric=balanced_accuracy,
             decision_thresholds=[-0.01, 0.5],
+        )
+
+
+def test_calibrate_decision_threshold_invalid_args():
+    y, y_pred_proba = _get_sample_data()
+    with pytest.raises(AssertionError):
+        calibrate_decision_threshold(
+            y=y,
+            y_pred_proba=y_pred_proba,
+            metric=balanced_accuracy,
+            decision_thresholds="invalid",
+        )
+    with pytest.raises(AssertionError):
+        calibrate_decision_threshold(
+            y=y,
+            y_pred_proba=y_pred_proba,
+            metric=balanced_accuracy,
+            decision_thresholds=0.01,
+        )
+    with pytest.raises(AssertionError):
+        calibrate_decision_threshold(
+            y=y,
+            y_pred_proba=y_pred_proba,
+            metric=balanced_accuracy,
+            decision_thresholds=None,
+        )
+    with pytest.raises(AssertionError):
+        calibrate_decision_threshold(
+            y=y,
+            y_pred_proba=y_pred_proba,
+            metric=balanced_accuracy,
+            secondary_decision_thresholds=[0.2, 0.4],
         )

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -1042,7 +1042,8 @@ class AbstractTabularLearner(AbstractLearner):
         data: pd.DataFrame | None = None,
         metric: str | Scorer | None = None,
         model: str = "best",
-        decision_thresholds: int | List[float] = 50,
+        decision_thresholds: int | List[float] = 25,
+        secondary_decision_thresholds: int | None = 19,
         verbose: bool = True,
         **kwargs,
     ) -> float:
@@ -1067,6 +1068,7 @@ class AbstractTabularLearner(AbstractLearner):
             model=model,
             weights=weights,
             decision_thresholds=decision_thresholds,
+            secondary_decision_thresholds=secondary_decision_thresholds,
             verbose=verbose,
             **kwargs,
         )

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -3370,7 +3370,8 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         data: str | TabularDataset | pd.DataFrame | None = None,
         metric: str | Scorer | None = None,
         model: str = "best",
-        decision_thresholds: int | List[float] = 50,
+        decision_thresholds: int | List[float] = 25,
+        secondary_decision_thresholds: int | None = 19,
         subsample_size: int | None = 1000000,
         verbose: bool = True,
     ) -> float:
@@ -3396,10 +3397,16 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         model : str, default = 'best'
             The model to use prediction probabilities of when calibrating the threshold.
             If 'best', will use `predictor.model_best`.
-        decision_thresholds : Union[int, List[float]], default = 50
+        decision_thresholds : int | List[float], default = 25
             The number of decision thresholds on either side of `0.5` to search.
-            The default of 50 will result in 101 searched thresholds: [0.00, 0.01, 0.02, ..., 0.49, 0.50, 0.51, ..., 0.98, 0.99, 1.00]
+            The default of 25 will result in 51 searched thresholds: [0.00, 0.02, 0.04, ..., 0.48, 0.50, 0.52, ..., 0.96, 0.98, 1.00]
             Alternatively, a list of decision thresholds can be passed and only the thresholds in the list will be searched.
+        secondary_decision_thresholds : int | None, default = 19
+            The number of secondary decision thresholds to check on either side of the threshold identified in the first phase.
+            Skipped if None.
+            For example, if decision_thresholds=50 and 0.14 was identified as the optimal threshold, while secondary_decision_threshold=9,
+                Then the following additional thresholds are checked:
+                    [0.131, 0.132, 0.133, 0.134, 0.135, 0.136, 0.137, 0.138, 0.139, 0.141, 0.142, 0.143, 0.144, 0.145, 0.146, 0.147, 0.148, 0.149]
         subsample_size : int | None, default = 1000000
             When `subsample_size` is not None and `data` contains more rows than `subsample_size`, samples to `subsample_size` rows to speed up calibration.
             Usually it is not necessary to use more than 1 million rows for calibration.
@@ -3437,6 +3444,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             metric=metric,
             model=model,
             decision_thresholds=decision_thresholds,
+            secondary_decision_thresholds=secondary_decision_thresholds,
             subsample_size=subsample_size,
             verbose=verbose,
         )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds `secondary_decision_thresholds` argument to decision threshold calibration.
This enables a 2nd-round fine-grained search of the optimal threshold.

In total this is 25% faster with 10x finer granularity than the previous implementation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
