### PR TITLE
[tabular] Add roc_auc_ovo / ovr

### DIFF
--- a/core/src/autogluon/core/data/label_cleaner.py
+++ b/core/src/autogluon/core/data/label_cleaner.py
@@ -125,6 +125,22 @@ class LabelCleanerMulticlass(LabelCleaner):
         y = y.map(self.cat_mappings_dependent_var)
         return y
 
+    def transform_pred_uncleaned(self, y: Union[Series, np.ndarray]) -> Series:
+        """
+        Transform y labels to uncleaned internal labels.
+        """
+        y = self._convert_to_valid_series(y=y)
+        y = y.map(self.inv_map_uncleaned)
+        return y
+
+    def inverse_transform_pred_uncleaned(self, y: Union[Series, np.ndarray]) -> Series:
+        """
+        Inverse transforms uncleaned internal labels to external labels.
+        """
+        y = self._convert_to_valid_series(y=y)
+        y = y.map(self.cat_mappings_dependent_var_uncleaned)
+        return y
+
     # TODO: Unused? There are not many reasonable situations that seem to require this method.
     def transform_proba(self, y: Union[DataFrame, np.ndarray], as_pandas=False) -> Union[DataFrame, np.ndarray]:
         if self.invalid_class_count > 0:

--- a/core/src/autogluon/core/metrics/__init__.py
+++ b/core/src/autogluon/core/metrics/__init__.py
@@ -626,6 +626,7 @@ def customized_log_loss(y_true, y_pred, eps=1e-15):
     else:
         assert y_pred.ndim == 2, "Only ndim=2 is supported"
         labels = np.arange(y_pred.shape[1], dtype=np.int32)
+        # FIXME: -1 used for something, why log_loss works? This is super bugged...
         return sklearn.metrics.log_loss(y_true.astype(np.int32), y_pred, labels=labels)
 
 
@@ -636,6 +637,7 @@ def customized_roc_auc(y_true, y_pred, **kwargs):
     else:
         # Avoid exception if not all classes are present in y_true
         assert y_pred.ndim == 2, "Only ndim=2 is supported"
+        # FIXME: -1 used for something, why log_loss works?
         labels = np.arange(y_pred.shape[1], dtype=np.int32)
         return sklearn.metrics.roc_auc_score(y_true.astype(np.int32), y_pred, labels=labels, **kwargs)
 

--- a/core/src/autogluon/core/metrics/__init__.py
+++ b/core/src/autogluon/core/metrics/__init__.py
@@ -626,7 +626,6 @@ def customized_log_loss(y_true, y_pred, eps=1e-15):
     else:
         assert y_pred.ndim == 2, "Only ndim=2 is supported"
         labels = np.arange(y_pred.shape[1], dtype=np.int32)
-        # FIXME: -1 used for something, why log_loss works? This is super bugged...
         return sklearn.metrics.log_loss(y_true.astype(np.int32), y_pred, labels=labels)
 
 
@@ -637,7 +636,6 @@ def customized_roc_auc(y_true, y_pred, **kwargs):
     else:
         # Avoid exception if not all classes are present in y_true
         assert y_pred.ndim == 2, "Only ndim=2 is supported"
-        # FIXME: -1 used for something, why log_loss works?
         labels = np.arange(y_pred.shape[1], dtype=np.int32)
         return sklearn.metrics.roc_auc_score(y_true.astype(np.int32), y_pred, labels=labels, **kwargs)
 
