### PR TITLE
[tabular] Add readable error message for invalid models in persist

### DIFF
--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -3189,7 +3189,15 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         List of persisted model names.
         """
         self._assert_is_fit("persist")
-        return self._learner.persist_trainer(low_memory=False, models=models, with_ancestors=with_ancestors, max_memory=max_memory)
+        try:
+            return self._learner.persist_trainer(low_memory=False, models=models, with_ancestors=with_ancestors, max_memory=max_memory)
+        except Exception as e:
+            valid_models = self.model_names()
+            if isinstance(models, list):
+                invalid_models = [m for m in models if m not in valid_models]
+                if invalid_models:
+                    raise ValueError(f"Invalid models specified. The following models do not exist:\n\t{invalid_models}\nValid models:\n\t{valid_models}")
+            raise e
 
     def unpersist(self, models="all") -> List[str]:
         """

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -29,7 +29,6 @@ from random import seed
 import numpy as np
 import pandas as pd
 import pytest
-from networkx.exception import NetworkXError
 
 from autogluon.common import space
 from autogluon.common.utils.simulation_utils import convert_simulation_artifacts_to_tabular_predictions_dict
@@ -251,7 +250,7 @@ def test_advanced_functionality():
     assert predictor.model_names(persisted=True) == []  # Assert that all models were unpersisted
 
     # Raise exception
-    with pytest.raises(NetworkXError):
+    with pytest.raises(ValueError):
         predictor.persist(models=["UNKNOWN_MODEL_1", "UNKNOWN_MODEL_2"])
 
     assert predictor.model_names(persisted=True) == []


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add readable error message for invalid models in persist

## Code Example

```
import pandas as pd
from autogluon.tabular import TabularPredictor


if __name__ == '__main__':
    label = 'class'
    train_data = pd.read_csv('https://autogluon.s3.amazonaws.com/datasets/Inc/train.csv')

    hyperparameters = {
        "GBM": {},
    }

    predictor = TabularPredictor(
        label=label,
    )

    predictor = predictor.fit(
        train_data=train_data,
        hyperparameters=hyperparameters,
    )

    predictor.persist(["abc"])
```

## Error Message

### This PR 

```
ValueError: Invalid models specified. The following models do not exist:
	['abc']
Valid models:
	['LightGBM', 'WeightedEnsemble_L2']
```

### Mainline

```
networkx.exception.NetworkXError: The node abc is not in the digraph.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
