### PR TITLE
[tabular] add infer throughput logging

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -151,6 +151,7 @@ class AbstractModel:
 
         self.fit_time = None  # Time taken to fit in seconds (Training data)
         self.predict_time = None  # Time taken to predict in seconds (Validation data)
+        self._predict_n_size = None  # Batch size used to calculate predict_time
         self.predict_1_time = None  # Time taken to predict 1 row of data in seconds (with batch size `predict_1_batch_size` in params_aux)
         self.compile_time = None  # Time taken to compile the model in seconds
         self.val_score = None  # Score with eval_metric (Validation data)
@@ -931,31 +932,57 @@ class AbstractModel:
     def predict(self, X, **kwargs) -> np.ndarray:
         """
         Returns class predictions of X.
-        For binary and multiclass problems, this returns the predicted class labels as a Series.
-        For regression problems, this returns the predicted values as a Series.
+        For binary and multiclass problems, this returns the predicted class labels as a 1d numpy array.
+        For regression problems, this returns the predicted values as a 1d numpy array.
         """
         y_pred_proba = self.predict_proba(X, **kwargs)
         y_pred = get_pred_from_proba(y_pred_proba=y_pred_proba, problem_type=self.problem_type)
         return y_pred
 
-    def predict_proba(self, X, normalize=None, **kwargs) -> np.ndarray:
+    def predict_proba(self, X, *, normalize: bool | None = None, record_time: bool = False, **kwargs) -> np.ndarray:
         """
         Returns class prediction probabilities of X.
-        For binary problems, this returns the positive class label probability as a Series.
-        For multiclass problems, this returns the class label probabilities of each class as a DataFrame.
-        For regression problems, this returns the predicted values as a Series.
+        For binary problems, this returns the positive class label probability as a 1d numpy array.
+        For multiclass problems, this returns the class label probabilities of each class as a 2d numpy array.
+        For regression problems, this returns the predicted values as a 1d numpy array.
+
+        Parameters
+        ----------
+        X
+            The data used for prediction.
+        normalize: bool | None, default = None
+            Whether to normalize the predictions prior to returning.
+            If None, will default to `self.normalize_pred_probas`.
+        record_time: bool, default = False
+            If True, will record the time taken for prediction in `self.predict_time` and the number of rows of X in `self.predict_n_size`.
+        kwargs
+            Keyword arguments to pass into `self._predict_proba`.
+
+        Returns
+        -------
+        y_pred_proba : np.ndarray
+            The prediction probabilities
         """
+        time_start = time.time() if record_time else None
+
+        y_pred_proba = self._predict_proba_internal(X=X, normalize=normalize, **kwargs)
+
+        if self.params_aux.get("temperature_scalar", None) is not None:
+            y_pred_proba = self._apply_temperature_scaling(y_pred_proba)
+        elif self.conformalize is not None:
+            y_pred_proba = self._apply_conformalization(y_pred_proba)
+        if record_time:
+            self.predict_time = time.time() - time_start
+            self.record_predict_info(X=X)
+        return y_pred_proba
+
+    def _predict_proba_internal(self, X, *, normalize: bool | None = None, **kwargs):
         if normalize is None:
             normalize = self.normalize_pred_probas
         y_pred_proba = self._predict_proba(X=X, **kwargs)
         if normalize:
             y_pred_proba = normalize_pred_probas(y_pred_proba, self.problem_type)
         y_pred_proba = y_pred_proba.astype(np.float32)
-
-        if self.params_aux.get("temperature_scalar", None) is not None:
-            y_pred_proba = self._apply_temperature_scaling(y_pred_proba)
-        elif self.conformalize is not None:
-            y_pred_proba = self._apply_conformalization(y_pred_proba)
         return y_pred_proba
 
     def predict_from_proba(self, y_pred_proba: np.ndarray) -> np.ndarray:
@@ -1877,6 +1904,34 @@ class AbstractModel:
         json_path = os.path.join(self.path, self.model_info_json_name)
         save_json.save(path=json_path, obj=info)
         return info
