### PR TITLE
[tabular] Fix exception in HPO when only specifying one of `num_cpus`/`num_gpus`

### DIFF
--- a/core/src/autogluon/core/hpo/executors.py
+++ b/core/src/autogluon/core/hpo/executors.py
@@ -162,10 +162,23 @@ class HpoExecutor(ABC):
                     ), f"The model requires minimum gpu {minimum_model_num_gpus}, but you only specified {user_specified_fold_num_gpus}"
                     if minimum_model_num_gpus > 0:
                         num_folds_in_parallel_with_gpu = total_num_gpus_per_trial // user_specified_fold_num_gpus
-                num_folds_in_parallel = min(num_folds_in_parallel_with_cpu, num_folds_in_parallel_with_gpu)
+                num_folds_in_parallel = min(k_fold, num_folds_in_parallel_with_cpu, num_folds_in_parallel_with_gpu)
 
-                cpu_per_trial = user_specified_fold_num_cpus * min(k_fold, num_folds_in_parallel)
-                gpu_per_trial = user_specified_fold_num_gpus * min(k_fold, num_folds_in_parallel)
+                # Infer the unspecified value if only one of CPU/GPU was specified by the user
+                if user_specified_fold_num_cpus is None:
+                    user_specified_fold_num_cpus = total_num_cpus_per_trial // num_folds_in_parallel
+                if user_specified_fold_num_gpus is None:
+                    user_specified_fold_num_gpus = total_num_gpus_per_trial // num_folds_in_parallel
+
+                assert (
+                        user_specified_fold_num_cpus >= minimum_model_num_cpus
+                ), f"The model requires minimum cpu {minimum_model_num_cpus}, but you only specified {user_specified_fold_num_cpus}"
+                assert (
+                        user_specified_fold_num_gpus >= minimum_model_num_gpus
+                ), f"The model requires minimum gpu {minimum_model_num_gpus}, but you only specified {user_specified_fold_num_gpus}"
+
+                cpu_per_trial = user_specified_fold_num_cpus * num_folds_in_parallel
+                gpu_per_trial = user_specified_fold_num_gpus * num_folds_in_parallel
 
                 # Custom backend should set its total resource to be resources_per_trial
                 self.hyperparameter_tune_kwargs["resources_per_trial"] = {"num_cpus": cpu_per_trial, "num_gpus": gpu_per_trial}

--- a/core/src/autogluon/core/hpo/executors.py
+++ b/core/src/autogluon/core/hpo/executors.py
@@ -171,10 +171,10 @@ class HpoExecutor(ABC):
                     user_specified_fold_num_gpus = total_num_gpus_per_trial // num_folds_in_parallel
 
                 assert (
-                        user_specified_fold_num_cpus >= minimum_model_num_cpus
+                    user_specified_fold_num_cpus >= minimum_model_num_cpus
                 ), f"The model requires minimum cpu {minimum_model_num_cpus}, but you only specified {user_specified_fold_num_cpus}"
                 assert (
-                        user_specified_fold_num_gpus >= minimum_model_num_gpus
+                    user_specified_fold_num_gpus >= minimum_model_num_gpus
                 ), f"The model requires minimum gpu {minimum_model_num_gpus}, but you only specified {user_specified_fold_num_gpus}"
 
                 cpu_per_trial = user_specified_fold_num_cpus * num_folds_in_parallel

--- a/core/src/autogluon/core/hpo/ray_hpo.py
+++ b/core/src/autogluon/core/hpo/ray_hpo.py
@@ -420,12 +420,13 @@ class TabularRayTuneAdapter(RayTuneAdapter):
         return ResourceCalculatorFactory.get_resource_calculator(calculator_type="cpu" if num_gpus == 0 else "gpu")
 
     def trainable_args_update_method(self, trainable_args: dict) -> dict:
+        # Convert num_cpus to int to avoid bug with RayTune converting int to float in tune.PlacementGroupFactory
         if isinstance(self.resources_per_trial, dict):
-            trainable_args["fit_kwargs"]["num_cpus"] = self.resources_per_trial.get("cpu", 1)
+            trainable_args["fit_kwargs"]["num_cpus"] = int(self.resources_per_trial.get("cpu", 1))
             trainable_args["fit_kwargs"]["num_gpus"] = self.resources_per_trial.get("gpu", 0)
         elif isinstance(self.resources_per_trial, tune.PlacementGroupFactory):
             required_resources = self.resources_per_trial.required_resources
-            trainable_args["fit_kwargs"]["num_cpus"] = required_resources.get("CPU", 1)
+            trainable_args["fit_kwargs"]["num_cpus"] = int(required_resources.get("CPU", 1))
             trainable_args["fit_kwargs"]["num_gpus"] = required_resources.get("GPU", 0)
         return trainable_args
 

--- a/core/src/autogluon/core/ray/resources_calculator.py
+++ b/core/src/autogluon/core/ray/resources_calculator.py
@@ -50,7 +50,7 @@ class CpuResourceCalculator(ResourceCalculator):
         user_resources_per_job=None,
         **kwargs,
     ):
