### PR TITLE
[timeseries] Fix tabular models sometimes failing because of a bug in preprocessing logic

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -86,6 +86,7 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
         self._residuals_std_per_item: Optional[pd.Series] = None
         self._avg_residuals_std: Optional[float] = None
         self._train_target_median: Optional[float] = None
+        self._non_boolean_real_covariates: List[str] = []
 
     def preprocess(self, data: TimeSeriesDataFrame, is_train: bool = False, **kwargs) -> Any:
         if is_train:
@@ -252,10 +253,9 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
         if static_features is not None:
             df = pd.merge(df, static_features, how="left", on=ITEMID, suffixes=(None, "_static_feat"))
 
-        for col in self.metadata.known_covariates_real:
+        for col in self._non_boolean_real_covariates:
             # Normalize non-boolean features using mean_abs scaling
-            if not df[col].isin([0, 1]).all():
-                df[f"__scaled_{col}"] = df[col] / df[col].abs().groupby(df[ITEMID]).mean().reindex(df[ITEMID]).values
+            df[f"__scaled_{col}"] = df[col] / df[col].abs().groupby(df[ITEMID]).mean().reindex(df[ITEMID]).values
 
         # Convert float64 to float32 to reduce memory usage
         float64_cols = list(df.select_dtypes(include="float64"))
@@ -277,6 +277,9 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
         self._check_fit_params()
         fit_start_time = time.time()
         self._train_target_median = train_data[self.target].median()
+        for col in self.metadata.known_covariates_real:
+            if not train_data[col].isin([0, 1]).all():
+                self._non_boolean_real_covariates.append(col)
         # TabularEstimator is passed to MLForecast later to include tuning_data
         model_params = self._get_model_params()
 


### PR DESCRIPTION
Tabular forecasting models would occasionally fail when a non-boolean known real covariate was mistakenly interpreted as a boolean covariate.

MWE:
```python
import pandas as pd
from autogluon.timeseries import TimeSeriesPredictor
N = 30
df = pd.DataFrame(
    {
        "item_id": ["A"] * N,
        "timestamp": pd.date_range("2020-01-01", freq="D", periods=N),
        "target": np.random.normal(size=N),
        "feat": np.tile([5, 0, 0], int(N/3)),
    }
)
predictor = TimeSeriesPredictor(known_covariates_names=["feat"]).fit(df, hyperparameters={"RecursiveTabular": {}})
```
This code will fail with the following exception
```
	Warning: Exception caused RecursiveTabular to fail during training... Skipping this model.
	"['__scaled_feat'] not in index"
```

This happens because during `fit()`, the feature `feat` is interpreted as non-boolean, so a scaled copy of the feature is added. At predict time, when transforming `known_covariates` (containing one row with only the `0` value), the feature was interpreted as boolean, so no scaled version of the feature was added. This results in the model failing at prediction time.

*Description of changes:*
- This PR fixes the above bug.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
