### PR TITLE
[tabular] Improve logging for invalid label

### DIFF
--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -370,11 +370,17 @@ class AbstractTabularLearner(AbstractLearner):
         return y_pred
 
     def _validate_fit_input(self, X: DataFrame, **kwargs):
-        if self.label not in X.columns:
-            raise KeyError(f"Label column '{self.label}' is missing from training data. Training data columns: {list(X.columns)}")
+        self.validate_label(X=X)
         X_val = kwargs.get("X_val", None)
         self._validate_sample_weight(X, X_val)
         self._validate_groups(X, X_val)
+
+    def validate_label(self, X: DataFrame):
+        """
+        Ensure that the label column is present in the training data
+        """
+        if self.label not in X.columns:
+            raise KeyError(f"Label column '{self.label}' is missing from training data. Training data columns: {list(X.columns)}")
 
     def _validate_sample_weight(self, X, X_val):
         if self.sample_weight is not None:

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1047,6 +1047,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         if self.problem_type is not None:
             inferred_problem_type = self.problem_type
         else:
+            self._learner.validate_label(X=train_data)
             inferred_problem_type = self._learner.infer_problem_type(y=train_data[self.label], silent=True)
 
         num_bag_folds, num_bag_sets, num_stack_levels, dynamic_stacking, use_bag_holdout = self._sanitize_stack_args(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Improve logging for invalid label when problem_type is not specified by user

## Error Message

### This PR

```
KeyError: "Label column 'target' is missing from training data. Training data columns: ['age', 'workclass', 'fnlwgt', 'education', 'education-num', 'marital-status', 'occupation', 'relationship', 'race', 'sex', 'capital-gain', 'capital-loss', 'hours-per-week', 'native-country', 'class']"
```

### Mainline
```
KeyError: 'target'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