-        if user_resources_per_job is not None:
+        if user_resources_per_job is not None and "num_cpus" in user_resources_per_job:
             cpu_per_job = user_resources_per_job.get("num_cpus", 0)
             assert cpu_per_job <= total_num_cpus, f"Detected model level cpu requirement = {cpu_per_job} > total cpu granted to AG predictor = {total_num_cpus}"
             assert cpu_per_job >= minimum_cpu_per_job, f"The model requires minimum cpu {minimum_cpu_per_job}, but you only specified {cpu_per_job}"


### PR DESCRIPTION
*Issue #, if available:*

Resolves #4375

*Description of changes:*

- Fix exception in HPO when only specifying one of `num_cpus` or `num_gpus` in `ag_args_fit`.
- Fix exception in HPO for FASTAI and NN_TORCH when `num_cpus` specified in `ag_args_fit`, caused by RayTune converting int to float for `num_cpus`, which leads to a failure in a downstream type assertion as reported in #4375.

## Example

For example, in mainline the following with raise an exception:

```python
import pandas as pd
from autogluon.tabular import TabularPredictor


if __name__ == '__main__':
    label = 'class'
    train_data = pd.read_csv('https://autogluon.s3.amazonaws.com/datasets/Inc/train.csv')
    subsample_size = 1000  # subsample subset of data for faster demo, try setting this to much larger values
    if subsample_size is not None and subsample_size < len(train_data):
        train_data = train_data.sample(n=subsample_size, random_state=0)
    test_data = pd.read_csv('https://autogluon.s3.amazonaws.com/datasets/Inc/test.csv')
    hyperparameters = {'FASTAI': {}, 'NN_TORCH': {}, 'CAT': {}, 'GBM': {}, }
    predictor = TabularPredictor(
        label=label,
    )

    predictor = predictor.fit(
        train_data=train_data,
        hyperparameters=hyperparameters,
        dynamic_stacking=False,
        presets="best_quality",
        time_limit=45,
        ag_args_fit={"num_cpus": 1},
        hyperparameter_tune_kwargs='auto',
    )

    predictor.leaderboard(test_data, display=True)

```

This results in the following exception:

```
Hyperparameter tuning model: LightGBM_BAG_L1 ... Tuning model for up to 10.11s of the 44.95s of remaining time.
/opt/conda/envs/ag-111-310v2/lib/python3.10/site-packages/torch/cuda/__init__.py:628: UserWarning: Can't initialize NVML
  warnings.warn("Can't initialize NVML")
Warning: Exception caused LightGBM_BAG_L1 to fail during hyperparameter tuning... Skipping this model.
Traceback (most recent call last):
  File "/home/ubuntu/workspace/code/autogluon/core/src/autogluon/core/trainer/abstract_trainer.py", line 2278, in _train_single_full
    hpo_models, hpo_results = model.hyperparameter_tune(
  File "/home/ubuntu/workspace/code/autogluon/core/src/autogluon/core/models/abstract/abstract_model.py", line 1538, in hyperparameter_tune
    hpo_executor.register_resources(self, **kwargs)
  File "/home/ubuntu/workspace/code/autogluon/core/src/autogluon/core/hpo/executors.py", line 501, in register_resources
    super().register_resources(initialized_model, **kwargs)
  File "/home/ubuntu/workspace/code/autogluon/core/src/autogluon/core/hpo/executors.py", line 168, in register_resources
    gpu_per_trial = user_specified_fold_num_gpus * min(k_fold, num_folds_in_parallel)
TypeError: unsupported operand type(s) for *: 'NoneType' 
```

Similarly, replacing with `ag_args_fit={"num_gpus": 0}` causes an exception:

```
Hyperparameter tuning model: LightGBM_BAG_L1 ... Tuning model for up to 10.11s of the 44.95s of remaining time.
/opt/conda/envs/ag-111-310v2/lib/python3.10/site-packages/torch/cuda/__init__.py:628: UserWarning: Can't initialize NVML
  warnings.warn("Can't initialize NVML")
Warning: Exception caused LightGBM_BAG_L1 to fail during hyperparameter tuning... Skipping this model.
Traceback (most recent call last):
  File "/home/ubuntu/workspace/code/autogluon/core/src/autogluon/core/trainer/abstract_trainer.py", line 2278, in _train_single_full
    hpo_models, hpo_results = model.hyperparameter_tune(
  File "/home/ubuntu/workspace/code/autogluon/core/src/autogluon/core/models/abstract/abstract_model.py", line 1538, in hyperparameter_tune
    hpo_executor.register_resources(self, **kwargs)
  File "/home/ubuntu/workspace/code/autogluon/core/src/autogluon/core/hpo/executors.py", line 501, in register_resources
    super().register_resources(initialized_model, **kwargs)
  File "/home/ubuntu/workspace/code/autogluon/core/src/autogluon/core/hpo/executors.py", line 167, in register_resources
    cpu_per_trial = user_specified_fold_num_cpus * min(k_fold, num_folds_in_parallel)
TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'
unsupported operand type(s) for *: 'NoneType' and 'int'
```

This PR fixes these exceptions and allows the models to fit as intended.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
