### PR TITLE
[tabular] Make refit_full respect user `num_cpus` and `num_gpus`

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -795,8 +795,8 @@ class AbstractModel:
             self._fit_metadata = self._compute_fit_metadata(**kwargs)
             self._is_fit_metadata_registered = True
 
-    def _compute_fit_metadata(self, X_val: pd.DataFrame = None, X_unlabeled: pd.DataFrame = None, **kwargs) -> dict:
-        fit_metadata = dict(val_in_fit=X_val is not None, unlabeled_in_fit=X_unlabeled is not None)
+    def _compute_fit_metadata(self, X_val: pd.DataFrame = None, X_unlabeled: pd.DataFrame = None, num_cpus: int = None, num_gpus: int = None, **kwargs) -> dict:
+        fit_metadata = dict(val_in_fit=X_val is not None, unlabeled_in_fit=X_unlabeled is not None, num_cpus=num_cpus, num_gpus=num_gpus)
         return fit_metadata
 
     def get_fit_metadata(self) -> dict:
@@ -2064,6 +2064,8 @@ class AbstractModel:
             "can_infer": self.can_infer(),
             "has_learning_curves": self.saved_learning_curves,
         }
+        if self._is_fit_metadata_registered:
+            info.update(self._fit_metadata)
         return info
 
     def get_params_aux_info(self) -> dict:

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -880,6 +880,7 @@ class AbstractTrainer:
         use_val_cache=True,
         fit_weighted_ensemble: bool = True,
         name_extra: str | None = None,
+        total_resources: dict | None = None,
     ) -> List[str]:
         """
         Trains auxiliary models (currently a single weighted ensemble) using the provided base models.
@@ -934,6 +935,7 @@ class AbstractTrainer:
             get_models_func=get_models_func,
             check_if_best=check_if_best,
             child_hyperparameters=child_hyperparameters,
+            total_resources=total_resources,
         )
 
     def predict(self, X, model=None):
@@ -1924,6 +1926,7 @@ class AbstractTrainer:
         check_if_best=True,
         child_hyperparameters=None,
         get_models_func=None,
+        total_resources: dict | None = None,
     ) -> List[str]:
         if get_models_func is None:
             get_models_func = self.construct_model_templates
@@ -1985,6 +1988,7 @@ class AbstractTrainer:
             time_limit=time_limit,
             ens_sample_weight=w,
             fit_kwargs=dict(feature_metadata=feature_metadata, num_classes=self.num_classes, groups=None),  # FIXME: Is this the right way to do this?
+            total_resources=total_resources,
         )
         for weighted_ensemble_model_name in models:
             if check_if_best and weighted_ensemble_model_name in self.get_model_names():
@@ -2369,7 +2373,7 @@ class AbstractTrainer:
         time_limit=None,
         fit_kwargs=None,
         compute_score=True,
-        total_resources=None,
+        total_resources: dict | None = None,
         **kwargs,
     ) -> List[str]:
         """

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1192,7 +1192,12 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             "excluded_model_types": excluded_model_types,
             "feature_prune_kwargs": kwargs.get("feature_prune_kwargs", None),
         }
-        aux_kwargs = {}
+        aux_kwargs = {
+            "total_resources": {
+                "num_cpus": num_cpus,
+                "num_gpus": num_gpus,
+            },
+        }
         if fit_weighted_ensemble is False:
             aux_kwargs["fit_weighted_ensemble"] = False
         aux_kwargs["fit_full_last_level_weighted_ensemble"] = fit_full_last_level_weighted_ensemble
@@ -1791,7 +1796,12 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         ag_args = self._set_hyperparameter_tune_kwargs_in_ag_args(kwargs["hyperparameter_tune_kwargs"], ag_args, time_limit=time_limit)
 
         fit_new_weighted_ensemble = False  # TODO: Add as option
-        aux_kwargs = {}
+        aux_kwargs = {
+            "total_resources": {
+                "num_cpus": num_cpus,
+                "num_gpus": num_gpus,
+            },
+        }
         if fit_weighted_ensemble is False:
             aux_kwargs = {"fit_weighted_ensemble": False}
         aux_kwargs["fit_full_last_level_weighted_ensemble"] = fit_full_last_level_weighted_ensemble
