### PR TITLE
[Tabular] Avoid Edge Case Divison By Zero Error

### DIFF
--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -2179,7 +2179,11 @@ class AbstractTrainer:
         predict_n_time_per_row = self.get_model_attribute_full(model=model.name, attribute="predict_n_time_per_row")
         predict_n_size = self.get_model_attribute_full(model=model.name, attribute="predict_n_size", func=min)
         if predict_n_time_per_row is not None and predict_n_size is not None:
-            logger.log(15, f"\t{round(1/(predict_n_time_per_row if predict_n_time_per_row else np.finfo(np.float16).eps), 1)}\t = Inference  throughput (rows/s | {int(predict_n_size)} batch size)")
+            logger.log(
+                15,
+                f"\t{round(1/(predict_n_time_per_row if predict_n_time_per_row else np.finfo(np.float16).eps), 1)}"
+                "\t = Inference  throughput (rows/s | {int(predict_n_size)} batch size)",
+            )
         if model.predict_1_time is not None:
             fit_metadata = model.get_fit_metadata()
             predict_1_batch_size = fit_metadata.get("predict_1_batch_size", None)

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -2178,8 +2178,8 @@ class AbstractTrainer:
             logger.log(20, f"\t{round(model.predict_time, 2)}s\t = Validation runtime")
         predict_n_time_per_row = self.get_model_attribute_full(model=model.name, attribute="predict_n_time_per_row")
         predict_n_size = self.get_model_attribute_full(model=model.name, attribute="predict_n_size", func=min)
-        if predict_n_time_per_row is not None and predict_n_time_per_row != 0 and predict_n_size is not None:
-            logger.log(15, f"\t{round(1 / predict_n_time_per_row, 1)}\t = Inference  throughput (rows/s | {int(predict_n_size)} batch size)")
+        if predict_n_time_per_row is not None and predict_n_size is not None:
+            logger.log(15, f"\t{round(1/(predict_n_time_per_row if predict_n_time_per_row else np.finfo(np.float16).eps), 1)}\t = Inference  throughput (rows/s | {int(predict_n_size)} batch size)")
         if model.predict_1_time is not None:
             fit_metadata = model.get_fit_metadata()
             predict_1_batch_size = fit_metadata.get("predict_1_batch_size", None)

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -2182,7 +2182,7 @@ class AbstractTrainer:
             logger.log(
                 15,
                 f"\t{round(1/(predict_n_time_per_row if predict_n_time_per_row else np.finfo(np.float16).eps), 1)}"
-                "\t = Inference  throughput (rows/s | {int(predict_n_size)} batch size)",
+                f"\t = Inference  throughput (rows/s | {int(predict_n_size)} batch size)",
             )
         if model.predict_1_time is not None:
             fit_metadata = model.get_fit_metadata()

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -144,7 +144,7 @@ class DefaultLearner(AbstractTabularLearner):
             predict_n_time_per_row = trainer.get_model_attribute_full(model=trainer.model_best, attribute="predict_n_time_per_row")
             predict_n_size = trainer.get_model_attribute_full(model=trainer.model_best, attribute="predict_n_size", func=min)
             if predict_n_time_per_row is not None and predict_n_size is not None:
-                log_throughput = f" | Estimated inference throughput: {(1/predict_n_time_per_row):.1f} rows/s ({int(predict_n_size)} batch size)"
+                log_throughput = f" | Estimated inference throughput: {1/(predict_n_time_per_row if predict_n_time_per_row else np.finfo(np.float16).eps):.1f} rows/s ({int(predict_n_size)} batch size)"
         logger.log(
             20, f"AutoGluon training complete, total runtime = {round(self._time_fit_total, 2)}s ... Best model: {trainer.model_best}" f"{log_throughput}"
         )


### PR DESCRIPTION
This is a minimal change to the code to avoid a divide-by-zero error that occurs when a tiny test dataset is used with a high-speed prediction model. 

This edge case occurs in some of my tests for an AutoGluon integration. 
The PR provides a simple workaround for the bug. This also depends highly on the machine. 

Here is the exact error that I run into very often with CatBoost in my tests:
```bash
        self.save_trainer(trainer=trainer)
        time_end = time.time()
        self._time_fit_training = time_end - time_preprocessing_end
        self._time_fit_total = time_end - time_preprocessing_start
        log_throughput = ""
        if trainer.model_best is not None:
            predict_n_time_per_row = trainer.get_model_attribute_full(model=trainer.model_best, attribute="predict_n_time_per_row")
            predict_n_size = trainer.get_model_attribute_full(model=trainer.model_best, attribute="predict_n_size", func=min)
            if predict_n_time_per_row is not None and predict_n_size is not None:
>               log_throughput = f" | Estimated inference throughput: {(1/predict_n_time_per_row):.1f} rows/s ({int(predict_n_size)} batch size)"
E               ZeroDivisionError: float division by zero
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
