### PR TITLE
[timeseries] Fix exception raised when invalid path provided

### DIFF
--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -1098,6 +1098,10 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
             raise ValueError("`path` cannot be None or empty in load().")
         path: str = setup_outputdir(path, warn_if_exist=False)
 
+        predictor_path = Path(path) / cls.predictor_file_name
+        if not predictor_path.exists():
+            raise FileNotFoundError(f"No such file '{predictor_path}'")
+
         try:
             version_saved = cls._load_version_file(path=path)
         except:
@@ -1116,7 +1120,7 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
 
         logger.info(f"Loading predictor from path {path}")
         learner = AbstractLearner.load(path)
-        predictor = load_pkl.load(path=os.path.join(learner.path, cls.predictor_file_name))
+        predictor = load_pkl.load(path=str(predictor_path))
         predictor._learner = learner
         predictor.path = learner.path
         return predictor

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -1751,3 +1751,7 @@ def test_when_predictor_saved_to_same_directory_and_loaded_then_number_of_models
         == set(loaded_predictor.model_names())
         == set(hyperparameters).union({"WeightedEnsemble"})
     )
+
+def test_when_invalid_path_provided_to_load_then_correct_exception_is_raised():
+    with pytest.raises(FileNotFoundError, match="No such file"):
+        TimeSeriesPredictor.load("some_invalid_path")

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -1752,6 +1752,7 @@ def test_when_predictor_saved_to_same_directory_and_loaded_then_number_of_models
         == set(hyperparameters).union({"WeightedEnsemble"})
     )
 
+
 def test_when_invalid_path_provided_to_load_then_correct_exception_is_raised():
     with pytest.raises(FileNotFoundError, match="No such file"):
         TimeSeriesPredictor.load("some_invalid_path")


### PR DESCRIPTION
*Issue #, if available:* Fixed #4291

*Description of changes:*
- Raise an informative error message if an invalid path is provided to `TimeSeriesPredictor.load`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
