### PR TITLE
Add Bandit Warning Mitigation for Internal `torch.save` and `torch.load` Usage

### DIFF
--- a/.github/workflow_scripts/lint_check.sh
+++ b/.github/workflow_scripts/lint_check.sh
@@ -22,6 +22,6 @@ function lint_check_all {
     # lint_check tabular
 }
 
-bandit -r multimodal/src -ll --skip B614
+bandit -r multimodal/src -ll
 lint_check_all
 ruff check timeseries/

--- a/examples/automm/memory_bank/memory_bank.py
+++ b/examples/automm/memory_bank/memory_bank.py
@@ -290,9 +290,9 @@ def train_logits(
         if acc > best_acc:
             best_acc = acc
             best_epoch = train_idx
-            torch.save(memory_bank_model.state_dict(), args.bank_dir + "/best_F_" + str(args.shots) + "shots.pt")
+            torch.save(memory_bank_model.state_dict(), args.bank_dir + "/best_F_" + str(args.shots) + "shots.pt") # nosec B614
     
-    memory_bank_model.load_state_dict(torch.load(args.bank_dir + "/best_F_" + str(args.shots) + "shots.pt"))
+    memory_bank_model.load_state_dict(torch.load(args.bank_dir + "/best_F_" + str(args.shots) + "shots.pt")) # nosec B614
     print(f"**** After fine-tuning {logits_type}, best val accuracy: {best_acc:.2f}, at epoch: {best_epoch}. ****\n")
     
     return memory_bank_model

--- a/multimodal/src/autogluon/multimodal/learners/base.py
+++ b/multimodal/src/autogluon/multimodal/learners/base.py
@@ -1477,7 +1477,7 @@ class BaseLearner(ExportMixin, DistillationMixin, RealtimeMixin):
                     "state_dict": {"model." + name: param for name, param in self._model.state_dict().items()}
                 }
 
-        torch.save(checkpoint, os.path.join(save_path, MODEL_CHECKPOINT))
+        torch.save(checkpoint, os.path.join(save_path, MODEL_CHECKPOINT)) # nosec B614
 
         if clean_ckpts:
             # clean old checkpoints + the intermediate files stored
@@ -2112,9 +2112,9 @@ class BaseLearner(ExportMixin, DistillationMixin, RealtimeMixin):
 
                 convert_zero_checkpoint_to_fp32_state_dict(path + "-dir", path)
                 shutil.rmtree(path + "-dir")
-                state_dict = torch.load(path, map_location=torch.device("cpu"))["state_dict"]
+                state_dict = torch.load(path, map_location=torch.device("cpu"))["state_dict"] # nosec B614
             else:
-                state_dict = torch.load(path, map_location=torch.device("cpu"))["state_dict"]
+                state_dict = torch.load(path, map_location=torch.device("cpu"))["state_dict"] # nosec B614
         state_dict = {k.partition(prefix)[2]: v for k, v in state_dict.items() if k.startswith(prefix)}
 
         # Some buffers like `position_ids` are registered as persistent=False since transformers 4.31.0
@@ -2222,7 +2222,7 @@ class BaseLearner(ExportMixin, DistillationMixin, RealtimeMixin):
 
         if save_model:
             checkpoint = {"state_dict": {"model." + name: param for name, param in model.state_dict().items()}}
-            torch.save(checkpoint, os.path.join(os.path.abspath(path), MODEL_CHECKPOINT))
+            torch.save(checkpoint, os.path.join(os.path.abspath(path), MODEL_CHECKPOINT)) # nosec B614
 
     @staticmethod
     def _load_metadata(

--- a/multimodal/src/autogluon/multimodal/learners/base.py
+++ b/multimodal/src/autogluon/multimodal/learners/base.py
@@ -1477,7 +1477,7 @@ class BaseLearner(ExportMixin, DistillationMixin, RealtimeMixin):
                     "state_dict": {"model." + name: param for name, param in self._model.state_dict().items()}
                 }
 
