### PR TITLE
[Master] Update installation instructions to use uv temporarily

### DIFF
--- a/docs/install-cpu-pip.md
+++ b/docs/install-cpu-pip.md
@@ -1,10 +1,11 @@
 ```console
 pip install -U pip
 pip install -U setuptools wheel
+pip install -U uv
 
 # CPU version of pytorch has smaller footprint - see installation instructions in
 # pytorch documentation - https://pytorch.org/get-started/locally/
-pip install torch==2.3.1 torchvision==0.18.1 --index-url https://download.pytorch.org/whl/cpu
+uv pip install torch==2.3.1 torchvision==0.18.1 --index-url https://download.pytorch.org/whl/cpu
 
-pip install autogluon
+uv pip install autogluon
 ```

--- a/docs/install-gpu-pip.md
+++ b/docs/install-gpu-pip.md
@@ -1,6 +1,7 @@
 ```console
 pip install -U pip
 pip install -U setuptools wheel
-pip install autogluon
+pip install -U uv
+uv pip install autogluon
 ```
 

--- a/docs/install-mac-cpu.md
+++ b/docs/install-mac-cpu.md
@@ -1,6 +1,7 @@
 ```console
 pip install -U pip
 pip install -U setuptools wheel
+pip install -U uv
 
-pip install autogluon
+uv pip install autogluon
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -212,7 +212,8 @@ Note that the above example is only valid while the branch still exists. A user 
 AutoGluon offers nightly builds that can be installed using the `--pre` argument. Nightly builds have the latest features but have not been as rigorously tested as stable releases.
 
 ```bash
-pip install --pre autogluon
+pip install -U uv
+uv pip install --pre autogluon
 ```
 :::
 

--- a/full_install.sh
+++ b/full_install.sh
@@ -1,10 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
-python3 -m pip install -e common/[tests]
-python3 -m pip install -e core/[all,tests]
-python3 -m pip install -e features/
-python3 -m pip install -e tabular/[all,tests]
-python3 -m pip install -e multimodal/[tests]
-python3 -m pip install -e timeseries/[all,tests]
-python3 -m pip install -e eda/
-python3 -m pip install -e autogluon/
+
+# Check if uv is installed
+if ! command -v uv &> /dev/null
+then
+    echo "uv could not be found. Installing uv..."
+    python3 -m pip install uv
+fi
+
+# Use uv to install packages
+uv pip install -e common/[tests]
+uv pip install -e core/[all,tests]
+uv pip install -e features/
+uv pip install -e tabular/[all,tests]
+uv pip install -e multimodal/[tests]
+uv pip install -e timeseries/[all,tests]
+uv pip install -e eda/
+uv pip install -e autogluon/


### PR DESCRIPTION
This change is a temporary measure to mitigate pip installation issues.

*Issue #, if available:* #4515

*Description of changes:*

- Updated installation instructions to use uv instead of pip
- Added uv installation step in all installation documentation
- Replaced pip install commands with uv pip install
- Updated full_install.sh to check for uv and install it if not present
- Used uv for installing AutoGluon and its dependencies

This change addresses the recent installation failures reported in issue #4515, where users are encountering problems with onnx and optimum dependencies. By using uv, we aim to provide a more stable installation process until a permanent solution can be implemented.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.