### PR TITLE
[tabular] Add "auto" option for calibrate_decision_threshold

### DIFF
--- a/core/src/autogluon/core/metrics/__init__.py
+++ b/core/src/autogluon/core/metrics/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from abc import ABCMeta, abstractmethod
 from functools import partial
@@ -187,6 +189,11 @@ class Scorer(object, metaclass=ABCMeta):
 
     @property
     @abstractmethod
+    def needs_class(self) -> bool:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
     def needs_threshold(self) -> bool:
         raise NotImplementedError
 
@@ -229,6 +236,51 @@ class _PredictScorer(Scorer):
         return False
 
     @property
+    def needs_class(self) -> bool:
+        return False
+
+    @property
+    def needs_threshold(self):
+        return False
+
+    @property
+    def needs_quantile(self):
+        return False
+
+
+class _ClassScorer(Scorer):
+    def _preprocess(self, y_true, y_pred, **kwargs):
+        if isinstance(y_true, list):
+            y_true = np.array(y_true)
+        if isinstance(y_pred, list):
+            y_pred = np.array(y_pred)
+
+        if len(y_pred.shape) == 1 or y_pred.shape[1] == 1:
+            pass  # FIXME
+        else:
+            type_true = type_of_target(y_true)
+            if type_true in ["binary", "multiclass"]:
+                y_pred = np.argmax(y_pred, axis=1)
+            elif type_true == "multilabel-indicator":
+                y_pred[y_pred > 0.5] = 1.0
+                y_pred[y_pred <= 0.5] = 0.0
+            else:
+                raise ValueError(type_true)
+        return y_true, y_pred, kwargs
+
+    @property
+    def needs_pred(self):
+        return True
+
+    @property
+    def needs_proba(self):
+        return False
+
+    @property
+    def needs_class(self) -> bool:
+        return True
+
+    @property
     def needs_threshold(self):
         return False
 
@@ -248,6 +300,10 @@ class _ProbaScorer(Scorer):
     @property
     def needs_proba(self):
         return True
+
+    @property
+    def needs_class(self) -> bool:
+        return False
 
     @property
     def needs_threshold(self):
@@ -281,6 +337,10 @@ class _ThresholdScorer(Scorer):
 
     @property
     def needs_proba(self):
+        return False
+
+    @property
+    def needs_class(self) -> bool:
         return False
 
     @property
@@ -320,6 +380,10 @@ class _QuantileScorer(Scorer):
         return False
 
     @property
+    def needs_class(self) -> bool:
+        return False
+
+    @property
     def needs_threshold(self):
         return False
 
