### PR TITLE
[timeseries] Fix incorrectly logged tuning data size

### DIFF
--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -712,7 +712,7 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
         if tuning_data is not None:
             tuning_data = self._check_and_prepare_data_frame(tuning_data, name="tuning_data")
             self._check_data_for_evaluation(tuning_data, name="tuning_data")
-            logger.info(f"Provided tuning_data has {self._get_dataset_stats(train_data)}")
+            logger.info(f"Provided tuning_data has {self._get_dataset_stats(tuning_data)}")
             # TODO: Use num_val_windows to perform multi-window backtests on tuning_data
             if num_val_windows > 0:
                 logger.warning(


### PR DESCRIPTION
*Issue #, if available:* Fixes: #4297

*Description of changes:*
- Fix typo in dataset statistics reporting in `TimeSeriesPredictor.fit`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