-        torch.save(checkpoint, os.path.join(save_path, MODEL_CHECKPOINT)) # nosec B614
+        torch.save(checkpoint, os.path.join(save_path, MODEL_CHECKPOINT))  # nosec B614
 
         if clean_ckpts:
             # clean old checkpoints + the intermediate files stored
@@ -2112,9 +2112,9 @@ class BaseLearner(ExportMixin, DistillationMixin, RealtimeMixin):
 
                 convert_zero_checkpoint_to_fp32_state_dict(path + "-dir", path)
                 shutil.rmtree(path + "-dir")
-                state_dict = torch.load(path, map_location=torch.device("cpu"))["state_dict"] # nosec B614
+                state_dict = torch.load(path, map_location=torch.device("cpu"))["state_dict"]  # nosec B614
             else:
-                state_dict = torch.load(path, map_location=torch.device("cpu"))["state_dict"] # nosec B614
+                state_dict = torch.load(path, map_location=torch.device("cpu"))["state_dict"]  # nosec B614
         state_dict = {k.partition(prefix)[2]: v for k, v in state_dict.items() if k.startswith(prefix)}
 
         # Some buffers like `position_ids` are registered as persistent=False since transformers 4.31.0
@@ -2222,7 +2222,7 @@ class BaseLearner(ExportMixin, DistillationMixin, RealtimeMixin):
 
         if save_model:
             checkpoint = {"state_dict": {"model." + name: param for name, param in model.state_dict().items()}}
-            torch.save(checkpoint, os.path.join(os.path.abspath(path), MODEL_CHECKPOINT)) # nosec B614
+            torch.save(checkpoint, os.path.join(os.path.abspath(path), MODEL_CHECKPOINT))  # nosec B614
 
     @staticmethod
     def _load_metadata(

--- a/multimodal/src/autogluon/multimodal/learners/matching.py
+++ b/multimodal/src/autogluon/multimodal/learners/matching.py
@@ -1057,7 +1057,7 @@ class MultiModalMatcher(BaseLearner):
         )
 
         checkpoint = {"state_dict": task.state_dict()}
-        torch.save(checkpoint, os.path.join(save_path, MODEL_CHECKPOINT))
+        torch.save(checkpoint, os.path.join(save_path, MODEL_CHECKPOINT)) # nosec B614
 
         if clean_ckpts:
             # clean old checkpoints + the intermediate files stored
@@ -1841,7 +1841,7 @@ class MultiModalMatcher(BaseLearner):
         response_prefix: str = "response_model.",
     ):
         if state_dict is None:
-            state_dict = torch.load(path, map_location=torch.device("cpu"))["state_dict"]
+            state_dict = torch.load(path, map_location=torch.device("cpu"))["state_dict"] # nosec B614
         query_state_dict = {
             k.partition(query_prefix)[2]: v for k, v in state_dict.items() if k.startswith(query_prefix)
         }
@@ -1986,7 +1986,7 @@ class MultiModalMatcher(BaseLearner):
                 response_model=self._response_model,
             )
             checkpoint = {"state_dict": task.state_dict()}
-            torch.save(checkpoint, os.path.join(path, MODEL_CHECKPOINT))
+            torch.save(checkpoint, os.path.join(path, MODEL_CHECKPOINT)) # nosec B614
 
     @staticmethod
     def _load_metadata(

--- a/multimodal/src/autogluon/multimodal/learners/matching.py
+++ b/multimodal/src/autogluon/multimodal/learners/matching.py
@@ -1057,7 +1057,7 @@ class MultiModalMatcher(BaseLearner):
         )
 
         checkpoint = {"state_dict": task.state_dict()}
-        torch.save(checkpoint, os.path.join(save_path, MODEL_CHECKPOINT)) # nosec B614
+        torch.save(checkpoint, os.path.join(save_path, MODEL_CHECKPOINT))  # nosec B614
 
         if clean_ckpts:
             # clean old checkpoints + the intermediate files stored
@@ -1841,7 +1841,7 @@ class MultiModalMatcher(BaseLearner):
         response_prefix: str = "response_model.",
     ):
         if state_dict is None:
