### PR TITLE
[timeseries] Fix refit_every_n_windows=None raising an exception if num_val_windows=1

### DIFF
--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -416,7 +416,7 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
         excluded_model_types: Optional[List[str]] = None,
         num_val_windows: int = 1,
         val_step_size: Optional[int] = None,
-        refit_every_n_windows: int = 1,
+        refit_every_n_windows: Optional[int] = 1,
         refit_full: bool = False,
         enable_ensemble: bool = True,
         skip_model_selection: bool = False,
@@ -720,7 +720,7 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
         if num_val_windows == 0 and tuning_data is None:
             raise ValueError("Please set num_val_windows >= 1 or provide custom tuning_data")
 
-        if num_val_windows <= 1 and refit_every_n_windows > 1:
+        if num_val_windows <= 1 and refit_every_n_windows is not None and refit_every_n_windows > 1:
             logger.warning(
                 f"\trefit_every_n_windows provided as {refit_every_n_windows} but num_val_windows is set to {num_val_windows}."
                 " Refit_every_n_windows will have no effect."

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -951,7 +951,8 @@ def test_given_only_short_series_in_train_data_then_exception_is_raised(
 
 
 @pytest.mark.parametrize(
-    "num_val_windows, refit_every_n_windows, expected_num_refits", [(5, None, 1), (7, 7, 1), (5, 1, 5), (6, 2, 3)]
+    "num_val_windows, refit_every_n_windows, expected_num_refits",
+    [(5, None, 1), (1, None, 1), (7, 7, 1), (5, 1, 5), (6, 2, 3)],
 )
 @pytest.mark.parametrize("model_name", ["Naive", "RecursiveTabular"])
 def test_given_refit_every_n_windows_when_fit_then_model_is_fit_correct_number_of_times(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Currently, calling `predictor.fit(..., num_val_windows=1, refit_every_n_windows=None)` raises an exception. This PR fixes the bug.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
