### PR TITLE
[Bug] Cap pyarrow to fix source installation issue

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -51,6 +51,7 @@ extras_require = {
         "ray[default]>=2.10.0,<2.32",  # sync with common/src/autogluon/common/utils/try_import.py
     ],
     "raytune": [
+        "pyarrow>=15.0.0,<17.0.1",  # cap Pyarrow to fix source installation
         "ray[default,tune]>=2.10.0,<2.32",  # sync with common/src/autogluon/common/utils/try_import.py
         # TODO: consider alternatives as hyperopt is not actively maintained.
         "hyperopt>=0.2.7,<0.2.8",  # This is needed for the bayes search to work.

--- a/core/setup.py
+++ b/core/setup.py
@@ -51,7 +51,7 @@ extras_require = {
         "ray[default]>=2.10.0,<2.32",  # sync with common/src/autogluon/common/utils/try_import.py
     ],
     "raytune": [
-        "pyarrow>=17.0.0",  # cap Pyarrow to fix source installation - https://github.com/autogluon/autogluon/issues/4519
+        "pyarrow>=15.0.0",  # cap Pyarrow to fix source installation - https://github.com/autogluon/autogluon/issues/4519
         "ray[default,tune]>=2.10.0,<2.32",  # sync with common/src/autogluon/common/utils/try_import.py
         # TODO: consider alternatives as hyperopt is not actively maintained.
         "hyperopt>=0.2.7,<0.2.8",  # This is needed for the bayes search to work.

--- a/core/setup.py
+++ b/core/setup.py
@@ -51,7 +51,7 @@ extras_require = {
         "ray[default]>=2.10.0,<2.32",  # sync with common/src/autogluon/common/utils/try_import.py
     ],
     "raytune": [
-        "pyarrow>=15.0.0,<17.0.1",  # cap Pyarrow to fix source installation
+        "pyarrow>=17.0.0",  # cap Pyarrow to fix source installation - https://github.com/autogluon/autogluon/issues/4519
         "ray[default,tune]>=2.10.0,<2.32",  # sync with common/src/autogluon/common/utils/try_import.py
         # TODO: consider alternatives as hyperopt is not actively maintained.
         "hyperopt>=0.2.7,<0.2.8",  # This is needed for the bayes search to work.


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/autogluon/autogluon/issues/4519

*Description of changes:*
Source installation now works on every supported version of Python - 3.9, 3.10, 3.11.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
