### PR TITLE
[timeseries] Use correct target and quantile_levels in fallback model for MLForecast

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -373,7 +373,12 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
                 "Fallback model SeasonalNaive is used for these time series."
             )
             data_short = data.query("item_id in @short_series")
-            seasonal_naive = SeasonalNaiveModel(freq=self.freq, prediction_length=self.prediction_length)
+            seasonal_naive = SeasonalNaiveModel(
+                freq=self.freq,
+                prediction_length=self.prediction_length,
+                target=self.target,
+                quantile_levels=self.quantile_levels,
+            )
             seasonal_naive.fit(train_data=data_short)
             forecast_for_short_series = seasonal_naive.predict(data_short)
 


### PR DESCRIPTION
*Description of changes:*
- Make sure that the fallback model uses the correct values for `target` and `quantile_levels`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
