### PR TITLE
[Tabular] Support for Raising an Error When No Models Were Trained Successfully During fit()

### DIFF
--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -933,8 +933,8 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
                 to any amount of labeled data.
             verbosity : int
                 If specified, overrides the existing `predictor.verbosity` value.
-            raise_on_no_models_fitted: bool
-                If True, will raise an exception if no models were successfully fit during `fit()`.
+            raise_on_no_models_fitted: bool, default = False
+                If True, will raise a RuntimeError if no models were successfully fit during `fit()`.
             calibrate: bool or str, default = 'auto'
                 Note: It is recommended to use ['auto', False] as the values and avoid True.
                 If 'auto' will automatically set to True if the problem_type and eval_metric are suitable for calibration.

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -933,6 +933,8 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
                 to any amount of labeled data.
             verbosity : int
                 If specified, overrides the existing `predictor.verbosity` value.
+            raise_on_no_models_fitted: bool
+                If True, will raise an exception if no models were successfully fit during `fit()`.
             calibrate: bool or str, default = 'auto'
                 Note: It is recommended to use ['auto', False] as the values and avoid True.
                 If 'auto' will automatically set to True if the problem_type and eval_metric are suitable for calibration.
@@ -1167,6 +1169,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             calibrate=kwargs["calibrate"],
             calibrate_decision_threshold=calibrate_decision_threshold,
             infer_limit=infer_limit,
+            raise_on_no_models_fitted=kwargs["raise_on_no_models_fitted"],
         )
         if dynamic_stacking:
             logger.log(
@@ -1505,10 +1508,17 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         calibrate_decision_threshold=False,
         infer_limit=None,
         refit_full_kwargs: dict = None,
+        raise_on_no_models_fitted: bool = False
     ):
         if refit_full_kwargs is None:
             refit_full_kwargs = {}
         if not self.model_names():
+
+            if raise_on_no_models_fitted:
+                raise RuntimeError("No models were trained successfully during fit()."
+                                   " Inspect the log output or increase verbosity to determine why no models were fit."
+                                   " Alternatively, set `raise_on_no_models_fitted` to False during the fit call.")
+
             logger.log(30, "Warning: No models found, skipping post_fit logic...")
             return
 
@@ -4648,6 +4658,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             # other
             verbosity=self.verbosity,
             feature_prune_kwargs=None,
+            raise_on_no_models_fitted=False,
             # private
             _save_bag_folds=None,
             calibrate="auto",

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1508,16 +1508,17 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         calibrate_decision_threshold=False,
         infer_limit=None,
         refit_full_kwargs: dict = None,
-        raise_on_no_models_fitted: bool = False
+        raise_on_no_models_fitted: bool = False,
     ):
         if refit_full_kwargs is None:
             refit_full_kwargs = {}
         if not self.model_names():
-
             if raise_on_no_models_fitted:
-                raise RuntimeError("No models were trained successfully during fit()."
-                                   " Inspect the log output or increase verbosity to determine why no models were fit."
-                                   " Alternatively, set `raise_on_no_models_fitted` to False during the fit call.")
+                raise RuntimeError(
+                    "No models were trained successfully during fit()."
+                    " Inspect the log output or increase verbosity to determine why no models were fit."
+                    " Alternatively, set `raise_on_no_models_fitted` to False during the fit call."
+                )
 
             logger.log(30, "Warning: No models found, skipping post_fit logic...")
             return


### PR DESCRIPTION
This PR enables users to make AutoGluon raise an error if no models are trained successfully during `fit`. 

Without this, people sometimes write their own code to catch this or ignore it and then believe AutoGluon is broken, although it is most likely a result of a broken environment or their memory being insufficient. 

So far, this defaults to False, but I would argue this should default to True in the future. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
