### PR TITLE
[timeseries] fix off-by-one bug in Chronos inference

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/chronos/pipeline.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/pipeline.py
@@ -163,7 +163,7 @@ class MeanScaleUniformBins(ChronosTokenizer):
     def output_transform(self, samples: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
         scale_unsqueezed = scale.unsqueeze(-1).unsqueeze(-1)
         indices = torch.clamp(
-            samples - self.config.n_special_tokens,
+            samples - self.config.n_special_tokens - 1,
             min=0,
             max=len(self.centers) - 1,
         )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes off by one error: https://github.com/amazon-science/chronos-forecasting/pull/73/files

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
