### PR TITLE
[tabular] Enhance predict_proba_multi

### DIFF
--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -1314,8 +1314,25 @@ class AbstractTrainer:
         else:
             return model_pred_dict
 
-    def get_model_oof(self, model: str) -> np.ndarray:
-        """Gets the out of fold prediction probabilities for a bagged ensemble model"""
+    def get_model_oof(self, model: str, use_refit_parent: bool = False) -> np.ndarray:
+        """
+        Gets the out of fold prediction probabilities for a bagged ensemble model
+
+        Parameters
+        ----------
+        model : str
+            Name of the model to get OOF.
+        use_refit_parent: bool = False
+            If True and the model is a refit model, will instead return the parent model's OOF.
+            If False and the model is a refit model, an exception will be raised.
+
+        Returns
+        -------
+        np.ndarray
+            model OOF prediction probabilities (if classification) or predictions (if regression)
+        """
+        if use_refit_parent and self.get_model_attribute(model=model, attribute="refit_full", default=False):
+            model = self.get_model_attribute(model=model, attribute="refit_full_parent")
         model_type = self.get_model_attribute(model=model, attribute="type")
         if issubclass(model_type, BaggedEnsembleModel):
             model_path = self.get_model_attribute(model=model, attribute="path")

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -267,6 +267,7 @@ class AbstractTabularLearner(AbstractLearner):
         as_multiclass: bool = True,
         transform_features: bool = True,
         inverse_transform: bool = True,
+        use_refit_parent_oof: bool = True,
     ) -> dict:
         """
         Returns a dictionary of prediction probabilities where the key is
@@ -302,6 +303,8 @@ class AbstractTabularLearner(AbstractLearner):
         inverse_transform : bool, default = True
             If True, will return prediction probabilities in the original format.
             If False (advanced), will return prediction probabilities in AutoGluon's internal format.
+        use_refit_parent_oof: bool = True
+            If True and data is None and returning OOF, will return the parent model's OOF for refit models instead of raising an exception.
 
         Returns
         -------
@@ -328,7 +331,7 @@ class AbstractTabularLearner(AbstractLearner):
                 X_index = copy.deepcopy(X.index) if as_pandas else None
                 predict_proba_dict = dict()
                 for m in models:
-                    predict_proba_dict[m] = trainer.get_model_oof(m)
+                    predict_proba_dict[m] = trainer.get_model_oof(m, use_refit_parent=use_refit_parent_oof)
 
         # Inverse Transform labels
         for m, pred_proba in predict_proba_dict.items():
@@ -344,6 +347,7 @@ class AbstractTabularLearner(AbstractLearner):
         as_pandas: bool = True,
         transform_features: bool = True,
         inverse_transform: bool = True,
+        use_refit_parent_oof: bool = True,
         *,
         decision_threshold: float = None,
     ) -> dict:
@@ -351,7 +355,12 @@ class AbstractTabularLearner(AbstractLearner):
         Identical to predict_proba_multi, except returns predictions instead of probabilities.
         """
         predict_proba_dict = self.predict_proba_multi(
-            X=X, models=models, as_pandas=as_pandas, transform_features=transform_features, inverse_transform=inverse_transform
+            X=X,
+            models=models,
+            as_pandas=as_pandas,
+            transform_features=transform_features,
+            inverse_transform=inverse_transform,
+            use_refit_parent_oof=use_refit_parent_oof,
         )
         if self.problem_type in [REGRESSION, QUANTILE]:
             return predict_proba_dict

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -2793,7 +2793,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             predict_proba_dict[m] = predictor.predict_proba(data, model=m)
         ```
 
-        Note that this will generally be much faster than calling `self.predict_proba` separately for each model
+        Note that this will generally be much faster than calling :meth:`TabularPredictor.predict_proba` separately for each model
         because this method leverages the model dependency graph to avoid redundant computation.
 
         Parameters
@@ -2802,7 +2802,12 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             The data to predict on.
             If None:
                 If self.has_val, the validation data is used.
-                Else, the out-of-fold prediction probabilities are used.
+                Else, prediction is skipped and the out-of-fold (OOF) prediction probabilities are returned, equivalent to:
+                ```
+                predict_proba_dict = {}
+                for m in models:
+                    predict_proba_dict[m] = predictor.predict_proba_oof(model=m)
+                ```
         models : List[str], default = None
             The list of models to get predictions for.
             If None, all models that can infer are used.
@@ -2861,7 +2866,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             predict_dict[m] = predictor.predict(data, model=m)
         ```
 