+
+    @property
+    def predict_n_size(self) -> int | None:
+        """
+        The number of rows in the data used when calculating `self.predict_time`.
+        """
+        return self._predict_n_size
+
+    @property
+    def predict_n_time_per_row(self) -> float | None:
+        """
+        The time in seconds required to predict 1 row of data given a batch size of `self.predict_n_size`.
+        Returns None if either `self.predict_time` or `self.predict_n_size` are None.
+        """
+        if self.predict_time is None or self.predict_n_size is None:
+            return None
+        return self.predict_time / self.predict_n_size
+
+    def record_predict_info(self, X: pd.DataFrame):
+        """
+        Records the necessary information to compute `self.predict_n_time_per_row`.
+
+        Parameters
+        ----------
+        X: pd.DataFrame
+            The data used to predict on when calculating `self.predict_time`.
+        """
+        self._predict_n_size = len(X)
 
     def _get_maximum_resources(self) -> Dict[str, Union[int, float]]:
         """

--- a/core/src/autogluon/core/models/abstract/model_trial.py
+++ b/core/src/autogluon/core/models/abstract/model_trial.py
@@ -103,13 +103,14 @@ def fit_and_save_model(model, fit_args, predict_proba_args, y_val, time_start, t
         # sample_weight = fit_args.get('sample_weight', None)
         model.val_score = model.score_with_y_pred_proba(y=fit_args["y"], y_pred_proba=oof_pred_proba)
     else:
-        y_pred_proba = model.predict_proba(**predict_proba_args)
+        y_pred_proba = model.predict_proba(record_time=True, **predict_proba_args)
         time_pred_end = time.time()
         sample_weight_val = fit_args.get("sample_weight_val", None)
         model.val_score = model.score_with_y_pred_proba(y=y_val, y_pred_proba=y_pred_proba, sample_weight=sample_weight_val)
 
     model.fit_time = time_fit_end - time_fit_start
-    model.predict_time = time_pred_end - time_fit_end
+    if model.predict_time is None:
+        model.predict_time = time_pred_end - time_fit_end
     model.save()
     return model
 

--- a/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
+++ b/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
@@ -251,8 +251,7 @@ class FoldFittingStrategy(AbstractFoldFittingStrategy):
         self.oof_pred_model_repeats[val_index] += 1
         self.bagged_ensemble_model._add_child_times_to_bag(model=fold_model)
 
-    def _predict_oof(self, fold_model, fold_ctx):
-        time_train_end_fold = time.time()
+    def _predict_oof(self, fold_model: AbstractModel, fold_ctx) -> Tuple[AbstractModel, ndarray]:
         fold, folds_finished, folds_left, folds_to_fit, is_last_fold, model_name_suffix = self._get_fold_properties(fold_ctx)
         _, val_index = fold
         X_val_fold = self.X.iloc[val_index, :]
@@ -267,13 +266,12 @@ class FoldFittingStrategy(AbstractFoldFittingStrategy):
                 expected_remaining_time_required = expected_time_required * (folds_left - 1) / folds_to_fit
                 if expected_remaining_time_required > time_left:
                     raise TimeLimitExceeded
-        pred_proba = fold_model.predict_proba(X_val_fold)
-        fold_model.predict_time = time.time() - time_train_end_fold
-        fold_model.val_score = fold_model.score_with_y_pred_proba(y=y_val_fold, y_pred_proba=pred_proba)
+        y_pred_proba = fold_model.predict_proba(X_val_fold, record_time=True)
+        fold_model.val_score = fold_model.score_with_y_pred_proba(y=y_val_fold, y_pred_proba=y_pred_proba)
         fold_model.reduce_memory_size(remove_fit=True, remove_info=False, requires_save=True)
         if not self.bagged_ensemble_model.params.get("save_bag_folds", True):
             fold_model.model = None
-        return fold_model, pred_proba
+        return fold_model, y_pred_proba
 
     @staticmethod
     def _get_fold_properties(fold_ctx):
@@ -404,24 +402,28 @@ def _ray_fit(
     fold_model.fit(X=X_fold, y=y_fold, X_val=X_val_fold, y_val=y_val_fold, time_limit=time_limit_fold, **resources, **kwargs_fold)
     time_train_end_fold = time.time()
     fold_model.fit_time = time_train_end_fold - time_start_fold
-    fold_model, pred_proba = _ray_predict_oof(fold_model, X_val_fold, y_val_fold, time_train_end_fold, resources["num_cpus"], save_bag_folds)
+    fold_model, pred_proba = _ray_predict_oof(
+        fold_model=fold_model,
+        X_val_fold=X_val_fold,
+        y_val_fold=y_val_fold,
+        num_cpus=resources["num_cpus"],
+        save_bag_folds=save_bag_folds,
+    )
     save_path = fold_model.save()
     if model_sync_path is not None and not is_head_node:
         model_sync_path = model_sync_path + f"{fold_model.name}/"  # s3 path hence need "/" as the saperator
         bucket, prefix = s3_path_to_bucket_prefix(model_sync_path)
         upload_s3_folder(bucket=bucket, prefix=prefix, folder_to_upload=save_path, verbose=False)
-    return fold_model.name, pred_proba, time_start_fold, time_train_end_fold, fold_model.predict_time, fold_model.predict_1_time
+    return fold_model.name, pred_proba, time_start_fold, time_train_end_fold, fold_model.predict_time, fold_model.predict_1_time, fold_model.predict_n_size
 
 
-def _ray_predict_oof(fold_model, X_val_fold, y_val_fold, time_train_end_fold, num_cpus=-1, save_bag_folds=True):
-    pred_proba = fold_model.predict_proba(X_val_fold, num_cpus=num_cpus)
-    time_pred_end_fold = time.time()
-    fold_model.predict_time = time_pred_end_fold - time_train_end_fold
-    fold_model.val_score = fold_model.score_with_y_pred_proba(y=y_val_fold, y_pred_proba=pred_proba)
+def _ray_predict_oof(fold_model: AbstractModel, X_val_fold: pd.DataFrame, y_val_fold: pd.Series, num_cpus: int = -1, save_bag_folds: bool = True):
+    y_pred_proba = fold_model.predict_proba(X_val_fold, record_time=True, num_cpus=num_cpus)
+    fold_model.val_score = fold_model.score_with_y_pred_proba(y=y_val_fold, y_pred_proba=y_pred_proba)
     fold_model.reduce_memory_size(remove_fit=True, remove_info=False, requires_save=True)
     if not save_bag_folds:
         fold_model.model = None
-    return fold_model, pred_proba
+    return fold_model, y_pred_proba
 
 
 class ParallelFoldFittingStrategy(FoldFittingStrategy):
@@ -473,6 +475,7 @@ class ParallelFoldFittingStrategy(FoldFittingStrategy):
         self.fit_time = 0
         self.predict_time = 0
         self.predict_1_time = None
+        self.predict_n_size_lst = None
         # max_calls to guarantee release of gpu resource
         self._ray_fit = self.ray.remote(max_calls=1)(_ray_fit)
         self.mem_est_model = self._initialized_model_base.estimate_memory_usage(X=self.X)
@@ -531,7 +534,7 @@ class ParallelFoldFittingStrategy(FoldFittingStrategy):
 
     def _process_fold_results(self, finished, unfinished, fold_ctx):
         try:
-            fold_model, pred_proba, time_start_fit, time_end_fit, predict_time, predict_1_time = self.ray.get(finished)
+            fold_model, pred_proba, time_start_fit, time_end_fit, predict_time, predict_1_time, predict_n_size = self.ray.get(finished)
             assert fold_ctx is not None
             self._update_bagged_ensemble(
                 fold_model=fold_model,
@@ -540,6 +543,7 @@ class ParallelFoldFittingStrategy(FoldFittingStrategy):
                 time_end_fit=time_end_fit,
                 predict_time=predict_time,
                 predict_1_time=predict_1_time,
+                predict_n_size=predict_n_size,
                 fold_ctx=fold_ctx,
             )
             model_sync_path = None
@@ -572,6 +576,7 @@ class ParallelFoldFittingStrategy(FoldFittingStrategy):
         if self.time_start_fit and self.time_end_fit:
             self.fit_time = self.time_end_fit - self.time_start_fit
         self.bagged_ensemble_model._add_parallel_child_times(fit_time=self.fit_time, predict_time=self.predict_time, predict_1_time=self.predict_1_time)
+        self.bagged_ensemble_model._add_predict_n_size(predict_n_size_lst=self.predict_n_size_lst)
 
     def _run_parallel(self, X, y, X_pseudo, y_pseudo, model_base_ref, time_limit_fold, head_node_id):
         job_refs = []
@@ -716,7 +721,7 @@ class ParallelFoldFittingStrategy(FoldFittingStrategy):
             model_sync_path=self.model_sync_path,
         )
 
-    def _update_bagged_ensemble(self, fold_model, pred_proba, time_start_fit, time_end_fit, predict_time, predict_1_time, fold_ctx):
+    def _update_bagged_ensemble(self, fold_model, pred_proba, time_start_fit, time_end_fit, predict_time, predict_1_time, predict_n_size, fold_ctx):
         _, val_index = fold_ctx["fold"]
         self.models.append(fold_model)
         self.oof_pred_proba[val_index] += pred_proba
@@ -734,6 +739,9 @@ class ParallelFoldFittingStrategy(FoldFittingStrategy):
             if self.predict_1_time is None:
                 self.predict_1_time = 0
             self.predict_1_time += predict_1_time
+        if self.predict_n_size_lst is None:
+            self.predict_n_size_lst = []
+        self.predict_n_size_lst.append(predict_n_size)
 
     def _get_fold_time_limit(self):
         time_elapsed = time.time() - self.time_start

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -1913,28 +1913,21 @@ class AbstractTrainer:
             if not compute_score:
                 score = None
                 model.predict_time = None
+            elif X_val is not None and y_val is not None:
+                y_pred_proba_val = model.predict_proba(X_val, record_time=True)
+                score = model.score_with_y_pred_proba(y=y_val, y_pred_proba=y_pred_proba_val, sample_weight=w_val)
             elif isinstance(model, BaggedEnsembleModel):
-                if X_val is not None and y_val is not None:
-                    y_pred_proba_val = model.predict_proba(X_val)
-                    score = model.score_with_y_pred_proba(y=y_val, y_pred_proba=y_pred_proba_val, sample_weight=w_val)
-                elif model.is_valid_oof() or isinstance(model, WeightedEnsembleModel):
+                if model.is_valid_oof() or isinstance(model, WeightedEnsembleModel):
                     score = model.score_with_oof(y=y, sample_weight=w)
                 else:
                     score = None
             else:
-                if X_val is not None and y_val is not None:
-                    y_pred_proba_val = model.predict_proba(X_val)
-                    score = model.score_with_y_pred_proba(y=y_val, y_pred_proba=y_pred_proba_val, sample_weight=w_val)
-                else:
-                    score = None
+                score = None
             pred_end_time = time.time()
             if model.fit_time is None:
                 model.fit_time = fit_end_time - fit_start_time
-            if model.predict_time is None:
-                if score is None:
-                    model.predict_time = None
-                else:
-                    model.predict_time = pred_end_time - fit_end_time
+            if model.predict_time is None and score is not None:
+                model.predict_time = pred_end_time - fit_end_time
             model.val_score = score
             # TODO: Add recursive=True to avoid repeatedly loading models each time this is called for bagged ensembles (especially during repeated bagging)
             self.save_model(model=model)
@@ -2003,6 +1996,8 @@ class AbstractTrainer:
             predict_1_time=model.predict_1_time,
             predict_child_time=predict_child_time,
             predict_1_child_time=predict_1_child_time,
+            predict_n_time_per_row=model.predict_n_time_per_row,
+            predict_n_size=model.predict_n_size,
             val_score=model.val_score,
             eval_metric=model.eval_metric.name,
             stopping_metric=model.stopping_metric.name,
@@ -2129,6 +2124,10 @@ class AbstractTrainer:
             logger.log(20, f"\t{round(model.fit_time, 2)}s\t = Training   runtime")
         if model.predict_time is not None:
             logger.log(20, f"\t{round(model.predict_time, 2)}s\t = Validation runtime")
+        predict_n_time_per_row = self.get_model_attribute_full(model=model.name, attribute="predict_n_time_per_row")
+        predict_n_size = self.get_model_attribute_full(model=model.name, attribute="predict_n_size", func=min)
+        if predict_n_time_per_row is not None and predict_n_time_per_row != 0 and predict_n_size is not None:
+            logger.log(30, f"\t{round(1 / predict_n_time_per_row, 1)}\t = Inference  throughput (rows/s | {int(predict_n_size)} batch size)")
         if model.predict_1_time is not None:
             fit_metadata = model.get_fit_metadata()
             predict_1_batch_size = fit_metadata.get("predict_1_batch_size", None)

--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -632,8 +632,8 @@ def infer_problem_type(y: Series, silent=False) -> str:
 
         logger.log(
             25,
-            f"\tIf '{problem_type}' is not the correct problem_type, please manually specify the problem_type parameter during predictor init "
-            f"(You may specify problem_type as one of: {[BINARY, MULTICLASS, REGRESSION]})",
+            f"\tIf '{problem_type}' is not the correct problem_type, please manually specify the problem_type parameter during Predictor init "
+            f"(You may specify problem_type as one of: {[BINARY, MULTICLASS, REGRESSION, QUANTILE]})",
         )
     return problem_type
 

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -142,7 +142,15 @@ class DefaultLearner(AbstractTabularLearner):
         time_end = time.time()
         self._time_fit_training = time_end - time_preprocessing_end
         self._time_fit_total = time_end - time_preprocessing_start
-        logger.log(20, f'AutoGluon training complete, total runtime = {round(self._time_fit_total, 2)}s ... Best model: "{trainer.model_best}"')
+        predict_n_time_per_row = trainer.get_model_attribute_full(model=trainer.model_best, attribute="predict_n_time_per_row")
+        predict_n_size = trainer.get_model_attribute_full(model=trainer.model_best, attribute="predict_n_size", func=min)
+        if predict_n_time_per_row is not None and predict_n_size is not None:
+            log_throughput = f" | Estimated inference throughput: {(1/predict_n_time_per_row):.1f} rows/s ({int(predict_n_size)} batch size)"
+        else:
+            log_throughput = ""
+        logger.log(
+            20, f"AutoGluon training complete, total runtime = {round(self._time_fit_total, 2)}s ... Best model: {trainer.model_best}" f"{log_throughput}"
+        )
 
     def _update_infer_limit(self, X: DataFrame, *, infer_limit_batch_size: int, infer_limit: float = None):
         """

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -142,12 +142,12 @@ class DefaultLearner(AbstractTabularLearner):
         time_end = time.time()
         self._time_fit_training = time_end - time_preprocessing_end
         self._time_fit_total = time_end - time_preprocessing_start