@@ -3663,6 +3673,11 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             y = trainer.load_y_val()
             fit = False
 
+        total_resources = {
+            "num_cpus": num_cpus,
+            "num_gpus": num_gpus,
+        }
+
         stack_name = "aux1"
         if base_models is None:
             base_models = trainer.get_model_names(stack_name="core")
@@ -3688,6 +3703,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
                     base_model_names=models_to_check_now,
                     name_suffix=name_suffix + "_Pareto" + str(i),
                     time_limit=time_limit,
+                    total_resources=total_resources,
                 )
 
         max_base_model_level = max([trainer.get_model_level(base_model) for base_model in base_models])
@@ -3700,6 +3716,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             base_model_names=base_models,
             name_suffix=name_suffix,
             time_limit=time_limit,
+            total_resources=total_resources,
         )
 
         if refit_full:

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1429,7 +1429,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
     def _sub_fit_memory_save_wrapper(
         self,
         train_data: Union[str, pd.DataFrame],
-        time_limit: int,
+        time_limit: float,
         time_start: float,
         ds_fit_kwargs: dict,
         ag_fit_kwargs: dict,
@@ -3616,10 +3616,10 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
     def fit_weighted_ensemble(
         self,
         base_models: list = None,
-        name_suffix="Best",
-        expand_pareto_frontier=False,
-        time_limit=None,
-        refit_full=False,
+        name_suffix: str = "Best",
+        expand_pareto_frontier: bool = False,
+        time_limit: float = None,
+        refit_full: bool = False,
         num_cpus: int | str = "auto",
         num_gpus: int | str = "auto",
     ):
@@ -3629,19 +3629,19 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
 
         Parameters
         ----------
-        base_models : list, default = None
+        base_models: list, default = None
             List of model names the weighted ensemble can consider as candidates.
             If None, all previously trained models are considered except for weighted ensemble models.
             As an example, to train a weighted ensemble that can only have weights assigned to the models 'model_a' and 'model_b', set `base_models=['model_a', 'model_b']`
-        name_suffix : str, default = 'Best'
+        name_suffix: str, default = 'Best'
             Name suffix to add to the name of the newly fitted ensemble model.
-        expand_pareto_frontier : bool, default = False
+        expand_pareto_frontier: bool, default = False
             If True, will train N-1 weighted ensemble models instead of 1, where `N=len(base_models)`.
             The final model trained when True is equivalent to the model trained when False.
             These weighted ensemble models will attempt to expand the pareto frontier.
             This will create many different weighted ensembles which have different accuracy/memory/inference-speed trade-offs.
             This is particularly useful when inference speed is an important consideration.
-        time_limit : int, default = None
+        time_limit: float, default = None
             Time in seconds each weighted ensemble model is allowed to train for. If `expand_pareto_frontier=True`, the `time_limit` value is applied to each model.
             If None, the ensemble models train without time restriction.
         refit_full : bool, default = False
@@ -5525,7 +5525,7 @@ class _TabularPredictorExperimental(TabularPredictor):
 def _dystack(
     predictor: TabularPredictor,
     train_data: Union[str, pd.DataFrame],
-    time_limit: int,
+    time_limit: float,
     ds_fit_kwargs: dict,
     ag_fit_kwargs: dict,
     ag_post_fit_kwargs: dict,

--- a/tabular/tests/unittests/models/test_advanced.py
+++ b/tabular/tests/unittests/models/test_advanced.py
@@ -1,3 +1,4 @@
+from autogluon.common.utils.resource_utils import ResourceManager
 from autogluon.core.models.ensemble.bagged_ensemble_model import BaggedEnsembleModel
 from autogluon.tabular.models.lgb.lgb_model import LGBModel
 
@@ -17,3 +18,44 @@ def test_bagged_predict_children(model_fit_helper):
         check_predict_children=True,
         sample_size=100,
     )
+
+
+def test_resource_constraints(fit_helper, dataset_loader_helper):
+    """
+    Verify that num_cpus and num_gpus are respected when specified in the fit call.
+    Also verifies that constraints are respected for weighted ensemble models and during refit_full.
+    Also verifies that specifying num_cpus > max_cpus will use max_cpus.
+    """
+    num_gpus = 0
+
+    max_cpus = ResourceManager.get_cpu_count()
+
+    num_cpus_to_check = [1, 3]
+    num_cpus_to_check = [c for c in num_cpus_to_check if c < max_cpus] + [max_cpus] + [max_cpus + 1000]
+
+    for num_cpus in num_cpus_to_check:
+        # Force DummyModel to raise an exception when fit.
+        fit_args = dict(
+            hyperparameters={"GBM": {"num_boost_round": 1}},
+            num_cpus=num_cpus,
+            num_gpus=num_gpus,
+            refit_full=True,
+        )
+
+        dataset_name = "adult"
+        predictor = fit_helper.fit_and_validate_dataset(
+            dataset_name=dataset_name,
+            fit_args=fit_args,
+            expected_model_count=4,
+            refit_full=False,
+            delete_directory=False,
+        )
+
+        info = predictor.info()
+
+        for model in predictor.model_names():
+            if num_cpus <= max_cpus:
+                assert info["model_info"][model]["num_cpus"] == num_cpus
+            else:
+                assert info["model_info"][model]["num_cpus"] == max_cpus  # Use max_cpus if num_cpus>max_cpus
+            assert info["model_info"][model]["num_gpus"] == num_gpus

--- a/tabular/tests/unittests/models/test_advanced.py
+++ b/tabular/tests/unittests/models/test_advanced.py
@@ -20,6 +20,7 @@ def test_bagged_predict_children(model_fit_helper):
     )
 
 