@@ -339,7 +403,18 @@ def _add_scorer_to_metric_dict(metric_dict, scorer):
 
 
 def make_scorer(
-    name, score_func, *, optimum=1, greater_is_better=True, needs_proba=False, needs_threshold=False, needs_quantile=False, metric_kwargs: dict = None, **kwargs
+    name: str,
+    score_func: callable,
+    *,
+    optimum: int | float = 1,
+    greater_is_better: bool = True,
+    needs_pred: bool | str = "auto",
+    needs_proba: bool = False,
+    needs_class: bool = False,
+    needs_threshold: bool = False,
+    needs_quantile: bool = False,
+    metric_kwargs: dict = None,
+    **kwargs,
 ) -> Scorer:
     """Make a scorer from a performance metric or loss function.
 
@@ -348,11 +423,15 @@ def make_scorer(
 
     Parameters
     ----------
+    name : str
+        The name of the Scorer.
+        Accessible via `scorer.name`
+
     score_func : callable
         Score function (or loss function) with signature
         ``score_func(y, y_pred, **kwargs)``.
 
-    optimum : int or float, default=1
+    optimum : int | float, default=1
         The best score achievable by the score function, i.e. maximum in case of
         scorer function and minimum in case of loss function.
 
@@ -361,17 +440,33 @@ def make_scorer(
         or a loss function, meaning low is good. In the latter case, the
         scorer object will sign-flip the outcome of the score_func.
 
-    needs_proba : boolean, default=False
-        Whether score_func requires predict_proba to get probability estimates
-        out of a classifier.
+    needs_pred : bool | str, default="auto"
+        Whether score_func requires the predict model method output as input to scoring.
+        If "auto", will be inferred based on the values of the other `needs_*` arguments.
+        Defaults to True if all other `needs_*` are False.
+        Examples: ["root_mean_squared_error", "mean_squared_error", "r2", "mean_absolute_error", "median_absolute_error", "spearmanr", "pearsonr"]
 
-    needs_threshold : boolean, default=False
+    needs_proba : bool, default=False
+        Whether score_func requires predict_proba to get probability estimates out of a classifier.
+        These scorers can benefit from calibration methods such as temperature scaling.
+        Examples: ["log_loss", "roc_auc_ovo_macro", "pac"]
+
+    needs_class : bool, default=False
+        Whether score_func requires class predictions (classification only).
+        This is required to determine if the scorer is impacted by a decision threshold.
+        These scorers can benefit from decision threshold calibration methods such as via `predictor.calibrate_decision_threshold()`.
+        Examples: ["accuracy", "balanced_accuracy", "f1", "precision", "recall", "mcc", "quadratic_kappa", "f1_micro", "f1_macro", "f1_weighted"]
+
+    needs_threshold : bool, default=False
         Whether score_func takes a continuous decision certainty.
         This only works for binary classification.
+        These scorers care about the rank order of the prediction probabilities to calculate their scores, and are undefined if given a single sample to score.
+        Examples: ["roc_auc", "average_precision"]
 
-    needs_quantile : boolean, default=False
+    needs_quantile : bool, default=False
         Whether score_func is based on quantile predictions.
         This only works for quantile regression.
+        Examples: ["pinball_loss"]
 
     metric_kwargs : dict
         Additional parameters to be passed to score_func, merged with kwargs if both are present.
@@ -385,8 +480,24 @@ def make_scorer(
     scorer
         Callable object that returns a scalar score; greater is better.
     """
+    num_true = sum([1 if needs else 0 for needs in [needs_class, needs_proba, needs_threshold, needs_quantile]])
+    if num_true > 1:
+        raise ValueError(
+            f"When creating a Scorer, at most one can be True, found {num_true}: "
+            f"(needs_class={needs_class}, needs_proba={needs_proba}, needs_threshold={needs_threshold}, needs_quantile={needs_quantile})"
+        )
+
+    if num_true == 0 and not needs_pred:
+        raise ValueError(
+            f"When creating a Scorer, at least one must be True: "
+            f"(needs_pred={needs_pred}, needs_class={needs_class}, "
+            f"needs_proba={needs_proba}, needs_threshold={needs_threshold}, needs_quantile={needs_quantile})"
+        )
+
     sign = 1 if greater_is_better else -1
-    if needs_proba:
+    if needs_class:
+        cls = _ClassScorer
+    elif needs_proba:
         cls = _ProbaScorer
     elif needs_threshold:
         cls = _ThresholdScorer
