### PR TITLE
[timeseries Enable season_length > 24 in ETS models

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/local/statsforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/local/statsforecast.py
@@ -284,7 +284,7 @@ class AutoETSModel(AbstractProbabilisticStatsForecastModel):
         # Disable seasonality if time series too short for chosen season_length, season_length is too high, or
         # season_length == 1. Otherwise model will crash
         season_length = local_model_args["season_length"]
-        if len(time_series) < 2 * season_length or season_length == 1 or season_length > 24:
+        if len(time_series) < 2 * season_length or season_length == 1:
             # changing last character to "N" disables seasonality, e.g., model="AAA" -> model="AAN"
             local_model_args["model"] = local_model_args["model"][:-1] + "N"
         return super()._predict_with_local_model(time_series=time_series, local_model_args=local_model_args)


### PR DESCRIPTION
*Description of changes:*
- Since we upgraded to StatsForecast 1.7.0, we can remove the cap `season_length <= 24` that was necessary for older version (fixed by https://github.com/Nixtla/statsforecast/pull/384)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
