### PR TITLE
Update infer_types.py to say the default handling is zero

### DIFF
--- a/multimodal/src/autogluon/multimodal/data/infer_types.py
+++ b/multimodal/src/autogluon/multimodal/data/infer_types.py
@@ -235,9 +235,9 @@ def is_image_column(
                 f"Among {sample_num} sampled images in column '{col_name}', "
                 f"{failure_ratio:.0%} images can't be open. "
                 "You may need to thoroughly check your data to see the percentage of missing images, "
-                "and estimate the potential influence. By default, we skip the samples with missing images. "
-                "You can also set hyperparameter 'data.image.missing_value_strategy' to be 'zero', "
-                "which uses a zero image to replace any missing image.",
+                "and estimate the potential influence. By default, we use an image with zero pixels. "
+                "You can also set hyperparameter 'data.image.missing_value_strategy' to be 'skip', "
+                "which skips samples that contain a missing image.",
                 UserWarning,
             )
         return True


### PR DESCRIPTION
*Description of changes:*

According to the documentation (https://auto.gluon.ai/stable/tutorials/multimodal/advanced_topics/customization.html#data-image-missing-value-strategy) and process_image.py (autogluon/multimodal/src/autogluon/multimodal/data
/process_image.py), Autogluon uses an image with zero pixels if an image is missing. There is a warning in infer_types.py (multimodal/src/autogluon/multimodal/data/infer_types.py) that says the default behavior is to skip samples, which I updated.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