@@ -394,15 +505,24 @@ def make_scorer(
         cls = _QuantileScorer
     else:
         cls = _PredictScorer
+
     if metric_kwargs is not None:
         kwargs.update(metric_kwargs)
-    return cls(
+    scorer = cls(
         name=name,
         score_func=score_func,
         optimum=optimum,
         sign=sign,
         kwargs=kwargs,
     )
+
+    if isinstance(needs_pred, bool) and needs_pred != scorer.needs_pred:
+        raise ValueError(
+            f"needs_pred specified by user does not match the required needs_pred value for {scorer.__class__.__name__}. (name={scorer.name}, "
+            f"actual_needs_pred={needs_pred}, expected_needs_pred={needs_pred})"
+        )
+
+    return scorer
 
 
 # Standard regression scores
@@ -460,12 +580,12 @@ pinball_loss.add_alias("pinball")
 
 
 # Standard Classification Scores
-accuracy = make_scorer("accuracy", sklearn.metrics.accuracy_score)
+accuracy = make_scorer("accuracy", sklearn.metrics.accuracy_score, needs_class=True)
 accuracy.add_alias("acc")
 
-balanced_accuracy = make_scorer("balanced_accuracy", classification_metrics.balanced_accuracy)
-f1 = make_scorer("f1", sklearn.metrics.f1_score)
-mcc = make_scorer("mcc", sklearn.metrics.matthews_corrcoef)
+balanced_accuracy = make_scorer("balanced_accuracy", classification_metrics.balanced_accuracy, needs_class=True)
+f1 = make_scorer("f1", sklearn.metrics.f1_score, needs_class=True)
+mcc = make_scorer("mcc", sklearn.metrics.matthews_corrcoef, needs_class=True)
 
 
 # Score functions that need decision values
@@ -476,11 +596,11 @@ roc_auc_ovo_macro = make_scorer(
 )
 
 average_precision = make_scorer("average_precision", sklearn.metrics.average_precision_score, needs_threshold=True)
-precision = make_scorer("precision", sklearn.metrics.precision_score)
-recall = make_scorer("recall", sklearn.metrics.recall_score)
+precision = make_scorer("precision", sklearn.metrics.precision_score, needs_class=True)
+recall = make_scorer("recall", sklearn.metrics.recall_score, needs_class=True)
 
 # Register other metrics
-quadratic_kappa = make_scorer("quadratic_kappa", classification_metrics.quadratic_kappa, needs_proba=False)
+quadratic_kappa = make_scorer("quadratic_kappa", classification_metrics.quadratic_kappa, needs_class=True)
 
 
 def customized_log_loss(y_true, y_pred, eps=1e-15):
@@ -561,11 +681,11 @@ for scorer in [
 
 
 for name, metric in [("precision", sklearn.metrics.precision_score), ("recall", sklearn.metrics.recall_score), ("f1", sklearn.metrics.f1_score)]:
-    globals()[name] = make_scorer(name, metric)
+    globals()[name] = make_scorer(name, metric, needs_class=True)
     _add_scorer_to_metric_dict(metric_dict=BINARY_METRICS, scorer=globals()[name])
     for average in ["macro", "micro", "weighted"]:
         qualified_name = "{0}_{1}".format(name, average)
-        globals()[qualified_name] = make_scorer(qualified_name, partial(metric, pos_label=None, average=average))
+        globals()[qualified_name] = make_scorer(qualified_name, partial(metric, pos_label=None, average=average), needs_class=True)
         _add_scorer_to_metric_dict(metric_dict=BINARY_METRICS, scorer=globals()[qualified_name])
         _add_scorer_to_metric_dict(metric_dict=MULTICLASS_METRICS, scorer=globals()[qualified_name])
 

--- a/core/tests/unittests/metrics/test_metric_kwargs.py
+++ b/core/tests/unittests/metrics/test_metric_kwargs.py
@@ -30,9 +30,9 @@ def test_metric_kwargs():
 def test_metric_kwargs_init():
     y_true = np.array([1, 1, 1, 0, 0, 0])
     y_pred = np.array([0, 1, 1, 0, 1, 1])
-    f1_pos_label_0 = make_scorer("f1", sklearn.metrics.f1_score, pos_label=0)
-    f1_pos_label_0_v2 = make_scorer("f1", sklearn.metrics.f1_score, metric_kwargs=dict(pos_label=0))
-    f1_pos_label_0_test_override = make_scorer("f1", sklearn.metrics.f1_score, metric_kwargs=dict(pos_label=0), pos_label=1)
+    f1_pos_label_0 = make_scorer("f1", sklearn.metrics.f1_score, pos_label=0, needs_class=True)
+    f1_pos_label_0_v2 = make_scorer("f1", sklearn.metrics.f1_score, metric_kwargs=dict(pos_label=0), needs_class=True)
+    f1_pos_label_0_test_override = make_scorer("f1", sklearn.metrics.f1_score, metric_kwargs=dict(pos_label=0), pos_label=1, needs_class=True)
 
     score_og = f1(y_true, y_pred)
     score_pos_label_0_og = f1(y_true, y_pred, pos_label=0)

--- a/core/tests/unittests/metrics/test_metrics.py
+++ b/core/tests/unittests/metrics/test_metrics.py
@@ -179,7 +179,7 @@ def _assert_valid_scorer_regressor(scorer: Scorer):
 def _assert_valid_scorer(scorer: Scorer):
     if scorer.needs_class and not scorer.needs_pred:
         raise AssertionError(
-            f"Invaid Scorer definition! If `needs_class=True`, then `needs_pred` must also be True. "
+            f"Invalid Scorer definition! If `needs_class=True`, then `needs_pred` must also be True. "
             f"(name={scorer.name}, needs_class={scorer.needs_class}, needs_pred={scorer.needs_pred})"
         )
 

--- a/docs/tutorials/tabular/advanced/tabular-custom-metric.ipynb
+++ b/docs/tutorials/tabular/advanced/tabular-custom-metric.ipynb
@@ -31,26 +31,27 @@
      "remove-cell"
     ]
    },
-   "outputs": [],
    "source": [
     "!pip install autogluon.tabular[all]\n"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "1b5cf360",
    "metadata": {},
-   "outputs": [],
    "source": [
     "import numpy as np\n",
     "\n",
-    "y_true = np.random.randint(low=0, high=2, size=10)\n",
-    "y_pred = np.random.randint(low=0, high=2, size=10)\n",
+    "rng = np.random.default_rng(seed=42)\n",
+    "y_true = rng.integers(low=0, high=2, size=10)\n",
+    "y_pred = rng.integers(low=0, high=2, size=10)\n",
     "\n",
     "print(f'y_true: {y_true}')\n",
     "print(f'y_pred: {y_pred}')"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -68,7 +69,9 @@
     "The custom metrics in this tutorial are **not** serializable for ease of demonstration. If the `best_quality` preset was used, calls to `fit()` would crash.\n",
     "\n",
     "## Custom Accuracy Metric\n",
-    "We will start by creating a customer accuracy metric. A prediction is correct if the predicted value is the same as the true value, otherwise it is wrong."
+    "We will start by creating a customer accuracy metric. A prediction is correct if the predicted value is the same as the true value, otherwise it is wrong.\n",
+    "\n",
+    "First, lets use the default sklearn accuracy scorer:"
    ]
   },
   {
@@ -76,12 +79,12 @@
    "execution_count": null,
    "id": "7fff1bb4",
    "metadata": {},
-   "outputs": [],
    "source": [
     "import sklearn.metrics\n",
     "\n",
     "sklearn.metrics.accuracy_score(y_true, y_pred)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -92,7 +95,7 @@
     "For example, without outside knowledge of the metric it is unknown:\n",
     "1. What the optimal value is (1)\n",
     "2. If higher values are better (True)\n",
-    "3. If the metric requires prediction labels or probabilities (labels)\n",
+    "3. If the metric requires predictions, class predictions, or class probabilities (class predictions)\n",
     "\n",
     "Now, let's convert this evaluation metric to an AutoGluon Scorer to address these limitations.\n",
     "\n",
@@ -102,17 +105,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6a6fac49",
+   "id": "d82fe4929dd18fab",
    "metadata": {},
-   "outputs": [],
    "source": [
     "from autogluon.core.metrics import make_scorer\n",
     "\n",
     "ag_accuracy_scorer = make_scorer(name='accuracy',\n",
     "                                 score_func=sklearn.metrics.accuracy_score,\n",
     "                                 optimum=1,\n",
-    "                                 greater_is_better=True)"
-   ]
+    "                                 greater_is_better=True,\n",
+    "                                 needs_class=True)"
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -129,10 +133,45 @@
     "It is also useful to identify when a score is optimal and cannot be improved.\n",
     "Because the best possible value from `sklearn.metrics.accuracy_score` is `1`, we specify `optimum=1`.\n",
     "\n",
-    "Finally, we need to specify `greater_is_better`. In this case, `greater_is_better=True`\n",
+    "Next we need to specify `greater_is_better`. In this case, `greater_is_better=True`\n",
     "because the best value returned is 1, and the worst value returned is less than 1 (0).\n",
     "It is very important to set this value correctly,\n",
     "otherwise AutoGluon will try to optimize for the **worst** model instead of the best.\n",
+    "\n",
+    "Finally, we specify a bool `needs_*` based on the type of metric we are using. The following options are available: [`needs_pred`, `needs_proba`, `needs_class`, `needs_threshold`, `needs_quantile`].\n",
+    "All of them default to False except `needs_pred` which is inferred based on the other 4, of which only one can be set to True. If none are specified, the metric is treated as a regression metric (`needs_pred=True`).\n",
+    "\n",
+    "Below is a detailed description of each:\n",
+    "\n",
+    "    needs_pred : bool | str, default=\"auto\"\n",
+    "        Whether score_func requires the predict model method output as input to scoring.\n",
+    "        If \"auto\", will be inferred based on the values of the other `needs_*` arguments.\n",
+    "        Defaults to True if all other `needs_*` are False.\n",
+    "        Examples: [\"root_mean_squared_error\", \"mean_squared_error\", \"r2\", \"mean_absolute_error\", \"median_absolute_error\", \"spearmanr\", \"pearsonr\"]\n",
+    "\n",
+    "    needs_proba : bool, default=False\n",
+    "        Whether score_func requires predict_proba to get probability estimates out of a classifier.\n",
+    "        These scorers can benefit from calibration methods such as temperature scaling.\n",
+    "        Examples: [\"log_loss\", \"roc_auc_ovo_macro\", \"pac\"]\n",
+    "\n",
+    "    needs_class : bool, default=False\n",
+    "        Whether score_func requires class predictions (classification only).\n",
+    "        This is required to determine if the scorer is impacted by a decision threshold.\n",
+    "        These scorers can benefit from decision threshold calibration methods such as via `predictor.calibrate_decision_threshold()`.\n",
+    "        Examples: [\"accuracy\", \"balanced_accuracy\", \"f1\", \"precision\", \"recall\", \"mcc\", \"quadratic_kappa\", \"f1_micro\", \"f1_macro\", \"f1_weighted\"]\n",
+    "\n",
+    "    needs_threshold : bool, default=False\n",
+    "        Whether score_func takes a continuous decision certainty.\n",
+    "        This only works for binary classification.\n",
+    "        These scorers care about the rank order of the prediction probabilities to calculate their scores, and are undefined if given a single sample to score.\n",
+    "        Examples: [\"roc_auc\", \"average_precision\"]\n",
+    "\n",
+    "    needs_quantile : bool, default=False\n",
+    "        Whether score_func is based on quantile predictions.\n",
+    "        This only works for quantile regression.\n",
+    "        Examples: [\"pinball_loss\"]\n",
+    "\n",
+    "Because we are creating an accuracy scorer, we need the class prediction, and therefore we specify `needs_class=True`.\n",
     "\n",
     "**Advanced Note**: `optimum` must correspond to the optimal value\n",
     "from the original metric callable (in this case `sklearn.metrics.accuracy_score`).\n",
@@ -150,11 +189,11 @@
    "execution_count": null,
    "id": "0114a6fe",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# score\n",
     "ag_accuracy_scorer(y_true, y_pred)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -169,10 +208,10 @@
    "execution_count": null,
    "id": "03894dd7",
    "metadata": {},
-   "outputs": [],
    "source": [
     "ag_accuracy_scorer.score(y_true, y_pred)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -187,15 +226,16 @@
    "execution_count": null,
    "id": "913e2a75",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# error, error=sign*optimum-score -> error=1*1-score -> error=1-score\n",
     "ag_accuracy_scorer.error(y_true, y_pred)\n",
     "\n",
-    "# Can also convert score to error:\n",
+    "# Can also convert score to error and vice-versa:\n",
     "# score = ag_accuracy_scorer(y_true, y_pred)\n",
-    "# error = ag_accuracy_scorer.convert_score_to_error(score)"
-   ]
+    "# error = ag_accuracy_scorer.convert_score_to_error(score)\n",
+    "# score = ag_accuracy_scorer.convert_error_to_score(error)"
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -217,14 +257,14 @@
    "execution_count": null,
    "id": "736399fb",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "y_true = np.random.rand(10)\n",
-    "y_pred = np.random.rand(10)\n",
+    "y_true = rng.random(10)\n",
+    "y_pred = rng.random(10)\n",
     "\n",
     "print(f'y_true: {y_true}')\n",
     "print(f'y_pred: {y_pred}')"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -239,23 +279,23 @@
    "execution_count": null,
    "id": "8d2776cc",
    "metadata": {},
-   "outputs": [],
    "source": [
     "sklearn.metrics.mean_squared_error(y_true, y_pred)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "451c4b49",
    "metadata": {},
-   "outputs": [],
    "source": [
     "ag_mean_squared_error_scorer = make_scorer(name='mean_squared_error',\n",
     "                                           score_func=sklearn.metrics.mean_squared_error,\n",
     "                                           optimum=0,\n",
     "                                           greater_is_better=False)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -279,22 +319,22 @@
    "execution_count": null,
    "id": "0bd5d590",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# score\n",
     "ag_mean_squared_error_scorer(y_true, y_pred)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "ea16f0e0",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# error, error=sign*optimum-score -> error=-1*0-score -> error=-score\n",
     "ag_mean_squared_error_scorer.error(y_true, y_pred)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -309,13 +349,13 @@
    "execution_count": null,
    "id": "5b65aab0",
    "metadata": {},
-   "outputs": [],
    "source": [
     "def mse_func(y_true: np.ndarray, y_pred: np.ndarray) -> float:\n",
     "    return ((y_true - y_pred) ** 2).mean()\n",
     "\n",
     "mse_func(y_true, y_pred)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -332,14 +372,14 @@
    "execution_count": null,
    "id": "80f9f81e",
    "metadata": {},
-   "outputs": [],
    "source": [
     "ag_mean_squared_error_custom_scorer = make_scorer(name='mean_squared_error',\n",
     "                                                  score_func=mse_func,\n",
     "                                                  optimum=0,\n",
     "                                                  greater_is_better=False)\n",
     "ag_mean_squared_error_custom_scorer(y_true, y_pred)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -356,24 +396,24 @@
    "execution_count": null,
    "id": "83967a37",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "y_true = np.random.randint(low=0, high=2, size=10)\n",
-    "y_pred_proba = np.random.rand(10)\n",
+    "y_true = rng.integers(low=0, high=2, size=10)\n",
+    "y_pred_proba = rng.random(10)\n",
     "\n",
     "print(f'y_true:       {y_true}')\n",
     "print(f'y_pred_proba: {y_pred_proba}')"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "cb4c1ef4",
    "metadata": {},
-   "outputs": [],
    "source": [
     "sklearn.metrics.roc_auc_score(y_true, y_pred_proba)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -388,7 +428,6 @@
    "execution_count": null,
    "id": "9230b917",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# Score functions that need decision values\n",
     "ag_roc_auc_scorer = make_scorer(name='roc_auc',\n",
@@ -397,7 +436,8 @@
     "                                greater_is_better=True,\n",
     "                                needs_threshold=True)\n",
     "ag_roc_auc_scorer(y_true, y_pred_proba)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -416,7 +456,6 @@
    "execution_count": null,
    "id": "252ac3a2",
    "metadata": {},
-   "outputs": [],
    "source": [
     "from autogluon.tabular import TabularDataset\n",
     "\n",
@@ -426,21 +465,22 @@
     "train_data = train_data.sample(n=1000, random_state=0)  # subsample dataset for faster demo\n",
     "\n",
     "train_data.head(5)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "6cb390fc",
    "metadata": {},
-   "outputs": [],
    "source": [
     "from autogluon.tabular import TabularPredictor\n",
     "\n",
     "predictor = TabularPredictor(label=label).fit(train_data, hyperparameters='toy')\n",
     "\n",
     "predictor.leaderboard(test_data)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -455,10 +495,10 @@
    "execution_count": null,
    "id": "499faaab",
    "metadata": {},
-   "outputs": [],
    "source": [
     "predictor.leaderboard(test_data, extra_metrics=[ag_roc_auc_scorer, ag_accuracy_scorer])"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -473,12 +513,12 @@
    "execution_count": null,
    "id": "807acda7",
    "metadata": {},
-   "outputs": [],
    "source": [
     "predictor_custom = TabularPredictor(label=label, eval_metric=ag_roc_auc_scorer).fit(train_data, hyperparameters='toy')\n",
     "\n",
     "predictor_custom.leaderboard(test_data)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/docs/tutorials/tabular/advanced/tabular-custom-metric.ipynb
+++ b/docs/tutorials/tabular/advanced/tabular-custom-metric.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "This tutorial describes how to add a custom evaluation metric to AutoGluon that is used to inform validation scores, model ensembling, hyperparameter tuning, and more.\n",
     "\n",
-    "In this example, we show a variety of evaluation metrics and how to convert them to an AutoGluon Scorer, which can then be passed to AutoGluon models and predictors.\n",
+    "In this example, we show a variety of evaluation metrics and how to convert them to an AutoGluon Scorer ([Scorer source code](https://github.com/autogluon/autogluon/blob/master/core/src/autogluon/core/metrics/__init__.py)), which can then be passed to AutoGluon models and predictors.\n",
     "\n",
     "First, we will randomly generate 10 ground truth labels and predictions and show how to calculate metric scores from them."
    ]
@@ -60,11 +60,12 @@
    "source": [
     "## Ensuring Metric is Serializable\n",
     "Custom metrics must be defined in a separate Python file and imported so that they can be [pickled](https://docs.python.org/3/library/pickle.html) (Python's serialization protocol).\n",
-    "If a customer metric is not picklable, AutoGluon will crash during fit when trying to parallelize model training with Ray.\n",
+    "If a custom metric is not pickleable, AutoGluon will crash during fit when trying to parallelize model training with Ray.\n",
     "In the below example, you would want to create a new python file such as `my_metrics.py` with `ag_accuracy_scorer` defined in it,\n",
     "and then use it via `from my_metrics import ag_accuracy_scorer`.\n",
     "\n",
     "If your metric is not serializable, you will get many errors similar to: `_pickle.PicklingError: Can't pickle`. Refer to https://github.com/autogluon/autogluon/issues/1637 for an example.\n",
+    "For an example of how to specify a custom metric on Kaggle, refer to [this Kaggle Notebook](https://www.kaggle.com/code/rzatemizel/prepare-for-automl-grand-prix-explore-autogluon#Custom-Metric-for-Autogluon).\n",
     "\n",
     "The custom metrics in this tutorial are **not** serializable for ease of demonstration. If the `best_quality` preset was used, calls to `fit()` would crash.\n",
     "\n",
@@ -99,7 +100,7 @@
     "\n",
     "Now, let's convert this evaluation metric to an AutoGluon Scorer to address these limitations.\n",
     "\n",
-    "We do this by calling `autogluon.core.metrics.make_scorer`."
+    "We do this by calling `autogluon.core.metrics.make_scorer` (Source code: [autogluon/core/metrics/\\_\\_init\\_\\_.py]((https://github.com/autogluon/autogluon/blob/master/core/src/autogluon/core/metrics/__init__.py)))."
    ]
   },
   {
@@ -233,7 +234,10 @@
     "# Can also convert score to error and vice-versa:\n",
     "# score = ag_accuracy_scorer(y_true, y_pred)\n",
     "# error = ag_accuracy_scorer.convert_score_to_error(score)\n",
-    "# score = ag_accuracy_scorer.convert_error_to_score(error)"
+    "# score = ag_accuracy_scorer.convert_error_to_score(error)\n",
+    "\n",
+    "# Can also convert score to the original score that would be returned in `score_func`:\n",
+    "# score_orig = ag_accuracy_scorer.convert_score_to_original(score)  # score_orig = sign * score"
    ],
    "outputs": []
   },

--- a/docs/tutorials/tabular/advanced/tabular-custom-metric.ipynb
+++ b/docs/tutorials/tabular/advanced/tabular-custom-metric.ipynb
@@ -69,7 +69,7 @@
     "The custom metrics in this tutorial are **not** serializable for ease of demonstration. If the `best_quality` preset was used, calls to `fit()` would crash.\n",
     "\n",
     "## Custom Accuracy Metric\n",
-    "We will start by creating a customer accuracy metric. A prediction is correct if the predicted value is the same as the true value, otherwise it is wrong.\n",
+    "We will start by creating a custom accuracy metric. A prediction is correct if the predicted value is the same as the true value, otherwise it is wrong.\n",
     "\n",
     "First, lets use the default sklearn accuracy scorer:"
    ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add "auto" option for calibrate_decision_threshold that sets to True for valid metrics in Binary Classification, otherwise False.
- Improve Scorer information on knowing if metrics are for regression or classification tasks (via the new `needs_class` property). This is important because while we technically can run metrics like root_mean_squared_error through decision_threshold_calibration and not crash, it would not lead to the intended functionality. With `needs_class`, we know that RMSE is not valid for threshold calibration and avoid it when `calibrate_decision_threshold="auto"`.
- In a future PR I intend to switch `calibrate_decision_threshold` to `"auto"` as the new default in TabularPredictor.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
