### PR TITLE
Skip temperature scaling if negative temperature, increase learning rate

### DIFF
--- a/core/src/autogluon/core/calibrate/temperature_scaling.py
+++ b/core/src/autogluon/core/calibrate/temperature_scaling.py
@@ -6,7 +6,7 @@ from ..constants import BINARY
 from ..data.label_cleaner import LabelCleanerMulticlassToBinary
 
 
-def tune_temperature_scaling(y_val_probs: np.ndarray, y_val: np.ndarray, init_val: float = 1, max_iter: int = 1000, lr: float = 0.01):
+def tune_temperature_scaling(y_val_probs: np.ndarray, y_val: np.ndarray, init_val: float = 1, max_iter: int = 200, lr: float = 0.1):
     """
     Tunes a temperature scalar term that divides the logits produced by autogluon model. Logits are generated
     by natural log the predicted probs from model then divides by a temperature scalar, which is tuned

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -3870,8 +3870,7 @@ class AbstractTrainer:
             elif temp_scalar <= 0:
                 logger.log(
                     30,
-                    f"Warning: Temperature scaling found optimal at a negative value ({temp_scalar}). "
-                    f"Disabling temperature scaling to avoid overfitting.",
+                    f"Warning: Temperature scaling found optimal at a negative value ({temp_scalar}). Disabling temperature scaling to avoid overfitting.",
                 )
             else:
                 # Check that scaling improves performance for the target metric

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -3867,7 +3867,7 @@ class AbstractTrainer:
                     f"Warning: Infinity found during calibration, skipping calibration on {model.name}! "
                     f"This can occur when the model is absolutely certain of a validation prediction (1.0 pred_proba).",
                 )
-            elif temp_scalar < 0:
+            elif temp_scalar <= 0:
                 logger.log(
                     30,
                     f"Warning: Temperature scaling found optimal at a negative value ({temp_scalar}). "

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -3793,7 +3793,7 @@ class AbstractTrainer:
         best_candidate_model_rows = candidate_model_rows.loc[candidate_model_rows["score_val"] == candidate_model_rows["score_val"].max()]
         return self.load_model(best_candidate_model_rows.loc[best_candidate_model_rows["fit_time"].idxmin()]["model"])
 
-    def calibrate_model(self, model_name: str = None, lr: float = 0.01, max_iter: int = 1000, init_val: float = 1.0):
+    def calibrate_model(self, model_name: str = None, lr: float = 0.1, max_iter: int = 200, init_val: float = 1.0):
         """
         Applies temperature scaling to a model.
         Applies inverse softmax to predicted probs then trains temperature scalar
@@ -3806,9 +3806,9 @@ class AbstractTrainer:
         model_name: str: default = None
             model name to tune temperature scaling on.
             If None, will tune best model only. Best model chosen by validation score
-        lr: float: default = 0.01
+        lr: float: default = 0.1
             The learning rate for temperature scaling algorithm
-        max_iter: int: default = 1000
+        max_iter: int: default = 200
             Number of iterations optimizer should take for
             tuning temperature scaler
         init_val: float: default = 1.0
@@ -3866,6 +3866,12 @@ class AbstractTrainer:
                     15,
                     f"Warning: Infinity found during calibration, skipping calibration on {model.name}! "
                     f"This can occur when the model is absolutely certain of a validation prediction (1.0 pred_proba).",
+                )
+            elif temp_scalar < 0:
+                logger.log(
+                    30,
+                    f"Warning: Temperature scaling found optimal at a negative value ({temp_scalar}). "
+                    f"Disabling temperature scaling to avoid overfitting.",
                 )
             else:
                 # Check that scaling improves performance for the target metric


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Skip temperature scaling if zero or negative temperature. A negative temperature could be selected if the model has a worse validation score than a model that predicts a constant `0.5` value. This can happen when there are very few rows of validation data and is an artifact of validation overfitting.
- increase learning rate by 10x to make convergence faster, reduce max iters by 5x to compensate. We can afford a more aggressive learning rate now that we pick the best iteration instead of the final iteration, so divergence is less problematic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
