### PR TITLE
[tabular] Remove unnecessary duplicate call to `_validate_calibrate_decision_threshold`

### DIFF
--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1391,7 +1391,6 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         infer_limit=None,
         refit_full_kwargs: dict = None,
     ):
-        self._validate_calibrate_decision_threshold(calibrate_decision_threshold=calibrate_decision_threshold)
 
         if refit_full_kwargs is None:
             refit_full_kwargs = {}

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1391,7 +1391,6 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         infer_limit=None,
         refit_full_kwargs: dict = None,
     ):
-
         if refit_full_kwargs is None:
             refit_full_kwargs = {}
         if not self.model_names():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- We are validating the `calibrate_decision_threshold` inside `fit` (L974). And then calling the validation function again inside `_post_fit`.
- Since `fit` calls `_post_fit`, there's no need to call the validation function again.
- This won't improve much, but the duplicated call is unnecessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
