### PR TITLE
update sagemaker base images to use pytorch 2.2

### DIFF
--- a/CI/docker/Dockerfile.cpu-inference
+++ b/CI/docker/Dockerfile.cpu-inference
@@ -1,4 +1,4 @@
-FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-inference:2.1.0-cpu-py310-ubuntu20.04-sagemaker
+FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-inference:2.2.0-cpu-py310-ubuntu20.04-sagemaker
 
 RUN apt-get update \
  && apt-get -y upgrade \

--- a/CI/docker/Dockerfile.cpu-training
+++ b/CI/docker/Dockerfile.cpu-training
@@ -1,4 +1,4 @@
-FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training:2.1.0-cpu-py310-ubuntu20.04-sagemaker
+FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training:2.2.0-cpu-py310-ubuntu20.04-sagemaker
 
 RUN apt-get update \
  && apt-get -y upgrade \

--- a/CI/docker/Dockerfile.gpu-inference
+++ b/CI/docker/Dockerfile.gpu-inference
@@ -1,4 +1,4 @@
-FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-inference:2.1.0-gpu-py310-cu118-ubuntu20.04-sagemaker
+FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-inference:2.2.0-gpu-py310-cu118-ubuntu20.04-sagemaker
 
 RUN apt-get update \
  && apt-get -y upgrade \

--- a/CI/docker/Dockerfile.gpu-training
+++ b/CI/docker/Dockerfile.gpu-training
@@ -1,4 +1,4 @@
-FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training:2.1.0-gpu-py310-cu121-ubuntu20.04-sagemaker
+FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training:2.2.0-gpu-py310-cu121-ubuntu20.04-sagemaker
 
 RUN apt-get update \
  && apt-get -y upgrade \

--- a/CI/docker/full_install_image.sh
+++ b/CI/docker/full_install_image.sh
@@ -11,5 +11,3 @@ python3 -m pip install autogluon/
 
 mim install "mmcv==2.1.0" --timeout 60
 python3 -m pip install --upgrade "mmdet==3.2.0"
-python3 -m pip install -U "mmengine<0.8"  # TODO: remove once compatible with the image
-# python3 -m pip install --upgrade "mmocr<1.0"  # not compatible with mmcv 2.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The original pytorch2.1 sagemaker base images installs `torchaudio` 2.1.x, however,  AutoGluon master installs `torch` 2.2.x will introduce incompatibility issues. Updating the sagemaker base image version would resolve this issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
