### PR TITLE
[timeseries] Ensure that prediction_length is stored as an integer

### DIFF
--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -190,7 +190,7 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
             raise ValueError(f"Target column {self.target} cannot be one of the known covariates.")
         self.known_covariates_names = list(known_covariates_names)
 
-        self.prediction_length = prediction_length
+        self.prediction_length = int(prediction_length)
         # For each validation fold, all time series in training set must have length >= _min_train_length
         self._min_train_length = max(self.prediction_length + 1, 5)
         self.freq = freq


### PR DESCRIPTION
*Issue #, if available:* Fixes #4012

*Description of changes:*
- Currently, predictor.fit() fails is `prediction_length` is provided as a `float` instead of `int`. This PR ensures that `prediction_length` is always stored as an `int`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
