### PR TITLE
[tabular] Fix HPO crash NN_TORCH, FASTAI

### DIFF
--- a/common/src/autogluon/common/utils/utils.py
+++ b/common/src/autogluon/common/utils/utils.py
@@ -151,7 +151,7 @@ def check_saved_predictor_version(
         logger.warning(
             "WARNING: AutoGluon version differs from the version used to create the predictor! "
             "This may lead to instability and it is highly recommended the predictor be loaded "
-            "with the exact AutoGluon version it was created with."
+            "with the exact AutoGluon version it was created with. AutoGluon does not support backwards compatibility."
         )
         logger.warning(f"\tPredictor Version: {version_saved}")
         logger.warning(f"\tCurrent Version:   {version_current}")
@@ -162,7 +162,9 @@ def check_saved_predictor_version(
             raise AssertionError(
                 f"Predictor was created on version {version_saved} but is being loaded with version {version_current}. "
                 f"Please ensure the versions match to avoid instability. While it is NOT recommended, "
-                f"this error can be bypassed by specifying `require_version_match=False`."
+                f"this error can be bypassed by specifying `require_version_match=False`. "
+                f"Exceptions encountered after setting `require_version_match=False` may be very cryptic, "
+                f"and in most cases mean that the predictor is fully incompatible with the installed version."
             )
 
 

--- a/docs/whats_new/index.md
+++ b/docs/whats_new/index.md
@@ -6,6 +6,7 @@ Here you can find the release notes for current and past releases of AutoGluon.
 :hidden: true
 :maxdepth: 1
 
+v1.1.1
 v1.1.0
 v1.0.0
 v0.8.2
@@ -23,8 +24,15 @@ v0.4.1
 v0.4.0
 ```
 
-:::{dropdown} v1.1.0
+:::{dropdown} v1.1.1
 :open:
+
+```{include} v1.1.1.md
+```
+
+:::
+
+:::{dropdown} v1.1.0
 
 ```{include} v1.1.0.md
 ```

--- a/docs/whats_new/v1.1.1.md
+++ b/docs/whats_new/v1.1.1.md
@@ -1,0 +1,5 @@
+# Version 1.1.1
+
+## Breaking Changes
+
+* Trying to load a TabularPredictor with a FastAI model trained on a previous AutoGluon release will raise an exception when calling `predict` due to a fix in the `model-interals.pkl` path. Please ensure matching versions.


### PR DESCRIPTION
*Issue #, if available:*

Resolves #4186 

*Description of changes:*

- Fix HPO crash NN_TORCH, FASTAI
- Ray 2.7+ requires absolute path for `storage_path`, so I've updated the code to do so.
- Also fixed incorrect save location for `model-internals.pkl` in FastAI model, which previously was saved outside of the intended directory of the model artifact (`"FastAImodel-internals.pkl"` -> `"FastAI/model-internals.pkl"`).
- Added extra logging for incompatible version loading, to make it even more explicit that users should not do this.
- Added note in v1.1.1 release notes on backwards incompatibility: The FastAI change is backwards incompatible, if users try to load an old artifact, it will fail to find `model-internals.pkl`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
