### PR TITLE
[timeseries] Upgrade GluonTS to v0.15.1

### DIFF
--- a/docs/tutorials/timeseries/forecasting-model-zoo.md
+++ b/docs/tutorials/timeseries/forecasting-model-zoo.md
@@ -66,6 +66,7 @@ Note that some of the models' hyperparameters have names and default values that
    PatchTSTModel
    SimpleFeedForwardModel
    TemporalFusionTransformerModel
+   TiDEModel
    WaveNetModel
    DirectTabularModel
    RecursiveTabularModel
@@ -228,6 +229,14 @@ Deep learning models use neural networks to capture complex patterns in the data
 
 
 ```{eval-rst}
+.. autoclass:: TiDEModel
+   :members: init
+
+
+```
+
+
+```{eval-rst}
 .. autoclass:: WaveNetModel
    :members: init
 
@@ -302,6 +311,10 @@ Models not included in this table currently do not support any additional featur
      - ✅
      - ✅
      - ✅
+   * - :class:`~autogluon.timeseries.models.TiDEModel`
+     - ✅
+     - ✅
+     - 
    * - :class:`~autogluon.timeseries.models.WaveNetModel`
      - ✅
      - ✅

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     "pytorch_lightning",  # version range defined in `core/_setup_utils.py`
     "transformers[sentencepiece]",  # version range defined in `core/_setup_utils.py`
     "accelerate",  # version range defined in `core/_setup_utils.py`
-    "gluonts>=0.14.0,<0.14.4",  # 0.14.4 caps pandas<2.2
+    "gluonts==0.15.0",
     "networkx",  # version range defined in `core/_setup_utils.py`
     # TODO: update statsforecast to v1.5.0 - resolve antlr4-python3-runtime dependency clash with multimodal
     "statsforecast>=1.4.0,<1.5",

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     "pytorch_lightning",  # version range defined in `core/_setup_utils.py`
     "transformers[sentencepiece]",  # version range defined in `core/_setup_utils.py`
     "accelerate",  # version range defined in `core/_setup_utils.py`
-    "gluonts==0.15.0",
+    "gluonts==0.15.1",
     "networkx",  # version range defined in `core/_setup_utils.py`
     # TODO: update statsforecast to v1.5.0 - resolve antlr4-python3-runtime dependency clash with multimodal
     "statsforecast>=1.4.0,<1.5",

--- a/timeseries/src/autogluon/timeseries/models/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/__init__.py
@@ -6,6 +6,7 @@ from .gluonts import (
     PatchTSTModel,
     SimpleFeedForwardModel,
     TemporalFusionTransformerModel,
+    TiDEModel,
     WaveNetModel,
 )
 from .local import (
@@ -55,6 +56,7 @@ __all__ = [
     "SimpleFeedForwardModel",
     "TemporalFusionTransformerModel",
     "ThetaModel",
+    "TiDEModel",
     "WaveNetModel",
     "ZeroModel",
 ]

--- a/timeseries/src/autogluon/timeseries/models/gluonts/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/__init__.py
@@ -4,6 +4,7 @@ from .torch.models import (
     PatchTSTModel,
     SimpleFeedForwardModel,
     TemporalFusionTransformerModel,
+    TiDEModel,
     WaveNetModel,
 )
 
@@ -13,5 +14,6 @@ __all__ = [
     "PatchTSTModel",
     "SimpleFeedForwardModel",
     "TemporalFusionTransformerModel",
+    "TiDEModel",
     "WaveNetModel",
 ]

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -424,3 +424,94 @@ class WaveNetModel(AbstractGluonTSModel):
         init_kwargs.setdefault("time_features", get_time_features_for_frequency(self.freq))
         init_kwargs.setdefault("num_parallel_samples", self.default_num_samples)
         return init_kwargs
+
+
+class TiDEModel(AbstractGluonTSModel):
+    """Time series dense encoder model from [Das2023]_.
+
+    Based on `gluonts.torch.model.tide.TiDEEstimator <https://ts.gluon.ai/stable/api/gluonts/gluonts.torch.model.tide.html>`_.
+    See GluonTS documentation for additional hyperparameters.
+
+
+    References
+    ----------
+    .. [Das2023] Das, Abhimanyu, et al.
+        "Long-term Forecasting with TiDE: Time-series Dense Encoder."
+        Transactions of Machine Learning Research. 2023.
+
+    Other Parameters
+    ----------------
+    context_length : int, default = max(64, 2 * prediction_length)
+        Number of past values used for prediction.
+    disable_static_features : bool, default = False
+        If True, static features won't be used by the model even if they are present in the dataset.
+        If False, static features will be used by the model if they are present in the dataset.
+    disable_known_covariates : bool, default = False
+        If True, known covariates won't be used by the model even if they are present in the dataset.
+        If False, known covariates will be used by the model if they are present in the dataset.
+    disable_past_covariates : bool, default = False
+        If True, past covariates won't be used by the model even if they are present in the dataset.
+        If False, past covariates will be used by the model if they are present in the dataset.
+    feat_proj_hidden_dim : int, default = 4
+        Size of the feature projection layer.
+    encoder_hidden_dim : int, default = 4
+        Size of the dense encoder layer.
+    decoder_hidden_dim : int, default = 4
+        Size of the dense decoder layer.
+    temporal_hidden_dim : int, default = 4
+        Size of the temporal decoder layer.
+    distr_hidden_dim : int, default = 4
+        Size of the distribution projection layer.
+    num_layers_encoder : int, default = 1
+        Number of layers in dense encoder.
+    num_layers_decoder : int, default = 1
+        Number of layers in dense decoder.
+    decoder_output_dim : int, default = 4
+        Output size of the dense decoder.
+    dropout_rate : float, default = 0.3
+        Dropout regularization parameter.
+    num_feat_dynamic_proj : int, default = 2
+        Output size of feature projection layer.
+    embedding_dimension : int, default = [16] * num_feat_static_cat
+        Dimension of the embeddings for categorical features
+    layer_norm : bool, default = False
+        Should layer normalization be enabled?
+    scaling : {"mean", "std", None}, default = "mean"
+        Scaling applied to the inputs. One of ``"mean"`` (mean absolute scaling), ``"std"`` (standardization), ``None`` (no scaling).
+    max_epochs : int, default = 100
+        Number of epochs the model will be trained for
+    batch_size : int, default = 64
+        Size of batches used during training
+    predict_batch_size : int, default = 500
+        Size of batches used during prediction.
+    num_batches_per_epoch : int, default = 50
+        Number of batches processed every epoch
+    lr : float, default = 1e-3,
+        Learning rate used during training
+    trainer_kwargs : dict, optional
+        Optional keyword arguments passed to ``lightning.Trainer``.
+    early_stopping_patience : int or None, default = 20
+        Early stop training if the validation loss doesn't improve for this many epochs.
+    keep_lightning_logs : bool, default = False
+        If True, ``lightning_logs`` directory will NOT be removed after the model finished training.
+    """
+
+    supports_known_covariates = True
+    supports_static_features = True
+
+    @property
+    def default_context_length(self) -> int:
+        return min(512, max(64, 2 * self.prediction_length))
+
+    def _get_estimator_class(self) -> Type[GluonTSEstimator]:
+        from gluonts.torch.model.tide import TiDEEstimator
+
+        return TiDEEstimator
+
+    def _get_estimator_init_args(self) -> Dict[str, Any]:
+        init_kwargs = super()._get_estimator_init_args()
+        init_kwargs["num_feat_static_cat"] = self.num_feat_static_cat
+        init_kwargs["num_feat_static_real"] = self.num_feat_static_real
+        init_kwargs["cardinality"] = self.feat_static_cat_cardinality
+        init_kwargs["num_feat_dynamic_real"] = self.num_feat_dynamic_real
+        return init_kwargs

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -30,8 +30,8 @@ from . import (
     SeasonalNaiveModel,
     SimpleFeedForwardModel,
     TemporalFusionTransformerModel,
-    TiDEModel,
     ThetaModel,
+    TiDEModel,
     WaveNetModel,
     ZeroModel,
 )

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -30,6 +30,7 @@ from . import (
     SeasonalNaiveModel,
     SimpleFeedForwardModel,
     TemporalFusionTransformerModel,
+    TiDEModel,
     ThetaModel,
     WaveNetModel,
     ZeroModel,
@@ -51,6 +52,7 @@ MODEL_TYPES = dict(
     DLinear=DLinearModel,
     PatchTST=PatchTSTModel,
     TemporalFusionTransformer=TemporalFusionTransformerModel,
+    TiDE=TiDEModel,
     WaveNet=WaveNetModel,
     RecursiveTabular=RecursiveTabularModel,
     DirectTabular=DirectTabularModel,
@@ -93,6 +95,7 @@ DEFAULT_MODEL_PRIORITY = dict(
     # Models that can early stop are trained at the end
     TemporalFusionTransformer=45,
     DeepAR=40,
+    TiDE=30,
     PatchTST=30,
     # Models below are not included in any presets
     WaveNet=25,

--- a/timeseries/tests/smoketests/test_all_models.py
+++ b/timeseries/tests/smoketests/test_all_models.py
@@ -78,6 +78,7 @@ ALL_MODELS = {
     "SimpleFeedForward": DUMMY_MODEL_HPARAMS,
     "TemporalFusionTransformer": DUMMY_MODEL_HPARAMS,
     "Theta": DUMMY_MODEL_HPARAMS,
+    "TiDE": DUMMY_MODEL_HPARAMS,
     "WaveNet": DUMMY_MODEL_HPARAMS,
     "Zero": DUMMY_MODEL_HPARAMS,
     # Override default hyperparameters for faster training

--- a/timeseries/tests/unittests/models/test_gluonts.py
+++ b/timeseries/tests/unittests/models/test_gluonts.py
@@ -12,6 +12,7 @@ from autogluon.timeseries.models.gluonts import (
     PatchTSTModel,
     SimpleFeedForwardModel,
     TemporalFusionTransformerModel,
+    TiDEModel,
     WaveNetModel,
 )
 from autogluon.timeseries.utils.features import TimeSeriesFeatureGenerator
@@ -19,8 +20,8 @@ from autogluon.timeseries.utils.features import TimeSeriesFeatureGenerator
 from ..common import DATAFRAME_WITH_COVARIATES, DATAFRAME_WITH_STATIC, DUMMY_TS_DATAFRAME
 from ..test_features import get_data_frame_with_covariates
 
-MODELS_WITH_STATIC_FEATURES = [DeepARModel, TemporalFusionTransformerModel, WaveNetModel]
-MODELS_WITH_KNOWN_COVARIATES = [DeepARModel, TemporalFusionTransformerModel, WaveNetModel]
+MODELS_WITH_STATIC_FEATURES = [DeepARModel, TemporalFusionTransformerModel, TiDEModel, WaveNetModel]
+MODELS_WITH_KNOWN_COVARIATES = [DeepARModel, TemporalFusionTransformerModel, TiDEModel, WaveNetModel]
 MODELS_WITH_STATIC_FEATURES_AND_KNOWN_COVARIATES = [
     m for m in MODELS_WITH_STATIC_FEATURES if m in MODELS_WITH_KNOWN_COVARIATES
 ]
@@ -30,6 +31,7 @@ TESTABLE_MODELS = [
     PatchTSTModel,
     SimpleFeedForwardModel,
     TemporalFusionTransformerModel,
+    TiDEModel,
     WaveNetModel,
 ]
 


### PR DESCRIPTION
*Description of changes:*
- Bump GluonTS dependency to v0.15.1
- Add wrapper for the `TiDE` model


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
