### PR TITLE
[tabular] Add support for controlling AutoGluon's repeated cross-validation behavior

### DIFF
--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -2675,6 +2675,7 @@ class AbstractTrainer:
         n_repeats=None,
         n_repeat_start=0,
         time_limit=None,
+        delay_bag_sets: bool = False,
         **kwargs,
     ) -> List[str]:
         """
@@ -2691,7 +2692,7 @@ class AbstractTrainer:
             n_repeats = self.n_repeats
         if (k_fold == 0) and (n_repeats != 1):
             raise ValueError(f"n_repeats must be 1 when k_fold is 0, values: ({n_repeats}, {k_fold})")
-        if time_limit is None and feature_prune_kwargs is None:
+        if (time_limit is None and feature_prune_kwargs is None) or (not delay_bag_sets):
             n_repeats_initial = n_repeats
         else:
             n_repeats_initial = 1

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -764,6 +764,15 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
                 Number of stacking levels to use in stack ensemble. Roughly increases model training time by factor of `num_stack_levels+1` (set = 0 to disable stack ensembling).
                 Disabled by default (0), but we recommend `num_stack_levels=1` to maximize predictive performance.
                 To prevent overfitting, `num_bag_folds >= 2` must also be set or else a ValueError will be raised.
+            delay_bag_sets : bool, default = False
+                Controls when repeats of kfold bagging are executed in AutoGluon when under a time limit.
+                We suggest sticking to `False` to avoid overfitting.
+                    If True, AutoGluon delays repeating kfold bagging until after evaluating all models
+                        from `hyperparameters`, if there is enough time. This allows AutoGluon to explore
+                        more hyperparameters to obtain a better final performance but it may lead to
+                        more overfitting.
+                    If False, AutoGluon repeats kfold bagging immediately after evaluating each model.
+                        Thus, AutoGluon might evaluate fewer models with less overfitting.
             holdout_frac : float, default = None
                 Fraction of train_data to holdout as tuning data for optimizing hyperparameters (ignored unless `tuning_data = None`, ignored if `num_bag_folds != 0` unless `use_bag_holdout == True`).
                 Default value (if None) is selected based on the number of rows in the training data. Default values range from 0.2 at 2,500 rows to 0.01 at 250,000 rows.
@@ -1083,6 +1092,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         excluded_model_types = kwargs["excluded_model_types"]
         use_bag_holdout = kwargs["use_bag_holdout"]
         ds_args: dict = kwargs["ds_args"]
+        delay_bag_sets: bool = kwargs["delay_bag_sets"]
         test_data = kwargs["test_data"]
         learning_curves = kwargs["learning_curves"]
 
@@ -1200,6 +1210,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             "included_model_types": included_model_types,
             "excluded_model_types": excluded_model_types,
             "feature_prune_kwargs": kwargs.get("feature_prune_kwargs", None),
+            "delay_bag_sets": delay_bag_sets,
         }
         aux_kwargs = {
             "total_resources": {
@@ -4880,6 +4891,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         return dict(
             # data split / ensemble architecture kwargs -> Don't nest but have nested documentation -> Actually do nesting
             num_bag_sets=None,
+            delay_bag_sets=False,
             num_stack_levels=None,
             hyperparameter_tune_kwargs=None,
             # core_kwargs -> +1 nest

--- a/tabular/tests/unittests/edgecases/test_edgecases.py
+++ b/tabular/tests/unittests/edgecases/test_edgecases.py
@@ -248,7 +248,7 @@ def test_raises_num_gpus_neg(fit_helper):
         )
 
 @pytest.mark.parametrize("delay_bag_sets", [True, False])
-def test_max_sets(fit_helper,delay_bag_sets):
+def test_delay_bag_sets(fit_helper,delay_bag_sets):
     """Tests that max_sets works"""
     fit_args = dict(
         hyperparameters={"DUMMY": [{}, {}]},

--- a/tabular/tests/unittests/edgecases/test_edgecases.py
+++ b/tabular/tests/unittests/edgecases/test_edgecases.py
@@ -2,6 +2,8 @@ import shutil
 
 import pytest
 
+from pathlib import Path
+
 from autogluon.core.constants import BINARY
 from autogluon.core.metrics import METRICS
 
@@ -244,3 +246,41 @@ def test_raises_num_gpus_neg(fit_helper):
             expected_model_count=None,
             delete_directory=True,
         )
+
+@pytest.mark.parametrize("delay_bag_sets", [True, False])
+def test_max_sets(fit_helper,delay_bag_sets):
+    """Tests that max_sets works"""
+    fit_args = dict(
+        hyperparameters={"DUMMY": [{}, {}]},
+        fit_weighted_ensemble=False,
+        num_bag_folds=2,
+        num_bag_sets=2,
+        time_limit=30,  # has no impact, but otherwise `delay_bag_sets` is ignored.
+        delay_bag_sets=delay_bag_sets,
+        ag_args_ensemble={"fold_fitting_strategy":"sequential_local"},
+    )
+    dataset_name = "adult"
+
+    predictor = fit_helper.fit_and_validate_dataset(
+        dataset_name=dataset_name,
+        fit_args=fit_args,
+        expected_model_count=2,
+        refit_full=False,
+        delete_directory=False,
+    )
+
+    # Verify fit order is correct.
+    model_1 = predictor._trainer.load_model('DummyModel_BAG_L1')
+    max_model_times_1 = max([(Path(model_1.path)/bm).stat().st_mtime_ns for bm in model_1.models])
+
+    model_2 = predictor._trainer.load_model('DummyModel_2_BAG_L1')
+    min_model_times_2 = min([(Path(model_2.path) / bm).stat().st_mtime_ns for bm in model_2.models])
+
+    if delay_bag_sets:
+        # Last model of model 1 should be trained after fist model of model 2
+        assert max_model_times_1 > min_model_times_2
+    else:
+        # Last model of model 1 should be trained before fist model of model 2
+        assert max_model_times_1 <= min_model_times_2
+
+    shutil.rmtree(predictor.path, ignore_errors=True)


### PR DESCRIPTION
> [!CAUTION]
> This PR changes the default behavior **if** a user manually has set `num_bag_sets != 1`


### Description of changes

This PR enables support for controlling when bagging is repeated in cross-validation.

### Argument For Change In Default Behavior

I also suggest changing the default behavior for two reasons:

- it is very unintuitive that if a user increases the number of bag sets (i.e., repeats) under a time limit, they might not even see a change in the results due to the entire portfolio being fit first;
- if we have enabled repeats, it is likely more important to do more repeats than evaluate more models to avoid overfitting, especially for small data;
- the current default AutoGluon behavior does not change, as we have  `num_bag_sets == 1` since AutoGluon 1.0.

Happy to discuss this in more detail. 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.
