### PR TITLE
[core] Speed up `EnsembleSelection._fit`

### DIFF
--- a/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py
+++ b/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py
@@ -110,19 +110,12 @@ class EnsembleSelection(AbstractWeightedEnsemble):
         round_scores = False
         epsilon = 1e-4
         round_decimals = 6
+        ensemble_prediction = np.zeros(predictions[0].shape)
         for i in range(ensemble_size):
             scores = np.zeros((len(predictions)))
             s = len(ensemble)
-            if s == 0:
-                weighted_ensemble_prediction = np.zeros(predictions[0].shape)
-            else:
-                # Memory-efficient averaging!
-                ensemble_prediction = np.zeros(ensemble[0].shape)
-                for pred in ensemble:
-                    ensemble_prediction += pred
-                ensemble_prediction /= s
 
-                weighted_ensemble_prediction = (s / float(s + 1)) * ensemble_prediction
+            weighted_ensemble_prediction = (s / float(s + 1)) * ensemble_prediction
             fant_ensemble_prediction = np.zeros(weighted_ensemble_prediction.shape)
             for j, pred in enumerate(predictions):
                 fant_ensemble_prediction[:] = weighted_ensemble_prediction + (1.0 / float(s + 1)) * pred
@@ -175,6 +168,10 @@ class EnsembleSelection(AbstractWeightedEnsemble):
             trajectory.append(best_score)
             order.append(best)
             used_models.add(best)
+
+            ensemble_prediction *= s
+            ensemble_prediction += ensemble[-1]
+            ensemble_prediction /= s+1
 
             # Handle special case
             if len(predictions) == 1:

--- a/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py
+++ b/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py
@@ -169,9 +169,7 @@ class EnsembleSelection(AbstractWeightedEnsemble):
             order.append(best)
             used_models.add(best)
 
-            ensemble_prediction *= s
-            ensemble_prediction += ensemble[-1]
-            ensemble_prediction /= s+1
+            ensemble_prediction = ensemble_prediction * (s / (s + 1)) + ensemble[-1] / (s + 1)
 
             # Handle special case
             if len(predictions) == 1:


### PR DESCRIPTION
*Issue #, if available:*
The current implementation of the greedy ensembling is unnecessarily slowed down, especially for large ensemble_sizes, as the `weighted_ensemble_prediction` computation here
https://github.com/autogluon/autogluon/blob/f5c7b7400596e1449fad2b4107fde55809a09bac/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py#L113-L125
is done in every iteration of the loop from scratch. This could be done on a rolling basis instead, which would reduce the complexity of this function from quadratic in the ensemble size to linear.

*Description of changes:*
This PR changes the current implementation to instead accumulate into the `ensemble_prediction` at each iteration. On a small local example I see a decrease in the ensembling time from 1.4s to 0.9s for the standard `ensemble_size=100`, and for `ensemble_size=1000` I see a decrease from 66s to 8.4s.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