+# TODO: Test num_gpus>0
 def test_resource_constraints(fit_helper, dataset_loader_helper):
     """
     Verify that num_cpus and num_gpus are respected when specified in the fit call.


### PR DESCRIPTION
*Issue #, if available:*

Resolves #3871

Follow-up #4496 

*Description of changes:*

- Make refit_full respect user `num_cpus` and `num_gpus`.
- Make WeightedEnsemble respect user `num_cpus` and `num_gpus`.
- User can now check the resources used to fit each model via `predictor.info()`

Now when the user specifies refit_full along with resource constraints, those resource constraints are respected during refit_full:

```python
predictor = TabularPredictor(label='class').fit(
    train_data=train_data, num_cpus=17, num_gpus=0, refit_full=True
)
```

The above code would previously fit the original models with the constraints, and then during refit_full it would ignore the constraints. For example, if you had a GPU, it would forcibly use the GPU during refit.

With this PR, this is no longer the case, and the refit models respect the constraints.

## Mainline

```
Fitting model: NeuralNetTorch_BAG_L1 ...
	Fitting NeuralNetTorch_BAG_L1 with 'num_gpus': 0, 'num_cpus': 17
Fitting model: WeightedEnsemble_L2 ...
	Fitting WeightedEnsemble_L2 with 'num_gpus': 0, 'num_cpus': 96
Fitting model: NeuralNetTorch_BAG_L1_FULL ...
	Fitting NeuralNetTorch_BAG_L1_FULL with 'num_gpus': 4, 'num_cpus': 96
Fitting model: WeightedEnsemble_L2_FULL | Skipping fit via cloning parent ...
```

## This PR

```
Fitting model: NeuralNetTorch_BAG_L1 ...
	Fitting NeuralNetTorch_BAG_L1 with 'num_gpus': 0, 'num_cpus': 17
Fitting model: WeightedEnsemble_L2 ...
	Fitting WeightedEnsemble_L2 with 'num_gpus': 0, 'num_cpus': 17
Fitting model: NeuralNetTorch_BAG_L1_FULL ...
	Fitting NeuralNetTorch_BAG_L1_FULL with 'num_gpus': 0, 'num_cpus': 17
Fitting model: WeightedEnsemble_L2_FULL | Skipping fit via cloning parent ...
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
