### PR TITLE
[core] Enhance generate_train_test_split

### DIFF
--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -359,8 +359,15 @@ def extract_label(data: DataFrame, label: str) -> (DataFrame, Series):
 
 
 def generate_train_test_split_combined(
-    data: DataFrame, label: str, problem_type: str, test_size: float = 0.1, random_state: int = 0, min_cls_count_train: int = 1
-) -> (DataFrame, DataFrame):
+    data: DataFrame,
+    label: str,
+    problem_type: str = None,
+    test_size: int | float = None,
+    train_size: int | float = None,
+    random_state: int = 0,
+    stratify: bool | Series = None,
+    min_cls_count_train: int = 1,
+) -> Tuple[DataFrame, DataFrame]:
     """
     Generate a train test split from a DataFrame that contains the label column.
 
@@ -371,12 +378,27 @@ def generate_train_test_split_combined(
     label : str
         The label column name.
         Used for stratification and to ensure all classes in multiclass classification are preserved in train data.
-    problem_type : str
+    problem_type : str, default = None
         The problem_type the label is used for. Determines if stratification is used.
+        If "binary" or "multiclass", enables the `min_cls_count_train` logic.
         Options: ["binary", "multiclass", "regression", "softclass", "quantile"]
-    test_size : float, default = 0.1
-        The proportion of data to use for the test set.
-        The remaining (1 - test_size) of data will be used for the training set.
+    stratify : bool | Series, default = None
+        The stratification strategy.
+        If True, will stratify using `y`.
+        If False, will not use stratification.
+        If None and problem_type is specified, will be set to True or False depending on the problem_type.
+            True if problem_type in ["binary", "multiclass"], else False.
+        If None and problem_type is None, defaults to False.
+    test_size : int | float, default = None
+        If float, should be between 0.0 and 1.0 and represent the proportion of the dataset to include in the test split.
+        If int, represents the absolute number of test samples.
+        If test_size is None and train_size is None, test_size defaults to 0.1
+    train_size : int | float, default = None
+        If float, should be between 0.0 and 1.0 and represent the proportion of the dataset to include in the train split.
+        If int, represents the absolute number of train samples.
+        If test_size is None, represents the complement of `test_size`.
+        For example, `train_size=0.7, test_size=None` is equivalent to `train_size=None, test_size=0.3`.
+        Note: It is possible for exceptions to be raised if both train_size and test_size are specified, stratification is enabled, and rare classes exist.
     random_state : int, default = 0
         Random seed to use during the split.
     min_cls_count_train : int, default = 1
@@ -392,7 +414,14 @@ def generate_train_test_split_combined(
     """
     X, y = extract_label(data=data, label=label)
     train_data, test_data, y_train, y_test = generate_train_test_split(
-        X=X, y=y, problem_type=problem_type, test_size=test_size, random_state=random_state, min_cls_count_train=min_cls_count_train
+        X=X,
+        y=y,
+        problem_type=problem_type,
+        test_size=test_size,
+        train_size=train_size,
+        random_state=random_state,
+        stratify=stratify,
+        min_cls_count_train=min_cls_count_train,
     )
     train_data[label] = y_train
     test_data[label] = y_test
