### PR TITLE
[tabular] Fix RuntimeWarning in LinearModel

### DIFF
--- a/features/src/autogluon/features/generators/one_hot_encoder.py
+++ b/features/src/autogluon/features/generators/one_hot_encoder.py
@@ -38,7 +38,6 @@ class CatToInt:
         self.cats = dict()
         self.num_cols = None
         self._dtype = None
-        self._label_encoder = None
 
     def fit(self, X: DataFrame):
         # dtype_buffer=2 is required to avoid edge case errors with invalid self.infrequent_val in 'na+1' mode.
@@ -50,8 +49,6 @@ class CatToInt:
         elif self.infrequent_val == "na+1":
             self.infrequent_val = self.fillna_val + 1
 
-        self._label_encoder = LabelEncoderFeatureGenerator(verbosity=0)
-        self._label_encoder.fit(X=X)
         X = self.pd_to_np(X)
         self.num_cols = X.shape[1]
         for col in range(self.num_cols):
@@ -76,17 +73,13 @@ class CatToInt:
     def pd_to_np(self, X: DataFrame) -> np.ndarray:
         """
         Converts pandas categoricals to a numpy ndarray of the codes of the categories.
-
-        This logic is ~1.5x slower than the identical code below:
-            return X.to_numpy(dtype=self._dtype, na_value=self.fillna_val, copy=True)
-        However, the commented out code logs RuntimeWarnings in pandas for unknown reasons, so we use the variant that doesn't trigger warnings.
         """
-
-        X_codes = self._label_encoder.transform(X)
-
-        # codes of -1 are NaN categories
-        X_codes.replace({-1: self.fillna_val}, inplace=True)
-        return X_codes.to_numpy(dtype=self._dtype, na_value=self.fillna_val, copy=True)
+        with warnings.catch_warnings():
+            if np.issubdtype(self._dtype, np.integer):
+                # Filter incorrect pandas RuntimeWarning message
+                # For more details, refer to https://github.com/autogluon/autogluon/pull/4224#issuecomment-2156423410
+                warnings.filterwarnings("ignore", category=RuntimeWarning)
+            return X.to_numpy(dtype=self._dtype, na_value=self.fillna_val, copy=True)
 
     def _get_dtype_and_fillna(self, X: DataFrame, dtype_buffer=2):
         assert dtype_buffer >= 1, "dtype_buffer must be >= 1 or else fillna_val could be invalid."

--- a/features/src/autogluon/features/generators/one_hot_encoder.py
+++ b/features/src/autogluon/features/generators/one_hot_encoder.py
@@ -9,7 +9,6 @@ from sklearn.preprocessing import OneHotEncoder
 from autogluon.common.features.types import R_CATEGORY, R_INT, S_BOOL, S_SPARSE
 
 from .abstract import AbstractFeatureGenerator
-from .label_encoder import LabelEncoderFeatureGenerator
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fix RuntimeWarning in LinearModel
- From what I can tell the RuntimeWarning is harmless, I can't find a situation where it is doing something incorrectly.
- @LennartPurucker's explanation below provides a good hypothesis for what is going on. Because of this, I will opt to silence the warning instead of reimplementing the logic.

RuntimeWarning:

```
/opt/conda/envs/ag-111-310/lib/python3.10/site-packages/pandas/core/arrays/categorical.py:1664: RuntimeWarning: invalid value encountered in cast
  return np.asarray(ret, dtype)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
