### PR TITLE
[tabular] raise_on_no_models_fitted=True

### DIFF
--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -933,7 +933,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
                 to any amount of labeled data.
             verbosity : int
                 If specified, overrides the existing `predictor.verbosity` value.
-            raise_on_no_models_fitted: bool, default = False
+            raise_on_no_models_fitted: bool, default = True
                 If True, will raise a RuntimeError if no models were successfully fit during `fit()`.
             calibrate: bool or str, default = 'auto'
                 Note: It is recommended to use ['auto', False] as the values and avoid True.
@@ -1508,7 +1508,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         calibrate_decision_threshold=False,
         infer_limit=None,
         refit_full_kwargs: dict = None,
-        raise_on_no_models_fitted: bool = False,
+        raise_on_no_models_fitted: bool = True,
     ):
         if refit_full_kwargs is None:
             refit_full_kwargs = {}
@@ -4659,7 +4659,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             # other
             verbosity=self.verbosity,
             feature_prune_kwargs=None,
-            raise_on_no_models_fitted=False,
+            raise_on_no_models_fitted=True,
             # private
             _save_bag_folds=None,
             calibrate="auto",

--- a/tabular/tests/unittests/models/test_dummy.py
+++ b/tabular/tests/unittests/models/test_dummy.py
@@ -8,10 +8,25 @@ from autogluon.core.metrics import METRICS
 from autogluon.core.models.dummy.dummy_model import DummyModel
 
 
-def test_no_models(fit_helper, dataset_loader_helper):
-    """Tests that logic works properly when no models are trained"""
+def test_no_models_will_raise(fit_helper, dataset_loader_helper):
+    """Tests that RuntimeError is raised when no models fit"""
     fit_args = dict(
         hyperparameters={},
+    )
+
+    dataset_name = "adult"
+    directory_prefix = "./datasets/"
+    train_data, test_data, dataset_info = dataset_loader_helper.load_dataset(name=dataset_name, directory_prefix=directory_prefix)
+
+    with pytest.raises(RuntimeError):
+        fit_helper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
+
+
+def test_no_models(fit_helper, dataset_loader_helper):
+    """Tests that logic works properly when no models are trained and raise_on_no_models_fitted=False"""
+    fit_args = dict(
+        hyperparameters={},
+        raise_on_no_models_fitted=False,
     )
 
     dataset_name = "adult"
@@ -29,13 +44,14 @@ def test_no_models(fit_helper, dataset_loader_helper):
 
 
 def test_no_models_raise(fit_helper, dataset_loader_helper):
-    """Tests that logic works properly when no models are trained, and tests predictor.model_failures()"""
+    """Tests that logic works properly when no models are trained, and tests predictor.model_failures() and raise_on_no_models_fitted=False"""
 
     expected_exc_str = "Test Error Message"
 
     # Force DummyModel to raise an exception when fit.
     fit_args = dict(
         hyperparameters={DummyModel: {"raise": ValueError, "raise_msg": expected_exc_str}},
+        raise_on_no_models_fitted=False,
     )
 
     dataset_name = "adult"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Switch the default behavior of TabularPredictor to raise a RuntimeError if no models were successfully fit in a fit call. Most users would prefer an error to be raised in this scenario, as not having an error raise may confuse them into thinking a model was fit successfully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
