### PR TITLE
[timeseries] Fix loading of Tabular models failing if predictor moved to a different directory

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -56,7 +56,7 @@ class TabularEstimator(BaseEstimator):
     @classmethod
     def load(cls, path: str) -> "TabularEstimator":
         # There is no need to pass init & fit kwargs since predictor is already trained
-        estimator = TabularEstimator()
+        estimator = cls()
         estimator.predictor = TabularPredictor.load(path)
         return estimator
 

--- a/timeseries/tests/unittests/models/test_mlforecast.py
+++ b/timeseries/tests/unittests/models/test_mlforecast.py
@@ -272,7 +272,6 @@ def test_when_trained_model_moved_to_different_folder_then_loaded_model_can_pred
     )
     model.fit(train_data=data)
     model.save()
-    del model
     new_model_dir = tempfile.mkdtemp()
     shutil.move(model.path, new_model_dir)
     loaded_model = model_type.load(os.path.join(new_model_dir, model.name))


### PR DESCRIPTION
*Issue #, if available:* Fixes #4133

*Description of changes:*
- Fix loading of Tabular models failing if predictor moved to a different directory. Now the path of the Tabular predictor is generated at runtime based on the model path.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
