### PR TITLE
[tabular] Fix eval bug with regression metrics in LightGBM

### DIFF
--- a/tabular/src/autogluon/tabular/models/lgb/lgb_utils.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_utils.py
@@ -38,7 +38,12 @@ def convert_ag_metric_to_lgbm(ag_metric_name, problem_type):
 
 
 def func_generator(metric, is_higher_better, needs_pred_proba, problem_type):
-    if needs_pred_proba:
+    if problem_type in [REGRESSION, QUANTILE]:
+        # TODO: Might not work for custom quantile metrics
+        def function_template(y_hat, data):
+            y_true = data.get_label()
+            return metric.name, metric(y_true, y_hat), is_higher_better
+    elif needs_pred_proba:
         if problem_type == MULTICLASS:
 
             def function_template(y_hat, data):


### PR DESCRIPTION
*Issue #, if available:*
Bug identified in AutoML Grand Prix competition with "r2" metric: https://www.kaggle.com/competitions/playground-series-s4e5/discussion/500783

*Description of changes:*

- Fixes a bug that causes LightGBM to internally calculate the metric score incorrectly in regression for custom metrics and metrics other than "mean_absolute_error", "mean_squared_error", and "root_mean_squared_error".
- For example, "r2" metric will cause LightGBM to perform very badly due to incorrect score calculations.
- This bug has been present since the origin of the library in 2019.

The logic previously treated the metric as a classification metric such as "accuracy", and would do:

```
y_hat = np.round(y_hat)
```

which is incorrect in regression.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
