### PR TITLE
[tabular] Fix incorrect return type in `predict_multi` for regression

### DIFF
--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -353,6 +353,8 @@ class AbstractTabularLearner(AbstractLearner):
         predict_proba_dict = self.predict_proba_multi(
             X=X, models=models, as_pandas=as_pandas, transform_features=transform_features, inverse_transform=inverse_transform
         )
+        if self.problem_type in [REGRESSION, QUANTILE]:
+            return predict_proba_dict
         predict_dict = {}
         for m in predict_proba_dict:
             predict_dict[m] = self.get_pred_from_proba(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fix incorrect return type in `predict_multi` for regression
- Previously would return np.ndarray when `as_pandas=True` when it should return `pd.Series`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
