### PR TITLE
[AutoMM] Fix Missing Validation Metric While Resuming A Model Failed At Checkpoint Fusing Stage

### DIFF
--- a/multimodal/src/autogluon/multimodal/learners/base.py
+++ b/multimodal/src/autogluon/multimodal/learners/base.py
@@ -1334,13 +1334,19 @@ class BaseLearner(ExportMixin, DistillationMixin, RealtimeMixin):
             model=model,
         )
 
+        best_score = (
+            trainer.callback_metrics[f"val_{self._validation_metric_name}"].item()
+            if f"val_{self._validation_metric_name}" in trainer.callback_metrics
+            else self._best_score
+        )  # https://github.com/autogluon/autogluon/issues/4428
+
         return dict(
             config=config,
             df_preprocessor=df_preprocessor,
             data_processors=data_processors,
             model=model,
             model_postprocess_fn=model_postprocess_fn,
-            best_score=trainer.callback_metrics[f"val_{self._validation_metric_name}"].item(),
+            best_score=best_score,
             strategy=strategy,
             strict_loading=not peft_param_names,
         )


### PR DESCRIPTION
Not able to reproduce the bug in https://github.com/autogluon/autogluon/issues/4428.
But this should fix it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
