### PR TITLE
Support python3.12

### DIFF
--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python: ["3.9", "3.10", "3.11"]
+        python: ["3.9", "3.10", "3.11", "3.12"]
     steps:  
       - name: Checkout repository for PR
         if: (github.event_name == 'workflow_dispatch')
@@ -84,7 +84,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python: ["3.9", "3.10", "3.11"]
+        python: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: Checkout repository for PR
         if: (github.event_name == 'workflow_dispatch')
@@ -117,7 +117,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python: ["3.9", "3.10", "3.11"]
+        python: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: Checkout repository for PR
         if: (github.event_name == 'workflow_dispatch')
@@ -150,7 +150,7 @@ jobs:
   #     fail-fast: false
   #     matrix:
   #       os: [macos-latest, windows-latest, ubuntu-latest]
-  #       python: ["3.9", "3.10", "3.11"]
+  #       python: ["3.9", "3.10", "3.11", "3.12"]
   #   steps:
   #     - name: Checkout repository for PR
   #       if: (github.event_name == 'workflow_dispatch')
@@ -183,7 +183,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python: ["3.9", "3.10", "3.11"]
+        python: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: Checkout repository for PR
         if: (github.event_name == 'workflow_dispatch')
@@ -228,7 +228,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python: ["3.9", "3.10", "3.11"]
+        python: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: Checkout repository for PR
         if: (github.event_name == 'workflow_dispatch')
@@ -272,7 +272,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python: ["3.9", "3.10", "3.11"]
+        python: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: Checkout repository for PR
         if: (github.event_name == 'workflow_dispatch')

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -11,7 +11,7 @@ LITE_MODE = "lite" in PACKAGE_NAME
 
 AUTOGLUON_ROOT_PATH = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..", ".."))
 
-PYTHON_REQUIRES = ">=3.9, <3.12"
+PYTHON_REQUIRES = ">=3.9, <3.13"
 
 
 # Only put packages here that would otherwise appear multiple times across different module's setup.py files.
@@ -142,6 +142,7 @@ def default_setup_args(*, version, submodule):
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
+            "Programming Language :: Python :: 3.12",
             "Topic :: Software Development",
             "Topic :: Scientific/Engineering :: Artificial Intelligence",
             "Topic :: Scientific/Engineering :: Information Analysis",

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,7 +2,7 @@
 
 :::{note} 
 
