### PR TITLE
[AutoMM] Modify the default of basic fine-tuning tricks

### DIFF
--- a/multimodal/src/autogluon/multimodal/configs/data/default.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/data/default.yaml
@@ -6,7 +6,7 @@ data:
   categorical:
     minimum_cat_count: 100  # The minimum number of occurrences a category must have in the training data to avoid being considered a rare category.
     maximum_num_cat: 20  # The maximum amount of categories that can be considered non-rare.
-    convert_to_text: False  # Whether to convert the feature to text.
+    convert_to_text: True  # Whether to convert the feature to text.
   numerical:
     convert_to_text: False  # Whether to convert the feature to text.
     scaler_with_mean: True  # Whether to normalize with mean.

--- a/multimodal/src/autogluon/multimodal/configs/data/default.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/data/default.yaml
@@ -6,7 +6,7 @@ data:
   categorical:
     minimum_cat_count: 100  # The minimum number of occurrences a category must have in the training data to avoid being considered a rare category.
     maximum_num_cat: 20  # The maximum amount of categories that can be considered non-rare.
-    convert_to_text: True  # Whether to convert the feature to text.
+    convert_to_text: False  # Whether to convert the feature to text.
   numerical:
     convert_to_text: False  # Whether to convert the feature to text.
     scaler_with_mean: True  # Whether to normalize with mean.

--- a/multimodal/src/autogluon/multimodal/configs/model/default.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/model/default.yaml
@@ -33,7 +33,7 @@ model:
     text_segment_num: 2
     stochastic_chunk: False
     text_aug_detect_length: 10                # We perform text augmentation only if a text has more than text_detection_length words. It is used to differentiate text columns versus tabular columns that are treated as text.
-    text_trivial_aug_maxscale: 0.0            # augmentation magnitude randomly drawn from [0, text_trivial_aug_maxscale]
+    text_trivial_aug_maxscale: 0.1            # augmentation magnitude randomly drawn from [0, text_trivial_aug_maxscale]
     text_train_augment_types:        # specify augmentation space manually, will randomly select one from the following and identity
       # - "random_swap(0.05)"          # less than 0.1 based on eda paper
       # - "random_delete(0.05)"        # less than 0.1 based on eda paper

--- a/multimodal/src/autogluon/multimodal/configs/optimization/default.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/optimization/default.yaml
@@ -5,7 +5,7 @@ optimization:
   lr_choice: "layerwise_decay"
   lr_decay: 0.9
   lr_schedule: "cosine_decay"
-  max_epochs: 10
+  max_epochs: 20
   max_steps: -1
   warmup_steps: 0.1
   end_lr: 0

--- a/multimodal/src/autogluon/multimodal/learners/ner.py
+++ b/multimodal/src/autogluon/multimodal/learners/ner.py
@@ -50,6 +50,12 @@ class NERLearner(BaseLearner):
             pretrained=pretrained,
             validation_metric=validation_metric,
         )
+        # set the convert_to_text=True assuming there are no categorical data in NER
+        convert_to_text = {"data.categorical.convert_to_text": True}
+        if self._hyperparameters:
+            self._hyperparameters.update(convert_to_text)
+        else:
+            self._hyperparameters = convert_to_text
 
     def infer_problem_type(self, train_data: pd.DataFrame):
         return  # problem type should be provided in learner initialization


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Not to convert the categorical features to text.
- Use text augmentation.
- Increase the number of training epochs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
