### PR TITLE
[timeseries] bump statsforecast version

### DIFF
--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -34,6 +34,8 @@ install_requires = [
     "networkx",  # version range defined in `core/_setup_utils.py`
     "statsforecast>=1.7.0,<1.8",
     "mlforecast>=0.10.0,<0.10.1",
+    "utilsforecast<=0.1.9",  # to prevent breaking changes that propagate through mlforecast's dependency
+    "fugue>=0.9.0",  # prevent dependency clash with omegaconf
     "tqdm",  # version range defined in `core/_setup_utils.py`
     "orjson~=3.9",  # use faster JSON implementation in GluonTS
     # TODO v1.1: use lightning[pytorch-extra] instead of explicitly installing tensorboard

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -32,10 +32,8 @@ install_requires = [
     "accelerate",  # version range defined in `core/_setup_utils.py`
     "gluonts==0.15.1",
     "networkx",  # version range defined in `core/_setup_utils.py`
-    # TODO: update statsforecast to v1.5.0 - resolve antlr4-python3-runtime dependency clash with multimodal
-    "statsforecast>=1.4.0,<1.5",
+    "statsforecast>=1.7.0,<1.8",
     "mlforecast>=0.10.0,<0.10.1",
-    "utilsforecast>=0.0.10,<0.0.11",
     "tqdm",  # version range defined in `core/_setup_utils.py`
     "orjson~=3.9",  # use faster JSON implementation in GluonTS
     # TODO v1.1: use lightning[pytorch-extra] instead of explicitly installing tensorboard

--- a/timeseries/src/autogluon/timeseries/models/local/statsforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/local/statsforecast.py
@@ -204,8 +204,6 @@ class ARIMAModel(AbstractProbabilisticStatsForecastModel):
         This significantly speeds up fitting and usually leads to no change in accuracy.
     """
 
-    # TODO: This model requires statsforecast >= 1.5.0, so it will only be available after we upgrade the dependency
-
     allowed_local_model_args = [
         "order",
         "seasonal_order",
@@ -491,8 +489,7 @@ class AbstractConformalizedStatsForecastModel(AbstractStatsForecastModel):
         return pd.DataFrame(predictions)
 
 
-# TODO: Starting from StatsForecast v1.5.0, AutoCES can inherit from AbstractProbabilisticStatsForecastModel
-class AutoCESModel(AbstractConformalizedStatsForecastModel):
+class AutoCESModel(AbstractProbabilisticStatsForecastModel):
     """Forecasting with an Complex Exponential Smoothing model where the model selection is performed using the
     Akaike Information Criterion.
 
@@ -541,16 +538,6 @@ class AutoCESModel(AbstractConformalizedStatsForecastModel):
         local_model_args = super()._update_local_model_args(local_model_args)
         local_model_args.setdefault("model", "Z")
         return local_model_args
-
-    def _get_point_forecast(self, time_series: pd.Series, local_model_args: Dict):
-        # Disable seasonality if time series too short for chosen season_length or season_length == 1,
-        # otherwise model will crash
-        if len(time_series) < 5:
-            # AutoCES does not handle "tiny" datasets, fall back to naive
-            return np.full(self.prediction_length, time_series.values[-1])
-        if len(time_series) < 2 * local_model_args["season_length"] + 1 or local_model_args["season_length"] == 1:
-            local_model_args["model"] = "N"
-        return super()._get_point_forecast(time_series, local_model_args)
 
 
 class AbstractStatsForecastIntermittentDemandModel(AbstractConformalizedStatsForecastModel):

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -10,6 +10,7 @@ from autogluon.timeseries.metrics import TimeSeriesScorer
 
 from . import (
     ADIDAModel,
+    ARIMAModel,
     AutoARIMAModel,
     AutoCESModel,
     AutoETSModel,
@@ -38,9 +39,6 @@ from . import (
 from .abstract import AbstractTimeSeriesModel
 from .multi_window.multi_window_model import MultiWindowBacktestingModel
 
-# TODO: Enable ARIMAModel after upgrading to StatsForecast >=1.5.0 - currently ARIMA model is broken
-
-
 logger = logging.getLogger(__name__)
 
 ModelHyperparameters = Dict[str, Any]
@@ -68,6 +66,7 @@ MODEL_TYPES = dict(
     NPTS=NPTSModel,
     Theta=ThetaModel,
     ETS=ETSModel,
+    ARIMA=ARIMAModel,
     ADIDA=ADIDAModel,
     CrostonSBA=CrostonSBAModel,
     IMAPA=IMAPAModel,

--- a/timeseries/tests/unittests/models/test_local.py
+++ b/timeseries/tests/unittests/models/test_local.py
@@ -8,6 +8,7 @@ import pytest
 from autogluon.timeseries import TimeSeriesDataFrame
 from autogluon.timeseries.models.local import (
     ADIDAModel,
+    ARIMAModel,
     AutoARIMAModel,
     AutoCESModel,
     AutoETSModel,
@@ -37,6 +38,7 @@ from ..common import (
 
 # models accepting seasonal_period
 SEASONAL_TESTABLE_MODELS = [
+    ARIMAModel,
     AutoARIMAModel,
     AutoETSModel,
     AutoCESModel,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

**Do not merge until after v1.1.1 release**

Bump StatsForecast version to v1.7. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
