### PR TITLE
[tabular] Dynamic Stacking Logging Enhancement

### DIFF
--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -8,7 +8,6 @@ import pandas as pd
 from pandas import DataFrame
 
 from autogluon.common.utils.log_utils import convert_time_in_s_to_log_friendly
-from autogluon.common.utils.system_info import get_ag_system_info
 from autogluon.core.constants import AUTO_WEIGHT, BALANCE_WEIGHT, BINARY, MULTICLASS, QUANTILE, REGRESSION
 from autogluon.core.data import LabelCleaner
 from autogluon.core.data.cleaner import Cleaner
@@ -65,15 +64,10 @@ class DefaultLearner(AbstractTabularLearner):
         # TODO: if provided, feature_types in X, X_val are ignored right now, need to pass to Learner/trainer and update this documentation.
         self._time_limit = time_limit
         if time_limit:
-            logger.log(20, f"Beginning AutoGluon training ... Time limit = {time_limit}s")
+            logger.log(20, f"Beginning AutoGluon training ... Time limit = {time_limit:.0f}s")
         else:
             logger.log(20, "Beginning AutoGluon training ...")
         logger.log(20, f'AutoGluon will save models to "{self.path}"')
-        include_gpu_count = False
-        if verbosity >= 3:
-            include_gpu_count = True
-        msg = get_ag_system_info(path=self.path, include_gpu_count=include_gpu_count)
-        logger.log(20, msg)
         logger.log(20, f"Train Data Rows:    {len(X)}")
         logger.log(20, f"Train Data Columns: {len([column for column in X.columns if column != self.label])}")
         if X_val is not None:

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1259,7 +1259,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             )
             n_splits = len(splits)
             logger.info(
-                f"\tStarting (repeated-)cross-validation-based sub-fits for dynamic stacking. Context path: \"{ds_fit_context}\""
+                f'\tStarting (repeated-)cross-validation-based sub-fits for dynamic stacking. Context path: "{ds_fit_context}"'
                 f"Run at most {n_splits} sub-fits based on {n_repeats}-repeated {n_folds}-fold cross-validation."
             )
             np.random.RandomState(42).shuffle(splits)  # shuffle splits to mix up order such that if only one of the repeats shows leakage we might stop early.

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1259,7 +1259,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             )
             n_splits = len(splits)
             logger.info(
-                f"\tStarting (repeated-)cross-validation-based sub-fits for dynamic stacking. Context path is: {ds_fit_context}. "
+                f"\tStarting (repeated-)cross-validation-based sub-fits for dynamic stacking. Context path: \"{ds_fit_context}\""
                 f"Run at most {n_splits} sub-fits based on {n_repeats}-repeated {n_folds}-fold cross-validation."
             )
             np.random.RandomState(42).shuffle(splits)  # shuffle splits to mix up order such that if only one of the repeats shows leakage we might stop early.
@@ -1380,9 +1380,9 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
                     return False
 
             if holdout_data is None:
-                logger.info(f"\t\tContext path: {ds_fit_kwargs['ds_fit_context']}.")
+                logger.info(f"\t\tContext path: \"{ds_fit_kwargs['ds_fit_context']}\"")
             else:
-                logger.info(f"\t\tRunning DyStack holdout-based sub-fit with custom validation data. Context path: {ds_fit_kwargs['ds_fit_context']}.")
+                logger.info(f"\t\tRunning DyStack holdout-based sub-fit with custom validation data. Context path: \"{ds_fit_kwargs['ds_fit_context']}\"")
 
             if _ds_ray is not None:
                 # Handle resources

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -956,9 +956,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             elif verbosity >= 4:
                 logger.log(20, f"Verbosity: {verbosity} (Maximum Logging)")
 
-        include_gpu_count = False
-        if verbosity >= 3:
-            include_gpu_count = True
+        include_gpu_count = (verbosity >= 3)
         sys_msg = get_ag_system_info(path=self.path, include_gpu_count=include_gpu_count)
         logger.log(20, sys_msg)
 
@@ -1307,8 +1305,6 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         time_spend_sub_fits = time.time() - time_start
         num_stack_levels = 0 if stacked_overfitting else org_num_stack_levels
         self._stacked_overfitting_occurred = stacked_overfitting
-
-        # logger.info(f"\tSpent {time_spend_sub_fits}s for the sub-fit(s) during dynamic stacking.")
 
         logger.info(f"\t{num_stack_levels}\t = Optimal   num_stack_levels (Stacked Overfitting Occurred: {self._stacked_overfitting_occurred})")
         log_str = f"\t{round(time_spend_sub_fits)}s\t = DyStack   runtime"

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -956,7 +956,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             elif verbosity >= 4:
                 logger.log(20, f"Verbosity: {verbosity} (Maximum Logging)")
 
-        include_gpu_count = (verbosity >= 3)
+        include_gpu_count = verbosity >= 3
         sys_msg = get_ag_system_info(path=self.path, include_gpu_count=include_gpu_count)
         logger.log(20, sys_msg)
 

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -20,6 +20,7 @@ from autogluon.common.savers import save_json
 from autogluon.common.utils.file_utils import get_directory_size, get_directory_size_per_file
 from autogluon.common.utils.log_utils import add_log_to_file, set_logger_verbosity
 from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
