### PR TITLE
Updated the PAT secrets used for CICD

### DIFF
--- a/.github/workflows/benchmark-command.yml
+++ b/.github/workflows/benchmark-command.yml
@@ -79,7 +79,7 @@ jobs:
         if: (github.event_name == 'workflow_dispatch')
         uses: peter-evans/create-or-update-comment@v4
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.CICD_PAT }}
           repository: ${{ github.event.inputs.repository }}
           comment-id: ${{ github.event.inputs.comment-id }}
           body: |
@@ -197,7 +197,7 @@ jobs:
       - name: Comment Evaluation Result of PR with Master
         uses: peter-evans/create-or-update-comment@v4
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.CICD_PAT }}
           repository: ${{ github.event.inputs.repository }}
           comment-id: ${{ github.event.inputs.comment-id }}
           body: ${{ steps.eval_result.outputs.body }}
@@ -213,7 +213,7 @@ jobs:
       - name: Comment Dashboard Website Link on PR
         uses: peter-evans/create-or-update-comment@v4
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.CICD_PAT }}
           repository: ${{ github.event.inputs.repository }}
           comment-id: ${{ github.event.inputs.comment-id }}
           body: ${{ steps.website.outputs.body }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -84,7 +84,7 @@ jobs:
   #         /bin/bash ./.github/workflow_scripts/version_diff.sh
   #     - name: Update pull request with diff
   #       env:
-  #         GH_TOKEN: ${{ secrets.PAT }}
+  #         GH_TOKEN: ${{ secrets.CICD_PAT }}
   #       run: |
   #         pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
   #         comment_body=$(jq -n --arg body "`cat ./table_output.txt`" '{body: $body}')

--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -33,7 +33,7 @@ jobs:
         if: (github.event_name == 'workflow_dispatch')
         uses: peter-evans/create-or-update-comment@v4
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.CICD_PAT }}
           repository: ${{ github.event.inputs.repository }}
           comment-id: ${{ github.event.inputs.comment-id }}
           body: |

--- a/.github/workflows/slash_command_dispatch.yml
+++ b/.github/workflows/slash_command_dispatch.yml
@@ -32,7 +32,7 @@ jobs:
         id: pr_info
         run: |
           # Use the GitHub API to fetch information about the pull request
-          pr_info=$(curl -s -H "Authorization: token ${{ secrets.PAT }}" \
+          pr_info=$(curl -s -H "Authorization: token ${{ secrets.CICD_PAT }}" \
                       "https://api.github.com/repos/${{ github.repository }}/pulls/${{ steps.pr_number.outputs.result }}")
 
           # Extract the forked repository and branch from the pull request info
@@ -46,7 +46,7 @@ jobs:
         id: scd
         uses: peter-evans/slash-command-dispatch@v4
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.CICD_PAT }}
           permission: write
           commands: |
             benchmark


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Update the PAT to have the correct scopes for runners from command triggered CICD tests such as `/platform_tests`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