-        predict_n_time_per_row = trainer.get_model_attribute_full(model=trainer.model_best, attribute="predict_n_time_per_row")
-        predict_n_size = trainer.get_model_attribute_full(model=trainer.model_best, attribute="predict_n_size", func=min)
-        if predict_n_time_per_row is not None and predict_n_size is not None:
-            log_throughput = f" | Estimated inference throughput: {(1/predict_n_time_per_row):.1f} rows/s ({int(predict_n_size)} batch size)"
-        else:
-            log_throughput = ""
+        log_throughput = ""
+        if trainer.model_best is not None:
+            predict_n_time_per_row = trainer.get_model_attribute_full(model=trainer.model_best, attribute="predict_n_time_per_row")
+            predict_n_size = trainer.get_model_attribute_full(model=trainer.model_best, attribute="predict_n_size", func=min)
+            if predict_n_time_per_row is not None and predict_n_size is not None:
+                log_throughput = f" | Estimated inference throughput: {(1/predict_n_time_per_row):.1f} rows/s ({int(predict_n_size)} batch size)"
         logger.log(
             20, f"AutoGluon training complete, total runtime = {round(self._time_fit_total, 2)}s ... Best model: {trainer.model_best}" f"{log_throughput}"
         )


### PR DESCRIPTION
*Issue #, if available:*
Resolves #4162 

*Description of changes:*
- add infer throughput logging, this implementation specifically introduces no overheads by avoiding calling predict separately, instead calculating the throughput at the same time as the score is being calculated for efficiency.
- code cleanup / code dedupe
- added additional method documentation

Mainline:

```
AutoGluon training complete, total runtime = 21.17s ... Best model: WeightedEnsemble_L2
```

This PR:

```
AutoGluon training complete, total runtime = 21.17s ... Best model: WeightedEnsemble_L2 | Estimated inference throughput: 23766.6 rows/s (1500 batch size)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
