### PR TITLE
[tabular] Add `ag.compile` parameter to models

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -897,6 +897,16 @@ class AbstractModel:
         -------
         Returns self
         """
+        compiler_configs = self.params_aux.get("compile", None)
+        if compiler_configs is not None:
+            compile_model = True
+            if isinstance(compiler_configs, bool):
+                if compiler_configs:
+                    compiler_configs = None
+                else:
+                    compile_model = False
+            if compile_model:
+                self.compile(compiler_configs=compiler_configs)
         predict_1_batch_size = self.params_aux.get("predict_1_batch_size", None)
         if self.predict_1_time is None and predict_1_batch_size is not None and "X" in kwargs and kwargs["X"] is not None:
             X_1 = sample_df_for_time_func(df=kwargs["X"], sample_size=predict_1_batch_size)

--- a/tabular/tests/unittests/models/test_tabular_nn.py
+++ b/tabular/tests/unittests/models/test_tabular_nn.py
@@ -1,4 +1,4 @@
-import pytest
+import shutil
 
 from autogluon.tabular.models.tabular_nn.torch.tabular_nn_torch import TabularNeuralNetTorchModel
 
@@ -49,6 +49,19 @@ def test_tabular_nn_binary_compile_onnx(fit_helper):
     from autogluon.tabular.models.tabular_nn.compilers.onnx import TabularNeuralNetTorchOnnxTransformer
 
     assert isinstance(predictor._learner.trainer.models["NeuralNetTorch"].processor, TabularNeuralNetTorchOnnxTransformer)
+
+
+def test_tabular_nn_binary_compile_onnx_as_ag_arg(fit_helper):
+    fit_args = dict(
+        hyperparameters={TabularNeuralNetTorchModel: {"ag.compile": {"compiler": "onnx"}}},
+    )
+    dataset_name = "adult"
+    predictor = fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, refit_full=True, delete_directory=False)
+    from autogluon.tabular.models.tabular_nn.compilers.onnx import TabularNeuralNetTorchOnnxTransformer
+
+    assert isinstance(predictor._learner.trainer.load_model("NeuralNetTorch").processor, TabularNeuralNetTorchOnnxTransformer)
+    assert isinstance(predictor._learner.trainer.load_model("NeuralNetTorch_FULL").processor, TabularNeuralNetTorchOnnxTransformer)
+    shutil.rmtree(predictor.path, ignore_errors=True)
 
 
 def test_tabular_nn_multiclass_compile_onnx(fit_helper):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add `ag.compile` parameter to models
- This allows the user to specify model compilation to occur directly after the model is fit, rather than in a separate `predictor.compile` call.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
