### PR TITLE
[tabular] Fix refit crash

### DIFF
--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -508,7 +508,7 @@ class AbstractTrainer:
             )
             model_names_fit += base_model_names + aux_models
         if (self.model_best is None or infer_limit is not None) and len(model_names_fit) != 0:
-            self.model_best = self.get_model_best(can_infer=True, infer_limit=infer_limit, infer_limit_as_child=True)
+            self.model_best = self.get_model_best(infer_limit=infer_limit, infer_limit_as_child=True)
         self._callbacks_conclude()
         self._fit_cleanup()
         self.save()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fix crash when refit_full is specified and no cloned refit models exist and there is no weighted ensemble.
- Bug first introduced in #4327 

For example, the following would crash:

```
predictor = TabularPredictor(...).fit(
    ..., presets="high_quality", hyperparameters={"GBM": {}}, fit_weighted_ensemble=False,
)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
