### PR TITLE
[Tabular] Fix ROC AUC Average for Macro is Macro

### DIFF
--- a/core/src/autogluon/core/metrics/__init__.py
+++ b/core/src/autogluon/core/metrics/__init__.py
@@ -700,7 +700,7 @@ for name, metric, kwargs in [
     ("roc_auc_ovr", customized_roc_auc, dict(multi_class="ovr")),
 ]:
     scorer_kwargs = dict(greater_is_better=True, needs_proba=True, needs_threshold=False)
-    globals()[name] = make_scorer(name, partial(metric, average=average, **kwargs), **scorer_kwargs)
+    globals()[name] = make_scorer(name, partial(metric, average="macro", **kwargs), **scorer_kwargs)
     macro_name = "{0}_{1}".format(name, "macro")
     globals()[name].add_alias(macro_name)
     _add_scorer_to_metric_dict(metric_dict=MULTICLASS_METRICS, scorer=globals()[name])


### PR DESCRIPTION
Unfortunately, so far in AutoGluon, when using the multiclass ROC AUC metric via the string key, the call to sklearn has been misconfigured. 

Instead of using `macro`, `weighted` has been passed to sklearn's `average` argument of ROC AUC.
This is unexpected by default and also occurs when explicitly using the `macro` string key for the metric.

*Description of changes:*
This bug resulted from re-using a previously initialized loop variable, which was set to `weighted` after a prior loop had finished.
I replaced the variable with an explicit statement, as there is no need for a variable. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
