### PR TITLE
[core] Add `flake8` to the `[test]` requirements in `core/setup.py`

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -63,6 +63,7 @@ tests_require = [
     "types-requests",
     "types-setuptools",
     "pytest-mypy",
+    "flake8",
 ]
 
 all_requires = []


### PR DESCRIPTION
*Issue #, if available:*
Tests in `core` failed due to a missing `flake8` dependency.

*Description of changes:*
I added `flake8` to the test requirements in `core/setup.py`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
