### PR TITLE
[tabular] Fix LightGBM quantile predict_proba dtype

### DIFF
--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -252,10 +252,13 @@ class LGBModel(AbstractModel):
         else:
             self.params_trained["num_boost_round"] = self.model.current_iteration()
 
-    def _predict_proba(self, X, num_cpus=0, **kwargs):
+    def _predict_proba(self, X, num_cpus=0, **kwargs) -> np.ndarray:
         X = self.preprocess(X, **kwargs)
 
         y_pred_proba = self.model.predict(X, num_threads=num_cpus)
+        if self.problem_type == QUANTILE:
+            # y_pred_proba is a pd.DataFrame, need to convert
+            y_pred_proba = y_pred_proba.to_numpy()
         if self.problem_type in [REGRESSION, QUANTILE, MULTICLASS]:
             return y_pred_proba
         elif self.problem_type == BINARY:

--- a/tabular/tests/conftest.py
+++ b/tabular/tests/conftest.py
@@ -289,8 +289,11 @@ class ModelFitHelper:
         X_test = test_data.drop(columns=[label])
         X_test = feature_generator.transform(X_test)
 
-        model.predict(X_test)
+        y_pred = model.predict(X_test)
+        assert isinstance(y_pred, np.ndarray), f"Expected np.ndarray as model.predict(X_test) output. Got: {y_pred.__class__}"
+
         y_pred_proba = model.predict_proba(X_test)
+        assert isinstance(y_pred_proba, np.ndarray), f"Expected np.ndarray as model.predict_proba(X_test) output. Got: {y_pred.__class__}"
         model.get_info()
 
         if check_predict_children:

--- a/tabular/tests/unittests/models/test_lightgbm.py
+++ b/tabular/tests/unittests/models/test_lightgbm.py
@@ -37,6 +37,15 @@ def test_lightgbm_regression(fit_helper):
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics)
 
 
+def test_lightgbm_quantile(fit_helper):
+    fit_args = dict(
+        hyperparameters={"GBM": {}},
+    )
+    dataset_name = "ames"
+    init_args = dict(problem_type="quantile", quantile_levels=[0.25, 0.5, 0.75])
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, init_args=init_args)
+
+
 def test_lightgbm_binary_model(model_fit_helper):
     fit_args = dict()
     dataset_name = "adult"
@@ -55,13 +64,17 @@ def test_lightgbm_regression_model(model_fit_helper):
     model_fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, model=LGBModel(), fit_args=fit_args)
 
 
-def test_lightgbm_quantile(fit_helper):
-    fit_args = dict(
-        hyperparameters={"GBM": {}},
-    )
+def test_lightgbm_quantile_model(model_fit_helper):
+    fit_args = dict()
     dataset_name = "ames"
-    init_args = dict(problem_type="quantile", quantile_levels=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, init_args=init_args)
+    model_fit_helper.fit_and_validate_dataset(
+        dataset_name=dataset_name,
+        model=LGBModel(
+            problem_type="quantile",
+            hyperparameters={"ag.quantile_levels": [0.25, 0.5, 0.75]},
+        ),
+        fit_args=fit_args,
+    )
 
 
 def test_lightgbm_binary_with_calibrate_decision_threshold(fit_helper):


### PR DESCRIPTION
*Issue #, if available:*

Resolves #4270 

*Description of changes:*

- Fix LightGBM quantile predict_proba dtype from pd.DataFrame to np.ndarray
- Add unit test assertion that return types are np.ndarray for model.predict and model.predict_proba

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
