### PR TITLE
[timeseries] Align TimeSeriesPredictor.leaderboard API with TabularPredictor

### DIFF
--- a/.github/workflow_scripts/lint_check.sh
+++ b/.github/workflow_scripts/lint_check.sh
@@ -22,6 +22,6 @@ function lint_check_all {
     # lint_check tabular
 }
 
-bandit -r multimodal/src -ll
+bandit -r multimodal/src -ll --skip B614
 lint_check_all
 ruff check timeseries/

--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -280,10 +280,18 @@ class TimeSeriesLearner(AbstractLearner):
 
         return importance_df
 
-    def leaderboard(self, data: Optional[TimeSeriesDataFrame] = None, use_cache: bool = True) -> pd.DataFrame:
+    def leaderboard(
+        self,
+        data: Optional[TimeSeriesDataFrame] = None,
+        extra_info: bool = False,
+        extra_metrics: Optional[List[Union[str, TimeSeriesScorer]]] = None,
+        use_cache: bool = True,
+    ) -> pd.DataFrame:
         if data is not None:
             data = self.feature_generator.transform(data)
-        return self.load_trainer().leaderboard(data, use_cache=use_cache)
+        return self.load_trainer().leaderboard(
+            data, extra_info=extra_info, extra_metrics=extra_metrics, use_cache=use_cache
+        )
 
     def get_info(self, include_model_info: bool = False, **kwargs) -> Dict[str, Any]:
         learner_info = super().get_info(include_model_info=include_model_info)

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -209,7 +209,7 @@ def get_preset_models(
     for model in model_priority_list:
         if isinstance(model, str):
             if model not in MODEL_TYPES:
-                raise ValueError(f"Model {model} is not supported yet.")
+                raise ValueError(f"Model {model} is not supported. Available models: {sorted(MODEL_TYPES)}")
             if model in excluded_models:
                 logger.info(
                     f"\tFound '{model}' model in `hyperparameters`, but '{model}' "

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -1248,7 +1248,10 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
             Only valid when `data` is specified. The scores refer to the scores on `data` (same data as used to
             calculate the `score_test` column).
 
-            This list can contain any values which would also be valid for `eval_metric` when creating a `TimeSeriesPredictor`.
+            This list can contain any values which would also be valid for `eval_metric` when creating a :class:`~autogluon.timeseries.TimeSeriesPredictor`.
+
+            For each provided `metric`, a column with name `str(metric)` will be added to the leaderboard, containing
+            the value of the metric computed on `data`.
         display : bool, default = False
             If True, the leaderboard DataFrame will be printed.
         use_cache : bool, default = True

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -110,8 +110,6 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
         known as dynamic features, exogenous variables, additional regressors or related time series. Examples of such
         covariates include holidays, promotions or weather forecasts.
 
-        Currently, only numeric (float of integer dtype) are supported.
-
         If ``known_covariates_names`` are provided, then:
 
         - :meth:`~autogluon.timeseries.TimeSeriesPredictor.fit`, :meth:`~autogluon.timeseries.TimeSeriesPredictor.evaluate`, and :meth:`~autogluon.timeseries.TimeSeriesPredictor.leaderboard` will expect a data frame with columns listed in ``known_covariates_names`` (in addition to the ``target`` column).
@@ -437,7 +435,6 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
 
             If ``known_covariates_names`` were specified when creating the predictor, ``train_data`` must include the
             columns listed in ``known_covariates_names`` with the covariates values aligned with the target time series.
-            The known covariates must have a numeric (float or integer) dtype.
 
             Columns of ``train_data`` except ``target`` and those listed in ``known_covariates_names`` will be
             interpreted as ``past_covariates`` - covariates that are known only in the past.

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -1240,7 +1240,7 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
 
         extra_info : bool, default = False
             If True, the leaderboard will contain an additional column `hyperparameters` with the hyperparameters used
-            by model during training. An empty dictionary `{}` means that the model was trained with default
+            by each model during training. An empty dictionary `{}` means that the model was trained with default
             hyperparameters.
         extra_metrics : List[Union[str, TimeSeriesScorer]], optional
             A list of metrics to calculate scores for and include in the output DataFrame.


### PR DESCRIPTION
*Issue #, if available:* #4152

*Description of changes:*
- Two new arguments to `TimeSeriesPredictor.leaderboard()`:
  - `extra_metrics` allows computing additional metrics on the test set
  - `extra_info` returns hyperparameters selected by hyperparameter tuning for each model


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
