### PR TITLE
[tabular] Fix Stacker max_models logic

### DIFF
--- a/common/src/autogluon/common/features/feature_metadata.py
+++ b/common/src/autogluon/common/features/feature_metadata.py
@@ -51,6 +51,19 @@ class FeatureMetadata:
 
         self._validate()
 
+    def __eq__(self, other) -> bool:
+        if set(self.type_map_raw.keys()) != set(other.type_map_raw.keys()):
+            return False
+        for k in self.type_map_raw.keys():
+            if self.type_map_raw[k] != other.type_map_raw[k]:
+                return False
+        if set(self.type_group_map_special.keys()) != set(other.type_group_map_special.keys()):
+            return False
+        for k in self.type_group_map_special.keys():
+            if set(self.type_group_map_special[k]) != set(other.type_group_map_special[k]):
+                return False
+        return True
+
     # Confirms if inputs are valid
     def _validate(self):
         type_group_map_special_expanded = []

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -457,7 +457,7 @@ class AbstractModel:
             feature_metadata = self._infer_feature_metadata(X=X)
         else:
             feature_metadata = copy.deepcopy(feature_metadata)
-        feature_metadata = self._update_feature_metadata(feature_metadata=feature_metadata)
+        feature_metadata = self._update_feature_metadata(X=X, feature_metadata=feature_metadata)
         get_features_kwargs = self.params_aux.get("get_features_kwargs", None)
         if get_features_kwargs is not None:
             valid_features = feature_metadata.get_features(**get_features_kwargs)
@@ -505,7 +505,7 @@ class AbstractModel:
         if error_if_no_features and not self._features_internal:
             raise NoValidFeatures
 