-* AutoGluon requires Python version 3.8, 3.9, 3.10, 3.11, or 3.12 and is available on Linux, MacOS, and Windows.
+* AutoGluon requires Python version 3.9, 3.10, 3.11, or 3.12 and is available on Linux, MacOS, and Windows.
  
 * The AutoGluon library comes pre-installed in all releases of [Amazon SageMaker Distribution](https://github.com/aws/sagemaker-distribution). For more information, refer to the dropdown [AutoGluon in Amazon SageMaker Studio](#dropdown-sagemaker) in this page. 
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,7 +2,7 @@
 
 :::{note} 
 
-* AutoGluon requires Python version 3.8, 3.9, 3.10, or 3.11 and is available on Linux, MacOS, and Windows.
+* AutoGluon requires Python version 3.8, 3.9, 3.10, 3.11, or 3.12 and is available on Linux, MacOS, and Windows.
  
 * The AutoGluon library comes pre-installed in all releases of [Amazon SageMaker Distribution](https://github.com/aws/sagemaker-distribution). For more information, refer to the dropdown [AutoGluon in Amazon SageMaker Studio](#dropdown-sagemaker) in this page. 
 

--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -31,13 +31,13 @@ install_requires = [
     "lightning",  # version range defined in `core/_setup_utils.py`
     "transformers[sentencepiece]",  # version range defined in `core/_setup_utils.py`
     "accelerate",  # version range defined in `core/_setup_utils.py`
-    "requests>=2.21,<3",
+    "requests>=2.30,<3",
     "jsonschema>=4.18,<4.22",
     "seqeval>=1.2.2,<1.3.0",
     "evaluate>=0.4.0,<0.5.0",
     "timm>=0.9.5,<0.10.0",
     "torchvision>=0.16.0,<0.21.0",
-    "scikit-image>=0.19.1,<0.21.0",
+    "scikit-image>=0.19.1,<0.25.0",
     "text-unidecode>=1.3,<1.4",
     "torchmetrics>=1.2.0,<1.3.0",
     "nptyping>=1.4.4,<2.5.0",
@@ -63,8 +63,8 @@ tests_require = [
     "ruff",
     "datasets>=2.10.0,<2.15.0",
     "onnx>=1.13.0,<1.16.2",  # cap at 1.16.1 for issue https://github.com/autogluon/autogluon/issues/3804, https://github.com/onnx/onnx/issues/6267
-    "onnxruntime>=1.15.0,<1.18.0",
-    "onnxruntime-gpu>=1.15.0,<1.18.0;platform_system!='Darwin'",
+    "onnxruntime>=1.17.0,<1.20.0",
+    "onnxruntime-gpu>=1.17.0,<1.20.0;platform_system!='Darwin'",
     "tensorrt>=8.6.0,<10.3;platform_system=='Linux' and python_version<'3.11'",
 ]
 

--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -62,7 +62,8 @@ install_requires = ag.get_dependency_version_ranges(install_requires)
 tests_require = [
     "ruff",
     "datasets>=2.10.0,<2.15.0",
-    "onnx>=1.13.0,<1.16.2",  # cap at 1.16.1 for issue https://github.com/onnx/onnx/issues/6267
+    "onnx>=1.13.0,<1.16.2;platform_system=='Windows'",  # cap at 1.16.1 for issue https://github.com/onnx/onnx/issues/6267
+    "onnx>=1.13.0,<1.18.0;platform_system!='Windows'",
     "onnxruntime>=1.17.0,<1.20.0",  # install for gpu system due to https://github.com/autogluon/autogluon/issues/3804
     "onnxruntime-gpu>=1.17.0,<1.20.0;platform_system!='Darwin'",
     "tensorrt>=8.6.0,<10.3;platform_system=='Linux' and python_version<'3.11'",

--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -62,8 +62,8 @@ install_requires = ag.get_dependency_version_ranges(install_requires)
 tests_require = [
     "ruff",
     "datasets>=2.10.0,<2.15.0",
-    "onnx>=1.13.0,<1.16.2",  # cap at 1.16.1 for issue https://github.com/autogluon/autogluon/issues/3804, https://github.com/onnx/onnx/issues/6267
-    "onnxruntime>=1.17.0,<1.20.0",
+    "onnx>=1.13.0,<1.16.2",  # cap at 1.16.1 for issue https://github.com/onnx/onnx/issues/6267
+    "onnxruntime>=1.17.0,<1.20.0",  # install for gpu system due to https://github.com/autogluon/autogluon/issues/3804
     "onnxruntime-gpu>=1.17.0,<1.20.0;platform_system!='Darwin'",
     "tensorrt>=8.6.0,<10.3;platform_system=='Linux' and python_version<'3.11'",
 ]

--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -62,9 +62,9 @@ install_requires = ag.get_dependency_version_ranges(install_requires)
 tests_require = [
     "ruff",
     "datasets>=2.10.0,<2.15.0",
-    "onnx>=1.13.0,<1.14.0",
-    "onnxruntime>=1.15.0,<1.16.0",
-    "onnxruntime-gpu>=1.15.0,<1.16.0;platform_system!='Darwin'",
+    "onnx>=1.13.0,<1.16.2",  # cap at 1.16.1 for issue https://github.com/autogluon/autogluon/issues/3804, https://github.com/onnx/onnx/issues/6267
+    "onnxruntime>=1.15.0,<1.18.0",
+    "onnxruntime-gpu>=1.15.0,<1.18.0;platform_system!='Darwin'",
     "tensorrt>=8.6.0,<10.3;platform_system=='Linux' and python_version<'3.11'",
 ]
 

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -75,14 +75,14 @@ extras_require = {
         "skl2onnx>=1.15.0,<1.18.0",
         # For macOS, there isn't a onnxruntime-gpu package installed with skl2onnx.
         # Therefore, we install onnxruntime explicitly here just for macOS.
-        "onnxruntime>=1.15.0,<1.18.0",
+        "onnxruntime>=1.17.0,<1.20.0",
     ]
     if sys.platform == "darwin"
     else [
         "onnx>=1.13.0,<1.16.2",  # cap at 1.16.1 for issue https://github.com/onnx/onnx/issues/6267
         "skl2onnx>=1.15.0,<1.18.0", 
-        "onnxruntime>=1.15.0,<1.18.0",
-        "onnxruntime-gpu>=1.15.0,<1.18.0"],
+        "onnxruntime>=1.17.0,<1.20.0",
+        "onnxruntime-gpu>=1.17.0,<1.20.0"],
 }
 
 # TODO: v1.0: Rename `all` to `core`, make `all` contain everything.

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -71,7 +71,8 @@ extras_require = {
         "vowpalwabbit>=9,<9.10; python_version < '3.11' and sys_platform != 'darwin'",
     ],
     "skl2onnx": [
-        "onnx>=1.13.0,<1.16.2",  # cap at 1.16.1 for issue https://github.com/onnx/onnx/issues/6267
+        "onnx>=1.13.0,<1.16.2;platform_system=='Windows'",  # cap at 1.16.1 for issue https://github.com/onnx/onnx/issues/6267
+        "onnx>=1.13.0,<1.18.0;platform_system!='Windows'",
         "skl2onnx>=1.15.0,<1.18.0",
         # For macOS, there isn't a onnxruntime-gpu package installed with skl2onnx.
         # Therefore, we install onnxruntime explicitly here just for macOS.
@@ -79,7 +80,8 @@ extras_require = {
     ]
     if sys.platform == "darwin"
     else [
-        "onnx>=1.13.0,<1.16.2",  # cap at 1.16.1 for issue https://github.com/onnx/onnx/issues/6267
+        "onnx>=1.13.0,<1.16.2;platform_system=='Windows'",  # cap at 1.16.1 for issue https://github.com/onnx/onnx/issues/6267
+        "onnx>=1.13.0,<1.18.0;platform_system!='Windows'",
         "skl2onnx>=1.15.0,<1.18.0", 
         "onnxruntime>=1.17.0,<1.20.0",   # install for gpu system due to https://github.com/autogluon/autogluon/issues/3804
         "onnxruntime-gpu>=1.17.0,<1.20.0"],

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -49,6 +49,7 @@ extras_require = {
         "xgboost>=1.6,<2.2",  # <{N+1} upper cap, where N is the latest released minor version
     ],
     "fastai": [
+        "spacy<3.8",  # cap for issue https://github.com/explosion/spaCy/issues/13653
         "torch",  # version range defined in `core/_setup_utils.py`
         "fastai>=2.3.1,<2.8",  # <{N+1} upper cap, where N is the latest released minor version
     ],

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -81,7 +81,7 @@ extras_require = {
     else [
         "onnx>=1.13.0,<1.16.2",  # cap at 1.16.1 for issue https://github.com/onnx/onnx/issues/6267
         "skl2onnx>=1.15.0,<1.18.0", 
-        "onnxruntime>=1.17.0,<1.20.0",
+        "onnxruntime>=1.17.0,<1.20.0",   # install for gpu system due to https://github.com/autogluon/autogluon/issues/3804
         "onnxruntime-gpu>=1.17.0,<1.20.0"],
 }
 

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -58,7 +58,7 @@ extras_require = {
         "optimum[openvino,nncf]>=1.17,<1.19",
     ],
     "chronos-onnx": [  # for faster CPU inference in pretrained models with ONNX
-        "optimum[onnxruntime]>=1.17,<1.19",
+        "optimum[onnxruntime]>=1.17,<1.20",
     ],
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. adds support for Python3.12
2. updated `pip install` to `uv pip install` for tests in order to speed up the installation and avoid the installation [issue](https://github.com/autogluon/autogluon/issues/4515) at the moment 
3. fixed platform tests (most of them except for TimeSeries tests that fail on MacOS)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
