### PR TITLE
[timeseries] Add method to convert a TimeSeriesDataFrame to a regular pd.DataFrame

### DIFF
--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -1008,3 +1008,7 @@ class TimeSeriesDataFrame(pd.DataFrame, TimeSeriesDataFrameDeprecatedMixin):
         # This hides method from IPython autocomplete, but not VSCode autocomplete
         deprecated = ["get_reindexed_view", "to_regular_index"]
         return [d for d in super().__dir__() if d not in deprecated]
+
+    def to_data_frame(self) -> pd.DataFrame:
+        """Convert `TimeSeriesDataFrame` to a `pandas.DataFrame`"""
+        return pd.DataFrame(self)

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -1011,3 +1011,10 @@ def test_when_timestamps_have_datetime64_type_then_tsdf_can_be_constructed(dtype
     df[TIMESTAMP] = df[TIMESTAMP].astype(dtype)
     assert df[TIMESTAMP].dtype == dtype
     TimeSeriesDataFrame.from_data_frame(df)
+
+
+def test_when_to_data_frame_called_then_return_values_is_a_pandas_df():
+    tsdf = SAMPLE_TS_DATAFRAME.copy()
+    df = tsdf.to_data_frame()
+    assert isinstance(df, pd.DataFrame)
+    assert not isinstance(df, TimeSeriesDataFrame)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add method to convert a TimeSeriesDataFrame to a regular pd.DataFrame


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
