### PR TITLE
[Tabular,Core] Fix Temperature Scaling

### DIFF
--- a/core/src/autogluon/core/calibrate/temperature_scaling.py
+++ b/core/src/autogluon/core/calibrate/temperature_scaling.py
@@ -61,7 +61,10 @@ def tune_temperature_scaling(y_val_probs: np.ndarray, y_val: np.ndarray, init_va
 
     optimizer.step(temperature_scale_step)
 
-    best_loss_index = np.array(optimizer_trajectory)[:, 0].argmin()
+    try:
+        best_loss_index = np.nanargmin(np.array(optimizer_trajectory)[:, 0])
+    except ValueError:
+        return None
     temperature_scale = float(np.array(optimizer_trajectory)[best_loss_index, 1])
 
     if np.isnan(temperature_scale):

--- a/core/src/autogluon/core/calibrate/temperature_scaling.py
+++ b/core/src/autogluon/core/calibrate/temperature_scaling.py
@@ -80,9 +80,9 @@ def custom_softmax(logits: np.ndarray) -> np.ndarray:
     return y_pred_proba
 
 
-def apply_temperature_scaling(y_pred_proba: np.ndarray, temperature_scalar: float, problem_type: str) -> np.ndarray:
+def apply_temperature_scaling(y_pred_proba: np.ndarray, temperature_scalar: float, problem_type: str, *, transform_binary_proba: bool = True) -> np.ndarray:
     # TODO: This is expensive to convert at inference time, try to avoid in future
-    if problem_type == BINARY:
+    if transform_binary_proba and (problem_type == BINARY):
         y_pred_proba = LabelCleanerMulticlassToBinary.convert_binary_proba_to_multiclass_proba(y_pred_proba)
 
     logits = np.log(y_pred_proba)

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -26,7 +26,7 @@ from autogluon.common.utils.try_import import try_import_torch
 from ..augmentation.distill_utils import augment_data, format_distillation_labels
 from ..calibrate import calibrate_decision_threshold
 from ..calibrate.conformity_score import compute_conformity_score
-from ..calibrate.temperature_scaling import tune_temperature_scaling
+from ..calibrate.temperature_scaling import tune_temperature_scaling, apply_temperature_scaling
 from ..constants import (
     AG_ARGS,
     BINARY,
@@ -3868,9 +3868,17 @@ class AbstractTrainer:
                     f"This can occur when the model is absolutely certain of a validation prediction (1.0 pred_proba).",
                 )
             else:
-                logger.log(15, f"Temperature term found is: {temp_scalar}")
-                model.params_aux["temperature_scalar"] = temp_scalar
-                model.save()
+                # Check that scaling improves performance for the target metric
+                score_without_temp = self.score_with_y_pred_proba(y=y_val, y_pred_proba=y_val_probs, weights=None)
+                scaled_y_val_probs = apply_temperature_scaling(y_val_probs, temp_scalar, problem_type=self.problem_type)
+                score_with_temp = self.score_with_y_pred_proba(y=y_val, y_pred_proba=scaled_y_val_probs, weights=None)
+
+                if score_with_temp > score_without_temp:
+                    logger.log(15, f"Temperature term found is: {temp_scalar}")
+                    model.params_aux["temperature_scalar"] = temp_scalar
+                    model.save()
+                else:
+                    logger.log(15, "Temperature did not improve performance, skipping calibration.")
 
     def calibrate_decision_threshold(
         self,

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -26,7 +26,7 @@ from autogluon.common.utils.try_import import try_import_torch
 from ..augmentation.distill_utils import augment_data, format_distillation_labels
 from ..calibrate import calibrate_decision_threshold
 from ..calibrate.conformity_score import compute_conformity_score
-from ..calibrate.temperature_scaling import tune_temperature_scaling, apply_temperature_scaling
+from ..calibrate.temperature_scaling import apply_temperature_scaling, tune_temperature_scaling
 from ..constants import (
     AG_ARGS,
     BINARY,

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -3870,7 +3870,7 @@ class AbstractTrainer:
             else:
                 # Check that scaling improves performance for the target metric
                 score_without_temp = self.score_with_y_pred_proba(y=y_val, y_pred_proba=y_val_probs, weights=None)
-                scaled_y_val_probs = apply_temperature_scaling(y_val_probs, temp_scalar, problem_type=self.problem_type)
+                scaled_y_val_probs = apply_temperature_scaling(y_val_probs, temp_scalar, problem_type=self.problem_type, transform_binary_proba=False)
                 score_with_temp = self.score_with_y_pred_proba(y=y_val, y_pred_proba=scaled_y_val_probs, weights=None)
 
                 if score_with_temp > score_without_temp:


### PR DESCRIPTION
Heyho,

I have noticed that the predictions of my best model were often quite suboptimal compared to other models for metrics that were affected by temperature scaling. 

After looking more into it, I believe I found a bug and two crucial improvements to the temperature scaling logic. 

The proposed PR now does the following:
1. We take the best-found temperature instead of the last temperature when tuning temperature. 
2. We double-check that temperature improves performance on the target metric.

I am certain that 1. is very important, although it might overfit more.

For 2. it is a bit more complicated, as it is sometimes beneficial to even accept better calibration if it does not improve the target metric on validation data. Moreover, I am not too sure that my code works in all cases of all eval metrics (I also did not find an easy way to add sample weights into the metric call here). 

# Failure Case Examplee

I recently ran into this unhappy result when using default AutoGluon:

Default
```bash
Scores Before Tuning Temp: {'roc_auc_ovo': 0.9153388674076931, 'accuracy': 0.7211895910780669, 'balanced_accuracy': 0.7160878147673921, 'log_loss': -0.7753828493979228, 'mcc': 0.6275299996789895}
Temp After Tuning: -1242.176513671875
Scores After Tuning Temp: {'roc_auc_ovo': 0.09863829315371282, 'accuracy': 0.01486988847583643, 'balanced_accuracy': 0.014253449992886616, 'log_loss': -1.3871372218846423, 'mcc': -0.3297512402994374}
```

Here, the temperature is so low because, after 10 out of 100 iterations, the gradient-based optimizer started to diverge, and the exponential learning rate made it irrecoverable. Then, the old code picked the last iteration's temperature and returned it.
Btw. this is also likely the reason why this function sometimes returns None. 

My Code
```bash
Scores Before Tuning Temp: {'roc_auc_ovo': 0.9153388674076931, 'accuracy': 0.7211895910780669, 'balanced_accuracy': 0.7160878147673921, 'log_loss': -0.7753828493979228, 'mcc': 0.6275299996789895}
Temp After Tuning: 0.9741883873939514
Scores After Tuning Temp: {'roc_auc_ovo': 0.9154014511133995, 'accuracy': 0.7211895910780669, 'balanced_accuracy': 0.7160878147673921, 'log_loss': -0.7687201466930794, 'mcc': 0.6275299996789895}
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
