### PR TITLE
Changed type of _fillna_map in normalize_time_series

### DIFF
--- a/features/src/autogluon/features/generators/datetime.py
+++ b/features/src/autogluon/features/generators/datetime.py
@@ -58,7 +58,7 @@ class DatetimeFeatureGenerator(AbstractFeatureGenerator):
         if is_fit:
             good_rows = series[~series.isin(bad_rows)].astype(np.int64)
             self._fillna_map[feature] = pd.to_datetime(int(good_rows.mean()), utc=True, format="mixed")
-        series[broken_idx] = self._fillna_map[feature]
+        series[broken_idx] = pd.to_datetime(self._fillna_map[feature], utc=True)
         return series
 
     # TODO: Improve handling of missing datetimes


### PR DESCRIPTION


Issue #, if available:

Description of changes:
Changed the _fillna_map format to Timestamp with UTC. Previously this was changing the type of the series if the _fillna_map was not in the same format as the series, which later causes an error in the ".dt" parameter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
