### PR TITLE
Upgrade scikit-learn to 1.5.1

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -19,7 +19,7 @@ DEPENDENT_PACKAGES = {
     "boto3": ">=1.10,<2",  # <2 because unlikely to introduce breaking changes in minor releases. >=1.10 because 1.10 is 3 years old, no need to support older
     "numpy": ">=1.21,<1.29",  # "<{N+3}" upper cap, where N is the latest released minor version, assuming no warnings using N
     "pandas": ">=2.0.0,<2.3.0",  # "<{N+3}" upper cap
-    "scikit-learn": ">=1.4.0,<1.5.2",  # "<{N+1}" upper cap, capping to micro version as AutoMM HPO tests fail on upgrading to higher version
+    "scikit-learn": ">=1.4.0,<1.5.2",  # capping to latest version
     "scipy": ">=1.5.4,<1.13",  # "<{N+2}" upper cap
     "psutil": ">=5.7.3,<6",  # Major version cap
     "s3fs": ">=2023.1,<2025",  # Yearly cap

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -19,7 +19,7 @@ DEPENDENT_PACKAGES = {
     "boto3": ">=1.10,<2",  # <2 because unlikely to introduce breaking changes in minor releases. >=1.10 because 1.10 is 3 years old, no need to support older
     "numpy": ">=1.21,<1.29",  # "<{N+3}" upper cap, where N is the latest released minor version, assuming no warnings using N
     "pandas": ">=2.0.0,<2.3.0",  # "<{N+3}" upper cap
-    "scikit-learn": ">=1.4.0,<1.5.1",  # "<{N+1}" upper cap, capping to micro version as AutoMM HPO tests fail on upgrading to higher version
+    "scikit-learn": ">=1.4.0,<1.5.2",  # "<{N+1}" upper cap, capping to micro version as AutoMM HPO tests fail on upgrading to higher version
     "scipy": ">=1.5.4,<1.13",  # "<{N+2}" upper cap
     "psutil": ">=5.7.3,<6",  # Major version cap
     "s3fs": ">=2023.1,<2025",  # Yearly cap

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -19,7 +19,7 @@ DEPENDENT_PACKAGES = {
     "boto3": ">=1.10,<2",  # <2 because unlikely to introduce breaking changes in minor releases. >=1.10 because 1.10 is 3 years old, no need to support older
     "numpy": ">=1.21,<1.29",  # "<{N+3}" upper cap, where N is the latest released minor version, assuming no warnings using N
     "pandas": ">=2.0.0,<2.3.0",  # "<{N+3}" upper cap
-    "scikit-learn": ">=1.3.0,<1.4.1",  # "<{N+1}" upper cap, capping to micro version as AutoMM HPO tests fail on upgrading to higher version
+    "scikit-learn": ">=1.4.0,<1.5.1",  # "<{N+1}" upper cap, capping to micro version as AutoMM HPO tests fail on upgrading to higher version
     "scipy": ">=1.5.4,<1.13",  # "<{N+2}" upper cap
     "psutil": ">=5.7.3,<6",  # Major version cap
     "s3fs": ">=2023.1,<2025",  # Yearly cap

--- a/multimodal/src/autogluon/multimodal/data/preprocess_dataframe.py
+++ b/multimodal/src/autogluon/multimodal/data/preprocess_dataframe.py
@@ -306,6 +306,8 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
         if self._fit_x_called:
             raise RuntimeError("fit_x() has been called. Please create a new preprocessor and call it again!")
         self._fit_x_called = True
+        # Creating deep copy of the DataFrame, which allows writable buffer to be created for the new df
+        # This is needed for 1.4.1 < scikit-learn < 1.5.0, the versions 1.4.0 and 1.5.1 do not need a writable buffer
         X = X.copy(deep=True)
         X.flags.writeable = True
 
@@ -380,6 +382,8 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
         if self._fit_y_called:
             raise RuntimeError("fit_y() has been called. Please create a new preprocessor and call it again!")
         self._fit_y_called = True
+        # Creating deep copy of the DataFrame, which allows writable buffer to be created for the new df
+        # This is needed for 1.4.1 < scikit-learn < 1.5.0, the versions 1.4.0 and 1.5.1 do not need a writable buffer
         y = y.copy(deep=True)
         y.flags.writeable = True
         logger.debug(f'Process col "{self._label_column}" with type label')
@@ -743,6 +747,8 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
         assert (
             self._fit_called or self._fit_y_called
         ), "You will need to first call preprocessor.fit_y() before calling preprocessor.transform_label."
+        # Creating deep copy of the DataFrame, which allows writable buffer to be created for the new df
+        # This is needed for 1.4.1 < scikit-learn < 1.5.0, versions <=1.4.0 and >=1.5.1 do not need a writable buffer
         df = df.copy(deep=True)
         df.flags.writeable = True
         y_df = df[self._label_column]

--- a/multimodal/src/autogluon/multimodal/data/preprocess_dataframe.py
+++ b/multimodal/src/autogluon/multimodal/data/preprocess_dataframe.py
@@ -306,6 +306,8 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
         if self._fit_x_called:
             raise RuntimeError("fit_x() has been called. Please create a new preprocessor and call it again!")
         self._fit_x_called = True
+        X = X.copy(deep=True)
+        X.flags.writeable = True
 
         for col_name in sorted(X.columns):
             # Just in case X accidentally contains the label column
@@ -378,6 +380,8 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
         if self._fit_y_called:
             raise RuntimeError("fit_y() has been called. Please create a new preprocessor and call it again!")
         self._fit_y_called = True
+        y = y.copy(deep=True)
+        y.flags.writeable = True
         logger.debug(f'Process col "{self._label_column}" with type label')
         if self.label_type == CATEGORICAL:
             self._label_generator.fit(y)
@@ -739,6 +743,8 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
         assert (
             self._fit_called or self._fit_y_called
         ), "You will need to first call preprocessor.fit_y() before calling preprocessor.transform_label."
+        df = df.copy(deep=True)
+        df.flags.writeable = True
         y_df = df[self._label_column]
         if self.label_type == CATEGORICAL:
             y = self._label_generator.transform(y_df).astype(np.int64)


### PR DESCRIPTION
*Issue #, if available:* https://github.com/autogluon/autogluon/issues/4331

*Description of changes:*
Creating deep copy of the DataFrame, which allows writable buffer to be created.
This is needed for `1.4.1 < scikit-learn < 1.5.0`, the versions `1.4.0` and `1.5.1` do not need a writable buffer.
If there is no writeable buffer, the function - `_is_pandas_df_or_series()` in `scikit-learn` breaks, note that this function is present in `scikit_learn` versions ranging from `1.4.1` to `1.5.0`, but is fixed by the maintainers in the `1.5.1` release - https://github.com/scikit-learn/scikit-learn/pull/29018.

Hence, the deep copy solution is to fix **AutoMM HPO + respective tests** for `scikit-learn` versions ranging from `1.4.1` to `1.5.0` and is not needed for `1.5.1`. We still need this solution because we **do not** hard cap `scikit-learn` to a specific version.

Issue number in sklearn: https://github.com/scikit-learn/scikit-learn/issues/29182

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
