### PR TITLE
[tabular] Pipeline presets with automatic cross-validation preset

### DIFF
--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -184,7 +184,7 @@ def normalize_multi_probas(y_predprob, eps):
     return y_predprob
 
 
-def default_holdout_frac(num_train_rows, hyperparameter_tune: bool =False):
+def default_holdout_frac(num_train_rows, hyperparameter_tune: bool = False):
     """Returns default holdout_frac used in fit().
     Between row count 5,000 and 25,000 keep 0.1 holdout_frac, as we want to grow validation set to a stable 2500 examples.
     """

--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -184,7 +184,7 @@ def normalize_multi_probas(y_predprob, eps):
     return y_predprob
 
 
-def default_holdout_frac(num_train_rows, hyperparameter_tune=False):
+def default_holdout_frac(num_train_rows, hyperparameter_tune: bool =False):
     """Returns default holdout_frac used in fit().
     Between row count 5,000 and 25,000 keep 0.1 holdout_frac, as we want to grow validation set to a stable 2500 examples.
     """

--- a/tabular/src/autogluon/tabular/configs/pipeline_presets.py
+++ b/tabular/src/autogluon/tabular/configs/pipeline_presets.py
@@ -74,7 +74,7 @@ def get_validation_and_stacking_method(
 ) -> tuple[int, int, int, bool, bool, float, bool]:
     """Get the validation method for AutoGluon via a heuristic.
 
-    Input variables are `None` if they were not specified by the user or have an explict default.
+    Input variables are `None` if they were not specified by the user or have an explicit default.
 
     Parameters
     ----------

--- a/tabular/src/autogluon/tabular/configs/pipeline_presets.py
+++ b/tabular/src/autogluon/tabular/configs/pipeline_presets.py
@@ -16,15 +16,15 @@ def _get_validation_preset(num_train_rows: int, hpo_enabled: bool) -> dict[str, 
     num_bag_sets = 1
 
     use_bag_holdout = num_train_rows >= USE_BAG_HOLDOUT_AUTO_THRESHOLD
-    holdout_frac = default_holdout_frac(num_train_rows=num_train_rows, hyperparameter_tune=hpo_enabled)
+    holdout_frac = round(default_holdout_frac(num_train_rows=num_train_rows, hyperparameter_tune=hpo_enabled), 4)
 
     # Changes to avoid overfitting
     if num_train_rows <= 1_000:
-        num_bag_folds = min(8, max(5, math.floor(num_train_rows / 10)))
-        num_bag_sets = 4 + (2 * (8 - num_bag_folds))
-    elif num_train_rows <= 5_000:
-        num_bag_folds = 4
-    elif num_train_rows <= 10_000:
+        num_bag_folds = min(8, max(4, math.floor(num_train_rows / 100)))
+        num_bag_sets = min(10, 4 + (2 * (8 - num_bag_folds)))
+    elif num_train_rows < 5_000:
+        num_bag_sets = 4
+    elif num_train_rows < 10_000:
         num_bag_sets = 2
     elif num_train_rows < USE_BAG_HOLDOUT_AUTO_THRESHOLD:
         # TODO(improvement): go towards 4-fold cv for more than 100k rows?
@@ -61,7 +61,7 @@ def get_validation_and_stacking_method(
     num_bag_folds: int | None,
     num_bag_sets: int | None,
     use_bag_holdout: bool | None,
-    holdout_frac: float,
+    holdout_frac: float | None,
     # Stacking/Pipeline parameters
     auto_stack: bool,
     num_stack_levels: int | None,

--- a/tabular/src/autogluon/tabular/configs/pipeline_presets.py
+++ b/tabular/src/autogluon/tabular/configs/pipeline_presets.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import math
+
+from autogluon.core.constants import BINARY, PROBLEM_TYPES
+from autogluon.core.utils.utils import default_holdout_frac
+
+USE_BAG_HOLDOUT_AUTO_THRESHOLD = 1_000_000
+
+
+def _get_validation_preset(num_train_rows: int, hpo_enabled: bool) -> dict[str, int | float]:
+    """Recommended validation preset manually defined by the AutoGluon developers."""
+
+    # Default recommendation
+    num_bag_folds = 8  # due to 8 cores per CPU being very common.
+    num_bag_sets = 1
+
+    use_bag_holdout = num_train_rows >= USE_BAG_HOLDOUT_AUTO_THRESHOLD
+    holdout_frac = default_holdout_frac(num_train_rows=num_train_rows, hyperparameter_tune=hpo_enabled)
+
+    # Changes to avoid overfitting
+    if num_train_rows <= 1_000:
+        num_bag_folds = min(8, max(5, math.floor(num_train_rows / 10)))
+        num_bag_sets = 4 + (2 * (8 - num_bag_folds))
+    elif num_train_rows <= 5_000:
+        num_bag_folds = 4
+    elif num_train_rows <= 10_000:
+        num_bag_sets = 2
+    elif num_train_rows < USE_BAG_HOLDOUT_AUTO_THRESHOLD:
+        # TODO(improvement): go towards 4-fold cv for more than 100k rows?
+        pass
+    else:
+        # Only use holdout validation afterward
+        num_bag_folds = 0
+        num_bag_sets = 0
+
+    return dict(
+        num_bag_sets=num_bag_sets,
+        num_bag_folds=num_bag_folds,
+        use_bag_holdout=use_bag_holdout,
+        holdout_frac=holdout_frac,
+    )
+
+
+# TODO(refactor): use a data class for the config of the validation method.
+# TODO(improvement): Implement a more sophisticated solution.
+#   Could also use more metadata such as  num_features, num_models,
+#   or time_limit for a heuristic.
+#       num_features: The number of features in the dataset.
+#       num_models: The number of models in the portfolio to fit.
+#       time_limit: The time limit for fitting models.
+#   Pointer for more advanced heuristic:
+#       -> very large num features -> make less folds
+#       -> very large num models -> make more folds
+#       -> very small num models -> refit
+#       -> not enough time -> no bagging
+#   Pointer for non-heuristic approach:
+#       -> meta-learning via TabRepo 3.0 like Auto-Sklearn 2.0
+def get_validation_and_stacking_method(
+    # Validation parameters
+    num_bag_folds: int | None,
+    num_bag_sets: int | None,
+    use_bag_holdout: bool | None,
+    holdout_frac: float,
+    # Stacking/Pipeline parameters
+    auto_stack: bool,
+    num_stack_levels: int | None,
+    dynamic_stacking: bool | None,
+    refit_full: bool | None,
+    # Metadata
+    num_train_rows: int,
+    problem_type: PROBLEM_TYPES,
+    hpo_enabled: bool,
+) -> tuple[int, int, int, bool, bool, float, bool]:
+    """Get the validation method for AutoGluon via a heuristic.
+
+    Input variables are `None` if they were not specified by the user or have an explict default.
+
+    Parameters
+    ----------
+    num_bag_folds: int | None
+        The number of folds for cross-validation.
+    num_bag_sets: int | None
+        The number of repeats for cross-validation.
+    use_bag_holdout: bool | None
+        Whether to use (additional) holdout validation.
+    holdout_frac: float | None
+        The fraction of data to holdout for validation.
+    auto_stack: bool
+        Whether to automatically determine the stacking method.
+    num_stack_levels: int | None
+        The number of stacking levels.
+    dynamic_stacking: bool | None
+        Whether to use dynamic stacking.
+    refit_full: bool
+        Whether to refit the full training dataset.
+    num_train_rows: int
+        The number of rows in the training dataset.
+    problem_type: PROBLEM_TYPES
+        The type of problem to solve.
+    hpo_enabled: bool
+        If True, HPO is enabled during the run of AutoGluon.
+
+    Returns:
+    --------
+    Returns all variables needed to define the validation method.
+    """
+
+    cv_preset = _get_validation_preset(num_train_rows=num_train_rows, hpo_enabled=hpo_enabled)
+
+    # Independent of `auto_stack`
+    if use_bag_holdout is None:
+        use_bag_holdout = cv_preset["use_bag_holdout"]
+    if holdout_frac is None:
+        holdout_frac = cv_preset["holdout_frac"]
+    if dynamic_stacking is None:
+        dynamic_stacking = not use_bag_holdout
+    if refit_full is None:
+        refit_full = False
+
+    # Changed by `auto_stack`
+    if num_bag_folds is None:
+        # `num_bag_folds == 0` -> only use holdout validation
+        num_bag_folds = cv_preset["num_bag_folds"] if auto_stack else 0
+    if num_bag_sets is None:
+        # `num_bag_sets == 1` -> no repeats
+        num_bag_sets = cv_preset["num_bag_sets"] if auto_stack else 1
+    if num_stack_levels is None:
+        # Disable multi-layer stacking by default
+        num_stack_levels = 0
+
+        # Activate multi-layer stacking for `auto_stack` if
+        if auto_stack and (
+            dynamic_stacking  # -> We use dynamic stacking
+            or
+            # -> We have holdout validation or a non-binary problem with more than 750 training rows
+            ((use_bag_holdout or (problem_type != BINARY)) and (num_train_rows >= 750))
+        ):
+            num_stack_levels = 1
+
+    return (
+        num_bag_folds,
+        num_bag_sets,
+        num_stack_levels,
+        dynamic_stacking,
+        use_bag_holdout,
+        holdout_frac,
+        refit_full,
+    )

--- a/tabular/src/autogluon/tabular/configs/pipeline_presets.py
+++ b/tabular/src/autogluon/tabular/configs/pipeline_presets.py
@@ -27,12 +27,8 @@ def _get_validation_preset(num_train_rows: int, hpo_enabled: bool) -> dict[str, 
     elif num_train_rows < 10_000:
         num_bag_sets = 2
     elif num_train_rows < USE_BAG_HOLDOUT_AUTO_THRESHOLD:
-        # TODO(improvement): go towards 4-fold cv for more than 100k rows?
+        # TODO(improvement): go towards lower number of folds cv for more than 100k rows?
         pass
-    else:
-        # Only use holdout validation afterward
-        num_bag_folds = 0
-        num_bag_sets = 0
 
     return dict(
         num_bag_sets=num_bag_sets,

--- a/tabular/src/autogluon/tabular/configs/presets_configs.py
+++ b/tabular/src/autogluon/tabular/configs/presets_configs.py
@@ -6,7 +6,6 @@ tabular_presets_dict = dict(
     best_quality={
         "auto_stack": True,
         "dynamic_stacking": "auto",
-        "num_bag_sets": 1,
         "hyperparameters": "zeroshot",
         "time_limit": 3600,
     },
@@ -16,7 +15,6 @@ tabular_presets_dict = dict(
     high_quality={
         "auto_stack": True,
         "dynamic_stacking": "auto",
-        "num_bag_sets": 1,
         "hyperparameters": "zeroshot",
         "time_limit": 3600,
         "refit_full": True,
@@ -29,7 +27,6 @@ tabular_presets_dict = dict(
     good_quality={
         "auto_stack": True,
         "dynamic_stacking": "auto",
-        "num_bag_sets": 1,
         "hyperparameters": "light",
         "time_limit": 3600,
         "refit_full": True,

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1082,7 +1082,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         self._validate_and_set_memory_limit(memory_limit=memory_limit)
         self._validate_calibrate_decision_threshold(calibrate_decision_threshold=calibrate_decision_threshold)
 
-        auto_stack = kwargs["auto_stack"],
+        auto_stack = kwargs["auto_stack"]
         feature_generator = kwargs["feature_generator"]
         unlabeled_data = kwargs["unlabeled_data"]
         ag_args = kwargs["ag_args"]

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -50,8 +50,9 @@ from autogluon.core.utils import get_pred_from_proba_df, plot_performance_vs_tri
 from autogluon.core.utils.decorators import apply_presets
 from autogluon.core.utils.loaders import load_pkl, load_str
 from autogluon.core.utils.savers import save_pkl, save_str
-from autogluon.core.utils.utils import CVSplitter, default_holdout_frac, generate_train_test_split_combined
+from autogluon.core.utils.utils import CVSplitter, generate_train_test_split_combined
 
+from ..configs.pipeline_presets import get_validation_and_stacking_method, USE_BAG_HOLDOUT_AUTO_THRESHOLD
 from ..configs.feature_generator_presets import get_default_feature_generator
 from ..configs.hyperparameter_configs import get_hyperparameter_config
 from ..configs.presets_configs import tabular_presets_alias, tabular_presets_dict
@@ -1078,11 +1079,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         self._validate_and_set_memory_limit(memory_limit=memory_limit)
         self._validate_calibrate_decision_threshold(calibrate_decision_threshold=calibrate_decision_threshold)
 
-        holdout_frac = kwargs["holdout_frac"]
-        num_bag_folds = kwargs["num_bag_folds"]
-        num_bag_sets = kwargs["num_bag_sets"]
-        num_stack_levels = kwargs["num_stack_levels"]
-        auto_stack = kwargs["auto_stack"]
+        auto_stack = kwargs["auto_stack"],
         feature_generator = kwargs["feature_generator"]
         unlabeled_data = kwargs["unlabeled_data"]
         ag_args = kwargs["ag_args"]
@@ -1138,16 +1135,46 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         else:
             ag_args_fit = learning_curves
 
+        use_bag_holdout_was_auto = False
+        dynamic_stacking_was_auto = False
+        if isinstance(use_bag_holdout,str) and use_bag_holdout == "auto":
+            use_bag_holdout = None
+            use_bag_holdout_was_auto = True
+        if isinstance(dynamic_stacking,str) and dynamic_stacking == "auto":
+            dynamic_stacking = None
+            dynamic_stacking_was_auto = True
+
+        (
+            num_bag_folds,
+            num_bag_sets,
+            num_stack_levels,
+            dynamic_stacking,
+            use_bag_holdout,
+            holdout_frac,
+            refit_full,
+        ) = get_validation_and_stacking_method(
+            num_bag_folds=kwargs["num_bag_folds"],
+            num_bag_sets=kwargs["num_bag_sets"],
+            use_bag_holdout=use_bag_holdout,
+            holdout_frac=kwargs["holdout_frac"],
+            auto_stack=auto_stack,
+            num_stack_levels=kwargs["num_stack_levels"],
+            dynamic_stacking=dynamic_stacking,
+            refit_full=kwargs["refit_full"],
+            num_train_rows=len(train_data),
+            problem_type=inferred_problem_type,
+            hpo_enabled=ag_args.get("hyperparameter_tune_kwargs", None) is not None,
+        )
+
         num_bag_folds, num_bag_sets, num_stack_levels, dynamic_stacking, use_bag_holdout = self._sanitize_stack_args(
             num_bag_folds=num_bag_folds,
             num_bag_sets=num_bag_sets,
             num_stack_levels=num_stack_levels,
-            time_limit=time_limit,
-            auto_stack=auto_stack,
             num_train_rows=len(train_data),
-            problem_type=inferred_problem_type,
             dynamic_stacking=dynamic_stacking,
             use_bag_holdout=use_bag_holdout,
+            use_bag_holdout_was_auto=use_bag_holdout_was_auto,
+            dynamic_stacking_was_auto=dynamic_stacking_was_auto,
         )
         if auto_stack:
             logger.log(
@@ -1155,9 +1182,6 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
                 f"Stack configuration (auto_stack={auto_stack}): "
                 f"num_stack_levels={num_stack_levels}, num_bag_folds={num_bag_folds}, num_bag_sets={num_bag_sets}",
             )
-
-        if holdout_frac is None:
-            holdout_frac = default_holdout_frac(len(train_data), ag_args.get("hyperparameter_tune_kwargs", None) is not None)
 
         if kwargs["save_bag_folds"] is not None and kwargs["_save_bag_folds"] is not None:
             raise ValueError(
@@ -1244,7 +1268,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         )
         ag_post_fit_kwargs = dict(
             keep_only_best=kwargs["keep_only_best"],
-            refit_full=kwargs["refit_full"],
+            refit_full=refit_full,
             set_best_to_refit_full=kwargs["set_best_to_refit_full"],
             save_space=kwargs["save_space"],
             calibrate=kwargs["calibrate"],
@@ -4905,7 +4929,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             set_best_to_refit_full=False,
             keep_only_best=False,
             save_space=False,
-            refit_full=False,
+            refit_full=None,
             save_bag_folds=None,
             # other
             verbosity=self.verbosity,
@@ -5207,41 +5231,12 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         num_bag_folds: int,
         num_bag_sets: int,
         num_stack_levels: int,
-        time_limit: float | None,
-        auto_stack: bool,
         num_train_rows: int,
-        problem_type: str,
         dynamic_stacking: bool | str,
         use_bag_holdout: bool | str,
+        use_bag_holdout_was_auto: bool,
+        dynamic_stacking_was_auto: bool,
     ):
-        use_bag_holdout_auto_threshold = 1000000
-        use_bag_holdout_was_auto = False
-        dynamic_stacking_was_auto = False
-        if isinstance(use_bag_holdout, str) and use_bag_holdout == "auto":
-            # Leverage use_bag_holdout when data is large to safeguard against stack leakage
-            use_bag_holdout = num_train_rows >= use_bag_holdout_auto_threshold
-            use_bag_holdout_was_auto = True
-        if isinstance(dynamic_stacking, str) and dynamic_stacking == "auto":
-            dynamic_stacking = not use_bag_holdout
-            dynamic_stacking_was_auto = True
-        if auto_stack:
-            # TODO: What about datasets that are 100k+? At a certain point should we not bag?
-            # TODO: What about time_limit? Metalearning can tell us expected runtime of each model, then we can select optimal folds + stack levels to fit time constraint
-            if num_bag_folds is None:
-                num_bag_folds = min(8, max(5, math.floor(num_train_rows / 10)))
-            if num_stack_levels is None:
-                if dynamic_stacking:
-                    num_stack_levels = 1
-                else:
-                    if use_bag_holdout or problem_type != BINARY:
-                        num_stack_levels = min(1, max(0, math.floor(num_train_rows / 750)))
-                    else:
-                        # Disable multi-layer stacking to avoid stack info leakage
-                        num_stack_levels = 0
-        if num_bag_folds is None:
-            num_bag_folds = 0
-        if num_stack_levels is None:
-            num_stack_levels = 0
         if not isinstance(num_bag_folds, int):
             raise ValueError(f"num_bag_folds must be an integer. (num_bag_folds={num_bag_folds})")
         if not isinstance(num_stack_levels, int):
@@ -5250,8 +5245,6 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             raise ValueError(f"num_bag_folds must be equal to 0 or >=2. (num_bag_folds={num_bag_folds})")
         if num_stack_levels != 0 and num_bag_folds == 0:
             raise ValueError(f"num_stack_levels must be 0 if num_bag_folds is 0. (num_stack_levels={num_stack_levels}, num_bag_folds={num_bag_folds})")
-        if num_bag_sets is None:
-            num_bag_sets = 1
         if not isinstance(num_bag_sets, int):
             raise ValueError(f"num_bag_sets must be an integer. (num_bag_sets={num_bag_sets})")
         if not isinstance(dynamic_stacking, bool):
@@ -5261,11 +5254,11 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
 
         if use_bag_holdout_was_auto and num_bag_folds != 0:
             if use_bag_holdout:
-                log_extra = f"Reason: num_train_rows >= {use_bag_holdout_auto_threshold}. (num_train_rows={num_train_rows})"
+                log_extra = f"Reason: num_train_rows >= {USE_BAG_HOLDOUT_AUTO_THRESHOLD}. (num_train_rows={num_train_rows})"
             else:
-                log_extra = f"Reason: num_train_rows < {use_bag_holdout_auto_threshold}. (num_train_rows={num_train_rows})"
+                log_extra = f"Reason: num_train_rows < {USE_BAG_HOLDOUT_AUTO_THRESHOLD}. (num_train_rows={num_train_rows})"
             logger.log(20, f"Setting use_bag_holdout from 'auto' to {use_bag_holdout}. {log_extra}")
-        log_extra_ds = None
+
         if dynamic_stacking and num_stack_levels < 1:
             log_extra_ds = f"Reason: Stacking is not enabled. (num_stack_levels={num_stack_levels})"
             if not dynamic_stacking_was_auto:

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -52,9 +52,12 @@ from autogluon.core.utils.loaders import load_pkl, load_str
 from autogluon.core.utils.savers import save_pkl, save_str
 from autogluon.core.utils.utils import CVSplitter, generate_train_test_split_combined
 
-from ..configs.pipeline_presets import get_validation_and_stacking_method, USE_BAG_HOLDOUT_AUTO_THRESHOLD
 from ..configs.feature_generator_presets import get_default_feature_generator
 from ..configs.hyperparameter_configs import get_hyperparameter_config
+from ..configs.pipeline_presets import (
+    USE_BAG_HOLDOUT_AUTO_THRESHOLD,
+    get_validation_and_stacking_method,
+)
 from ..configs.presets_configs import tabular_presets_alias, tabular_presets_dict
 from ..learner import AbstractTabularLearner, DefaultLearner
 from ..trainer.model_presets.presets import MODEL_TYPES

--- a/tabular/tests/unittests/configs/test_pipline_presets.py
+++ b/tabular/tests/unittests/configs/test_pipline_presets.py
@@ -1,0 +1,104 @@
+from autogluon.tabular.configs.pipeline_presets import get_validation_and_stacking_method
+import pytest
+from autogluon.core.constants import BINARY
+
+
+def test_default_get_validation_and_stacking_method():
+    (
+        num_bag_folds,
+        num_bag_sets,
+        num_stack_levels,
+        dynamic_stacking,
+        use_bag_holdout,
+        holdout_frac,
+        refit_full,
+    ) = get_validation_and_stacking_method(
+        auto_stack=False,
+        # Default
+        num_bag_folds=None,
+        num_bag_sets=None,
+        use_bag_holdout=None,
+        holdout_frac=None,
+        num_stack_levels=None,
+        dynamic_stacking=None,
+        refit_full=None,
+        # Can change the default behavior
+        num_train_rows=1000,
+        hpo_enabled=False,
+        # Is ignored due to `auto_stack=False`
+        problem_type="N/A",
+    )
+
+    assert num_bag_folds == 0
+    assert num_bag_sets == 1
+    assert use_bag_holdout is False
+    assert holdout_frac == 0.2
+    assert refit_full is False
+    assert dynamic_stacking is True
+
+
+@pytest.mark.parametrize(
+    "metadata_and_expected_result",
+    [
+        # Reaction to dataset size checks
+        (dict(num_train_rows=400), dict(num_bag_folds=4, num_bag_sets=10)),
+        (dict(num_train_rows=700), dict(num_bag_folds=7, num_bag_sets=6)),
+        (dict(num_train_rows=4_999), dict(num_bag_folds=8, num_bag_sets=4, holdout_frac=0.1)),
+        (dict(num_train_rows=9_999), dict(num_bag_folds=8, num_bag_sets=2, holdout_frac=0.1)),
+        (dict(num_train_rows=10_000), dict(num_bag_folds=8, num_bag_sets=1, holdout_frac=0.1)),
+        # (also checks that dynamic stacking is disabled for holdout validation)
+        (
+            dict(num_train_rows=1_000_000),
+            dict(num_bag_folds=0, num_bag_sets=0, holdout_frac=0.01, dynamic_stacking=False, use_bag_holdout=True),
+        ),
+        # HPO On check
+        (
+            dict(num_train_rows=1_000_000, hpo_enabled=True),
+            dict(num_bag_folds=0, num_bag_sets=0, holdout_frac=0.02, dynamic_stacking=False, use_bag_holdout=True),
+        ),
+        # No dynamic stacking, auto_stack check
+        (dict(num_train_rows=749, dynamic_stacking=False), dict(dynamic_stacking=False, num_stack_levels=0)),
+        (dict(num_train_rows=750, dynamic_stacking=False), dict(dynamic_stacking=False, num_stack_levels=1)),
+        (
+            dict(num_train_rows=750, dynamic_stacking=False, problem_type=BINARY),
+            dict(dynamic_stacking=False, num_stack_levels=0),
+        ),
+        (
+            dict(num_train_rows=750, dynamic_stacking=False, problem_type=BINARY, use_bag_holdout=True),
+            dict(dynamic_stacking=False, num_stack_levels=1, use_bag_holdout=True),
+        ),
+    ],
+)
+def test_auto_stack_get_validation_and_stacking_method(metadata_and_expected_result):
+    metadata, expected_result = metadata_and_expected_result
+
+    metadata["hpo_enabled"] = metadata.get("hpo_enabled", False)
+    metadata["problem_type"] = metadata.get("problem_type", "N/A")
+    metadata["dynamic_stacking"] = metadata.get("dynamic_stacking", None)
+    metadata["use_bag_holdout"] = metadata.get("use_bag_holdout", None)
+
+    num_bag_folds = expected_result.get("num_bag_folds", 7)
+    num_bag_sets = expected_result.get("num_bag_sets", 6)
+    num_stack_levels = expected_result.get("num_stack_levels", 1)
+    dynamic_stacking = expected_result.get("dynamic_stacking", True)
+    use_bag_holdout = expected_result.get("use_bag_holdout", False)
+    holdout_frac = expected_result.get("holdout_frac", 0.2)
+
+    assert get_validation_and_stacking_method(
+        auto_stack=True,
+        # Default
+        num_bag_folds=None,
+        num_bag_sets=None,
+        holdout_frac=None,
+        num_stack_levels=None,
+        refit_full=None,
+        **metadata,
+    ) == (
+        num_bag_folds,
+        num_bag_sets,
+        num_stack_levels,
+        dynamic_stacking,
+        use_bag_holdout,
+        holdout_frac,
+        False,
+    )

--- a/tabular/tests/unittests/configs/test_pipline_presets.py
+++ b/tabular/tests/unittests/configs/test_pipline_presets.py
@@ -49,12 +49,12 @@ def test_default_get_validation_and_stacking_method():
         # (also checks that dynamic stacking is disabled for holdout validation)
         (
             dict(num_train_rows=1_000_000),
-            dict(num_bag_folds=0, num_bag_sets=0, holdout_frac=0.01, dynamic_stacking=False, use_bag_holdout=True),
+            dict(num_bag_folds=8, num_bag_sets=1, holdout_frac=0.01, dynamic_stacking=False, use_bag_holdout=True),
         ),
         # HPO On check
         (
             dict(num_train_rows=1_000_000, hpo_enabled=True),
-            dict(num_bag_folds=0, num_bag_sets=0, holdout_frac=0.02, dynamic_stacking=False, use_bag_holdout=True),
+            dict(num_bag_folds=8, num_bag_sets=1, holdout_frac=0.02, dynamic_stacking=False, use_bag_holdout=True),
         ),
         # No dynamic stacking, auto_stack check
         (dict(num_train_rows=749, dynamic_stacking=False), dict(dynamic_stacking=False, num_stack_levels=0)),


### PR DESCRIPTION
## Description of changes:

A refactor included in this PR introduces the first version of a "control center" in the form of `pipeline_presets` for all ML pipeline-related variables we might want to control before running AutoGluon. 

The pipeline presets can allow us to control, hopefully, all aspects of how we run the AutoML system in the future, with options such as the validation method, when to use (dynamic) stacking, and whether to refit. 

In addition, the PR includes a first proposal for adding a heuristic selection of validation methods to this control center. I believe this heuristic would already be very impactful for users, as this can avoid overfitting or speeding up training.

Obviously, we need to benchmark this and, ideally, in the future, learn which AutoML configuration to use and when. 

The PR only changes the default behavior if `auto_stack is True` (e.g., for `best_quality`) 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
