### PR TITLE
[tabular] Validate CPU/GPU settings

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -260,6 +260,16 @@ class AbstractModel:
         self._set_default_auxiliary_params()
         if hyperparameters_aux is not None:
             self.params_aux.update(hyperparameters_aux)
+        self._validate_params_aux()
+
+    def _validate_params_aux(self):
+        """
+        Verify correctness of self.params_aux
+        """
+        if "num_cpus" in self.params_aux:
+            num_cpus = self.params_aux["num_cpus"]
+            if num_cpus is not None and not isinstance(num_cpus, int):
+                raise TypeError(f"`num_cpus` must be an int or None. Found: {type(num_cpus)} | Value: {num_cpus}")
 
     @property
     def path_suffix(self) -> str:
@@ -586,6 +596,10 @@ class AbstractModel:
 
         # retrieve model level requirement when self is bagged model
         user_specified_model_level_resource = self._get_child_aux_val(key=resource_type, default=None)
+        if user_specified_model_level_resource is not None and not isinstance(user_specified_model_level_resource, (int, float)):
+            raise TypeError(
+                f"{resource_type} must be int or float. Found: {type(user_specified_model_level_resource)} | Value: {user_specified_model_level_resource}"
+            )
         if user_specified_model_level_resource is not None:
             assert user_specified_model_level_resource <= system_resource, f"Specified {resource_type} per model base is more than the total: {system_resource}"
         user_specified_lower_level_resource = user_specified_ensemble_resource
@@ -711,6 +725,9 @@ class AbstractModel:
         assert (
             num_gpus >= minimum_model_num_gpus
         ), f"Specified num_gpus={num_gpus} per {self.__class__.__name__} is less than minimum num_gpus={minimum_model_num_gpus}"
+
+        if not isinstance(num_cpus, int):
+            raise TypeError(f"`num_cpus` must be an int. Found: {type(num_cpus)} | Value: {num_cpus}")
 
         kwargs["num_cpus"] = num_cpus
         kwargs["num_gpus"] = num_gpus

--- a/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
+++ b/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
@@ -157,6 +157,8 @@ class FoldFittingStrategy(AbstractFoldFittingStrategy):
         self.num_gpus = num_gpus
         logger.debug(f"Upper level total_num_cpus, num_gpus {self.num_cpus} | {self.num_gpus}")
         self._validate_user_specified_resources()
+        if not isinstance(self.num_cpus, int):
+            raise TypeError(f"`num_cpus` must be an int! Found: {type(num_cpus)} | Value: {self.num_cpus}")
 
     def schedule_fold_model_fit(self, fold_ctx):
         raise NotImplementedError

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -989,6 +989,8 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             logger.log(20, f"{pprint.pformat(kwargs)}")
             logger.log(20, "========================================")
 
+        self._validate_num_cpus(num_cpus=num_cpus)
+        self._validate_num_gpus(num_gpus=num_gpus)
         self._validate_calibrate_decision_threshold(calibrate_decision_threshold=calibrate_decision_threshold)
 
         holdout_frac = kwargs["holdout_frac"]
@@ -1633,6 +1635,9 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             logger.log(20, "Full kwargs:")
             logger.log(20, f"{pprint.pformat(kwargs)}")
             logger.log(20, "========================================")
+
+        self._validate_num_cpus(num_cpus=num_cpus)
+        self._validate_num_gpus(num_gpus=num_gpus)
 
         # TODO: Allow disable aux (default to disabled)
         # TODO: num_bag_sets
@@ -4529,6 +4534,30 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             raise ValueError(
                 f"`calibrate_decision_threshold` must be a value in " f"{valid_calibrate_decision_threshold_options}, but is: {calibrate_decision_threshold}"
             )
