### PR TITLE
[codespell] Ignore "SME"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ profile = "black"
 [tool.codespell]
 skip = '.git,*.pdf,*.svg,*.ipynb,*.csv,kaggle_feedback_prize'
 #
-ignore-words-list = 'mape,ans,2st,fo,nd,te,fpr,coo,rouge'
+ignore-words-list = 'mape,ans,2st,fo,nd,te,fpr,coo,rouge,SME'
 
 
 [tool.ruff]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Ignore "SME" in codespell, false positive, was causing codespell to fail for timeseries.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
