### PR TITLE
[tabular] Disable sklearnex for LR models due to performance degradation

### DIFF
--- a/tabular/src/autogluon/tabular/models/lr/lr_model.py
+++ b/tabular/src/autogluon/tabular/models/lr/lr_model.py
@@ -43,7 +43,12 @@ class LinearModel(AbstractModel):
 
     def _get_model_type(self):
         penalty = self.params.get("penalty", "L2")
-        if self.params_aux.get("use_daal", True):
+        # FIXME: False by default because AdultIncome dataset shows worse results with use_daal=True.
+        #  Version: scikit-learn-intelex-2024.4.0
+        #                     model  score_test  score_val eval_metric
+        #  0            LinearModel    0.902293   0.904318     roc_auc
+        #  1  LinearModel_SKLEARNEX    0.863535   0.873544     roc_auc
+        if self.params_aux.get("use_daal", False):
             # Appears to give 20x training speedup when enabled
             try:
                 from sklearnex.linear_model import Lasso, LogisticRegression, Ridge


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Disable sklearnex for LR models due to performance degradation
- Unsure what version of sklearnex started causing this, but it is better to disable by default until we find a fix.

Version: scikit-learn-intelex-2024.4.0
Dataset: AdultIncome
```
                   model  score_test  score_val eval_metric
0            LinearModel    0.902293   0.904318     roc_auc
1  LinearModel_SKLEARNEX    0.863535   0.873544     roc_auc
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