-    def _update_feature_metadata(self, feature_metadata: FeatureMetadata) -> FeatureMetadata:
+    def _update_feature_metadata(self, X: pd.DataFrame, feature_metadata: FeatureMetadata) -> FeatureMetadata:
         """
         [Advanced] Method that performs updates to feature_metadata during initialization.
         Primarily present for use in stacker models.

--- a/core/src/autogluon/core/models/ensemble/stacker_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/stacker_ensemble_model.py
@@ -1,16 +1,17 @@
+from __future__ import annotations
+
 import copy
 import logging
 import os
 import time
 from collections import defaultdict
-from typing import Dict
+from typing import Dict, List
 
 import numpy as np
 import pandas as pd
 
 from autogluon.common.features.feature_metadata import FeatureMetadata
 from autogluon.common.features.types import R_FLOAT, S_STACK
-from autogluon.common.utils.path_converter import PathConverter
 
 from ...constants import MULTICLASS, QUANTILE, SOFTCLASS
 from ..abstract.abstract_model import AbstractModel
@@ -35,12 +36,12 @@ class StackerEnsembleModel(BaggedEnsembleModel):
 
     def __init__(
         self,
-        base_model_names=None,
-        base_models_dict=None,
-        base_model_paths_dict=None,
-        base_model_types_dict=None,
-        base_model_types_inner_dict=None,
-        base_model_performances_dict=None,
+        base_model_names: List[str] | None = None,
+        base_models_dict: Dict[str, AbstractModel] | None = None,
+        base_model_paths_dict: Dict[str, str] = None,
+        base_model_types_dict: dict | None = None,
+        base_model_types_inner_dict: dict | None = None,
+        base_model_performances_dict: Dict[str, float] | None = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -61,8 +62,10 @@ class StackerEnsembleModel(BaggedEnsembleModel):
         self._base_model_performances_dict = base_model_performances_dict
         self._base_model_types_inner_dict = base_model_types_inner_dict
 
-    def _initialize(self, **kwargs):
-        super()._initialize(**kwargs)
+    def _update_feature_metadata(self, feature_metadata: FeatureMetadata) -> FeatureMetadata:
+        """
+        Updates base_model_names and feature_metadata to reflect the used base models.
+        """
         base_model_performances_dict = self._base_model_performances_dict
         base_model_types_inner_dict = self._base_model_types_inner_dict
         if (base_model_performances_dict is not None) and (base_model_types_inner_dict is not None):
@@ -88,7 +91,21 @@ class StackerEnsembleModel(BaggedEnsembleModel):
             stack_column_prefix: self.base_model_names[i] for i, stack_column_prefix in enumerate(self.stack_column_prefix_lst)
         }
 
-        self._add_stack_to_feature_metadata()
+        feature_metadata = self._remove_unused_stack_in_feature_metadata(feature_metadata=feature_metadata)
+        return feature_metadata
+
+    def _infer_feature_metadata(self, X: pd.DataFrame) -> FeatureMetadata:
+        """
+        Additionally adds the stack feature special types to the inferred feature_metadata.
+        """
+        feature_metadata = super()._infer_feature_metadata(X=X)
+        stack_column_prefix_lst = copy.deepcopy(self.base_model_names)
+        stack_columns, num_pred_cols_per_model = self.set_stack_columns(stack_column_prefix_lst=stack_column_prefix_lst)
+        type_map_raw = {column: R_FLOAT for column in stack_columns}
+        type_group_map_special = {S_STACK: stack_columns}
+        stacker_feature_metadata = FeatureMetadata(type_map_raw=type_map_raw, type_group_map_special=type_group_map_special)
+        feature_metadata = feature_metadata.add_special_types(stacker_feature_metadata.get_type_map_special())
+        return feature_metadata
 
     @staticmethod
     def limit_models_per_type(models, model_types, model_scores, max_base_models_per_type):
@@ -215,19 +232,19 @@ class StackerEnsembleModel(BaggedEnsembleModel):
         info["children_info"] = children_info  # Ensure children_info is last in order
         return info
 
-    def _add_stack_to_feature_metadata(self):
-        if len(self.models) == 0:
-            type_map_raw = {column: R_FLOAT for column in self.stack_columns}
-            type_group_map_special = {S_STACK: self.stack_columns}
-            stacker_feature_metadata = FeatureMetadata(type_map_raw=type_map_raw, type_group_map_special=type_group_map_special)
-            if self.feature_metadata is None:  # TODO: This is probably not the best way to do this
-                self.feature_metadata = stacker_feature_metadata
-            else:
-                # FIXME: This is a hack, stack feature special types should be already present in feature_metadata, not added here
-                existing_stack_features = self.feature_metadata.get_features(required_special_types=[S_STACK])
-                # HACK: Currently AutoGluon auto-adds all base learner prediction features into self.feature_metadata.
-                # The two lines below are here because if feature pruning would crash if it prunes a base learner prediction feature.
-                existing_features = self.feature_metadata.get_features()
-                stacker_feature_metadata = stacker_feature_metadata.keep_features([feature for feature in existing_features if feature in type_map_raw])
-                if set(stacker_feature_metadata.get_features()) != set(existing_stack_features):
-                    self.feature_metadata = self.feature_metadata.add_special_types(stacker_feature_metadata.get_type_map_special())
+    def _remove_unused_stack_in_feature_metadata(self, feature_metadata: FeatureMetadata) -> FeatureMetadata:
+        """
+        Updates `self.feature_metadata` to only contain stack features specified in `self.stack_columns`.
+        """
+        assert feature_metadata is not None, f"feature_metadata must be specified prior to adding stack feature information."
+        # Trust feature metadata
+        original_stack_features = feature_metadata.get_features(required_special_types=[S_STACK])
+        current_stack_features = self.stack_columns
+        for stack_feature in current_stack_features:
+            assert stack_feature in original_stack_features, (
+                f"Missing expected stack feature '{stack_feature}' in original feature_metadata. "
+                f"Stack features in feature_metadata: {original_stack_features}"
+            )
+        stack_features_to_remove = [stack_feature for stack_feature in original_stack_features if stack_feature not in current_stack_features]
+        feature_metadata = feature_metadata.remove_features(features=stack_features_to_remove)
+        return feature_metadata

--- a/core/src/autogluon/core/models/ensemble/stacker_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/stacker_ensemble_model.py
@@ -125,7 +125,7 @@ class StackerEnsembleModel(BaggedEnsembleModel):
         return self.limit_models_per_type(models=models, model_types=model_types, model_scores=model_scores, max_base_models_per_type=max_base_models)
 
     def _set_default_params(self):
-        default_params = {"use_orig_features": True, "max_base_models": 25, "max_base_models_per_type": 5}
+        default_params = {"use_orig_features": True, "max_base_models": 50, "max_base_models_per_type": 5}
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
         super()._set_default_params()

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -1246,6 +1246,7 @@ class AbstractTrainer:
     ) -> pd.DataFrame:
         """
         Returns the valid X input for a stacker model with base models equal to `base_models`.
