### PR TITLE
Remove raytune default install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,7 @@ celerybeat-schedule
 .env
 
 # virtualenv
-.venv
+.venv*
 venv/
 ENV/
 

--- a/core/setup.py
+++ b/core/setup.py
@@ -68,7 +68,7 @@ tests_require = [
 
 all_requires = []
 
-for extra_package in ["ray", "raytune"]:
+for extra_package in ["ray"]:
     if extra_package in extras_require:
         all_requires += extras_require[extra_package]
 tests_require = list(set(tests_require))

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -41,7 +41,7 @@ install_requires = [
     "orjson~=3.9",  # use faster JSON implementation in GluonTS
     # TODO v1.1: use lightning[pytorch-extra] instead of explicitly installing tensorboard
     "tensorboard>=2.9,<3",  # fixes https://github.com/autogluon/autogluon/issues/3612
-    f"autogluon.core[raytune]=={version}",
+    f"autogluon.core=={version}",
     f"autogluon.common=={version}",
     f"autogluon.tabular[catboost,lightgbm,xgboost]=={version}",
 ]


### PR DESCRIPTION
*Issue #, if available:*
This resolves installation issue on pip failing to resolve `pyarrow` dependency when trying to install `raytune`. 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
