### PR TITLE
[tabular] Fix LightGBM multiclass custom metrics

### DIFF
--- a/tabular/src/autogluon/tabular/models/lgb/lgb_utils.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_utils.py
@@ -49,7 +49,6 @@ def func_generator(metric, is_higher_better, needs_pred_proba, problem_type):
 
             def function_template(y_hat, data):
                 y_true = data.get_label()
-                y_hat = y_hat.reshape(len(np.unique(y_true)), -1).T
                 return metric.name, metric(y_true, y_hat), is_higher_better
 
         elif problem_type == SOFTCLASS:  # metric must take in soft labels array, like soft_log_loss
@@ -72,8 +71,7 @@ def func_generator(metric, is_higher_better, needs_pred_proba, problem_type):
 
             def function_template(y_hat, data):
                 y_true = data.get_label()
-                y_hat = y_hat.reshape(len(np.unique(y_true)), -1)
-                y_hat = y_hat.argmax(axis=0)
+                y_hat = y_hat.argmax(axis=1)
                 return metric.name, metric(y_true, y_hat), is_higher_better
 
         else:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fix LightGBM multiclass custom metrics
- Previously they either crashed or computed the metric incorrectly.
- This is likely because the code that does this is >4 years old, and LightGBM probably changed how their internal logic worked at some point.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