+
+    def _validate_num_cpus(self, num_cpus: int | str):
+        if num_cpus is None:
+            raise ValueError(f"`num_cpus` must be an int or 'auto'. Value: {num_cpus}")
+        if isinstance(num_cpus, str):
+            if num_cpus != "auto":
+                raise ValueError(f"`num_cpus` must be an int or 'auto'. Value: {num_cpus}")
+        elif not isinstance(num_cpus, int):
+            raise TypeError(f"`num_cpus` must be an int or 'auto'. Found: {type(num_cpus)} | Value: {num_cpus}")
+        else:
+            if num_cpus < 1:
+                raise ValueError(f"`num_cpus` must be greater than or equal to 1. (num_cpus={num_cpus})")
+
+    def _validate_num_gpus(self, num_gpus: int | float | str):
+        if num_gpus is None:
+            raise ValueError(f"`num_gpus` must be an int, float, or 'auto'. Value: {num_gpus}")
+        if isinstance(num_gpus, str):
+            if num_gpus != "auto":
+                raise ValueError(f"`num_gpus` must be an int, float, or 'auto'. Value: {num_gpus}")
+        elif not isinstance(num_gpus, (int, float)):
+            raise TypeError(f"`num_gpus` must be an int, float, or 'auto'. Found: {type(num_gpus)} | Value: {num_gpus}")
+        else:
+            if num_gpus < 0:
+                raise ValueError(f"`num_gpus` must be greater than or equal to 0. (num_gpus={num_gpus})")
 
     def _fit_extra_kwargs_dict(self) -> dict:
         """

--- a/tabular/tests/conftest.py
+++ b/tabular/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import os
 import shutil
@@ -151,7 +153,7 @@ class FitHelper:
         refit_full=True,
         delete_directory=True,
         extra_metrics=None,
-        expected_model_count=2,
+        expected_model_count: int | None = 2,
         path_as_absolute=False,
         compile=False,
         compiler_configs=None,
@@ -204,10 +206,12 @@ class FitHelper:
 
         model_names = predictor.model_names()
         model_name = model_names[0]
-        assert len(model_names) == expected_model_count
+        if expected_model_count is not None:
+            assert len(model_names) == expected_model_count
         if refit_full:
             refit_model_names = predictor.refit_full()
-            assert len(refit_model_names) == expected_model_count
+            if expected_model_count is not None:
+                assert len(refit_model_names) == expected_model_count
             refit_model_name = refit_model_names[model_name]
             assert "_FULL" in refit_model_name
             predictor.predict(test_data, model=refit_model_name)

--- a/tabular/tests/unittests/edgecases/test_edgecases.py
+++ b/tabular/tests/unittests/edgecases/test_edgecases.py
@@ -1,5 +1,7 @@
 import shutil
 
+import pytest
+
 from autogluon.core.constants import BINARY
 from autogluon.core.metrics import METRICS
 
@@ -203,3 +205,42 @@ def test_num_folds_parallel(fit_helper, capsys):
     leaderboard = predictor.leaderboard(extra_info=True)
     assert leaderboard.iloc[0]["num_models"] == 2
     shutil.rmtree(predictor.path, ignore_errors=True)
+
+
+def test_raises_num_cpus_float(fit_helper):
+    """Tests that num_cpus specified as a float raises a TypeError"""
+    fit_args = dict(num_cpus=1.0)
+    dataset_name = "adult"
+    with pytest.raises(TypeError, match=r"`num_cpus` must be an int or 'auto'. Found: .*"):
+        fit_helper.fit_and_validate_dataset(
+            dataset_name=dataset_name,
+            fit_args=fit_args,
+            expected_model_count=None,
+            delete_directory=True,
+        )
+
+
+def test_raises_num_cpus_zero(fit_helper):
+    """Tests that num_cpus=0 raises a ValueError"""
+    fit_args = dict(num_cpus=0)
+    dataset_name = "adult"
+    with pytest.raises(ValueError, match=r"`num_cpus` must be greater than or equal to 1. .*"):
+        fit_helper.fit_and_validate_dataset(
+            dataset_name=dataset_name,
+            fit_args=fit_args,
+            expected_model_count=None,
+            delete_directory=True,
+        )
+
+
+def test_raises_num_gpus_neg(fit_helper):
+    """Tests that num_gpus<0 raises a ValueError"""
+    fit_args = dict(num_gpus=-1)
+    dataset_name = "adult"
+    with pytest.raises(ValueError, match=r"`num_gpus` must be greater than or equal to 0. .*"):
+        fit_helper.fit_and_validate_dataset(
+            dataset_name=dataset_name,
+            fit_args=fit_args,
+            expected_model_count=None,
+            delete_directory=True,
+        )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds additional checks to ensure CPU and GPU settings are valid.

- raise TypeError if num_cpus and num_gpus are invalid types.
- raise ValueError if num_cpus<1
- raise ValueError if num_gpus<0
- Fixes a cryptic failure caused when passing `num_cpus` as a float that could be converted to an int such as `12.0`, which will fail the process but not provide a useful error message to understand the root cause. Now it will fail immediately stating that `num_cpus` must be an int.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
