### PR TITLE
[tabular] Add initial callbacks support

### DIFF
--- a/core/src/autogluon/core/callbacks/__init__.py
+++ b/core/src/autogluon/core/callbacks/__init__.py
@@ -1,1 +1,3 @@
 from ._abstract_callback import AbstractCallback
+from ._early_stopping_callback import EarlyStoppingCallback
+from ._example_callback import ExampleCallback

--- a/core/src/autogluon/core/callbacks/__init__.py
+++ b/core/src/autogluon/core/callbacks/__init__.py
@@ -1,0 +1,1 @@
+from ._abstract_callback import AbstractCallback

--- a/core/src/autogluon/core/callbacks/__init__.py
+++ b/core/src/autogluon/core/callbacks/__init__.py
@@ -1,3 +1,4 @@
 from ._abstract_callback import AbstractCallback
 from ._early_stopping_callback import EarlyStoppingCallback
+from ._early_stopping_ensemble_callback import EarlyStoppingEnsembleCallback
 from ._example_callback import ExampleCallback

--- a/core/src/autogluon/core/callbacks/_abstract_callback.py
+++ b/core/src/autogluon/core/callbacks/_abstract_callback.py
@@ -11,7 +11,19 @@ class AbstractCallback(object, metaclass=ABCMeta):
     Abstract callback class for AutoGluon's TabularPredictor.
     The inner API and logic within `trainer` is considered private API. It may change without warning between releases.
 
-    # TODO: Docstring for init args
+    Parameters
+    ----------
+    allow_recursive_calls : bool, default = False
+        If True, will allow recursive calls to this callback.
+        For example, a recursive call can happen if inside `self.before_fit` or `self.after_fit`, the callback initiates a model fit in trainer.
+        This model fit will then trigger `self.before_fit` again, which could lead to an infinite loop if the callback is not implemented carefully.
+        If False, guarantees that the callback logic will be skipped if it is part of a recursive call.
+    skip_if_trainer_stopped : bool, default = False
+        If True, will skip self.before_fit and self.after_fit logic if `early_stop=True` was returned from any callback,
+        indicating that the trainer is stopping training.
+        This matters if you have 2 or more callbacks, and the first callback returns `early_stop=True`.
+        If the second callback has `skip_if_trainer_stopped=True`, it will skip its callback logic.
+        Otherwise, its callback logic will still trigger.
 
     Examples
     --------

--- a/core/src/autogluon/core/callbacks/_abstract_callback.py
+++ b/core/src/autogluon/core/callbacks/_abstract_callback.py
@@ -17,11 +17,11 @@ class AbstractCallback(object, metaclass=ABCMeta):
     ----------
     allow_recursive_calls : bool, default = False
         If True, will allow recursive calls to this callback.
-        For example, a recursive call can happen if inside `self.before_fit` or `self.after_fit`, the callback initiates a model fit in trainer.
-        This model fit will then trigger `self.before_fit` again, which could lead to an infinite loop if the callback is not implemented carefully.
+        For example, a recursive call can happen if inside `self.before_model_fit` or `self.after_model_fit`, the callback initiates a model fit in trainer.
+        This model fit will then trigger `self.before_model_fit` again, which could lead to an infinite loop if the callback is not implemented carefully.
         If False, guarantees that the callback logic will be skipped if it is part of a recursive call.
     skip_if_trainer_stopped : bool, default = False
-        If True, will skip self.before_fit and self.after_fit logic if `early_stop=True` was returned from any callback,
+        If True, will skip self.before_model_fit and self.after_model_fit logic if `early_stop=True` was returned from any callback,
         indicating that the trainer is stopping training.
         This matters if you have 2 or more callbacks, and the first callback returns `early_stop=True`.
         If the second callback has `skip_if_trainer_stopped=True`, it will skip its callback logic.

--- a/core/src/autogluon/core/callbacks/_abstract_callback.py
+++ b/core/src/autogluon/core/callbacks/_abstract_callback.py
@@ -1,0 +1,97 @@
+from abc import ABCMeta, abstractmethod
+from logging import Logger
+from typing import List, Tuple
+
+from ..models import AbstractModel
+from ..trainer import AbstractTrainer
+
+
+class AbstractCallback(object, metaclass=ABCMeta):
+    @abstractmethod
+    def before_fit(
+        self,
+        trainer: AbstractTrainer,
+        model: AbstractModel,
+        logger: Logger,
+        time_limit: float | None = None,
+        stack_name: str = "core",
+        level: int = 1,
+    ) -> Tuple[bool, bool]:
+        """
+        Called before fitting a model.
+
+        Parameters
+        ----------
+        trainer : AbstractTrainer
+            The AutoGluon trainer object
+        model : AbstractModel
+            The AutoGluon model object to be fit
+        logger : Logger
+            The Logger object used by trainer
+        time_limit : float | None, default = None
+            The time limit in seconds remaining to fit the model
+        stack_name : str, default = "core"
+            [Advanced] The stack_name the model originates from.
+            You can use this value to toggle logic on and off. For example, skipping core models while still fitting weighted ensemble models.
+            Potential Values:
+                "core": The default stack_name for all models that don't fit special criteria for other values. Most models will be under this stack_name.
+                "aux1": Used for WeightedEnsemble models fit at the end of each stack layer.
+        level : int, default = 1
+            [Advanced] The stack level of the model.
+            Model's that are not stacker models are always `level=1`.
+            `level` corresponds to the `Lx` suffix in the model name. For example, `WeightedEnsemble_L2` would have `level=2`.
+
+        Returns
+        -------
+        early_stop : bool
+            If True, the trainer skips fitting all models (including `model`) and ends the trainer fit process immediately.
+            If False, the trainer continues with its normal logic.
+        skip_model : bool
+            If True, the trainer skips fitting this model.
+            if False, the trainer continues with its normal logic.
+            Ignored if `early_stop=True`.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def after_fit(
+        self,
+        trainer: AbstractTrainer,
+        model_names: List[str],
+        logger: Logger,
+        stack_name: str = "core",
+        level: int = 1,
+    ) -> bool:
+        """
+        Called after fitting a model.
+
+        Parameters
+        ----------
+        trainer : AbstractTrainer
+            The AutoGluon trainer object
+        model_names : List[str]
+            The list of successfully fit model names in the most recent model fit.
+            In most cases this will be a list of size 1 corresponding to `model.name` from the previous `before_fit` call.
+            If hyperparameter tuning is enabled, the size can be >1.
+            If the model crashed or failed to train for some reason, the size will be 0.
+            You can load the model artifact using the model name via `model = trainer.load_model(model_name)`
+        logger : Logger
+            The Logger object used by trainer
+        stack_name : str, default = "core"
+            [Advanced] The stack_name the model originates from.
+            You can use this value to toggle logic on and off. For example, skipping core models while still fitting weighted ensemble models.
+            Potential Values:
+                "core": The default stack_name for all models that don't fit special criteria for other values. Most models will be under this stack_name.
+                "aux1": Used for WeightedEnsemble models fit at the end of each stack layer.
+        level : int, default = 1
+            [Advanced] The stack level of the model.
+            Model's that are not stacker models are always `level=1`.
+            `level` corresponds to the `Lx` suffix in the model name. For example, `WeightedEnsemble_L2` would have `level=2`.
+
+        Returns
+        -------
+        early_stop : bool
+            If True, the trainer stops training additional models and ends the fit process immediately.
+            If False, the trainer continues with its normal logic.
+        """
+        raise NotImplementedError

--- a/core/src/autogluon/core/callbacks/_abstract_callback.py
+++ b/core/src/autogluon/core/callbacks/_abstract_callback.py
@@ -7,6 +7,20 @@ from ..trainer import AbstractTrainer
 
 
 class AbstractCallback(object, metaclass=ABCMeta):
+    """
+    Abstract callback class for AutoGluon's TabularPredictor.
+    The inner API and logic within `trainer` is considered private API. It may change without warning between releases.
+
+    Examples
+    --------
+    >>> from autogluon.core.callbacks import ExampleCallback
+    >>> from autogluon.tabular import TabularDataset, TabularPredictor
+    >>> callbacks = [ExampleCallback()]
+    >>> train_data = TabularDataset('https://autogluon.s3.amazonaws.com/datasets/Inc/train.csv')
+    >>> label = 'class'
+    >>> predictor = TabularPredictor(label=label).fit(train_data, callbacks=callbacks)
+    """
+
     @abstractmethod
     def before_fit(
         self,

--- a/core/src/autogluon/core/callbacks/_abstract_callback.py
+++ b/core/src/autogluon/core/callbacks/_abstract_callback.py
@@ -22,6 +22,7 @@ class AbstractCallback(object, metaclass=ABCMeta):
     >>> label = 'class'
     >>> predictor = TabularPredictor(label=label).fit(train_data, callbacks=callbacks)
     """
