### PR TITLE
[tabular] Fix feature pruning crash on Windows

### DIFF
--- a/docs/tutorials/tabular/tabular-quick-start.ipynb
+++ b/docs/tutorials/tabular/tabular-quick-start.ipynb
@@ -13,7 +13,8 @@
     "In this tutorial, we will see how to use AutoGluon's `TabularPredictor` to predict the values of a target column based on the other columns in a tabular dataset.\n",
     "\n",
     "Begin by making sure AutoGluon is installed, and then import AutoGluon's `TabularDataset` and `TabularPredictor`. We will use the former to load data and the latter to train models and make predictions. "
-   ]
+   ],
+   "id": "998885f294556807"
   },
   {
    "cell_type": "code",
@@ -27,7 +28,8 @@
    "source": [
     "!python -m pip install --upgrade pip\n",
     "!python -m pip install autogluon"
-   ]
+   ],
+   "id": "f4d1edc3d2f610f6"
   },
   {
    "cell_type": "code",
@@ -36,14 +38,16 @@
    "outputs": [],
    "source": [
     "from autogluon.tabular import TabularDataset, TabularPredictor"
-   ]
+   ],
+   "id": "ff904c9d1af0ac39"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Example Data"
-   ]
+   ],
+   "id": "e42b07bc64929c80"
   },
   {
    "cell_type": "markdown",
@@ -52,7 +56,8 @@
     "For this tutorial we will use a dataset from the cover story of [Nature issue 7887](https://www.nature.com/nature/volumes/600/issues/7887): [AI-guided intuition for math theorems](https://www.nature.com/articles/s41586-021-04086-x.pdf). The goal is to predict a knot's signature based on its properties. We sampled 10K training and 5K test examples from the [original data](https://github.com/deepmind/mathematics_conjectures/blob/main/knot_theory.ipynb). The sampled dataset make this tutorial run quickly, but AutoGluon can handle the full dataset if desired.\n",
     "\n",
     "We load this dataset directly from a URL. AutoGluon's `TabularDataset` is a subclass of pandas [DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html), so any `DataFrame` methods can be used on `TabularDataset` as well."
-   ]
+   ],
+   "id": "f247a5c20c9be613"
   },
   {
    "cell_type": "code",
@@ -63,14 +68,16 @@
     "data_url = 'https://raw.githubusercontent.com/mli/ag-docs/main/knot_theory/'\n",
     "train_data = TabularDataset(f'{data_url}train.csv')\n",
     "train_data.head()"
-   ]
+   ],
+   "id": "bfda6620a2f2637"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Our targets are stored in the \"signature\" column, which has 18 unique integers. Even though pandas didn't correctly recognize this data type as categorical, AutoGluon will fix this issue.\n"
-   ]
+   ],
+   "id": "c810125a2b8aa286"
   },
   {
    "cell_type": "code",
@@ -80,7 +87,8 @@
    "source": [
     "label = 'signature'\n",
     "train_data[label].describe()"
-   ]
+   ],
+   "id": "735d0a050b701f31"
   },
   {
    "cell_type": "markdown",
@@ -89,7 +97,8 @@
     "## Training\n",
     "\n",
     "We now construct a `TabularPredictor` by specifying the label column name and then train on the dataset with `TabularPredictor.fit()`. We don't need to specify any other parameters. AutoGluon will recognize this is a multi-class classification task, perform automatic feature engineering, train multiple models, and then ensemble the models to create the final predictor. "
-   ]
+   ],
+   "id": "ec8a61ef4291bc39"
   },
   {
    "cell_type": "code",
@@ -102,7 +111,8 @@
    "outputs": [],
    "source": [
     "predictor = TabularPredictor(label=label).fit(train_data)"
-   ]
+   ],
+   "id": "362ff589bb29d77d"
   },
   {
    "cell_type": "markdown",
@@ -110,7 +120,8 @@
    "source": [
     "Model fitting should take a few minutes or less depending on your CPU. You can make training faster by specifying the `time_limit` argument. For example, `fit(..., time_limit=60)` will stop training after 60 seconds. Higher time limits will generally result in better prediction performance, and excessively low time limits will prevent AutoGluon from training and ensembling a reasonable set of models.\n",
     "\n"
-   ]
+   ],
+   "id": "1a0c76c9931ef02a"
   },
   {
    "cell_type": "markdown",
@@ -119,7 +130,8 @@
     "## Prediction\n",
     "\n",
     "Once we have a predictor that is fit on the training dataset, we can load a separate set of data to use for prediction and evaulation."
-   ]
+   ],
+   "id": "a14b3b77951c8885"
   },
   {
    "cell_type": "code",
@@ -131,7 +143,8 @@
     "\n",
     "y_pred = predictor.predict(test_data.drop(columns=[label]))\n",
     "y_pred.head()"
-   ]
+   ],
+   "id": "71c5ca4d79e46793"
   },
   {
    "cell_type": "markdown",
@@ -140,7 +153,8 @@
     "## Evaluation\n",
     "\n",
     "We can evaluate the predictor on the test dataset using the `evaluate()` function, which measures how well our predictor performs on data that was not used for fitting the models."
-   ]
+   ],
+   "id": "a07dc2dd8e3225a"
   },
   {
    "cell_type": "code",
@@ -149,14 +163,16 @@
    "outputs": [],
    "source": [
     "predictor.evaluate(test_data, silent=True)"
-   ]
+   ],
+   "id": "95d51e36939dcc95"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "AutoGluon's `TabularPredictor` also provides the `leaderboard()` function, which allows us to evaluate the performance of each individual trained model on the test data."
-   ]
+   ],
+   "id": "23ad005fd976a13e"
   },
   {
    "cell_type": "code",
@@ -165,7 +181,8 @@
    "outputs": [],
    "source": [
     "predictor.leaderboard(test_data)"
-   ]
+   ],
+   "id": "43a52983e6d38da1"
   },
   {
    "cell_type": "markdown",
@@ -176,7 +193,8 @@
     "## Conclusion\n",
     "\n",
     "In this quickstart tutorial we saw AutoGluon's basic fit and predict functionality using `TabularDataset` and `TabularPredictor`. AutoGluon simplifies the model training process by not requiring feature engineering or model hyperparameter tuning. Check out the in-depth tutorials to learn more about AutoGluon's other features like customizing the training and prediction steps or extending AutoGluon with custom feature generators, models, or metrics."
-   ]
+   ],
+   "id": "79eb2f75ce0e5eed"
   }
  ],
  "metadata": {


### PR DESCRIPTION
*Issue #, if available:*

Resolves #4390

*Description of changes:*

- Fix crash on Windows when feature pruning is enabled due to numpy random integer generator returning a different dtype int on Windows compared to Linux/MacOS. Now it is consistently converted to Python int.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
