### PR TITLE
Replace ray-default with necessary submodules

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -48,10 +48,10 @@ install_requires = (
 
 extras_require = {
     "ray": [
-        "ray[default]>=2.10.0,<2.11",  # sync with common/src/autogluon/common/utils/try_import.py
+        "ray[air,core,train]>=2.10.0,<2.11",  # sync with common/src/autogluon/common/utils/try_import.py
     ],
     "raytune": [
-        "ray[default,tune]>=2.10.0,<2.11",  # sync with common/src/autogluon/common/utils/try_import.py
+        "ray[air,core,train,tune]>=2.10.0,<2.11",  # sync with common/src/autogluon/common/utils/try_import.py
         # TODO: consider alternatives as hyperopt is not actively maintained.
         "hyperopt>=0.2.7,<0.2.8",  # This is needed for the bayes search to work.
         # 'GPy>=1.10.0,<1.11.0'  # TODO: Enable this once PBT/PB2 are supported by ray lightning


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`ray-default` installs `NodeJS` as a dependency while we are not really making use of the UI component of Ray in AutoGluon. By removing `NodeJS`, we could help reduce AutoGluon's surface area in services which has AG as a dependency. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
