### PR TITLE
[tabular] Fix exception when >20 configs present in medium quality preset

### DIFF
--- a/tabular/src/autogluon/tabular/trainer/auto_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/auto_trainer.py
@@ -115,10 +115,17 @@ class AutoTrainer(AbstractTrainer):
         log_str = f"{extra_log_str}User-specified model hyperparameters to be fit:\n" "{\n"
         if display_all:
             for k in hyperparameters.keys():
-                log_str += f"\t'{k}': {hyperparameters[k]},\n"
+                # TODO: Make hyperparameters[k] be a list upstream to avoid needing these edge-cases
+                if not isinstance(hyperparameters[k], list):
+                    log_str += f"\t'{k}': {[hyperparameters[k]]},\n"
+                else:
+                    log_str += f"\t'{k}': {hyperparameters[k]},\n"
         else:
             for k in hyperparameters.keys():
-                log_str += f"\t'{k}': {hyperparameters[k][:3]},\n"
+                if not isinstance(hyperparameters[k], list):
+                    log_str += f"\t'{k}': {[hyperparameters[k]]},\n"
+                else:
+                    log_str += f"\t'{k}': {hyperparameters[k][:3]},\n"
         log_str += "}"
         logger.log(20, log_str)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

-  Fix exception when >20 configs present in medium quality preset
- The old hyperparameters configs had single models be in a special format where they aren't in a list, such as:

```
{
    'XGB': {},
}
```

This will cause an exception if logged in an edge-case where there are more than 20 configs in the hyperparameters dict.
This impacts medium and good quality presets.

This PR fixes this issue by converting to list before logging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