+        Pairs with `feature_metadata = self.get_feature_metadata(...)`. The contents of the returned `X` should reflect `feature_metadata`.
 
         Parameters
         ----------
@@ -1299,6 +1300,26 @@ class AbstractTrainer:
         return X
 
     def get_feature_metadata(self, use_orig_features: bool = True, model: str | None = None, base_models: List[str] | None = None) -> FeatureMetadata:
+        """
+        Returns the FeatureMetadata input to a `model.fit` call.
+        Pairs with `X = self.get_inputs_to_stacker(...)`. The returned FeatureMetadata should reflect the contents of `X`.
+
+        Parameters
+        ----------
+        use_orig_features : bool, default = True
+            If True, will include the original features in the FeatureMetadata.
+            If False, will only include the stack features in the FeatureMetadata.
+        model : str, default = None
+            If specified, it must be an already existing model.
+            `base_models` will be set to the base models of `model`.
+        base_models : List[str], default = None
+            If specified, will add the stack features of the `base_models` to FeatureMetadata.
+
+        Returns
+        -------
+        FeatureMetadata
+            The FeatureMetadata that should be passed into a `model.fit` call.
+        """
         if model is not None and base_models is not None:
             raise AssertionError("Only one of `model`, `base_models` is allowed to be set.")
         if model is not None and base_models is None:

--- a/features/tests/features/test_feature_metadata.py
+++ b/features/tests/features/test_feature_metadata.py
@@ -196,3 +196,30 @@ def test_feature_metadata_get_features():
     assert feature_metadata.get_features(valid_raw_types=["2", "3"], required_special_types=["s1"], required_exact=True) == []
     assert feature_metadata.get_features(valid_raw_types=["2", "3"], required_special_types=["s1", "s3"]) == ["b"]
     assert feature_metadata.get_features(valid_raw_types=["2", "3"], required_special_types=["s1", "s3"], required_exact=True) == ["b"]
+
+
+def test_feature_metadata_equals():
+    type_map_raw = dict(
+        a="1",
+        b="2",
+        c="3",
+        d="1",
+        e="1",
+        f="4",
+    )
+    type_group_map_special = {"s1": ["a", "b", "d"], "s2": ["a", "e"], "s3": ["a", "b"], "s4": ["f"]}
+    feature_metadata = FeatureMetadata(type_map_raw=type_map_raw, type_group_map_special=type_group_map_special)
+    feature_metadata_2 = FeatureMetadata(type_map_raw=type_map_raw, type_group_map_special=type_group_map_special)
+    assert feature_metadata == feature_metadata_2
+    feature_metadata_2 = feature_metadata_2.remove_features(features=["a"])
+    assert feature_metadata != feature_metadata_2
+
+    feature_metadata_3 = FeatureMetadata(type_map_raw=dict(a="1"))
+    feature_metadata_2 = feature_metadata_2.join_metadata(feature_metadata_3)
+    assert feature_metadata != feature_metadata_2
+
+    feature_metadata_2 = feature_metadata_2.add_special_types(type_map_special={"a": ["s1"]})
+    assert feature_metadata != feature_metadata_2
+
+    feature_metadata_2 = feature_metadata_2.add_special_types(type_map_special={"a": ["s2", "s3"]})
+    assert feature_metadata == feature_metadata_2