-            state_dict = torch.load(path, map_location=torch.device("cpu"))["state_dict"] # nosec B614
+            state_dict = torch.load(path, map_location=torch.device("cpu"))["state_dict"]  # nosec B614
         query_state_dict = {
             k.partition(query_prefix)[2]: v for k, v in state_dict.items() if k.startswith(query_prefix)
         }
@@ -1986,7 +1986,7 @@ class MultiModalMatcher(BaseLearner):
                 response_model=self._response_model,
             )
             checkpoint = {"state_dict": task.state_dict()}
-            torch.save(checkpoint, os.path.join(path, MODEL_CHECKPOINT)) # nosec B614
+            torch.save(checkpoint, os.path.join(path, MODEL_CHECKPOINT))  # nosec B614
 
     @staticmethod
     def _load_metadata(

--- a/multimodal/src/autogluon/multimodal/models/ft_transformer.py
+++ b/multimodal/src/autogluon/multimodal/models/ft_transformer.py
@@ -609,12 +609,12 @@ class FT_Transformer(nn.Module):
 
         if pretrained and checkpoint_name:
             if os.path.exists(checkpoint_name):
-                ckpt = torch.load(checkpoint_name) # nosec B614
+                ckpt = torch.load(checkpoint_name)  # nosec B614
             else:
                 with tempfile.TemporaryDirectory() as tmpdirname:
                     checkpoint_path = os.path.join(tmpdirname, "./ft_transformer_pretrained.ckpt")
                     download(checkpoint_name, checkpoint_path)
-                    ckpt = torch.load(checkpoint_path) # nosec B614
+                    ckpt = torch.load(checkpoint_path)  # nosec B614
             self.transformer.load_state_dict(ckpt["state_dict"])
 
         self.name_to_id = self.get_layer_ids()

--- a/multimodal/src/autogluon/multimodal/models/ft_transformer.py
+++ b/multimodal/src/autogluon/multimodal/models/ft_transformer.py
@@ -609,12 +609,12 @@ class FT_Transformer(nn.Module):
 
         if pretrained and checkpoint_name:
             if os.path.exists(checkpoint_name):
-                ckpt = torch.load(checkpoint_name)
+                ckpt = torch.load(checkpoint_name) # nosec B614
             else:
                 with tempfile.TemporaryDirectory() as tmpdirname:
                     checkpoint_path = os.path.join(tmpdirname, "./ft_transformer_pretrained.ckpt")
                     download(checkpoint_name, checkpoint_path)
-                    ckpt = torch.load(checkpoint_path)
+                    ckpt = torch.load(checkpoint_path) # nosec B614
             self.transformer.load_state_dict(ckpt["state_dict"])
 
         self.name_to_id = self.get_layer_ids()

--- a/multimodal/src/autogluon/multimodal/models/mmdet_image.py
+++ b/multimodal/src/autogluon/multimodal/models/mmdet_image.py
@@ -169,7 +169,7 @@ class MMDetAutoModelForObjectDetection(nn.Module):
         if not save_path:
             save_path = f"./{self.checkpoint_name}_autogluon.pth"
 
-        torch.save({"state_dict": self.model.state_dict(), "meta": {"CLASSES": self.model.CLASSES}}, save_path) # nosec B614
+        torch.save({"state_dict": self.model.state_dict(), "meta": {"CLASSES": self.model.CLASSES}}, save_path)  # nosec B614
 
     def _save_configs(self, save_path=None):
         if not save_path:
@@ -500,7 +500,7 @@ class MMDetAutoModelForObjectDetection(nn.Module):
         """
         sd = source_path
 
-        model_dict = torch.load(sd, map_location=torch.device("cpu")) # nosec B614
+        model_dict = torch.load(sd, map_location=torch.device("cpu"))  # nosec B614
         if "state_dict" in model_dict:
             model_dict = model_dict["state_dict"]
         if "model" in model_dict:
@@ -617,6 +617,6 @@ class MMDetAutoModelForObjectDetection(nn.Module):
         data = {"state_dict": new_dict}
 
         target_directory = os.path.splitext(sd)[0] + f"_cvt.pth"
-        torch.save(data, target_directory) # nosec B614
+        torch.save(data, target_directory)  # nosec B614
 
         return target_directory

--- a/multimodal/src/autogluon/multimodal/models/mmdet_image.py
+++ b/multimodal/src/autogluon/multimodal/models/mmdet_image.py
@@ -169,7 +169,7 @@ class MMDetAutoModelForObjectDetection(nn.Module):
         if not save_path:
             save_path = f"./{self.checkpoint_name}_autogluon.pth"
 
-        torch.save({"state_dict": self.model.state_dict(), "meta": {"CLASSES": self.model.CLASSES}}, save_path)
+        torch.save({"state_dict": self.model.state_dict(), "meta": {"CLASSES": self.model.CLASSES}}, save_path) # nosec B614
 
     def _save_configs(self, save_path=None):
         if not save_path:
@@ -500,7 +500,7 @@ class MMDetAutoModelForObjectDetection(nn.Module):
         """
         sd = source_path
 
-        model_dict = torch.load(sd, map_location=torch.device("cpu"))
+        model_dict = torch.load(sd, map_location=torch.device("cpu")) # nosec B614
         if "state_dict" in model_dict:
             model_dict = model_dict["state_dict"]
         if "model" in model_dict:
@@ -617,6 +617,6 @@ class MMDetAutoModelForObjectDetection(nn.Module):
         data = {"state_dict": new_dict}
 
         target_directory = os.path.splitext(sd)[0] + f"_cvt.pth"
-        torch.save(data, target_directory)
+        torch.save(data, target_directory) # nosec B614
 
         return target_directory

--- a/multimodal/src/autogluon/multimodal/models/timm_image.py
+++ b/multimodal/src/autogluon/multimodal/models/timm_image.py
@@ -294,7 +294,7 @@ class TimmAutoModelForImagePrediction(nn.Module):
 
     def save(self, save_path: str = "./", tokenizers: Optional[dict] = None):
         weights_path = f"{save_path}/pytorch_model.bin"
-        torch.save(self.model.state_dict(), weights_path)
+        torch.save(self.model.state_dict(), weights_path) # nosec B614
         logger.info(f"Model {self.prefix} weights saved to {weights_path}.")
         config_path = f"{save_path}/config.json"
         self.dump_config(config_path)

--- a/multimodal/src/autogluon/multimodal/models/timm_image.py
+++ b/multimodal/src/autogluon/multimodal/models/timm_image.py
@@ -294,7 +294,7 @@ class TimmAutoModelForImagePrediction(nn.Module):
 
     def save(self, save_path: str = "./", tokenizers: Optional[dict] = None):
         weights_path = f"{save_path}/pytorch_model.bin"
-        torch.save(self.model.state_dict(), weights_path) # nosec B614
+        torch.save(self.model.state_dict(), weights_path)  # nosec B614
         logger.info(f"Model {self.prefix} weights saved to {weights_path}.")
         config_path = f"{save_path}/config.json"
         self.dump_config(config_path)

--- a/multimodal/src/autogluon/multimodal/utils/cache.py
+++ b/multimodal/src/autogluon/multimodal/utils/cache.py
@@ -92,10 +92,10 @@ class DDPPredictionWriter(BasePredictionWriter):
         """
         # this will create N (num processes) files in `cache_dir` each containing
         # the predictions of its respective rank
-        torch.save(predictions, self.get_predictions_cache_dir(trainer.global_rank))
+        torch.save(predictions, self.get_predictions_cache_dir(trainer.global_rank)) # nosec B614
         # here we save `batch_indices` to get the information about the data index
         # from prediction data
-        torch.save(batch_indices, self.get_batch_indices_cache_dir(trainer.global_rank))
+        torch.save(batch_indices, self.get_batch_indices_cache_dir(trainer.global_rank)) # nosec B614
 
     def read_single_gpu_results(self, global_rank: Optional[int]):
         """
@@ -109,8 +109,8 @@ class DDPPredictionWriter(BasePredictionWriter):
         while (not os.path.exists(sample_indices_file)) or (not os.path.exists(predictions_file)):
             logger.info(f"waiting for rank #{global_rank} to finish saving predictions...")
             time.sleep(self.sleep_time)
-        sample_indices = torch.load(sample_indices_file)
-        predictions = torch.load(predictions_file)
+        sample_indices = torch.load(sample_indices_file) # nosec B614
+        predictions = torch.load(predictions_file) # nosec B614
 
         return sample_indices, predictions
 

--- a/multimodal/src/autogluon/multimodal/utils/cache.py
+++ b/multimodal/src/autogluon/multimodal/utils/cache.py
@@ -92,10 +92,10 @@ class DDPPredictionWriter(BasePredictionWriter):
         """
         # this will create N (num processes) files in `cache_dir` each containing
         # the predictions of its respective rank
-        torch.save(predictions, self.get_predictions_cache_dir(trainer.global_rank)) # nosec B614
+        torch.save(predictions, self.get_predictions_cache_dir(trainer.global_rank))  # nosec B614
         # here we save `batch_indices` to get the information about the data index
         # from prediction data
-        torch.save(batch_indices, self.get_batch_indices_cache_dir(trainer.global_rank)) # nosec B614
+        torch.save(batch_indices, self.get_batch_indices_cache_dir(trainer.global_rank))  # nosec B614
 
     def read_single_gpu_results(self, global_rank: Optional[int]):
         """
@@ -109,8 +109,8 @@ class DDPPredictionWriter(BasePredictionWriter):
         while (not os.path.exists(sample_indices_file)) or (not os.path.exists(predictions_file)):
             logger.info(f"waiting for rank #{global_rank} to finish saving predictions...")
             time.sleep(self.sleep_time)
-        sample_indices = torch.load(sample_indices_file) # nosec B614
-        predictions = torch.load(predictions_file) # nosec B614
+        sample_indices = torch.load(sample_indices_file)  # nosec B614
+        predictions = torch.load(predictions_file)  # nosec B614
 
         return sample_indices, predictions
 

--- a/multimodal/src/autogluon/multimodal/utils/checkpoint.py
+++ b/multimodal/src/autogluon/multimodal/utils/checkpoint.py
@@ -40,9 +40,9 @@ def average_checkpoints(
 
                 convert_zero_checkpoint_to_fp32_state_dict(per_path + "-dir", per_path)
                 shutil.rmtree(per_path + "-dir")
-                state_dict = torch.load(per_path, map_location=torch.device("cpu"))["state_dict"] # nosec B614
+                state_dict = torch.load(per_path, map_location=torch.device("cpu"))["state_dict"]  # nosec B614
             else:
-                state_dict = torch.load(per_path, map_location=torch.device("cpu"))["state_dict"] # nosec B614
+                state_dict = torch.load(per_path, map_location=torch.device("cpu"))["state_dict"]  # nosec B614
             for k, v in state_dict.items():
                 if k not in avg_state_dict:
                     avg_state_dict[k] = v.clone().to(dtype=torch.float64)
@@ -60,7 +60,7 @@ def average_checkpoints(
         for k in avg_state_dict:
             avg_state_dict[k].clamp_(float32_info.min, float32_info.max).to(dtype=torch.float32)
     else:
-        avg_state_dict = torch.load(checkpoint_paths[0], map_location=torch.device("cpu"))["state_dict"] # nosec B614
+        avg_state_dict = torch.load(checkpoint_paths[0], map_location=torch.device("cpu"))["state_dict"]  # nosec B614
 
     return avg_state_dict
 

--- a/multimodal/src/autogluon/multimodal/utils/checkpoint.py
+++ b/multimodal/src/autogluon/multimodal/utils/checkpoint.py
@@ -40,9 +40,9 @@ def average_checkpoints(
 
                 convert_zero_checkpoint_to_fp32_state_dict(per_path + "-dir", per_path)
                 shutil.rmtree(per_path + "-dir")
-                state_dict = torch.load(per_path, map_location=torch.device("cpu"))["state_dict"]
+                state_dict = torch.load(per_path, map_location=torch.device("cpu"))["state_dict"] # nosec B614
             else:
-                state_dict = torch.load(per_path, map_location=torch.device("cpu"))["state_dict"]
+                state_dict = torch.load(per_path, map_location=torch.device("cpu"))["state_dict"] # nosec B614
             for k, v in state_dict.items():
                 if k not in avg_state_dict:
                     avg_state_dict[k] = v.clone().to(dtype=torch.float64)
@@ -60,7 +60,7 @@ def average_checkpoints(
         for k in avg_state_dict:
             avg_state_dict[k].clamp_(float32_info.min, float32_info.max).to(dtype=torch.float32)
     else:
-        avg_state_dict = torch.load(checkpoint_paths[0], map_location=torch.device("cpu"))["state_dict"]
+        avg_state_dict = torch.load(checkpoint_paths[0], map_location=torch.device("cpu"))["state_dict"] # nosec B614
 
     return avg_state_dict
 

--- a/multimodal/src/autogluon/multimodal/utils/cloud_io.py
+++ b/multimodal/src/autogluon/multimodal/utils/cloud_io.py
@@ -48,7 +48,7 @@ def _load(
     """
     if not isinstance(path_or_url, (str, Path)):
         # any sort of BytesIO or similar
-        return torch.load(path_or_url, map_location=map_location)
+        return torch.load(path_or_url, map_location=map_location)  # nosec B614
     if str(path_or_url).startswith("http"):
         return torch.hub.load_state_dict_from_url(
             str(path_or_url),
@@ -56,7 +56,7 @@ def _load(
         )
     fs = get_filesystem(path_or_url)
     with fs.open(path_or_url, "rb") as f:
-        return torch.load(f, map_location=map_location)
+        return torch.load(f, map_location=map_location)  # nosec B614
 
 
 def get_filesystem(path: _PATH, **kwargs: Any) -> AbstractFileSystem:
@@ -75,6 +75,6 @@ def _atomic_save(checkpoint: Dict[str, Any], filepath: Union[str, Path]) -> None
             This points to the file that the checkpoint will be stored in.
     """
     bytesbuffer = io.BytesIO()
-    torch.save(checkpoint, bytesbuffer)
+    torch.save(checkpoint, bytesbuffer)  # nosec B614
     with fsspec.open(filepath, "wb") as f:
         f.write(bytesbuffer.getvalue())

--- a/tabular/src/autogluon/tabular/models/fastainn/fastai_helpers.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/fastai_helpers.py
@@ -23,7 +23,7 @@ def export(model, filename_or_stream="export.pkl", pickle_module=pickle, pickle_
     with warnings.catch_warnings():
         # To avoid the warning that come from PyTorch about model not being checked
         warnings.simplefilter("ignore")
-        torch.save(model, target, pickle_module=pickle_module, pickle_protocol=pickle_protocol)
+        torch.save(model, target, pickle_module=pickle_module, pickle_protocol=pickle_protocol)  # nosec B614
     model.create_opt()
     if state is not None:
         model.opt.load_state_dict(state)

--- a/tabular/src/autogluon/tabular/models/tab_transformer/tab_transformer_model.py
+++ b/tabular/src/autogluon/tabular/models/tab_transformer/tab_transformer_model.py
@@ -341,7 +341,7 @@ class TabTransformerModel(AbstractNeuralNetworkModel):
 
                     best_val_epoch = e
                     os.makedirs(os.path.dirname(self.path), exist_ok=True)
-                    torch.save(self.model, os.path.join(self.path, self._temp_file_name))
+                    torch.save(self.model, os.path.join(self.path, self._temp_file_name)) # nosec B614
 
             # If time limit has exceeded or we haven't improved in some number of epochs, stop early.
             if e - best_val_epoch > epochs_wo_improve:
@@ -355,7 +355,7 @@ class TabTransformerModel(AbstractNeuralNetworkModel):
 
         if loader_val is not None:
             try:
-                self.model = torch.load(os.path.join(self.path, self._temp_file_name))
+                self.model = torch.load(os.path.join(self.path, self._temp_file_name)) # nosec B614
                 os.remove(os.path.join(self.path, self._temp_file_name))
             except:
                 pass
@@ -496,7 +496,7 @@ class TabTransformerModel(AbstractNeuralNetworkModel):
 
         temp_model = self.model
         if self.model is not None:
-            torch.save(self.model, params_filepath)
+            torch.save(self.model, params_filepath) # nosec B614
 
         self.model = None  # Avoiding pickling the weights.
         modelobj_filepath = super().save(path=path, verbose=verbose)
@@ -513,7 +513,7 @@ class TabTransformerModel(AbstractNeuralNetworkModel):
         if reset_paths:
             obj.set_contexts(path)
 
-        obj.model = torch.load(os.path.join(path, cls.params_file_name))
+        obj.model = torch.load(os.path.join(path, cls.params_file_name)) # nosec B614
 
         return obj
 

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -335,7 +335,7 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
                 self.optimizer.step()
 
             os.makedirs(os.path.dirname(self.path), exist_ok=True)
-            torch.save(self.model, net_filename)
+            torch.save(self.model, net_filename) # nosec B614
             logger.log(15, "Untrained Tabular Neural Network saved to file")
             return
 
@@ -443,7 +443,7 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
                         is_best = True
                     best_val_metric = val_metric
                     os.makedirs(os.path.dirname(self.path), exist_ok=True)
-                    torch.save(self.model, net_filename)
+                    torch.save(self.model, net_filename) # nosec B614
                     best_epoch = epoch
                     best_val_update = total_updates
                 early_stop = early_stopping_method.update(cur_round=epoch-1, is_best=is_best)
@@ -495,7 +495,7 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
         if val_dataset is not None:
             logger.log(15, f"Best model found on Epoch {best_epoch} (Update {best_val_update}). Val {self.stopping_metric.name}: {best_val_metric}")
             try:
-                self.model = torch.load(net_filename)
+                self.model = torch.load(net_filename) # nosec B614
                 os.remove(net_filename)
             except FileNotFoundError:
                 pass

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_torch_dataset.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_torch_dataset.py
@@ -231,14 +231,14 @@ class TabularTorchDataset(torch.utils.data.IterableDataset):
         dataobj_file = file_prefix + self.DATAOBJ_SUFFIX
         if not os.path.exists(os.path.dirname(dataobj_file)):
             os.makedirs(os.path.dirname(dataobj_file))
-        torch.save(self, dataobj_file)
+        torch.save(self, dataobj_file) # nosec B614
         logger.debug("TabularPyTorchDataset Dataset saved to a file: \n %s" % dataobj_file)
 
     @classmethod
     def load(cls, file_prefix=""):
         """Additional naming changes will be appended to end of file_prefix (must contain full absolute path)"""
         dataobj_file = file_prefix + cls.DATAOBJ_SUFFIX
-        dataset: TabularTorchDataset = torch.load(dataobj_file)
+        dataset: TabularTorchDataset = torch.load(dataobj_file) # nosec B614
         logger.debug("TabularNN Dataset loaded from a file: \n %s" % dataobj_file)
         return dataset
 


### PR DESCRIPTION


This PR addresses the need for safe usage of `torch.save` and `torch.load` within the internal codebase. The main changes include:

1. **Inline Warning Mitigation**: Added `# nosec B614` comments to mitigate Bandit warnings for `torch.save` and `torch.load` usage in internal functions. This ensures that these functions are used safely and intentionally within the codebase.
2. **Remove Repo-Level Mitigation**: Removed the repo-level Bandit warning mitigation (`--skip B614`) to prevent accidental usage of `torch.save` and `torch.load` in external-facing APIs. This change ensures that any new usage of these functions will be flagged by Bandit, promoting safer coding practices.