@@ -400,7 +429,14 @@ def generate_train_test_split_combined(
 
 
 def generate_train_test_split(
-    X: DataFrame, y: Series, problem_type: str, test_size: Union[float, int] = 0.1, random_state=0, min_cls_count_train=1
+    X: DataFrame,
+    y: Series,
+    problem_type: str = None,
+    test_size: int | float = None,
+    train_size: int | float = None,
+    random_state: int = 0,
+    stratify: bool | Series = None,
+    min_cls_count_train: int = 1,
 ) -> Tuple[DataFrame, DataFrame, Series, Series]:
     """
     Generate a train test split from input X, y.
@@ -413,12 +449,27 @@ def generate_train_test_split(
     y : Series
         pd.Series containing the label with matching indices to X.
         Used for stratification and to ensure all classes in multiclass classification are preserved in train data.
-    problem_type : str
+    problem_type : str, default = None
         The problem_type the label is used for. Determines if stratification is used.
+        If "binary" or "multiclass", enables the `min_cls_count_train` logic.
         Options: ["binary", "multiclass", "regression", "softclass", "quantile"]
-    test_size : float or int, default = 0.1
+    stratify : bool | Series, default = None
+        The stratification strategy.
+        If True, will stratify using `y`.
+        If False, will not use stratification.
+        If None and problem_type is specified, will be set to True or False depending on the problem_type.
+            True if problem_type in ["binary", "multiclass"], else False.
+        If None and problem_type is None, defaults to False.
+    test_size : int | float, default = None
         If float, should be between 0.0 and 1.0 and represent the proportion of the dataset to include in the test split.
         If int, represents the absolute number of test samples.
+        If test_size is None and train_size is None, test_size defaults to 0.1
+    train_size : int | float, default = None
+        If float, should be between 0.0 and 1.0 and represent the proportion of the dataset to include in the train split.
+        If int, represents the absolute number of train samples.
+        If test_size is None, represents the complement of `test_size`.
+        For example, `train_size=0.7, test_size=None` is equivalent to `train_size=None, test_size=0.3`.
+        Note: It is possible for exceptions to be raised if both train_size and test_size are specified, stratification is enabled, and rare classes exist.
     random_state : int, default = 0
         Random seed to use during the split.
     min_cls_count_train : int, default = 1
@@ -435,20 +486,42 @@ def generate_train_test_split(
     """
     if len(X) == 1:
         raise ValueError(f"Cannot split data into train/val as it contains only one sample.")
-    if isinstance(test_size, float):
-        if (test_size <= 0.0) or (test_size >= 1.0):
-            raise ValueError("fraction of data to hold-out must be specified between 0 and 1")
-    elif isinstance(test_size, int):
-        assert test_size > 0
-    valid_problem_types = [BINARY, MULTICLASS, REGRESSION, SOFTCLASS, QUANTILE]
-    assert problem_type in valid_problem_types, f'Unknown problem type "{problem_type}" | Valid problem types: {valid_problem_types}'
+    if test_size is None and train_size is None:
+        test_size = 0.1
+    if train_size is not None:
+        if isinstance(train_size, float):
+            if (train_size <= 0.0) or (train_size >= 1.0):
+                raise ValueError(f"train_size fraction must be specified between 0 and 1. Value: {train_size}")
+        elif isinstance(train_size, int):
+            assert train_size > 0
+        else:
+            raise TypeError(f"train_size was specified, but is not of type int or float! Type: {type(train_size)}, Value: {train_size}")
+    if train_size is not None and test_size is None:
+        # Set train_size to None to avoid edge-case exceptions with rare classes during stratification
+        if isinstance(train_size, float):
+            test_size = 1.0 - train_size - 1e-10  # -1e-10 to fix numerical imprecision issues, ensuring `test_size=0.1` gets same result as `train_size=0.9`
+        else:
+            test_size = len(X) - train_size
+        train_size = None
+    if test_size is not None:
+        if isinstance(test_size, float):
+            if (test_size <= 0.0) or (test_size >= 1.0):
+                raise ValueError(f"test_size fraction must be specified between 0 and 1. Value: {test_size}")
+        elif isinstance(test_size, int):
+            assert test_size > 0
+        else:
+            raise TypeError(f"test_size was specified, but is not of type int or float! Type: {type(test_size)}, Value: {test_size}")
+    if problem_type is not None:
+        valid_problem_types = [BINARY, MULTICLASS, REGRESSION, SOFTCLASS, QUANTILE]
+        assert problem_type in valid_problem_types, f'Unknown problem type "{problem_type}" | Valid problem types: {valid_problem_types}'
 
     X_split = X
     y_split = y
-    if problem_type in [BINARY, MULTICLASS]:
-        stratify = y
-    else:
-        stratify = None
+    if stratify is None:
+        if problem_type is not None and problem_type in [BINARY, MULTICLASS]:
+            stratify = y
+    elif isinstance(stratify, bool):
+        stratify = y if stratify else None
 
     # This code block is necessary to avoid crashing when performing a stratified split and only 1 sample exists for a class.
     # This code will ensure that the sample will be part of the train split, meaning the test split will have 0 samples of the rare class.
@@ -473,7 +546,7 @@ def generate_train_test_split(
 
     try:
         X_train, X_test, y_train, y_test = train_test_split(
-            X_split, y_split.values, test_size=test_size, shuffle=True, random_state=random_state, stratify=stratify
+            X_split, y_split.values, test_size=test_size, train_size=train_size, shuffle=True, random_state=random_state, stratify=stratify
         )
     except ValueError:
         # This logic is necessary to avoid an edge-case limitation of scikit-learn's train_test_split function that leads to the following error:
@@ -484,23 +557,20 @@ def generate_train_test_split(
         if stratify is None:
             raise
         X_train, X_test, y_train, y_test = train_test_split(
-            X_split, y_split.values, test_size=test_size, shuffle=True, random_state=random_state, stratify=None
+            X_split, y_split.values, test_size=test_size, train_size=train_size, shuffle=True, random_state=random_state, stratify=None
         )
         if len(y_test) >= len(y_split.unique()):
             # This should never occur, otherwise the original exception is not an expected one
             raise
-    if problem_type != SOFTCLASS:
-        y_train = pd.Series(y_train, index=X_train.index)
-        y_test = pd.Series(y_test, index=X_test.index)
-    else:
-        y_train = pd.DataFrame(y_train, index=X_train.index)
-        y_test = pd.DataFrame(y_test, index=X_test.index)
+    cls_y = type(y)
+    y_train = cls_y(y_train, index=X_train.index)
+    y_test = cls_y(y_test, index=X_test.index)
 
     if rare_indices:
         X_train = pd.concat([X_train, X.loc[rare_indices]])
         y_train = pd.concat([y_train, y.loc[rare_indices]])
 
-    if problem_type in [BINARY, MULTICLASS]:
+    if problem_type is not None and problem_type in [BINARY, MULTICLASS]:
         class_counts_dict_orig = y.value_counts().to_dict()
         class_counts_dict = y_train.value_counts().to_dict()
         class_counts_dict_test = y_test.value_counts().to_dict()

--- a/core/tests/unittests/utils/test_utils.py
+++ b/core/tests/unittests/utils/test_utils.py
@@ -81,6 +81,54 @@ class TestInferProblemType(unittest.TestCase):
         assert inferred_problem_type == REGRESSION
 
 
+def _assert_equals_generate_train_test_split(X, y, test_size, problem_type=None, test_equals=True, train_size=None):
+    X_train, X_test, y_train, y_test = generate_train_test_split(X=X, y=y, problem_type=problem_type, test_size=test_size, train_size=train_size)
+    assert len(X_train) == len(y_train)
+    assert list(X_train.index) == list(y_train.index)
+    assert len(X_test) == len(y_test)
+    assert list(X_test.index) == list(y_test.index)
+    assert len(X_train.index.intersection(X_test.index)) == 0  # No shared indices
+    if test_equals:
+        if isinstance(test_size, int):
+            assert len(X_test) == test_size
+        else:
+            test_size_int = round(len(X) * test_size)
+            assert len(X_test) == test_size_int
+    else:
+        if isinstance(test_size, int):
+            assert len(X_test) <= test_size
+        else:
+            test_size_int = round(len(X) * test_size)
+            assert len(X_test) <= test_size_int
+    if train_size is not None:
+        if isinstance(train_size, int):
+            assert len(X_train) == train_size
+        else:
+            train_size_int = round(len(X) * train_size)
+            assert len(X_train) == train_size_int
+    if train_size is None or test_size is None:
+        assert len(X_train) == len(X) - len(X_test)
+
+    if train_size is None:
+        if isinstance(test_size, int):
+            train_size = len(X) - test_size
+        else:
+            train_size = 1.0 - test_size
+        X_train_v2, X_test_v2, y_train_v2, y_test_v2 = generate_train_test_split(X=X, y=y, problem_type=problem_type, train_size=train_size)
+        assert X_train.equals(X_train_v2)
+        assert y_train.equals(y_train_v2)
+        assert X_test.equals(X_test_v2)
+        assert y_test.equals(y_test_v2)
+        train_size = None
+
+    if problem_type is not None and problem_type in ["binary", "multiclass"]:
+        X_train_v3, X_test_v3, y_train_v3, y_test_v3 = generate_train_test_split(X=X, y=y, test_size=test_size, train_size=train_size, stratify=y)
+        assert X_train.loc[X_train_v3.index].equals(X_train_v3)
+        assert y_train.loc[y_train_v3.index].equals(y_train_v3)
+        assert X_test.equals(X_test_v3.loc[X_test.index])
+        assert y_test.equals(y_test_v3.loc[y_test.index])
+
+
 def test_generate_train_test_split_edgecase():
     """
     Test rare edge-cases when data has many classes or very few samples when doing train test splits.
@@ -89,47 +137,57 @@ def test_generate_train_test_split_edgecase():
     data["label"] = [0, 1, 1, 2, 3, 4, 5, 5, 5, 5, 5, 5]
 
     for test_size in range(1, 12):
-        """
-        Normal Case: Regression should always work
-        """
-        X_train, X_test, y_train, y_test = generate_train_test_split(X=data, y=data["label"], problem_type="regression", test_size=test_size)
-        assert len(X_train) == len(y_train)
-        assert list(X_train.index) == list(y_train.index)
-        assert len(X_test) == len(y_test)
-        assert list(X_test.index) == list(y_test.index)
-        assert len(X_test) == test_size
-        assert len(X_train) == len(data) - test_size
+        _assert_equals_generate_train_test_split(X=data, y=data["label"], test_size=test_size)
+        _assert_equals_generate_train_test_split(X=data, y=data["label"], test_size=test_size / len(data))
+        for problem_type in ["regression", "softclass", "quantile"]:
+            """
+            Normal Case: Regression should always work
+            """
+            _assert_equals_generate_train_test_split(X=data, y=data["label"], problem_type=problem_type, test_size=test_size)
+            _assert_equals_generate_train_test_split(X=data, y=data["label"], problem_type=problem_type, test_size=test_size / len(data))
+        for train_size in range(1, len(data) - test_size + 1):
+            _assert_equals_generate_train_test_split(X=data, y=data["label"], test_size=test_size, train_size=train_size)
+            _assert_equals_generate_train_test_split(X=data, y=data["label"], test_size=test_size / len(data), train_size=train_size / len(data))
 
-    for test_size in range(1, 6):
-        """
-        Edge-case: There are fewer test rows than classes
-         This only works because of special try/except logic in `generate_train_test_split`.
-        """
-        X_train, X_test, y_train, y_test = generate_train_test_split(X=data, y=data["label"], problem_type="multiclass", test_size=test_size)
-        assert len(X_train) == len(y_train)
-        assert list(X_train.index) == list(y_train.index)
-        assert len(X_test) == len(y_test)
-        assert list(X_test.index) == list(y_test.index)
-        assert len(X_test) <= test_size
-        assert len(X_train) == len(data) - len(X_test)
+    for test_size in range(1, 12):
+        _assert_equals_generate_train_test_split(X=data, y=data["label"], test_size=test_size)
+        _assert_equals_generate_train_test_split(X=data, y=data["label"], test_size=test_size / len(data))
+        for problem_type in ["regression", "softclass", "quantile"]:
+            """
+            Normal Case: Regression should always work
+            """
+            _assert_equals_generate_train_test_split(X=data, y=data["label"], problem_type=problem_type, test_size=test_size)
+            _assert_equals_generate_train_test_split(X=data, y=data["label"], problem_type=problem_type, test_size=test_size / len(data))
 
-    for test_size in range(6, 7):
-        """
-        Normal Case
-        """
-        X_train, X_test, y_train, y_test = generate_train_test_split(X=data, y=data["label"], problem_type="multiclass", test_size=test_size)
-        assert len(X_train) == len(y_train)
-        assert list(X_train.index) == list(y_train.index)
-        assert len(X_test) == len(y_test)
-        assert list(X_test.index) == list(y_test.index)
-        assert len(X_test) <= test_size
-        assert len(X_train) == len(data) - len(X_test)
+    for problem_type in ["binary", "multiclass"]:
+        for test_size in range(1, 6):
+            """
+            Edge-case: There are fewer test rows than classes
+             This only works because of special try/except logic in `generate_train_test_split`.
+            """
+            _assert_equals_generate_train_test_split(X=data, y=data["label"], problem_type=problem_type, test_size=test_size, test_equals=False)
+            _assert_equals_generate_train_test_split(X=data, y=data["label"], problem_type=problem_type, test_size=test_size / len(data), test_equals=False)
 
-    for test_size in range(7, 12):
-        """
-        Edge-case: There are fewer train rows than classes
-        Error due to not enough training data to have at least one instance of every class in train.
-        Note: Ideally this shouldn't raise an exception, but writing the logic to avoid the error is tricky and the scenario should never occur in practice.
-        """
-        with pytest.raises(ValueError):
-            X_train, X_test, y_train, y_test = generate_train_test_split(X=data, y=data["label"], problem_type="multiclass", test_size=test_size)
+        for test_size in range(6, 7):
+            """
+            Normal Case
+            """
+            _assert_equals_generate_train_test_split(X=data, y=data["label"], problem_type=problem_type, test_size=test_size, test_equals=False)
+            _assert_equals_generate_train_test_split(X=data, y=data["label"], problem_type=problem_type, test_size=test_size / len(data), test_equals=False)
+
+        for test_size in range(7, 12):
+            """
+            Edge-case: There are fewer train rows than classes
+            Error due to not enough training data to have at least one instance of every class in train.
+            Note: Ideally this shouldn't raise an exception, but writing the logic to avoid the error is tricky and the scenario should never occur in practice.
+            """
+            with pytest.raises(ValueError):
+                X_train, X_test, y_train, y_test = generate_train_test_split(X=data, y=data["label"], problem_type=problem_type, test_size=test_size)
+
+        # FIXME: Different for fractional inputs, because there is an inconsistency between float test_size and integer test_size in the internal logic.
+        #  We should fix this eventually. Once it is fixed, this test will fail.
+        for test_size in range(7, 10):
+            _assert_equals_generate_train_test_split(X=data, y=data["label"], problem_type=problem_type, test_size=test_size / len(data), test_equals=False)
+        for test_size in range(10, 12):
+            with pytest.raises(ValueError):
+                X_train, X_test, y_train, y_test = generate_train_test_split(X=data, y=data["label"], problem_type=problem_type, test_size=test_size / len(data))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add `train_size` argument to `generate_train_test_split`. This allows the user to specify the train size directly, akin to the argument `train_size` in sklearn's `train_test_split`.
- Add `stratify` argument to `generate_train_test_split`. This allows the user to specify the stratification logic, akin to the argument `stratify` in sklearn's `train_test_split`.
- Made `problem_type` argument optional. Defaults to the equivalent of `regression`.
- Added extensive unit tests
- This logic is partly preparation for resolving #4453 in a future PR, as we need the `stratify` argument.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
