### PR TITLE
add +cpu tag for cpu installation guide

### DIFF
--- a/docs/install-cpu-pip.md
+++ b/docs/install-cpu-pip.md
@@ -5,7 +5,7 @@ pip install -U uv
 
 # CPU version of pytorch has smaller footprint - see installation instructions in
 # pytorch documentation - https://pytorch.org/get-started/locally/
-uv pip install torch==2.3.1 torchvision==0.18.1 --index-url https://download.pytorch.org/whl/cpu
+uv pip install torch==2.3.1+cpu torchvision==0.18.1+cpu --index-url https://download.pytorch.org/whl/cpu
 
 uv pip install autogluon
 ```


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/autogluon/autogluon/issues/4541

*Description of changes:*
Fix the installation issue for CPU by adding `+cpu` tag



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
