### PR TITLE
Fix dynamic_stacking hanging with num_gpus>0

### DIFF
--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1355,6 +1355,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
                 #  For `num_gpus`, the process will reserve the capacity and is unable to share it to child ray processes, causing a deadlock.
                 #  For `num_cpus`, the value is completely ignored by children, and they can even use more num_cpus than the parent.
                 #  Because of this, num_gpus is set to 0 here to avoid a deadlock, but num_cpus does not need to be changed.
+                #  For more info, refer to Ray documentation: https://docs.ray.io/en/latest/ray-core/tasks/nested-tasks.html#yielding-resources-while-blocked
                 ref = sub_fit_caller.options(num_cpus=num_cpus, num_gpus=0).remote(
                     predictor=predictor_ref,
                     train_data=train_data_ref,


### PR DESCRIPTION
*Issue #, if available:*

Resolves #4196 
Resolves #3870

*Description of changes:*

- Fix dynamic_stacking hanging with num_gpus>0
- Refer to the root cause here: https://docs.ray.io/en/latest/ray-core/tasks/nested-tasks.html#yielding-resources-while-blocked

TODO in follow-up PR: #4214 

Details:

Seems like nested ray jobs don't properly handle `num_gpus`.

For example:

```
sub_fit_caller = _ds_ray.remote(max_calls=1)(_sub_fit)
sub_fit_caller.options(num_cpus=num_cpus, num_gpus=1).remote(...)
```

Inside this `_sub_fit` call in ray, if we try to launch nested ray jobs, such as using `num_gpus=1` to fit a fold model, it will deadlock.

This is because the parent call already reserved the `num_gpus=1`, and thus there are no more GPU resources available to launch the nested job that requires GPU resources, so it will wait for the parent call to finish and release the GPU resources before the child call starts, which never happens.

However, `num_cpus` doesn't work like this, and it appears as if the `num_cpus` value of the parent for some reason is fully ignored by child calls. The parent can have `num_cpus=1` and the child can still run with `num_cpus=16` without issue.


Output of `ray status` during dynamic stacking subfit deadlock (parent num_gpus=1, num_cpus=32):

```
Resources
---------------------------------------------------------------
Usage:
 0.0/32.0 CPU
 1.0/1.0 GPU
 0B/74.92GiB memory
 482.93KiB/36.10GiB object_store_memory

Demands:
 {'CPU': 16.0, 'GPU': 0.5}: 2+ pending tasks/actors
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
