### PR TITLE
[features] Speed up DropDuplicatesFeatureGenerator

### DIFF
--- a/features/src/autogluon/features/generators/drop_duplicates.py
+++ b/features/src/autogluon/features/generators/drop_duplicates.py
@@ -34,7 +34,7 @@ class DropDuplicatesFeatureGenerator(AbstractFeatureGenerator):
         Refer to :class:`AbstractFeatureGenerator` documentation for details on valid key word arguments.
     """
 
-    def __init__(self, sample_size_init=500, sample_size_final=2000, **kwargs):
+    def __init__(self, sample_size_init=500, sample_size_final=3000, **kwargs):
         super().__init__(**kwargs)
         self.sample_size_init = sample_size_init
         self.sample_size_final = sample_size_final
@@ -53,8 +53,10 @@ class DropDuplicatesFeatureGenerator(AbstractFeatureGenerator):
         self._remove_features_in(features_to_drop)
         if features_to_drop:
             self._log(15, f"\t{len(features_to_drop)} duplicate columns removed: {features_to_drop}")
-        X_out = X[self.features_in]
-        return X_out, self.feature_metadata_in.type_group_map_special
+        # Avoid creating an unnecessary copy with X[self.features_in], if possible
+        if self.features_in != X.columns.to_list():
+            X = X[self.features_in]
+        return X, self.feature_metadata_in.type_group_map_special
 
     def _transform(self, X: DataFrame) -> DataFrame:
         return X
@@ -68,7 +70,7 @@ class DropDuplicatesFeatureGenerator(AbstractFeatureGenerator):
         cls, X: DataFrame, feature_metadata_in, keep: Union[str, bool] = "first", sample_size=None
     ) -> list:
         if sample_size is not None and len(X) > sample_size:
-            X = X.sample(sample_size, random_state=0)
+            X = X.sample(sample_size, random_state=0, replace=True)
         features_to_remove = []
 
         X_columns = set(X.columns)

--- a/features/src/autogluon/features/generators/drop_duplicates.py
+++ b/features/src/autogluon/features/generators/drop_duplicates.py
@@ -24,7 +24,7 @@ class DropDuplicatesFeatureGenerator(AbstractFeatureGenerator):
         The number of rows to sample when doing an initial filter of duplicate feature candidates.
         Usually, the majority of features can be filtered out using this smaller amount of rows which greatly speeds up the computation of the final check.
         If None or greater than the number of rows, no initial filter will occur. This may increase the time to fit immensely for large datasets.
-    sample_size_final : int, default 2000
+    sample_size_final : int, default 3000
         The number of rows to sample when doing the final filter to determine duplicate features.
         This theoretically can lead to features that are very nearly duplicates but not exact duplicates being removed,
         but should be near impossible in practice.
@@ -70,6 +70,7 @@ class DropDuplicatesFeatureGenerator(AbstractFeatureGenerator):
         cls, X: DataFrame, feature_metadata_in, keep: Union[str, bool] = "first", sample_size=None
     ) -> list:
         if sample_size is not None and len(X) > sample_size:
+            # Sampling with replacement is much faster than without replacement
             X = X.sample(sample_size, random_state=0, replace=True)
         features_to_remove = []
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Speed up fitting time & reduce memory usage for `DropDuplicatesFeatureGenerator`

Benchmark results for a dataset with 47M rows, 7 features
```python
import time
import pandas as pd
from autogluon.features.generators import DropDuplicatesFeatureGenerator

df = pd.read_parquet("http://m5-benchmarks.s3.amazonaws.com/data/train/temporal.parquet")

print(len(df))
# 47649940
print(df.dtypes)
# item_id       category
# timestamp       object
# snap_CA        float32
# snap_TX        float32
# snap_WI        float32
# sell_price     float32

start = time.time()
gen = DropDuplicatesFeatureGenerator()
out = gen.fit_transform(df)
print(f"duration: {time.time() - start:.1f} s")
# master branch: 10.3 s
# this PR: 4.9 s
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
