### PR TITLE
Fix py38 import

### DIFF
--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import math
 import pickle


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

A recent merged commit leads to a import error with Python 3.8 due to the usage of `|` type hints, which were introduced in Python 3.9. This PR fixes this by adding `from __future__ import annotations` for backwards compatibility.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