-        Note that this will generally be much faster than calling `self.predict` separately for each model
+        Note that this will generally be much faster than calling :meth:`TabularPredictor.predict` separately for each model
         because this method leverages the model dependency graph to avoid redundant computation.
 
         Parameters
@@ -2870,14 +2875,17 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             The data to predict on.
             If None:
                 If self.has_val, the validation data is used.
-                Else, the out-of-fold prediction probabilities are used.
+                Else, prediction is skipped and the out-of-fold (OOF) predictions are returned, equivalent to:
+                ```
+                predict_dict = {}
+                for m in models:
+                    predict_dict[m] = predictor.predict_oof(model=m)
+                ```
         models : List[str], default = None
             The list of models to get predictions for.
             If None, all models that can infer are used.
         as_pandas : bool, default = True
-            Whether to return the output of each model as a pandas object (True) or numpy array (False).
-            Pandas object is a DataFrame if this is a multiclass problem, otherwise it is a Series.
-            If the output is a DataFrame, the column order will be equivalent to `predictor.class_labels`.
+            Whether to return the output of each model as a pandas Series (True) or numpy array (False).
         transform_features : bool, default = True
             If True, preprocesses data before predicting with models.
             If False, skips global feature preprocessing.
@@ -2890,7 +2898,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             Only relevant for binary classification, otherwise ignored.
             If None, defaults to `0.5`.
             Valid values are in the range [0.0, 1.0]
-            You can obtain an optimized `decision_threshold` by first calling `predictor.calibrate_decision_threshold()`.
+            You can obtain an optimized `decision_threshold` by first calling :meth:`TabularPredictor.calibrate_decision_threshold`.
             Useful to set for metrics such as `balanced_accuracy` and `f1` as `0.5` is often not an optimal threshold.
             Predictions are calculated via the following logic on the positive class: `1 if pred > decision_threshold else 0`
 

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -2843,7 +2843,13 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             )
         data = self._get_dataset(data, allow_nan=True)
         return self._learner.predict_proba_multi(
-            X=data, models=models, as_pandas=as_pandas, as_multiclass=as_multiclass, transform_features=transform_features, inverse_transform=inverse_transform
+            X=data,
+            models=models,
+            as_pandas=as_pandas,
+            as_multiclass=as_multiclass,
+            transform_features=transform_features,
+            inverse_transform=inverse_transform,
+            use_refit_parent_oof=True,
         )
 
     @overload

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -9,7 +9,7 @@ import pprint
 import shutil
 import time
 import warnings
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import overload, Any, Dict, List, Literal, Optional, Tuple, Union
 
 import networkx as nx
 import numpy as np
@@ -2775,13 +2775,13 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
 
     def predict_proba_multi(
         self,
-        data=None,
+        data: pd.DataFrame = None,
         models: List[str] = None,
         as_pandas: bool = True,
         as_multiclass: bool = True,
         transform_features: bool = True,
         inverse_transform: bool = True,
-    ) -> dict:
+    ) -> dict[str, pd.DataFrame] | dict[str, pd.Series] | dict[str, np.ndarray]:
         """
         Returns a dictionary of prediction probabilities where the key is
         the model name and the value is the model's prediction probabilities on the data.
@@ -2813,8 +2813,8 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             If None, all models that can infer are used.
         as_pandas : bool, default = True
             Whether to return the output of each model as a pandas object (True) or numpy array (False).
-            Pandas object is a DataFrame if this is a multiclass problem or `as_multiclass=True`, otherwise it is a Series.
-            If the output is a DataFrame, the column order will be equivalent to `predictor.class_labels`.
+            Pandas object is a :class:`pd.DataFrame` if this is a multiclass problem or `as_multiclass=True`, otherwise it is a :class:`pd.Series`.
+            If the output is a :class:`pd.DataFrame`, the column order will be equivalent to `predictor.classes_`.
         as_multiclass : bool, default = True
             Whether to return binary classification probabilities as if they were for multiclass classification.
                 Output will contain two columns, and if `as_pandas=True`, the column names will correspond to the binary class labels.
@@ -2831,7 +2831,8 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
 
         Returns
         -------
-        Dictionary with model names as keys and model prediction probabilities as values.
+        dict
+            Dictionary with model names as keys and model prediction probabilities as values.
         """
         self._assert_is_fit("predict_proba_multi")
         if not self.can_predict_proba:
