### PR TITLE
[tabular, timeseries] Rename cached version file to `version.txt` from `__version__`

### DIFF
--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -35,7 +35,7 @@ from autogluon.common import space
 from autogluon.common.utils.simulation_utils import convert_simulation_artifacts_to_tabular_predictions_dict
 from autogluon.core.constants import BINARY, MULTICLASS, PROBLEM_TYPES_CLASSIFICATION, QUANTILE, REGRESSION
 from autogluon.core.utils import download, unzip
-from autogluon.tabular import TabularDataset, TabularPredictor
+from autogluon.tabular import TabularDataset, TabularPredictor, __version__
 from autogluon.tabular.configs.hyperparameter_configs import get_hyperparameter_config
 
 PARALLEL_LOCAL_BAGGING = "parallel_local"
@@ -149,6 +149,10 @@ def test_advanced_functionality():
     shutil.rmtree(savedir, ignore_errors=True)  # Delete AutoGluon output directory to ensure previous runs' information has been removed.
     savedir_predictor_original = savedir + "predictor/"
     predictor: TabularPredictor = TabularPredictor(label=label, path=savedir_predictor_original).fit(train_data)
+
+    version_in_file = predictor._load_version_file(path=predictor.path)
+    assert version_in_file == __version__
+
     leaderboard = predictor.leaderboard(data=test_data)
 
     # test metric_error leaderboard

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -1041,18 +1041,27 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
 
     @classmethod
     def _load_version_file(cls, path: str) -> str:
-        version_file_path = os.path.join(path, cls._predictor_version_file_name)
-        version = load_str.load(path=version_file_path)
-        return version
+        """
+        Loads the version file that is part of the saved predictor artifact.
 
-    @classmethod
-    def _load_version_file_old(cls, path) -> str:
+        Parameters
+        ----------
+        path: str
+            The path that would be used to load the predictor via `predictor.load(path)`
+
+        Returns
+        -------
+        The version of AutoGluon used to fit the predictor, as a string.
+
         """
-        Loads the old version file used in `autogluon.timeseries<=1.1.0`, named `__version__`.
-        This file name was changed because Kaggle does not allow uploading files named `__version__`.
-        """
-        version_file_path = os.path.join(path, "__version__")
-        version = load_str.load(path=version_file_path)
+        version_file_path = os.path.join(path, cls._predictor_version_file_name)
+        try:
+            version = load_str.load(path=version_file_path)
+        except:
+            # Loads the old version file used in `autogluon.timeseries<=1.1.0`, named `__version__`.
+            # This file name was changed because Kaggle does not allow uploading files named `__version__`.
+            version_file_path = os.path.join(path, "__version__")
+            version = load_str.load(path=version_file_path)
         return version
 
     @classmethod
@@ -1085,15 +1094,11 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
         try:
             version_saved = cls._load_version_file(path=path)
         except:
-            try:
-                # Try to see if a version file in the old format prior to v1.1.1 exists
-                version_saved = cls._load_version_file_old(path=path)
-            except:
-                logger.warning(
-                    f'WARNING: Could not find version file at "{os.path.join(path, cls._predictor_version_file_name)}".\n'
-                    f"This means that the predictor was fit in an AutoGluon version `<=0.7.0`."
-                )
-                version_saved = "Unknown (Likely <=0.7.0)"
+            logger.warning(
+                f'WARNING: Could not find version file at "{os.path.join(path, cls._predictor_version_file_name)}".\n'
+                f"This means that the predictor was fit in an AutoGluon version `<=0.7.0`."
+            )
+            version_saved = "Unknown (Likely <=0.7.0)"
 
         check_saved_predictor_version(
             version_current=current_ag_version,


### PR DESCRIPTION
*Issue #, if available:*
Resolves #4161 

*Description of changes:*

- Previously AutoGluon's TabularPredictor and TimeSeriesPredictor would save a file named `__version__` that contained the AutoGluon version as a string at the time of saving. However, Kaggle doesn't allow files named `__version__` to be uploaded for an unknown reason.
- This PR renames the file to `version.txt`, while keeping backwards compatibility.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