--- a/tabular/tests/unittests/models/advanced/test_stack_feature_usage.py
+++ b/tabular/tests/unittests/models/advanced/test_stack_feature_usage.py
@@ -1,0 +1,145 @@
+"""
+Unit tests to ensure correctness of internal stacking logic.
+"""
+import shutil
+
+from autogluon.common.features.types import S_STACK
+from autogluon.core.models.ensemble.stacker_ensemble_model import StackerEnsembleModel
+from autogluon.tabular.predictor import TabularPredictor
+
+
+def test_stack_feature_usage_binary(fit_helper):
+    """Tests that stacker models use base model predictions as features correctly for binary"""
+    dataset_name = "adult"
+    expected_ancestors = {"LightGBM_BAG_L1", "DummyModel_BAG_L1"}
+    _fit_predictor_stack_feature_usage(
+        dataset_name=dataset_name,
+        max_base_models_per_type=1,
+        max_base_models=2,
+        sample_size=100,
+        expected_ancestors=expected_ancestors,
+        fit_helper=fit_helper,
+    )
+
+
+def test_stack_feature_usage_multiclass(fit_helper):
+    """Tests that stacker models use base model predictions as features correctly for multiclass"""
+    dataset_name = "covertype_small"
+    expected_ancestors = {"LightGBM_BAG_L1", "DummyModel_BAG_L1"}
+    _fit_predictor_stack_feature_usage(
+        dataset_name=dataset_name,
+        max_base_models_per_type=1,
+        max_base_models=2,
+        sample_size=100,
+        expected_ancestors=expected_ancestors,
+        fit_helper=fit_helper,
+    )
+
+
+def test_stack_feature_usage_regression(fit_helper):
+    """Tests that stacker models use base model predictions as features correctly for regression"""
+    dataset_name = "ames"
+    expected_ancestors = {"LightGBM_BAG_L1", "KNeighbors_BAG_L1"}
+    _fit_predictor_stack_feature_usage(
+        dataset_name=dataset_name,
+        max_base_models_per_type=1,
+        max_base_models=2,
+        sample_size=100,
+        expected_ancestors=expected_ancestors,
+        fit_helper=fit_helper,
+    )
+
+
+def test_stack_feature_usage_binary_all(fit_helper):
+    """Tests that stacker models use base model predictions as features correctly for binary"""
+    dataset_name = "adult"
+    expected_ancestors = {"LightGBM_BAG_L1", "LightGBM_2_BAG_L1", "KNeighbors_BAG_L1", "DummyModel_BAG_L1"}
+    _fit_predictor_stack_feature_usage(
+        dataset_name=dataset_name,
+        max_base_models_per_type=0,  # uncapped
+        max_base_models=0,  # uncapped
+        sample_size=100,
+        expected_ancestors=expected_ancestors,
+        fit_helper=fit_helper,
+    )
+
+
+def test_stack_feature_usage_binary_only_max_models(fit_helper):
+    """Tests that stacker models use base model predictions as features correctly for binary"""
+    dataset_name = "adult"
+    expected_ancestors = {"LightGBM_BAG_L1", "LightGBM_2_BAG_L1"}
+    _fit_predictor_stack_feature_usage(
+        dataset_name=dataset_name,
+        max_base_models_per_type=0,  # uncapped
+        max_base_models=2,
+        sample_size=100,
+        expected_ancestors=expected_ancestors,
+        fit_helper=fit_helper,
+    )
+
+
+def _fit_predictor_stack_feature_usage(
+    dataset_name: str,
+    max_base_models_per_type: int,
+    max_base_models: int,
+    sample_size: int,
+    expected_ancestors: set,
+    fit_helper,
+):
+    """Tests that stacker models use base model predictions as features correctly"""
+    fit_args = dict(
+        hyperparameters={
+            "GBM": [
+                {"num_iterations": 200},
+                {"num_iterations": 50},
+            ],
+            "KNN": {},
+            "DUMMY": {},
+        },
+        ag_args_ensemble={
+            "max_base_models_per_type": max_base_models_per_type,
+            "max_base_models": max_base_models,
+            "fold_fitting_strategy": "sequential_local",
+        },
+        num_bag_folds=2,
+        num_stack_levels=1,
+        fit_weighted_ensemble=False,
+    )
+    predictor = fit_helper.fit_and_validate_dataset(
+        dataset_name=dataset_name,
+        fit_args=fit_args,
+        refit_full=False,
+        sample_size=sample_size,
+        expected_model_count=7,
+        delete_directory=False,
+    )
+    _assert_stack_features(predictor=predictor, expected_ancestors=expected_ancestors)
+    shutil.rmtree(predictor.path, ignore_errors=True)
+
+
+def _assert_stack_features(predictor: TabularPredictor, expected_ancestors: set):
+    """
+    Verifies that stack features are correctly set and used
+    """
+    leaderboard = predictor.leaderboard(extra_info=True)
+    leaderboard_l2 = leaderboard[leaderboard["stack_level"] == 2]
+    leaderboard_l2 = leaderboard_l2.set_index("model")
+    for m in leaderboard_l2.index:
+        ancestors = set(leaderboard_l2.loc[m, "ancestors"])
+        assert expected_ancestors == ancestors
+        model = predictor._trainer.load_model(model_name=m)
+        assert isinstance(model, StackerEnsembleModel)
+        assert expected_ancestors == set(model.base_model_names)
+        assert expected_ancestors == set(predictor._trainer.get_minimum_model_set(model=m, include_self=False))
+        stack_columns = model.stack_columns
+        stack_columns_fm = model.feature_metadata.get_features(required_special_types=[S_STACK])
+        assert set(stack_columns) == set(stack_columns_fm)
+        features = model.feature_metadata.get_features()
+        assert set(features) == set(model.features)
+        # Asserts that child models use the same features as parent models
+        for child_model_name in model.models:
+            child_model = model.load_child(model=child_model_name)
+            child_stack_columns_fm = child_model.feature_metadata.get_features(required_special_types=[S_STACK])
+            assert set(stack_columns) == set(child_stack_columns_fm)
+            assert set(features) == set(child_model.features)
+            assert model.feature_metadata == child_model.feature_metadata


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fix a long standing major bug where L2+ stacker models that are not weighted ensembles will not respect the `max_models` and `max_models_per_type` parameters, and will instead use all base models during fit.
- This bug has been present forever, since the original code was written, but only started majorly impacting AutoGluon in v1.0+ with the introduction of Zeroshot-HPO.
- Fixing this should lead to faster training and inference times for stack layers, and a potential quality improvement.

Results: 3x inference speedup with no noticeable model quality drop:

![pr4290_boxplot](https://github.com/autogluon/autogluon/assets/16392542/783da815-87d5-40df-897e-f7d9b8e91532)

TODO:

- [x] Benchmark `best` and `high` quality presets.
- [x] Consider changing defaults for `max_models` and `max_models_per_type`. Currently they are 25 and 5 respectively. Likely `max_models` should be increased to ~50.
- [x] Add additional documentation for `get_feature_metadata` in Trainer.
- [x] Add advanced unit tests.

Follow-up PRs:

- [ ] Potentially delete StackerEnsembleModel, move logic to Trainer.
- [ ] Add option for user to specify WeightedEnsemble max_models and max_models_per_type
- [ ] Remove `base_models_dict` parameter.
- [x] Bug: `sample_weight` column is present in `X` in the `model.fit` call, it should not be present. (Created issue: https://github.com/autogluon/autogluon/issues/4304)
- [x] Bug: `sample_weight` column is passed to `feature_prune` if both sample_weight and feature_prune are enabled. This shouldn't happen. (Created issue: https://github.com/autogluon/autogluon/issues/4304)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