+
     def __init__(
         self,
         allow_recursive_calls: bool = False,

--- a/core/src/autogluon/core/callbacks/_abstract_callback.py
+++ b/core/src/autogluon/core/callbacks/_abstract_callback.py
@@ -13,7 +13,7 @@ class AbstractCallback(object, metaclass=ABCMeta):
     Abstract callback class for AutoGluon's TabularPredictor.
     The inner API and logic within `trainer` is considered private API. It may change without warning between releases.
 
-    Parameters
+    Attributes
     ----------
     allow_recursive_calls : bool, default = False
         If True, will allow recursive calls to this callback.
@@ -37,15 +37,10 @@ class AbstractCallback(object, metaclass=ABCMeta):
     >>> predictor = TabularPredictor(label=label).fit(train_data, callbacks=callbacks)
     """
 
-    def __init__(
-        self,
-        allow_recursive_calls: bool = False,
-        skip_if_trainer_stopped: bool = False,
-    ):
-        assert isinstance(allow_recursive_calls, bool)
-        assert isinstance(skip_if_trainer_stopped, bool)
-        self.allow_recursive_calls = allow_recursive_calls
-        self.skip_if_trainer_stopped = skip_if_trainer_stopped
+    allow_recursive_calls: bool = False
+    skip_if_trainer_stopped: bool = False
+
+    def __init__(self):
         self._skip = False
 
     def before_trainer_fit(self, trainer: AbstractTrainer, **kwargs):

--- a/core/src/autogluon/core/callbacks/_abstract_callback.py
+++ b/core/src/autogluon/core/callbacks/_abstract_callback.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import typing
 from abc import ABCMeta
 
 from ..models import AbstractModel
-from ..trainer import AbstractTrainer
+
+if typing.TYPE_CHECKING:
+    # avoid circular import for type hints
+    from ..trainer import AbstractTrainer
 
 
 # TODO: Open design questions:

--- a/core/src/autogluon/core/callbacks/_early_stopping_callback.py
+++ b/core/src/autogluon/core/callbacks/_early_stopping_callback.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from logging import Logger
-from typing import Tuple
 
 from ..trainer import AbstractTrainer
 from ._abstract_callback import AbstractCallback
@@ -8,9 +9,11 @@ from ._abstract_callback import AbstractCallback
 class EarlyStoppingCallback(AbstractCallback):
     """
     A simple early stopping callback.
-
     Will early stop AutoGluon's training process after `patience` number of models fitted sequentially without improvement to score_val.
+    Sensitive to `infer_limit` if it was specified in the fit call. Will not consider models that go above the infer_limit.
+
     [Note] This callback is primarily for example purposes. Using this callback as-is will likely lead to a performance drop in AutoGluon.
+    For better results, consider using `EarlyStoppingEnsembleCallback`.
 
     Parameters
     ----------
@@ -31,55 +34,86 @@ class EarlyStoppingCallback(AbstractCallback):
         self.patience_per_level = patience_per_level
         self.last_improvement = 0
         self.last_level = None
-        # TODO: Better logging when `patience_per_level=True`
+        self.logged_stopping_msg = False  # skips logging if True
         self.score_best = None
         self.verbose = verbose
         self.model_best: str | None = None
 
-    def _before_fit(self, logger: Logger, stack_name: str, level: int, **kwargs) -> Tuple[bool, bool]:
+        # Set in `before_trainer_fit` call
+        self.infer_limit = None
+
+    def before_trainer_fit(self, trainer: AbstractTrainer, **kwargs):
+        self.infer_limit = kwargs.get("infer_limit", None)
+
+    def _before_model_fit(self, trainer: AbstractTrainer, stack_name: str, level: int, **kwargs) -> tuple[bool, bool]:
         if self.patience_per_level and (self.last_level is None or self.last_level != level):
             self.last_improvement = 0
             self.last_level = level
+            self.logged_stopping_msg = False
         early_stop = self._early_stop()
         if self.verbose and early_stop:
-            msg = f"Stopping trainer fit due to callback early stopping. Reason: No score_val improvement in the past {self.last_improvement} models."
-            self._log(logger, 20, msg=msg)
+            if not self.logged_stopping_msg:
+                self.logged_stopping_msg = True
+                if self.patience_per_level:
+                    msg = (f"Early stopping trainer fit for level={level}. "
+                           f"Reason: No score_val improvement in the past {self.last_improvement} models.")
+                else:
+                    msg = f"Early stopping trainer fit. Reason: No score_val improvement in the past {self.last_improvement} models."
+                self._log(trainer.logger, 20, msg=msg)
         if self.patience_per_level:
             return False, early_stop
         else:
             return early_stop, False
 
-    def _after_fit(self, trainer: AbstractTrainer, logger: Logger, **kwargs) -> bool:
-        self.calc_new_best(trainer=trainer)
-        early_stop = self._early_stop()
+    def _after_model_fit(self, trainer: AbstractTrainer, **kwargs) -> bool:
+        self.calc_new_best(trainer=trainer, **kwargs)
         if self.verbose:
             msg = f"Best Score: {self.score_best:.4f} | Patience: {self.last_improvement}/{self.patience} | Best Model: {self.model_best}"
             if self.last_improvement == 0:
                 msg += " (New Best)"
-            self._log(logger, 20, msg=msg)
-        if self.verbose and early_stop:
-            msg = f"Stopping trainer fit due to callback early stopping. Reason: No score_val improvement in the past {self.last_improvement} models."
-            self._log(logger, 20, msg=msg)
+            self._log(trainer.logger, 20, msg=msg)
         return False
 
-    def calc_new_best(self, trainer: AbstractTrainer):
+    def calc_new_best(self, trainer: AbstractTrainer, **kwargs):
+        """
+        Computes the new best model and validation score, and then resets `self.last_improvement` to 0 if an improvement is observed or increments it otherwise.
+        """
         self._calc_new_best(trainer=trainer)
 
     def _calc_new_best(self, trainer: AbstractTrainer):
-        leaderboard = trainer.leaderboard()
-        if len(leaderboard) == 0:
-            score_cur = None
-            self.model_best = None
-        else:
-            score_cur = leaderboard["score_val"].max()
+        model_cur, score_cur = self._cur_best(trainer=trainer)
         if score_cur is None:
             self.last_improvement += 1
         elif self.score_best is None or score_cur > self.score_best:
             self.score_best = score_cur
-            self.model_best = leaderboard[leaderboard["score_val"] == self.score_best]["model"].iloc[0]
+            self.model_best = model_cur
             self.last_improvement = 0
         else:
             self.last_improvement += 1
+
+    def _cur_best(self, trainer: AbstractTrainer) -> tuple[str, float]:
+        """
+        Returns the current best model in terms of validation score that satisfies `self.infer_limit` (if specified)
+
+        Returns
+        -------
+        model : str
+            The model name with the best validation score.
+            If no models exist, returns None.
+        val_score: float
+            The validation score of `model`.
+            If `model=None`, returns None.
+        """
+        val_score_dict = trainer.get_models_attribute_dict("val_score")
+        if len(val_score_dict) == 0:
+            score_best = None
+            model_best = None
+        else:
+            # TODO: infer_limit_as_child should be controlled by trainer, but currently trainer always uses True
+            #  Trainer should be updated to adjust `infer_limit_as_child` value based on if refit_full is specified.
+            model_best = trainer.get_model_best(can_infer=None, infer_limit=self.infer_limit, infer_limit_as_child=True)
+            score_best = trainer.get_model_attribute(model=model_best, attribute="val_score")
+        return model_best, score_best
 
     def _early_stop(self):
         if self.last_improvement >= self.patience:

--- a/core/src/autogluon/core/callbacks/_early_stopping_callback.py
+++ b/core/src/autogluon/core/callbacks/_early_stopping_callback.py
@@ -16,26 +16,41 @@ class EarlyStoppingCallback(AbstractCallback):
     ----------
     patience : int, default = 10
         The number of models fit in a row without improvement in score_val before early stopping the training process.
+    patience_per_level : bool, default = True
+        If True, patience is reset after each stack level.
+        Instead of stopping the trainer's fit process, reaching patience threshold will instead skip to fitting the next stack layer.
+        If False, the entire trainer fit process will be stopped when reaching threshold, and patience will not be reset after each stack level.
+        It is recommended to keep as `True` for the best result quality.
     verbose : bool, default = True
         If True, will log a stopping message when early stopping triggers.
     """
 
-    def __init__(self, patience: int = 10, verbose: bool = True):
+    def __init__(self, patience: int = 10, patience_per_level: bool = True, verbose: bool = True, **kwargs):
+        super().__init__(**kwargs)
         self.patience = patience
+        self.patience_per_level = patience_per_level
         self.last_improvement = 0
+        self.last_level = None
+        # TODO: Better logging when `patience_per_level=True`
         self.score_best = None
         self.verbose = verbose
         self.model_best: str | None = None
 
-    def before_fit(self, logger: Logger, **kwargs) -> Tuple[bool, bool]:
+    def _before_fit(self, logger: Logger, stack_name: str, level: int, **kwargs) -> Tuple[bool, bool]:
+        if self.patience_per_level and (self.last_level is None or self.last_level != level):
+            self.last_improvement = 0
+            self.last_level = level
         early_stop = self._early_stop()
         if self.verbose and early_stop:
             msg = f"Stopping trainer fit due to callback early stopping. Reason: No score_val improvement in the past {self.last_improvement} models."
             self._log(logger, 20, msg=msg)
-        return early_stop, False
+        if self.patience_per_level:
+            return False, early_stop
+        else:
+            return early_stop, False
 
-    def after_fit(self, trainer: AbstractTrainer, logger: Logger, **kwargs) -> bool:
-        self._calc_new_best(trainer=trainer)
+    def _after_fit(self, trainer: AbstractTrainer, logger: Logger, **kwargs) -> bool:
+        self.calc_new_best(trainer=trainer)
         early_stop = self._early_stop()
         if self.verbose:
             msg = f"Best Score: {self.score_best:.4f} | Patience: {self.last_improvement}/{self.patience} | Best Model: {self.model_best}"
@@ -45,7 +60,10 @@ class EarlyStoppingCallback(AbstractCallback):
         if self.verbose and early_stop:
             msg = f"Stopping trainer fit due to callback early stopping. Reason: No score_val improvement in the past {self.last_improvement} models."
             self._log(logger, 20, msg=msg)
-        return early_stop
+        return False
+
+    def calc_new_best(self, trainer: AbstractTrainer):
+        self._calc_new_best(trainer=trainer)
 
     def _calc_new_best(self, trainer: AbstractTrainer):
         leaderboard = trainer.leaderboard()

--- a/core/src/autogluon/core/callbacks/_early_stopping_callback.py
+++ b/core/src/autogluon/core/callbacks/_early_stopping_callback.py
@@ -55,8 +55,7 @@ class EarlyStoppingCallback(AbstractCallback):
             if not self.logged_stopping_msg:
                 self.logged_stopping_msg = True
                 if self.patience_per_level:
-                    msg = (f"Early stopping trainer fit for level={level}. "
-                           f"Reason: No score_val improvement in the past {self.last_improvement} models.")
+                    msg = f"Early stopping trainer fit for level={level}. " f"Reason: No score_val improvement in the past {self.last_improvement} models."
                 else:
                     msg = f"Early stopping trainer fit. Reason: No score_val improvement in the past {self.last_improvement} models."
                 self._log(trainer.logger, 20, msg=msg)

--- a/core/src/autogluon/core/callbacks/_early_stopping_callback.py
+++ b/core/src/autogluon/core/callbacks/_early_stopping_callback.py
@@ -10,20 +10,22 @@ class EarlyStoppingCallback(AbstractCallback):
     A simple early stopping callback.
 
     Will early stop AutoGluon's training process after `patience` number of models fitted sequentially without improvement to score_val.
+    [Note] This callback is primarily for example purposes. Using this callback as-is will likely lead to a performance drop in AutoGluon.
 
     Parameters
     ----------
     patience : int, default = 10
         The number of models fit in a row without improvement in score_val before early stopping the training process.
-    verbose : bool, default = False
+    verbose : bool, default = True
         If True, will log a stopping message when early stopping triggers.
     """
 
-    def __init__(self, patience: int = 10, verbose: bool = False):
+    def __init__(self, patience: int = 10, verbose: bool = True):
         self.patience = patience
         self.last_improvement = 0
         self.score_best = None
         self.verbose = verbose
+        self.model_best: str | None = None
 
     def before_fit(self, logger: Logger, **kwargs) -> Tuple[bool, bool]:
         early_stop = self._early_stop()
@@ -35,6 +37,11 @@ class EarlyStoppingCallback(AbstractCallback):
     def after_fit(self, trainer: AbstractTrainer, logger: Logger, **kwargs) -> bool:
         self._calc_new_best(trainer=trainer)
         early_stop = self._early_stop()
+        if self.verbose:
+            msg = f"Best Score: {self.score_best:.4f} | Patience: {self.last_improvement}/{self.patience} | Best Model: {self.model_best}"
+            if self.last_improvement == 0:
+                msg += " (New Best)"
+            self._log(logger, 20, msg=msg)
         if self.verbose and early_stop:
             msg = f"Stopping trainer fit due to callback early stopping. Reason: No score_val improvement in the past {self.last_improvement} models."
             self._log(logger, 20, msg=msg)
@@ -44,12 +51,14 @@ class EarlyStoppingCallback(AbstractCallback):
         leaderboard = trainer.leaderboard()
         if len(leaderboard) == 0:
             score_cur = None
+            self.model_best = None
         else:
             score_cur = leaderboard["score_val"].max()
         if score_cur is None:
             self.last_improvement += 1
         elif self.score_best is None or score_cur > self.score_best:
             self.score_best = score_cur
+            self.model_best = leaderboard[leaderboard["score_val"] == self.score_best]["model"].iloc[0]
             self.last_improvement = 0
         else:
             self.last_improvement += 1

--- a/core/src/autogluon/core/callbacks/_early_stopping_callback.py
+++ b/core/src/autogluon/core/callbacks/_early_stopping_callback.py
@@ -47,7 +47,7 @@ class EarlyStoppingCallback(AbstractCallback):
     def before_trainer_fit(self, trainer: AbstractTrainer, **kwargs):
         self.infer_limit = kwargs.get("infer_limit", None)
 
-    def _before_model_fit(self, trainer: AbstractTrainer, *, stack_name: str, level: int, **kwargs) -> tuple[bool, bool]:
+    def _before_model_fit(self, trainer: AbstractTrainer, stack_name: str = "core", level: int = 1, **kwargs) -> tuple[bool, bool]:
         if self.patience_per_level and (self.last_level is None or self.last_level != level):
             self.last_improvement = 0
             self.last_level = level

--- a/core/src/autogluon/core/callbacks/_early_stopping_callback.py
+++ b/core/src/autogluon/core/callbacks/_early_stopping_callback.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import typing
 from logging import Logger
 
-from ..trainer import AbstractTrainer
 from ._abstract_callback import AbstractCallback
+
+if typing.TYPE_CHECKING:
+    # avoid circular import for type hints
+    from ..trainer import AbstractTrainer
 
 
 class EarlyStoppingCallback(AbstractCallback):

--- a/core/src/autogluon/core/callbacks/_early_stopping_callback.py
+++ b/core/src/autogluon/core/callbacks/_early_stopping_callback.py
@@ -1,0 +1,68 @@
+from logging import Logger
+from typing import Tuple
+
+from ..trainer import AbstractTrainer
+from ._abstract_callback import AbstractCallback
+
+
+class EarlyStoppingCallback(AbstractCallback):
+    """
+    A simple early stopping callback.
+
+    Will early stop AutoGluon's training process after `patience` number of models fitted sequentially without improvement to score_val.
+
+    Parameters
+    ----------
+    patience : int, default = 10
+        The number of models fit in a row without improvement in score_val before early stopping the training process.
+    verbose : bool, default = False
+        If True, will log a stopping message when early stopping triggers.
+    """
+
+    def __init__(self, patience: int = 10, verbose: bool = False):
+        self.patience = patience
+        self.last_improvement = 0
+        self.score_best = None
+        self.verbose = verbose
+
+    def before_fit(self, logger: Logger, **kwargs) -> Tuple[bool, bool]:
+        early_stop = self._early_stop()
+        if self.verbose and early_stop:
+            msg = f"Stopping trainer fit due to callback early stopping. Reason: No score_val improvement in the past {self.last_improvement} models."
+            self._log(logger, 20, msg=msg)
+        return early_stop, False
+
+    def after_fit(self, trainer: AbstractTrainer, logger: Logger, **kwargs) -> bool:
+        self._calc_new_best(trainer=trainer)
+        early_stop = self._early_stop()
+        if self.verbose and early_stop:
+            msg = f"Stopping trainer fit due to callback early stopping. Reason: No score_val improvement in the past {self.last_improvement} models."
+            self._log(logger, 20, msg=msg)
+        return early_stop
+
+    def _calc_new_best(self, trainer: AbstractTrainer):
+        leaderboard = trainer.leaderboard()
+        if len(leaderboard) == 0:
+            score_cur = None
+        else:
+            score_cur = leaderboard["score_val"].max()
+        if score_cur is None:
+            self.last_improvement += 1
+        elif self.score_best is None or score_cur > self.score_best:
+            self.score_best = score_cur
+            self.last_improvement = 0
+        else:
+            self.last_improvement += 1
+
+    def _early_stop(self):
+        if self.last_improvement >= self.patience:
+            return True
+        else:
+            return False
+
+    def _log(self, logger: Logger, level, msg: str):
+        msg = f"{self.__class__.__name__}: {msg}"
+        logger.log(
+            level,
+            msg,
+        )

--- a/core/src/autogluon/core/callbacks/_early_stopping_callback.py
+++ b/core/src/autogluon/core/callbacks/_early_stopping_callback.py
@@ -28,8 +28,10 @@ class EarlyStoppingCallback(AbstractCallback):
         If True, will log a stopping message when early stopping triggers.
     """
 
-    def __init__(self, patience: int = 10, patience_per_level: bool = True, verbose: bool = True, **kwargs):
-        super().__init__(**kwargs)
+    skip_if_trainer_stopped: bool = True
+
+    def __init__(self, patience: int = 10, patience_per_level: bool = True, verbose: bool = True):
+        super().__init__()
         self.patience = patience
         self.patience_per_level = patience_per_level
         self.last_improvement = 0
@@ -45,7 +47,7 @@ class EarlyStoppingCallback(AbstractCallback):
     def before_trainer_fit(self, trainer: AbstractTrainer, **kwargs):
         self.infer_limit = kwargs.get("infer_limit", None)
 
-    def _before_model_fit(self, trainer: AbstractTrainer, stack_name: str, level: int, **kwargs) -> tuple[bool, bool]:
+    def _before_model_fit(self, trainer: AbstractTrainer, *, stack_name: str, level: int, **kwargs) -> tuple[bool, bool]:
         if self.patience_per_level and (self.last_level is None or self.last_level != level):
             self.last_improvement = 0
             self.last_level = level

--- a/core/src/autogluon/core/callbacks/_early_stopping_ensemble_callback.py
+++ b/core/src/autogluon/core/callbacks/_early_stopping_ensemble_callback.py
@@ -35,6 +35,8 @@ class EarlyStoppingEnsembleCallback(EarlyStoppingCallback):
             return
         use_val = trainer._X_val_saved and trainer._y_val_saved
 
+        # TODO: Can optimize this with some code refactoring in AbstractTrainer
+        #  It shouldn't be necessary to load `X` since the features are not used by the weighted ensemble.
         if use_val:  # holdout
             X = trainer.load_X_val()
             y = trainer.load_y_val()

--- a/core/src/autogluon/core/callbacks/_early_stopping_ensemble_callback.py
+++ b/core/src/autogluon/core/callbacks/_early_stopping_ensemble_callback.py
@@ -20,10 +20,11 @@ class EarlyStoppingEnsembleCallback(EarlyStoppingCallback):
         super().before_trainer_fit(trainer=trainer, **kwargs)
         self.infer_limit_batch_size = kwargs.get("infer_limit_batch_size", None)
 
-    def calc_new_best(self, trainer: AbstractTrainer, stack_name: str = "core", **kwargs):
-        if stack_name == "core":
+    def calc_new_best(self, trainer: AbstractTrainer, **kwargs):
+        if kwargs["stack_name"] == "core" and len(kwargs["model_names"]) != 0:
+            # only fit weighted ensemble if stack_name == "core" and at least one new model has been fit.
             self._fit_weighted_ensemble(trainer=trainer)
-        return super().calc_new_best(trainer=trainer)
+        return super().calc_new_best(trainer=trainer, **kwargs)
 
     def _fit_weighted_ensemble(self, trainer: AbstractTrainer):
         """

--- a/core/src/autogluon/core/callbacks/_early_stopping_ensemble_callback.py
+++ b/core/src/autogluon/core/callbacks/_early_stopping_ensemble_callback.py
@@ -9,6 +9,7 @@ class EarlyStoppingEnsembleCallback(EarlyStoppingCallback):
     Identical to `EarlyStoppingCallback`, except that it fits a weighted ensemble model after every normal model fit.
     This should generally lead to a better solution than the simpler `EarlyStoppingCallback` because it captures the improvement in the ensemble strength.
     """
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 

--- a/core/src/autogluon/core/callbacks/_early_stopping_ensemble_callback.py
+++ b/core/src/autogluon/core/callbacks/_early_stopping_ensemble_callback.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from ..trainer import AbstractTrainer
+from ._early_stopping_callback import EarlyStoppingCallback
+
+
+class EarlyStoppingEnsembleCallback(EarlyStoppingCallback):
+    """
+    Identical to `EarlyStoppingCallback`, except that it fits a weighted ensemble model after every normal model fit.
+    This should generally lead to a better solution than the simpler `EarlyStoppingCallback` because it captures the improvement in the ensemble strength.
+    """
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        # Set in `before_trainer_fit` call
+        self.infer_limit_batch_size = None
+
+    def before_trainer_fit(self, trainer: AbstractTrainer, **kwargs):
+        super().before_trainer_fit(trainer=trainer, **kwargs)
+        self.infer_limit_batch_size = kwargs.get("infer_limit_batch_size", None)
+
+    def calc_new_best(self, trainer: AbstractTrainer, stack_name: str = "core", **kwargs):
+        if stack_name == "core":
+            self._fit_weighted_ensemble(trainer=trainer)
+        return super().calc_new_best(trainer=trainer)
+
+    def _fit_weighted_ensemble(self, trainer: AbstractTrainer):
+        """
+        Fits a weighted ensemble using the available models.
+        """
+        base_model_names = trainer.get_model_names(stack_name="core")
+        if len(base_model_names) < 2:
+            # Skip ensemble fitting if 0 or 1 base models exist (no benefit to gain).
+            return
+        use_val = trainer._X_val_saved and trainer._y_val_saved
+
+        if use_val:  # holdout
+            X = trainer.load_X_val()
+            y = trainer.load_y_val()
+            fit = False
+        else:  # out-of-fold
+            X = trainer.load_X()
+            y = trainer.load_y()
+            fit = True
+        time_limit = trainer.time_left
+        if time_limit is not None:
+            time_limit = min(time_limit * 0.9, 360.0)
+        # Fit weighted ensemble
+        trainer.stack_new_level_aux(
+            X=X,
+            y=y,
+            base_model_names=base_model_names,
+            fit=fit,
+            infer_limit=self.infer_limit,
+            infer_limit_batch_size=self.infer_limit_batch_size,
+            time_limit=time_limit,
+            name_extra="_ES",
+        )

--- a/core/src/autogluon/core/callbacks/_early_stopping_ensemble_callback.py
+++ b/core/src/autogluon/core/callbacks/_early_stopping_ensemble_callback.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
-from ..trainer import AbstractTrainer
+import typing
+
 from ._early_stopping_callback import EarlyStoppingCallback
+
+if typing.TYPE_CHECKING:
+    # avoid circular import for type hints
+    from ..trainer import AbstractTrainer
 
 
 class EarlyStoppingEnsembleCallback(EarlyStoppingCallback):

--- a/core/src/autogluon/core/callbacks/_example_callback.py
+++ b/core/src/autogluon/core/callbacks/_example_callback.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import time
+import typing
 
 import pandas as pd
 
 from ..models import AbstractModel
-from ..trainer import AbstractTrainer
 from ._abstract_callback import AbstractCallback
+
+if typing.TYPE_CHECKING:
+    # avoid circular import for type hints
+    from ..trainer import AbstractTrainer
 
 
 class ExampleCallback(AbstractCallback):

--- a/core/src/autogluon/core/callbacks/_example_callback.py
+++ b/core/src/autogluon/core/callbacks/_example_callback.py
@@ -1,6 +1,6 @@
+from __future__ import annotations
+
 import time
-from logging import Logger
-from typing import List, Tuple
 
 import pandas as pd
 
@@ -14,16 +14,15 @@ class ExampleCallback(AbstractCallback):
     Example callback showcasing how to access and log information from the trainer.
     """
 
-    def _before_fit(
+    def _before_model_fit(
         self,
         trainer: AbstractTrainer,
         model: AbstractModel,
-        logger: Logger,
         time_limit: float | None = None,
         stack_name: str = "core",
         level: int = 1,
         **kwargs,
-    ) -> Tuple[bool, bool]:
+    ) -> tuple[bool, bool]:
         time_limit_trainer = trainer._time_limit
         if time_limit_trainer is not None and trainer._time_train_start is not None:
             time_left_total = time_limit_trainer - (time.time() - trainer._time_train_start)
@@ -34,9 +33,9 @@ class ExampleCallback(AbstractCallback):
         time_limit_trainer_log = f"\ttime_limit = {time_limit_trainer:.1f}\t(trainer)\n" if time_limit_trainer else ""
         time_left_log = f"\ttime_left  = {time_left_total:.1f}\t(trainer)\n" if time_left_total else ""
         time_used_log = f"\ttime_used  = {time_limit_trainer - time_left_total:.1f}\t(trainer)\n" if time_limit_trainer else ""
-        logger.log(
+        trainer.log(
             20,
-            f"{self.__class__.__name__}: before_fit\n"
+            f"{self.__class__.__name__}.before_model_fit\n"
             f"\tmodel      = {model.name}\n"
             f"{time_limit_log}"
             f"{time_limit_trainer_log}"
@@ -49,12 +48,19 @@ class ExampleCallback(AbstractCallback):
 
         return False, False
 
-    def _after_fit(
+    def _after_model_fit(
         self,
         trainer: AbstractTrainer,
-        logger: Logger,
         **kwargs,
     ) -> bool:
         with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
-            logger.log(20, f"{self.__class__.__name__}: after_fit | Leaderboard:\n{trainer.leaderboard()}")
+            trainer.log(20, f"{self.__class__.__name__}.after_model_fit | Leaderboard:\n{trainer.leaderboard()}")
         return False
+
+    def before_trainer_fit(self, trainer: AbstractTrainer, **kwargs):
+        trainer.log(20, f"{self.__class__.__name__}.before_trainer_fit | kwargs:\n")
+        for k, v in kwargs.items():
+            trainer.log(20, f"\t{k}={v}")
+
+    def after_trainer_fit(self, trainer: AbstractTrainer):
+        trainer.log(20, f"{self.__class__.__name__}.after_trainer_fit | Training Complete")

--- a/core/src/autogluon/core/callbacks/_example_callback.py
+++ b/core/src/autogluon/core/callbacks/_example_callback.py
@@ -14,7 +14,7 @@ class ExampleCallback(AbstractCallback):
     Example callback showcasing how to access and log information from the trainer.
     """
 
-    def before_fit(
+    def _before_fit(
         self,
         trainer: AbstractTrainer,
         model: AbstractModel,
@@ -49,7 +49,7 @@ class ExampleCallback(AbstractCallback):
 
         return False, False
 
-    def after_fit(
+    def _after_fit(
         self,
         trainer: AbstractTrainer,
         logger: Logger,

--- a/core/src/autogluon/core/callbacks/_example_callback.py
+++ b/core/src/autogluon/core/callbacks/_example_callback.py
@@ -1,0 +1,60 @@
+import time
+from logging import Logger
+from typing import List, Tuple
+
+import pandas as pd
+
+from ..models import AbstractModel
+from ..trainer import AbstractTrainer
+from ._abstract_callback import AbstractCallback
+
+
+class ExampleCallback(AbstractCallback):
+    """
+    Example callback showcasing how to access and log information from the trainer.
+    """
+
+    def before_fit(
+        self,
+        trainer: AbstractTrainer,
+        model: AbstractModel,
+        logger: Logger,
+        time_limit: float | None = None,
+        stack_name: str = "core",
+        level: int = 1,
+        **kwargs,
+    ) -> Tuple[bool, bool]:
+        time_limit_trainer = trainer._time_limit
+        if time_limit_trainer is not None and trainer._time_train_start is not None:
+            time_left_total = time_limit_trainer - (time.time() - trainer._time_train_start)
+        else:
+            time_left_total = None
+
+        time_limit_log = f"\ttime_limit = {time_limit:.1f}\t(model)\n" if time_limit else ""
+        time_limit_trainer_log = f"\ttime_limit = {time_limit_trainer:.1f}\t(trainer)\n" if time_limit_trainer else ""
+        time_left_log = f"\ttime_left  = {time_left_total:.1f}\t(trainer)\n" if time_left_total else ""
+        time_used_log = f"\ttime_used  = {time_limit_trainer - time_left_total:.1f}\t(trainer)\n" if time_limit_trainer else ""
+        logger.log(
+            20,
+            f"{self.__class__.__name__}: before_fit\n"
+            f"\tmodel      = {model.name}\n"
+            f"{time_limit_log}"
+            f"{time_limit_trainer_log}"
+            f"{time_left_log}"
+            f"{time_used_log}"
+            f"\tmodels_fit = {len(trainer.get_model_names())}\n"
+            f"\tstack_name = {stack_name}\n"
+            f"\tlevel      = {level}",
+        )
+
+        return False, False
+
+    def after_fit(
+        self,
+        trainer: AbstractTrainer,
+        logger: Logger,
+        **kwargs,
+    ) -> bool:
+        with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
+            logger.log(20, f"{self.__class__.__name__}: after_fit | Leaderboard:\n{trainer.leaderboard()}")
+        return False

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -9,7 +9,7 @@ import time
 import traceback
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import networkx as nx
 import numpy as np
@@ -219,7 +219,7 @@ class AbstractTrainer:
 
         # self._exceptions_list = []  # TODO: Keep exceptions list for debugging during benchmarking.
 
-        self.callbacks: List[callable] = []
+        self.callbacks: List[Callable] = []
         self._callback_early_stop = False
 
     # path_root is the directory containing learner.pkl
@@ -401,7 +401,7 @@ class AbstractTrainer:
         level_time_modifier=0.333,
         infer_limit=None,
         infer_limit_batch_size=None,
-        callbacks: List[callable] = None,
+        callbacks: List[Callable] = None,
     ) -> List[str]:
         """
         Trains a multi-layer stack ensemble using the input data on the hyperparameters dict input.
@@ -512,7 +512,7 @@ class AbstractTrainer:
         self.save()
         return model_names_fit
 
-    def _fit_setup(self, time_limit: float | None = None, callbacks: List[callable] = None):
+    def _fit_setup(self, time_limit: float | None = None, callbacks: List[Callable] = None):
         """
         Prepare the trainer state at the start of / prior to a fit call.
         Should be paired with a `self._fit_cleanup()` at the conclusion of the fit call.

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -812,7 +812,7 @@ class AbstractTrainer:
         X,
         y,
         base_model_names: List[str],
-        level,
+        level: int | str = "auto",
         fit=True,
         stack_name="aux1",
         time_limit=None,
@@ -841,6 +841,15 @@ class AbstractTrainer:
         if len(base_model_names) == 0:
             logger.log(20, f"No base models to train on, skipping auxiliary stack level {level}...")
             return []
+
+        if isinstance(level, str):
+            assert level == "auto", f"level must be 'auto' if str, found: {level}"
+            levels_dict = self.get_models_attribute_dict(attribute="level", models=base_model_names)
+            base_model_level_max = None
+            for k, v in levels_dict.items():
+                if base_model_level_max is None or v > base_model_level_max:
+                    base_model_level_max = v
+            level = base_model_level_max + 1
 
         if infer_limit_batch_size is not None:
             ag_args_fit = dict()

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -685,6 +685,8 @@ class AbstractTrainer:
         If self.bagged_mode, then models will be trained as StackerEnsembleModels.
         The data provided in this method should not contain stack features, as they will be automatically generated if necessary.
         """
+        if self._callback_early_stop:
+            return []
         if get_models_func is None:
             get_models_func = self.construct_model_templates
         if base_model_names is None:
@@ -825,6 +827,8 @@ class AbstractTrainer:
         Level must be greater than the level of any of the base models.
         Auxiliary models never use the original features and only train with the predictions of other models as features.
         """
+        if self._callback_early_stop:
+            return []
         if fit_weighted_ensemble is False:
             # Skip fitting of aux models
             return []

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -528,6 +528,10 @@ class AbstractTrainer:
         self.reset_callbacks()
         if callbacks is not None:
             assert isinstance(callbacks, list), f"`callbacks` must be a list. Found invalid type: `{type(callbacks)}`."
+            for callback in callbacks:
+                assert isinstance(
+                    callback, AbstractCallback
+                ), f"Elements in `callbacks` must be of type AbstractCallback. Found invalid type: `{type(callback)}`."
         else:
             callbacks = []
         self.callbacks = callbacks

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -7,6 +7,7 @@ import shutil
 import sys
 import time
 import traceback
+import typing
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
@@ -47,6 +48,10 @@ from ..utils.feature_selection import FeatureSelector
 from ..utils.loaders import load_pkl
 from ..utils.savers import save_json, save_pkl
 from .utils import process_hyperparameters
+
+if typing.TYPE_CHECKING:
+    # avoid circular import for type hints
+    from ..callbacks import AbstractCallback
 
 logger = logging.getLogger(__name__)
 
@@ -219,7 +224,7 @@ class AbstractTrainer:
 
         # self._exceptions_list = []  # TODO: Keep exceptions list for debugging during benchmarking.
 
-        self.callbacks: List[Callable] = []
+        self.callbacks: List[AbstractCallback] = []
         self._callback_early_stop = False
 
     # path_root is the directory containing learner.pkl
@@ -401,7 +406,7 @@ class AbstractTrainer:
         level_time_modifier=0.333,
         infer_limit=None,
         infer_limit_batch_size=None,
-        callbacks: List[Callable] = None,
+        callbacks: List[AbstractCallback] = None,
     ) -> List[str]:
         """
         Trains a multi-layer stack ensemble using the input data on the hyperparameters dict input.

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -246,6 +246,20 @@ class AbstractTrainer:
         return self._num_rows_val is not None
 
     @property
+    def time_left(self) -> float | None:
+        """
+        Remaining time left in the fit call.
+        None if time_limit was unspecified.
+        """
+        if self._time_train_start is None:
+            return None
+        elif self._time_limit is None:
+            return None
+        time_elapsed = time.time() - self._time_train_start
+        time_left = self._time_limit - time_elapsed
+        return time_left
+
+    @property
     def logger(self) -> logging.Logger:
         return logger
 

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -28,6 +28,7 @@ from ..augmentation.distill_utils import augment_data, format_distillation_label
 from ..calibrate import calibrate_decision_threshold
 from ..calibrate.conformity_score import compute_conformity_score
 from ..calibrate.temperature_scaling import apply_temperature_scaling, tune_temperature_scaling
+from ..callbacks import AbstractCallback
 from ..constants import AG_ARGS, BINARY, MULTICLASS, QUANTILE, REFIT_FULL_NAME, REFIT_FULL_SUFFIX, REGRESSION, SOFTCLASS
 from ..data.label_cleaner import LabelCleanerMulticlassToBinary
 from ..metrics import Scorer, get_metric
@@ -48,10 +49,6 @@ from ..utils.feature_selection import FeatureSelector
 from ..utils.loaders import load_pkl
 from ..utils.savers import save_json, save_pkl
 from .utils import process_hyperparameters
-
-if typing.TYPE_CHECKING:
-    # avoid circular import for type hints
-    from ..callbacks import AbstractCallback
 
 logger = logging.getLogger(__name__)
 

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -400,6 +400,9 @@ class AbstractTrainer:
         """
         self._fit_setup(time_limit=time_limit, callbacks=callbacks)
         time_train_start = self._time_train_start
+        if callbacks:
+            callback_classes = [c.__class__.__name__ for c in callbacks]
+            logger.log(20, f"User-specified callbacks ({len(callbacks)}): {callback_classes}")
 
         hyperparameters = self._process_hyperparameters(hyperparameters=hyperparameters)
 

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -10,7 +10,7 @@ import traceback
 import typing
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import networkx as nx
 import numpy as np
@@ -517,7 +517,7 @@ class AbstractTrainer:
         self.save()
         return model_names_fit
 
-    def _fit_setup(self, time_limit: float | None = None, callbacks: List[Callable] = None):
+    def _fit_setup(self, time_limit: float | None = None, callbacks: List[AbstractCallback] = None):
         """
         Prepare the trainer state at the start of / prior to a fit call.
         Should be paired with a `self._fit_cleanup()` at the conclusion of the fit call.

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -701,9 +701,10 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             cgroups). Otherwise, AutoGluon might wrongly assume more resources are available for fitting a model than the operating system allows,
             which can result in model training failing or being very inefficient.
         callbacks : List[AbstractCallback], default = None
-            [Experimental] Callback support is preliminary, targeted towards developers, and is subject to change.
-            The API, class structure, and overall functionality may be changed without warning between releases while it remains experimental.
-
+            :::{warning}
+            Callbacks are an experimental feature and may change in future releases without warning.
+            Callback support is preliminary and targeted towards developers.
+            :::
             A list of callback objects inheriting from `autogluon.core.callbacks.AbstractCallback`.
             These objects will be called before and after each model fit within trainer.
             They have the ability to skip models or early stop the training process.

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -25,6 +25,7 @@ from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
 from autogluon.common.utils.system_info import get_ag_system_info
 from autogluon.common.utils.try_import import try_import_ray
 from autogluon.common.utils.utils import check_saved_predictor_version, compare_autogluon_metadata, get_autogluon_metadata, setup_outputdir
+from autogluon.core.callbacks import AbstractCallback
 from autogluon.core.constants import (
     AUTO_WEIGHT,
     BALANCE_WEIGHT,
@@ -403,6 +404,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         num_cpus: int | str = "auto",
         num_gpus: int | str = "auto",
         memory_limit: float | str = "auto",
+        callbacks: List[AbstractCallback] = None,
         **kwargs,
     ) -> "TabularPredictor":
         """
@@ -698,6 +700,21 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             setting the memory limit (and any other resources) on systems with shared resources that are controlled by the operating system (e.g., SLURM and
             cgroups). Otherwise, AutoGluon might wrongly assume more resources are available for fitting a model than the operating system allows,
             which can result in model training failing or being very inefficient.
+        callbacks : List[AbstractCallback], default = None
+            [Experimental] Callback support is preliminary, targeted towards developers, and is subject to change.
+            The API, class structure, and overall functionality may be changed without warning between releases while it remains experimental.
+
+            A list of callback objects inheriting from `autogluon.core.callbacks.AbstractCallback`.
+            These objects will be called before and after each model fit within trainer.
+            They have the ability to skip models or early stop the training process.
+            They can also theoretically change the entire logical flow of the trainer code by interacting with the passed `trainer` object.
+            For more details, refer to `AbstractCallback` source code.
+            If None, no callback objects will be used.
+
+            [Note] Callback objects can be mutated in-place by the fit call if they are stateful.
+            Ensure that you avoid re-using a mutated callback object between multiple fit calls.
+
+            [Note] Callback objects are deleted from trainer at the end of the fit call. They will not impact operations such as `refit_full` or `fit_extra`.
         **kwargs :
             auto_stack : bool, default = False
                 Whether AutoGluon should automatically utilize bagging and multi-layer stack ensembling to boost predictive accuracy.
@@ -1177,6 +1194,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             infer_limit_batch_size=infer_limit_batch_size,
             verbosity=verbosity,
             use_bag_holdout=use_bag_holdout,
+            callbacks=callbacks,
         )
         ag_post_fit_kwargs = dict(
             keep_only_best=kwargs["keep_only_best"],

--- a/tabular/src/autogluon/tabular/trainer/auto_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/auto_trainer.py
@@ -58,6 +58,7 @@ class AutoTrainer(AbstractTrainer):
         infer_limit_batch_size=None,
         use_bag_holdout=False,
         groups=None,
+        callbacks: List[callable] = None,
         **kwargs,
     ):
         for key in kwargs:
@@ -147,6 +148,7 @@ class AutoTrainer(AbstractTrainer):
             infer_limit=infer_limit,
             infer_limit_batch_size=infer_limit_batch_size,
             groups=groups,
+            callbacks=callbacks,
         )
 
     def construct_model_templates_distillation(self, hyperparameters, **kwargs):

--- a/tabular/tests/unittests/callbacks/test_callbacks.py
+++ b/tabular/tests/unittests/callbacks/test_callbacks.py
@@ -44,7 +44,7 @@ def test_early_stopping_callback_v2(fit_helper):
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=6, refit_full=False)
 
     assert callback.model_best == "DummyModel_BAG_L1"
-    assert callback.score_best == 0.744
+    assert callback.score_best == 0.76
     assert callback.infer_limit is None
 
 
@@ -70,7 +70,7 @@ def test_early_stopping_callback_v3(fit_helper):
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=3, refit_full=False)
 
     assert callback.model_best == "DummyModel_BAG_L1"
-    assert callback.score_best == 0.744
+    assert callback.score_best == 0.76
     assert callback.infer_limit is None
 
 
@@ -116,7 +116,7 @@ def test_early_stopping_ensemble_callback_v2(fit_helper):
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=9, refit_full=False)
 
     assert callback.model_best == "DummyModel_BAG_L1"
-    assert callback.score_best == 0.744
+    assert callback.score_best == 0.76
     assert callback.infer_limit is None
     assert callback.infer_limit_batch_size is None
 
@@ -143,6 +143,6 @@ def test_early_stopping_ensemble_callback_v3(fit_helper):
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=5, refit_full=False)
 
     assert callback.model_best == "DummyModel_BAG_L1"
-    assert callback.score_best == 0.744
+    assert callback.score_best == 0.76
     assert callback.infer_limit is None
     assert callback.infer_limit_batch_size is None

--- a/tabular/tests/unittests/callbacks/test_callbacks.py
+++ b/tabular/tests/unittests/callbacks/test_callbacks.py
@@ -1,0 +1,148 @@
+from autogluon.core.callbacks import EarlyStoppingCallback, EarlyStoppingEnsembleCallback, ExampleCallback
+from autogluon.core.models import DummyModel
+from autogluon.tabular.models.lgb.lgb_model import LGBModel
+
+
+def test_early_stopping_callback(fit_helper):
+    callback = EarlyStoppingCallback()
+
+    fit_args = dict(
+        hyperparameters={
+            DummyModel: {},
+            LGBModel: {},
+        },
+        infer_limit=100,
+        infer_limit_batch_size=1000,
+        callbacks=[callback],
+    )
+    dataset_name = "adult"
+
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=3, refit_full=False)
+
+    assert callback.model_best == "LightGBM"
+    assert callback.infer_limit is not None
+
+
+def test_early_stopping_callback_v2(fit_helper):
+    """
+    Tests EarlyStoppingCallback early stops prior to fitting LightGBM.
+    Tests `patience_per_level=True`
+    """
+    callback = EarlyStoppingCallback(patience=2, patience_per_level=True)
+
+    fit_args = dict(
+        hyperparameters={
+            DummyModel: [{}, {}, {}, {}],
+            LGBModel: {},
+        },
+        callbacks=[callback],
+        num_bag_folds=2,
+        num_stack_levels=1,
+    )
+    dataset_name = "adult"
+
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=6, refit_full=False)
+
+    assert callback.model_best == "DummyModel_BAG_L1"
+    assert callback.score_best == 0.744
+    assert callback.infer_limit is None
+
+
+def test_early_stopping_callback_v3(fit_helper):
+    """
+    Test EarlyStoppingCallback early stops prior to fitting LightGBM.
+    Tests `patience_per_level=False`
+    Tests passing multiple callbacks.
+    """
+    callback = EarlyStoppingCallback(patience=2, patience_per_level=False)
+
+    fit_args = dict(
+        hyperparameters={
+            DummyModel: [{}, {}, {}, {}],
+            LGBModel: {},
+        },
+        callbacks=[callback, ExampleCallback()],
+        num_bag_folds=2,
+        num_stack_levels=1,
+    )
+    dataset_name = "adult"
+
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=3, refit_full=False)
+
+    assert callback.model_best == "DummyModel_BAG_L1"
+    assert callback.score_best == 0.744
+    assert callback.infer_limit is None
+
+
+def test_early_stopping_ensemble_callback(fit_helper):
+    callback = EarlyStoppingEnsembleCallback()
+
+    fit_args = dict(
+        hyperparameters={
+            DummyModel: {},
+            LGBModel: {},
+        },
+        infer_limit=100,
+        infer_limit_batch_size=1000,
+        callbacks=[callback],
+    )
+    dataset_name = "adult"
+
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=4, refit_full=False)
+
+    assert callback.model_best == "LightGBM"
+    assert callback.infer_limit is not None
+    assert callback.infer_limit_batch_size == 1000
+
+
+def test_early_stopping_ensemble_callback_v2(fit_helper):
+    """
+    Tests EarlyStoppingEnsembleCallback early stops prior to fitting LightGBM.
+    Tests `patience_per_level=True`
+    """
+    callback = EarlyStoppingEnsembleCallback(patience=2, patience_per_level=True)
+
+    fit_args = dict(
+        hyperparameters={
+            DummyModel: [{}, {}, {}, {}],
+            LGBModel: {},
+        },
+        callbacks=[callback],
+        num_bag_folds=2,
+        num_stack_levels=1,
+    )
+    dataset_name = "adult"
+
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=9, refit_full=False)
+
+    assert callback.model_best == "DummyModel_BAG_L1"
+    assert callback.score_best == 0.744
+    assert callback.infer_limit is None
+    assert callback.infer_limit_batch_size is None
+
+
+def test_early_stopping_ensemble_callback_v3(fit_helper):
+    """
+    Test EarlyStoppingEnsembleCallback early stops prior to fitting LightGBM.
+    Tests `patience_per_level=False`
+    Tests passing multiple callbacks.
+    """
+    callback = EarlyStoppingEnsembleCallback(patience=2, patience_per_level=False)
+
+    fit_args = dict(
+        hyperparameters={
+            DummyModel: [{}, {}, {}, {}],
+            LGBModel: {},
+        },
+        callbacks=[callback, ExampleCallback()],
+        num_bag_folds=2,
+        num_stack_levels=1,
+    )
+    dataset_name = "adult"
+
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=5, refit_full=False)
+
+    assert callback.model_best == "DummyModel_BAG_L1"
+    assert callback.score_best == 0.744
+    assert callback.infer_limit is None
+    assert callback.infer_limit_batch_size is None


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add initial callbacks support to TabularPredictor
- Callbacks allow users to inject custom logic into the training process, and theoretically allow the user to completely override the training logic with their own custom logic.

Example Code:

```
import pandas as pd
from autogluon.tabular import TabularPredictor

from autogluon.core.callbacks import EarlyStoppingCallback


if __name__ == '__main__':
    label = 'class'
    train_data = pd.read_csv('https://autogluon.s3.amazonaws.com/datasets/Inc/train.csv')

    callbacks = [EarlyStoppingCallback(patience=3)]
    predictor = TabularPredictor(label=label).fit(train_data=train_data, callbacks=callbacks)
```

Example Output:

```
...
User-specified callbacks (1): ['EarlyStoppingCallback']
Fitting 13 L1 models ...
Fitting model: KNeighborsUnif ...
	0.7736	 = Validation score   (accuracy)
	1.63s	 = Training   runtime
	0.02s	 = Validation runtime
EarlyStoppingCallback: Best Score: 0.7736 | Patience: 0/3 | Best Model: KNeighborsUnif (New Best)
Fitting model: KNeighborsDist ...
	0.7652	 = Validation score   (accuracy)
	0.2s	 = Training   runtime
	0.01s	 = Validation runtime
EarlyStoppingCallback: Best Score: 0.7736 | Patience: 1/3 | Best Model: KNeighborsUnif
Fitting model: LightGBMXT ...
	0.8792	 = Validation score   (accuracy)
	1.74s	 = Training   runtime
	0.0s	 = Validation runtime
EarlyStoppingCallback: Best Score: 0.8792 | Patience: 0/3 | Best Model: LightGBMXT (New Best)
Fitting model: LightGBM ...
	0.8824	 = Validation score   (accuracy)
	1.37s	 = Training   runtime
	0.0s	 = Validation runtime
EarlyStoppingCallback: Best Score: 0.8824 | Patience: 0/3 | Best Model: LightGBM (New Best)
Fitting model: RandomForestGini ...
	0.8612	 = Validation score   (accuracy)
	0.91s	 = Training   runtime
	0.08s	 = Validation runtime
EarlyStoppingCallback: Best Score: 0.8824 | Patience: 1/3 | Best Model: LightGBM
Fitting model: RandomForestEntr ...
	0.8584	 = Validation score   (accuracy)
	1.0s	 = Training   runtime
	0.09s	 = Validation runtime
EarlyStoppingCallback: Best Score: 0.8824 | Patience: 2/3 | Best Model: LightGBM
Fitting model: CatBoost ...
	0.8824	 = Validation score   (accuracy)
	6.89s	 = Training   runtime
	0.01s	 = Validation runtime
EarlyStoppingCallback: Best Score: 0.8824 | Patience: 3/3 | Best Model: LightGBM
EarlyStoppingCallback: Early stopping trainer fit for level=1. Reason: No score_val improvement in the past 3 models.
Fitting model: WeightedEnsemble_L2 ...
	Ensemble Weights: {'CatBoost': 0.5, 'LightGBM': 0.45, 'KNeighborsUnif': 0.05}
	0.886	 = Validation score   (accuracy)
	0.06s	 = Training   runtime
	0.0s	 = Validation runtime
EarlyStoppingCallback: Best Score: 0.8860 | Patience: 0/3 | Best Model: WeightedEnsemble_L2 (New Best)
AutoGluon training complete, total runtime = 15.16s ... Best model: WeightedEnsemble_L2 | Estimated inference throughput: 69200.6 rows/s (2500 batch size)
TabularPredictor saved. To load, use: predictor = TabularPredictor.load("AutogluonModels/ag-20240730_021147")
```

TODO:
- [x] Add PR description
- [x] Add example callback
- [x] Add unit tests
- [x] Add docstrings
- [x] Add tutorial: Moved to a future PR, tracking issue: #4351

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