@@ -2845,16 +2846,39 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             X=data, models=models, as_pandas=as_pandas, as_multiclass=as_multiclass, transform_features=transform_features, inverse_transform=inverse_transform
         )
 
+    @overload
     def predict_multi(
         self,
-        data=None,
+        data: pd.DataFrame = None,
+        models: List[str] = None,
+        as_pandas: Literal[True] = True,
+        transform_features: bool = True,
+        inverse_transform: bool = True,
+        decision_threshold: float = None,
+    ) -> dict[str, pd.Series]: ...
+
+    @overload
+    def predict_multi(
+        self,
+        data: pd.DataFrame = None,
+        models: List[str] = None,
+        *,
+        as_pandas: Literal[False],
+        transform_features: bool = True,
+        inverse_transform: bool = True,
+        decision_threshold: float = None,
+    ) -> dict[str, np.ndarray]: ...
+
+    def predict_multi(
+        self,
+        data: pd.DataFrame = None,
         models: List[str] = None,
         as_pandas: bool = True,
         transform_features: bool = True,
         inverse_transform: bool = True,
         *,
         decision_threshold: float = None,
-    ) -> dict:
+    ) -> dict[str, pd.Series] | dict[str, np.ndarray]:
         """
         Returns a dictionary of predictions where the key is
         the model name and the value is the model's prediction probabilities on the data.
@@ -2885,7 +2909,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             The list of models to get predictions for.
             If None, all models that can infer are used.
         as_pandas : bool, default = True
-            Whether to return the output of each model as a pandas Series (True) or numpy array (False).
+            Whether to return the output of each model as a :class:`pd.Series` (True) or :class:`np.ndarray` (False).
         transform_features : bool, default = True
             If True, preprocesses data before predicting with models.
             If False, skips global feature preprocessing.
@@ -2904,7 +2928,8 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
 
         Returns
         -------
-        Dictionary with model names as keys and model predictions as values.
+        dict[str, pd.Series] | dict[str, np.ndarray]
+            Dictionary with model names as keys and model predictions as values.
         """
         self._assert_is_fit("predict_multi")
         if decision_threshold is None:

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -395,6 +395,11 @@ def test_advanced_functionality_bagging():
         predict_proba_oof = predictor.predict_proba_oof(model=m)
         assert predict_proba_oof.equals(predict_proba_dict_oof[m])
 
+    predict_dict_oof = predictor.predict_multi()
+    for m in predictor.model_names():
+        predict_oof = predictor.predict_oof(model=m)
+        assert predict_oof.equals(predict_dict_oof[m])
+
     score_oof = predictor.evaluate_predictions(train_data[label], oof_pred_proba)
     model_best = predictor.model_best
 
@@ -408,6 +413,18 @@ def test_advanced_functionality_bagging():
     # assert that refit model uses original model's OOF predictions
     oof_pred_proba_refit = predictor.predict_proba_oof()
     assert oof_pred_proba.equals(oof_pred_proba_refit)
+
+    # check predict_proba_multi after refit does not raise an exception
+    predict_proba_dict_oof = predictor.predict_proba_multi()
+    for m in predictor.model_names():
+        predict_proba_oof = predictor.predict_proba_oof(model=m)
+        assert predict_proba_oof.equals(predict_proba_dict_oof[m])
+
+    # check predict_multi after refit does not raise an exception
+    predict_dict_oof = predictor.predict_multi()
+    for m in predictor.model_names():
+        predict_oof = predictor.predict_oof(model=m)
+        assert predict_oof.equals(predict_dict_oof[m])
 
 
 def load_data(directory_prefix, train_file, test_file, name, url=None):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Update predict_proba_multi docstring
- Update predict_multi docstring, add overrides to improve type hinting based on the user's value of `as_pandas`
- Added helper arg to trainer.get_model_oof to use parent model if refit for OOF loading
- Added logic to ensure predict_proba_multi will not crash if getting OOF for refit models. Previously it would crash.
- Added unit test to verify that the logic works correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
