### PR TITLE
[features] Add AsType detailed exception logging

### DIFF
--- a/features/src/autogluon/features/generators/astype.py
+++ b/features/src/autogluon/features/generators/astype.py
@@ -171,7 +171,7 @@ class AsTypeFeatureGenerator(AbstractFeatureGenerator):
         logger.log(
             40,
             f"Exception encountered in {self.__class__.__name__} ... "
-            f"Please check if feature data types differ between train and test (via df.dtypes).\nException breakdown by feature:"
+            f"Please check if feature data types differ between train and test (via df.dtypes).\nException breakdown by feature:",
         )
         for f in self._type_map_real_opt.keys():
             f_type_out = self._type_map_real_opt[f]

--- a/features/src/autogluon/features/generators/astype.py
+++ b/features/src/autogluon/features/generators/astype.py
@@ -154,8 +154,41 @@ class AsTypeFeatureGenerator(AbstractFeatureGenerator):
                 # TODO: Confirm this works with sparse and other feature types!
                 # FIXME: Address situation where test-time invalid type values cause crash:
                 #  https://stackoverflow.com/questions/49256211/how-to-set-unexpected-data-type-to-na?noredirect=1&lq=1
-                X = X.astype(self._type_map_real_opt)
+                try:
+                    X = X.astype(self._type_map_real_opt)
+                except ValueError as e:
+                    self._log_invalid_dtypes(X=X)
+                    raise e
         return X
+
+    def _log_invalid_dtypes(self, X: pd.DataFrame):
+        """
+        Logs detailed information on all feature transformations, including exceptions that occur.
+        """
+        pd_cols = ["feature", "status", "dtype_input", "dtype_to_convert_to", "exception"]
+        rows = []
+
+        logger.log(
+            40,
+            f"Exception encountered in {self.__class__.__name__} ... "
+            f"Please check if feature data types differ between train and test (via df.dtypes).\nException breakdown by feature:"
+        )
+        for f in self._type_map_real_opt.keys():
+            f_type_out = self._type_map_real_opt[f]
+            f_type_in = X[f].dtype
+            try:
+                X[f].astype(f_type_out)
+            except Exception as e:
+                status = f"{e.__class__.__name__}"
+                exception = e
+            else:
+                status = "Success"
+                exception = None
+            row = [f, status, f_type_in, f_type_out, exception]
+            rows.append(row)
+        df_debug = pd.DataFrame(rows, columns=pd_cols)
+        with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
+            logger.log(40, df_debug)
 
     def _convert_to_bool(self, X: DataFrame) -> DataFrame:
         if self._use_fast_bool_method:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add detailed exception logging to AsTypeFeatureGenerator if the data at test time cannot be successfully converted to the expected dtype.

Example output when switching `age` column from int to a string column at test time in AdultIncome:

## This PR

```
Exception encountered in AsTypeFeatureGenerator ... Please check if feature data types differ between train and test (via df.dtypes).
Exception breakdown by feature:
           feature      status dtype_input   dtype_to_convert_to                                          exception
0              age  ValueError      object                 int64  invalid literal for int() with base 10: ' Priv...
1        workclass     Success      object                object                                               None
2           fnlwgt     Success       int64                 int64                                               None
3        education     Success      object                object                                               None
4    education-num     Success       int64                 int64                                               None
5   marital-status     Success      object                object                                               None
6       occupation     Success      object                object                                               None
7     relationship     Success      object                object                                               None
8             race     Success      object                object                                               None
9              sex     Success        int8  <class 'numpy.int8'>                                               None
10    capital-gain     Success       int64                 int64                                               None
11    capital-loss     Success       int64                 int64                                               None
12  hours-per-week     Success       int64                 int64                                               None
13  native-country     Success      object                object                                               None

ValueError: invalid literal for int() with base 10: ' Private': Error while type casting for column 'age'
```

## Mainline

```
ValueError: invalid literal for int() with base 10: ' Private': Error while type casting for column 'age'
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
