### PR TITLE
[tabular] Fix file path for RF ONNX

### DIFF
--- a/tabular/src/autogluon/tabular/models/rf/compilers/onnx.py
+++ b/tabular/src/autogluon/tabular/models/rf/compilers/onnx.py
@@ -109,8 +109,9 @@ class RFOnnxCompiler:
     @staticmethod
     def save(model, path: str) -> str:
         """Save the compiled model into onnx file format."""
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        with open(os.path.join(path, "model.onnx"), "wb") as f:
+        file_path = os.path.join(path, "model.onnx")
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+        with open(file_path, "wb") as f:
             f.write(model.SerializeToString())
         return os.path.join(path, "model.onnx")
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Previously, the ONNX compilation code would crash if RandomForest's model directory was not yet created. This didn't trigger in normal usage, but it does if we want to compile prior to saving the original model. This PR fixes this by ensuring the parent directory is created.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
