### PR TITLE
[timeseries] Fix cached predictions error when predictor saved to directory with an existing predictor

### DIFF
--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -292,6 +292,10 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         self.cache_predictions = cache_predictions
         self.hpo_results = {}
 
+        if self._cached_predictions_path.exists():
+            logger.debug(f"Removing existing cached predictions file {self._cached_predictions_path}")
+            self._cached_predictions_path.unlink()
+
     def save_train_data(self, data: TimeSeriesDataFrame, verbose: bool = True) -> None:
         path = os.path.join(self.path_data, "train.pkl")
         save_pkl.save(path=path, object=data, verbose=verbose)

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -1727,3 +1727,12 @@ def test_given_predictor_takes_known_only_when_feature_importance_called_with_im
                 assert np.allclose(importance, 0, atol=1e-8)
             else:
                 assert np.isfinite(importance)
+
+
+def test_when_predictor_saved_to_same_directory_then_models_can_predict(temp_model_path):
+    data = DUMMY_TS_DATAFRAME
+    old_predictor = TimeSeriesPredictor(path=temp_model_path).fit(data, hyperparameters={"Naive": {}})
+    old_predictor.leaderboard(data)
+
+    new_predictor = TimeSeriesPredictor(path=temp_model_path).fit(data, hyperparameters={"Average": {}})
+    new_predictor.leaderboard(data)


### PR DESCRIPTION
*Issue #, if available:* Fixes #4183 #4195

*Description of changes:*
- Currently there is a bug in cached prediction logic that occurs if we re-use a directory where a predictor has been trained before. Specifically, the trainer tries to load some metadata for each model mentioned in the `cached_predictions.pkl` dictionary. However, if the model was trained by the old predictor (but isn't trained by the new predictor), this will result in an error.
- We fix this problem by making sure that the cached predictions are deleted whenever a new trainer is created.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