@@ -706,7 +704,11 @@ for name, metric, kwargs in [
     macro_name = "{0}_{1}".format(name, "macro")
     globals()[name].add_alias(macro_name)
     _add_scorer_to_metric_dict(metric_dict=MULTICLASS_METRICS, scorer=globals()[name])
-    for average in ["micro", "weighted"]:
+    if name == "roc_auc_ovo":
+        averages = ["weighted"]
+    else:
+        averages = ["micro", "weighted"]
+    for average in averages:
         qualified_name = "{0}_{1}".format(name, average)
         globals()[qualified_name] = make_scorer(qualified_name, partial(metric, average=average, **kwargs), **scorer_kwargs)
         _add_scorer_to_metric_dict(metric_dict=MULTICLASS_METRICS, scorer=globals()[qualified_name])

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -85,7 +85,7 @@ class AbstractModel:
         If `eval_metric = None`, it is automatically chosen based on `problem_type`.
         Defaults to 'accuracy' for binary and multiclass classification and 'root_mean_squared_error' for regression.
         Otherwise, options for classification:
-            ['accuracy', 'balanced_accuracy', 'f1', 'f1_macro', 'f1_micro', 'f1_weighted', 'roc_auc', 'roc_auc_ovo_macro',
+            ['accuracy', 'balanced_accuracy', 'f1', 'f1_macro', 'f1_micro', 'f1_weighted', 'roc_auc', 'roc_auc_ovo', 'roc_auc_ovr',
             'average_precision', 'precision', 'precision_macro', 'precision_micro', 'precision_weighted', 'recall',
             'recall_macro', 'recall_micro', 'recall_weighted', 'log_loss', 'pac_score', 'quadratic_kappa']
         Options for regression:

--- a/core/tests/unittests/metrics/test_metrics.py
+++ b/core/tests/unittests/metrics/test_metrics.py
@@ -35,7 +35,6 @@ EXPECTED_BINARY_METRICS = {
     "recall_micro",
     "recall_weighted",
     "roc_auc",
-    "roc_auc_ovo_macro",
 }
 
 EXPECTED_MULTICLASS_METRICS = {
@@ -57,7 +56,14 @@ EXPECTED_MULTICLASS_METRICS = {
     "recall_macro",
     "recall_micro",
     "recall_weighted",
+    "roc_auc_ovo",
     "roc_auc_ovo_macro",
+    "roc_auc_ovo_micro",
+    "roc_auc_ovo_weighted",
+    "roc_auc_ovr",
+    "roc_auc_ovr_macro",
+    "roc_auc_ovr_micro",
+    "roc_auc_ovr_weighted",
 }
 
 EXPECTED_REGRESSION_METRICS = {

--- a/core/tests/unittests/metrics/test_metrics.py
+++ b/core/tests/unittests/metrics/test_metrics.py
@@ -58,7 +58,6 @@ EXPECTED_MULTICLASS_METRICS = {
     "recall_weighted",
     "roc_auc_ovo",
     "roc_auc_ovo_macro",
-    "roc_auc_ovo_micro",
     "roc_auc_ovo_weighted",
     "roc_auc_ovr",
     "roc_auc_ovr_macro",

--- a/docs/tutorials/tabular/advanced/tabular-custom-metric.ipynb
+++ b/docs/tutorials/tabular/advanced/tabular-custom-metric.ipynb
@@ -153,7 +153,7 @@
     "    needs_proba : bool, default=False\n",
     "        Whether score_func requires predict_proba to get probability estimates out of a classifier.\n",
     "        These scorers can benefit from calibration methods such as temperature scaling.\n",
-    "        Examples: [\"log_loss\", \"roc_auc_ovo_macro\", \"pac\"]\n",
+    "        Examples: [\"log_loss\", \"roc_auc_ovo\", \"roc_auc_ovr\", \"pac\"]\n",
     "\n",
     "    needs_class : bool, default=False\n",
     "        Whether score_func requires class predictions (classification only).\n",

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -61,6 +61,7 @@ class AbstractTabularLearner(AbstractLearner):
             self.ignored_columns = []
         self.threshold = label_count_threshold
         self.problem_type = problem_type
+        self._eval_metric_was_str = (eval_metric is not None and isinstance(eval_metric, str))
         self.eval_metric = get_metric(eval_metric, self.problem_type, "eval_metric")
 
         if self.problem_type == QUANTILE and quantile_levels is None:
@@ -1072,6 +1073,12 @@ class AbstractTabularLearner(AbstractLearner):
             verbose=verbose,
             **kwargs,
         )
+
+    def _verify_metric(self, eval_metric: Scorer, problem_type: str):
+        """
+        Raises an exception if the eval_metric does not exist in the default metrics list for the problem type
+        """
+        get_metric(metric=eval_metric.name, problem_type=problem_type, metric_type="eval_metric")
 
     # TODO: Add data info gathering at beginning of .fit() that is used by all learners to add to get_info output
     # TODO: Add feature inference / feature engineering info to get_info output

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -61,7 +61,7 @@ class AbstractTabularLearner(AbstractLearner):
             self.ignored_columns = []
         self.threshold = label_count_threshold
         self.problem_type = problem_type
-        self._eval_metric_was_str = (eval_metric is not None and isinstance(eval_metric, str))
+        self._eval_metric_was_str = eval_metric is not None and isinstance(eval_metric, str)
         self.eval_metric = get_metric(eval_metric, self.problem_type, "eval_metric")
 
         if self.problem_type == QUANTILE and quantile_levels is None:

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -214,7 +214,8 @@ class DefaultLearner(AbstractTabularLearner):
 
             holdout_frac = 1
 
-        if (self.eval_metric is not None) and (self.eval_metric.name in ["log_loss", "pac_score"]) and (self.problem_type == MULTICLASS):
+        if self.eval_metric is not None and self.eval_metric.needs_proba and self.problem_type == MULTICLASS:
+            # Metric requires all classes present in training to be able to compute a score
             if num_bag_folds > 0:
                 self.threshold = 2
                 if self.groups is None:

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -79,6 +79,9 @@ class DefaultLearner(AbstractTabularLearner):
         if self.problem_type is None:
             self.problem_type = self.infer_problem_type(y=X[self.label])
         logger.log(20, f"Problem Type:       {self.problem_type}")
+        if self._eval_metric_was_str:
+            # Ensure that the eval_metric is valid for the problem_type
+            self._verify_metric(eval_metric=self.eval_metric, problem_type=self.problem_type)
         if self.groups is not None:
             num_bag_sets = 1
             num_bag_folds = len(X[self.groups].unique())

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -100,8 +100,9 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
 
         Otherwise, options for classification:
             ['accuracy', 'balanced_accuracy', 'f1', 'f1_macro', 'f1_micro', 'f1_weighted',
-            'roc_auc', 'roc_auc_ovo_macro', 'average_precision', 'precision', 'precision_macro', 'precision_micro',
-            'precision_weighted', 'recall', 'recall_macro', 'recall_micro', 'recall_weighted', 'log_loss', 'pac_score']
+            'roc_auc', 'roc_auc_ovo', 'roc_auc_ovo_macro', 'roc_auc_ovo_micro', 'roc_auc_ovo_weighted', 'roc_auc_ovr', 'roc_auc_ovr_macro', 'roc_auc_ovr_micro',
+            'roc_auc_ovr_weighted', 'average_precision', 'precision', 'precision_macro', 'precision_micro', 'precision_weighted',
+            'recall', 'recall_macro', 'recall_micro', 'recall_weighted', 'log_loss', 'pac_score']
         Options for regression:
             ['root_mean_squared_error', 'mean_squared_error', 'mean_absolute_error', 'median_absolute_error', 'mean_absolute_percentage_error', 'r2', 'symmetric_mean_absolute_percentage_error']
         For more information on these options, see `sklearn.metrics`: https://scikit-learn.org/stable/modules/classes.html#sklearn-metrics-metrics

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -100,7 +100,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
 
         Otherwise, options for classification:
             ['accuracy', 'balanced_accuracy', 'f1', 'f1_macro', 'f1_micro', 'f1_weighted',
-            'roc_auc', 'roc_auc_ovo', 'roc_auc_ovo_macro', 'roc_auc_ovo_micro', 'roc_auc_ovo_weighted', 'roc_auc_ovr', 'roc_auc_ovr_macro', 'roc_auc_ovr_micro',
+            'roc_auc', 'roc_auc_ovo', 'roc_auc_ovo_macro', 'roc_auc_ovo_weighted', 'roc_auc_ovr', 'roc_auc_ovr_macro', 'roc_auc_ovr_micro',
             'roc_auc_ovr_weighted', 'average_precision', 'precision', 'precision_macro', 'precision_micro', 'precision_weighted',
             'recall', 'recall_macro', 'recall_micro', 'recall_weighted', 'log_loss', 'pac_score']
         Options for regression:

--- a/tabular/tests/unittests/data/test_label_cleaner.py
+++ b/tabular/tests/unittests/data/test_label_cleaner.py
@@ -107,6 +107,12 @@ def test_label_cleaner_multiclass():
     output_labels_with_shifted_index_inverse = label_cleaner.inverse_transform(output_labels_with_shifted_index)
     output_labels_new_inverse = label_cleaner.inverse_transform(output_labels_new)
 
+    output_labels_uncleaned = label_cleaner.transform_pred_uncleaned(y=input_labels)
+    output_labels_uncleaned_inverse = label_cleaner.inverse_transform_pred_uncleaned(y=output_labels_uncleaned)
+
+    output_labels_uncleaned_new = label_cleaner.transform_pred_uncleaned(y=input_labels_new)
+    output_labels_uncleaned_new_inverse = label_cleaner.inverse_transform_pred_uncleaned(y=output_labels_uncleaned_new)
+
     assert expected_output_labels.equals(output_labels)
     assert expected_output_labels.equals(output_labels_with_numpy)
     assert expected_output_labels.equals(output_labels_category)
@@ -118,6 +124,8 @@ def test_label_cleaner_multiclass():
     assert input_labels.equals(output_labels_inverse)
     assert input_labels_with_shifted_index.equals(output_labels_with_shifted_index_inverse)
     assert expected_output_labels_new_inverse.equals(output_labels_new_inverse)
+    assert input_labels.equals(output_labels_uncleaned_inverse)
+    assert expected_output_labels_new_inverse.equals(output_labels_uncleaned_new_inverse)
 
 
 def test_label_cleaner_multiclass_to_binary():
@@ -129,7 +137,8 @@ def test_label_cleaner_multiclass_to_binary():
     input_labels_category = input_labels.astype("category")
     input_labels_with_shifted_index = input_labels.copy()
     input_labels_with_shifted_index.index += 5
-    input_labels_new = np.array(["l0", "l1", "l2"])
+    input_labels_new = pd.Series(["l0", "l1", "l2"])
+    input_labels_new_with_unknown = pd.Series(["l0", "l1", "l2", "UNKNOWN_1", "l4", "UNKNOWN_2"])
     input_labels_proba_transformed = pd.Series([0.7, 0.2, 0.5], index=[5, 2, 8])
     expected_output_labels = pd.Series([0, 1, 1, 0, 0, 1], dtype="uint8")
     expected_output_labels_new = pd.Series([np.nan, 0, 1])
@@ -137,6 +146,8 @@ def test_label_cleaner_multiclass_to_binary():
     expected_output_labels_proba_transformed_inverse = pd.DataFrame(
         data=[[0, 0.3, 0.7, 0, 0], [0, 0.8, 0.2, 0, 0], [0, 0.5, 0.5, 0, 0]], index=[5, 2, 8], columns=["l0", "l1", "l2", "l3", "l4"], dtype=np.float32
     )
+    expected_output_labels_new_with_unknown = pd.Series([0, 1, 2, np.nan, 4, np.nan])
+    expected_output_labels_new_with_unknown_inverse = pd.Series(["l0", "l1", "l2", np.nan, "l4", np.nan])
 
     # When
     label_cleaner = LabelCleaner.construct(problem_type=problem_type, y=input_labels, y_uncleaned=input_labels_uncleaned)
@@ -156,6 +167,15 @@ def test_label_cleaner_multiclass_to_binary():
     output_labels_with_shifted_index_inverse = label_cleaner.inverse_transform(output_labels_with_shifted_index)
     output_labels_new_inverse = label_cleaner.inverse_transform(output_labels_new)
 
+    output_labels_uncleaned = label_cleaner.transform_pred_uncleaned(y=input_labels)
+    output_labels_uncleaned_inverse = label_cleaner.inverse_transform_pred_uncleaned(y=output_labels_uncleaned)
+
+    output_labels_uncleaned_new = label_cleaner.transform_pred_uncleaned(y=input_labels_new)
+    output_labels_uncleaned_new_inverse = label_cleaner.inverse_transform_pred_uncleaned(y=output_labels_uncleaned_new)
+
+    output_labels_uncleaned_new_with_unknown = label_cleaner.transform_pred_uncleaned(y=input_labels_new_with_unknown)
+    output_labels_uncleaned_new_with_unknown_inverse = label_cleaner.inverse_transform_pred_uncleaned(y=output_labels_uncleaned_new_with_unknown)
+
     assert expected_output_labels.equals(output_labels)
     assert expected_output_labels.equals(output_labels_with_numpy)
     assert expected_output_labels.equals(output_labels_category)
@@ -167,6 +187,12 @@ def test_label_cleaner_multiclass_to_binary():
     assert input_labels.equals(output_labels_inverse)
     assert input_labels_with_shifted_index.equals(output_labels_with_shifted_index_inverse)
     assert expected_output_labels_new_inverse.equals(output_labels_new_inverse)
+
+    assert input_labels.equals(output_labels_uncleaned_inverse)
+    assert input_labels_new.equals(output_labels_uncleaned_new_inverse)
+
+    assert expected_output_labels_new_with_unknown.equals(output_labels_uncleaned_new_with_unknown)
+    assert expected_output_labels_new_with_unknown_inverse.equals(output_labels_uncleaned_new_with_unknown_inverse)
 
     output_labels_proba_transformed_inverse = label_cleaner.inverse_transform_proba(input_labels_proba_transformed, as_pandas=True)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add roc_auc_ovo metrics
- Add roc_auc_ovr metrics
- Remove roc_auc_ovo_macro from binary metrics (not a binary metric) 
- Raise exception if inferred problem_type mismatches eval_metric.
- Improve logging when metric related errors occur (invalid metric specified)  
- Fix edge-case crash / incorrect metric calculation in multiclass when rare classes are dropped at fit time and then leaderboard is called with those rare classes and extra_metrics specified.

TODO:

- [x] Fix unit tests, edge cases are not handled
- [x] Address FIXME comments
- [x] [Fixed] See if log loss is bugged for rare classes when passing `extra_metrics`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