+from autogluon.common.utils.system_info import get_ag_system_info
 from autogluon.common.utils.try_import import try_import_ray
 from autogluon.common.utils.utils import (
     check_saved_predictor_version,
@@ -943,6 +944,20 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
 
         verbosity = kwargs.get("verbosity", self.verbosity)
         set_logger_verbosity(verbosity)
+
+        if verbosity >= 2:
+            if verbosity == 2:
+                logger.log(20, f"Verbosity: 2 (Standard Logging)")
+            elif verbosity == 3:
+                logger.log(20, f"Verbosity: 3 (Detailed Logging)")
+            elif verbosity >= 4:
+                logger.log(20, f"Verbosity: {verbosity} (Maximum Logging)")
+
+        include_gpu_count = False
+        if verbosity >= 3:
+            include_gpu_count = True
+        sys_msg = get_ag_system_info(path=self.path, include_gpu_count=include_gpu_count)
+        logger.log(20, sys_msg)
 
         if presets:
             if not isinstance(presets, list):

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1451,7 +1451,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             logger.log(20, "Leaderboard on holdout data from dynamic stacking:")
             with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
                 # Rename to avoid confusion for the user
-                logger.log(20, ho_leaderboard.rename({"score_test": "holdout_score"}, axis=1))
+                logger.log(20, ho_leaderboard.rename({"score_test": "score_holdout"}, axis=1))
 
         return stacked_overfitting
 


### PR DESCRIPTION
*Issue #, if available:*
Resolves #4148

*Description of changes:*

- Overhauled the logging for Dynamic Stacking to provide more useful information.
- Added option to show ray logs during dynamic stacking: `force_ray_logging=True`.
- Added extra type hints.
- Moved system info logging to earlier in `fit` so it is logged prior to Dynamic Stacking.
- Added exception handling if dynamic stacking errors (for example, having negative time remaining after preprocessing).

This PR:
```
DyStack is enabled (dynamic_stacking=True). AutoGluon will try to determine whether the input data is affected by stacked overfitting and enable or disable stacking as a consequence.
	This is used to identify the optimal `num_stack_levels` value. Copies of AutoGluon will be fit on subsets of the data. Then holdout validation data is used to detect stacked overfitting.
	Running DyStack for up to 15s of the 60s of remaining time (25%).
	Running DyStack sub-fit in a ray process to avoid memory leakage. Logs will not be shown until this process is complete, due to a limitation in ray. You can force logging by specifying `ds_args={'force_ray_logging': True}`.
		Context path: "AutogluonModels/ag-20240518_004300/ds_sub_fit/sub_fit_ho"
Leaderboard on holdout data from dynamic stacking:
                 model  score_holdout  score_val eval_metric  pred_time_test  pred_time_val  fit_time  pred_time_test_marginal  pred_time_val_marginal  fit_time_marginal  stack_level  can_infer  fit_order
0       XGBoost_BAG_L1      -0.337663  -0.333345    log_loss        0.202160       0.017601  0.657651                 0.202160                0.017601           0.657651            1       True          2
1  WeightedEnsemble_L3      -0.339735  -0.331134    log_loss        0.360134       0.033437  2.938443                 0.001720                0.000586           0.010818            3       True          6
2  WeightedEnsemble_L2      -0.339999  -0.332223    log_loss        0.351907       0.026324  1.826918                 0.001708                0.000594           0.007622            2       True          3
3       XGBoost_BAG_L2      -0.345056  -0.349410    log_loss        0.372647       0.043121  2.426904                 0.022447                0.017391           0.607608            2       True          5
4      LightGBM_BAG_L2      -0.349683  -0.351669    log_loss        0.358413       0.032851  2.927625                 0.008214                0.007121           1.108329            2       True          4
5      LightGBM_BAG_L1      -0.357196  -0.346560    log_loss        0.148039       0.008130  1.161645                 0.148039                0.008130           1.161645            1       True          1
	1	 = Optimal   num_stack_levels (Stacked Overfitting Occurred: False)
	17s	 = DyStack   runtime |	43s	 = Remaining runtime
Starting main fit with num_stack_levels=1.
	For future fit calls on this dataset, you can skip dynamic stacking to save time: `predictor.fit(..., dynamic_stacking=False, num_stack_levels=1)`
Beginning AutoGluon training ... Time limit = 43s
```

Mainline:

```
Dynamic stacking is enabled (dynamic_stacking=True). AutoGluon will try to determine whether the input data is affected by stacked overfitting and enable or disable stacking as a consequence.
Detecting stacked overfitting by sub-fitting AutoGluon on the input data. That is, copies of AutoGluon will be sub-fit on subset(s) of the data. Then, the holdout validation data is used to detect stacked overfitting.
Sub-fit(s) time limit is: 60 seconds.
Starting holdout-based sub-fit for dynamic stacking. Context path is: AutogluonModels/ag-20240518_004822/ds_sub_fit/sub_fit_ho.
Running the sub-fit in a ray process to avoid memory leakage.
Spend 17 seconds for the sub-fit(s) during dynamic stacking.
Time left for full fit of AutoGluon: 43 seconds.
Starting full fit now with num_stack_levels 1.
Beginning AutoGluon training ... Time limit = 43s
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
