### PR TITLE
[features] Make AsType exception logging handle all exception types

### DIFF
--- a/features/src/autogluon/features/generators/astype.py
+++ b/features/src/autogluon/features/generators/astype.py
@@ -156,7 +156,7 @@ class AsTypeFeatureGenerator(AbstractFeatureGenerator):
                 #  https://stackoverflow.com/questions/49256211/how-to-set-unexpected-data-type-to-na?noredirect=1&lq=1
                 try:
                     X = X.astype(self._type_map_real_opt)
-                except ValueError as e:
+                except Exception as e:
                     self._log_invalid_dtypes(X=X)
                     raise e
         return X


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Make AsType exception logging handle all exception types, instead of just ValueError. For example, NaNs can lead to exceptions types such as `IntCastingNaNError`, which previously wouldn't benefit from the improved exception logging. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
