### PR TITLE
[tabular] Add refit_full support for LinearRegression

### DIFF
--- a/tabular/src/autogluon/tabular/models/lr/lr_model.py
+++ b/tabular/src/autogluon/tabular/models/lr/lr_model.py
@@ -292,3 +292,7 @@ class LinearModel(AbstractModel):
         )
         default_auxiliary_params.update(extra_auxiliary_params)
         return default_auxiliary_params
+
+    def _more_tags(self):
+        # `can_refit_full=True` because validation data isn't used during fit.
+        return {"can_refit_full": True}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- When `can_refit_full` tag was added, I forgot to add the tag to linear models. This meant we were skipping refit and using the first fold model, which gives slightly worse results that doing a proper refit.
- This PR enables LinearModels to do the refit.
- Because we don't yet use LinearModels in default portfolios, this doesn't impact the normal user experience.

Example on AdultIncome dataset:

Mainline:

```
                      model  score_test  score_val eval_metric
0          LinearModel_FULL   -0.352494  -0.326698    log_loss
1               LinearModel   -0.352494  -0.326698    log_loss
```

This PR:

```
                      model  score_test  score_val eval_metric
0          LinearModel_FULL   -0.351792        NaN    log_loss
1               LinearModel   -0.352380  -0.326852    log_loss
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
