### PR TITLE
[timeseries] Fix off-by-one error in DirectTabular length check

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -365,7 +365,7 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
             Seasonal naive forecast for short series, if there are any in the dataset.
         """
         ts_lengths = data.num_timesteps_per_item()
-        short_series = ts_lengths.index[ts_lengths <= self._sum_of_differences + 1]
+        short_series = ts_lengths.index[ts_lengths <= self._sum_of_differences]
         if len(short_series) > 0:
             logger.warning(
                 f"Warning: {len(short_series)} time series ({len(short_series) / len(ts_lengths):.1%}) are shorter "


### PR DESCRIPTION
*Issue #, if available:* Fixes #4369

*Description of changes:*
- Fixed the off-by-one error in the length check for DirectTabular when determining if a fallback model should be used.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
