### PR TITLE
[tabular] Add informative logging for NN_TORCH time exceeded

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -335,6 +335,12 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
                             raise TimeLimitExceeded
                     time_elapsed = time_cur - start_fit_time
                     if time_limit < time_elapsed:
+                        if epoch == 0:
+                            logger.log(
+                                30,
+                                f"\tNot enough time to train first epoch. Stopped on Update {total_updates} (Epoch {epoch}))",
+                            )
+                            raise TimeLimitExceeded
                         logger.log(15, f"\tRan out of time, stopping training early. (Stopped on Update {total_updates} (Epoch {epoch}))")
                         do_update = False
                         break


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add informative logging for NN_TORCH time exceeded
- Previously, if out of time on first epoch, will raise an `AssertionError`. Better to instead raise a `TimeLimitExceeded` error for better tracking and logging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
