### PR TITLE
[timeseries] disable non-CUDA backends for chronos

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/chronos/model.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/model.py
@@ -230,7 +230,7 @@ class ChronosModel(AbstractTimeSeriesModel):
                 "`import torch; torch.cuda.is_available()` returns `True`."
             )
 
-        device = self.device or ("cuda" if gpu_available else "auto")
+        device = self.device or ("cuda" if gpu_available else "cpu")
 
         pipeline = OptimizedChronosPipeline.from_pretrained(
             self.model_path,


### PR DESCRIPTION
*Issue #, if available:*

#4544 

*Description of changes:*

The MPS backend leads to bugs for Chronos in PyTorch 2.2 and 2.3. This PR disables all non-CUDA backends for Chronos.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
