### PR TITLE
[tabular] Remove sklearnex RF logic that raises exception

### DIFF
--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -230,10 +230,6 @@ class RFModel(AbstractModel):
                 for j in range(len(n_estimator_increments)):
                     if n_estimator_increments[j] > n_estimators_ideal:
                         n_estimator_increments[j] = n_estimators_ideal
-        if self._daal and model.criterion != "entropy":
-            # TODO: entropy is not accelerated by sklearnex, need to not set estimators_ to None to avoid crash
-            # This reduces memory usage / disk usage.
-            model.estimators_ = None
         self.model = model
         self.params_trained["n_estimators"] = self.model.n_estimators
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Remove sklearnex RF logic that raises exception
- Previously this code worked and halved the disk usage / memory usage of the RandomForest model.
- Now the code crashes, due to a change at some point in sklearnex. Therefore, we have to remove the code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
