### PR TITLE
[timeseries] Add CovariatesRegressor for forecasting models

### DIFF
--- a/docs/tutorials/timeseries/forecasting-model-zoo.md
+++ b/docs/tutorials/timeseries/forecasting-model-zoo.md
@@ -272,8 +272,14 @@ Deep learning models pretrained on large time series datasets, able to perform z
    - `"standard"` - standard scaler, `loc = mean(y)`, `scale = std(y)`
    - `"mean_abs"` - mean absolute scaler, `loc = 0`, `scale = mean(abs(y))`
    - `"robust"` - robust scaler, `loc = median(y)`, `scale = quantile(y, 0.75) - quantile(y, 0.25)`
-   - `"min_max"` - min-max scaler that converts data into the (0, 1) range, `loc = min(y) / scale`, `scale = max(y) - min(y)`.
+   - `"min_max"` - min-max scaler that converts data into the (0, 1) range, `loc = min(y)`, `scale = max(y) - min(y)`.
    - `None` - no scaling
+
+- **covariate_regressor** *({"LR", "GBM", "CAT", "XGB", None}, default = None)* - If provided, the chosen tabular
+   regression model will be fit on the known covariates & static features. The predictions of this regression model
+   will be subtracted from the target column, and the forecasting model will be used to forecast the residuals.
+
+   At prediction time, the predictions of the regression model will be added to the predictions of the forecasting model.
 
 
 ## MXNet Models

--- a/docs/tutorials/timeseries/forecasting-model-zoo.md
+++ b/docs/tutorials/timeseries/forecasting-model-zoo.md
@@ -276,10 +276,16 @@ Deep learning models pretrained on large time series datasets, able to perform z
    - `None` - no scaling
 
 - **covariate_regressor** *({"LR", "GBM", "CAT", "XGB", None}, default = None)* - If provided, the chosen tabular
-   regression model will be fit on the known covariates & static features. The predictions of this regression model
-   will be subtracted from the target column, and the forecasting model will be used to forecast the residuals.
+   regression model will be fit on the known covariates & static features to predict the target column at the same time
+   step.
+
+   The predictions of the regression model will be subtracted from the target column, and the forecasting model will
+   be used to forecast the residuals.
 
    At prediction time, the predictions of the regression model will be added to the predictions of the forecasting model.
+
+   If both a `target_scaler` and a `covariate_regressor` are provided, then scaling will be performed before the
+   regressor is applied.
 
 
 ## MXNet Models

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -168,6 +168,8 @@ class AbstractTimeSeriesModel(AbstractModel):
     def _initialize(self, **kwargs) -> None:
         self._init_params_aux()
         self._init_params()
+        self.target_scaler = self._create_target_scaler()
+        self.covariate_regressor = self._create_covariate_regressor()
 
     def _compute_fit_metadata(self, val_data: TimeSeriesDataFrame = None, **kwargs):
         fit_metadata = dict(
@@ -253,11 +255,9 @@ class AbstractTimeSeriesModel(AbstractModel):
         """
         start_time = time.monotonic()
         self.initialize(**kwargs)
-        self.target_scaler = self._create_target_scaler()
         if self.target_scaler is not None:
             train_data = self.target_scaler.fit_transform(train_data)
 
-        self.covariate_regressor = self._create_covariate_regressor()
         if self.covariate_regressor is not None:
             train_data = self.covariate_regressor.fit_transform(
                 train_data,

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -257,9 +257,9 @@ class AbstractTimeSeriesModel(AbstractModel):
         if self.target_scaler is not None:
             train_data = self.target_scaler.fit_transform(train_data)
 
-        self.covariates_regressor = self._create_covariates_regressor()
-        if self.covariates_regressor is not None:
-            train_data = self.covariates_regressor.fit_transform(
+        self.covariate_regressor = self._create_covariate_regressor()
+        if self.covariate_regressor is not None:
+            train_data = self.covariate_regressor.fit_transform(
                 train_data,
                 time_limit=0.5 * time_limit if time_limit is not None else None,
             )
@@ -268,8 +268,8 @@ class AbstractTimeSeriesModel(AbstractModel):
         if self._get_tags()["can_use_val_data"] and val_data is not None:
             if self.target_scaler is not None:
                 val_data = self.target_scaler.transform(val_data)
-            if self.covariates_regressor is not None:
-                val_data = self.covariates_regressor.transform(val_data)
+            if self.covariate_regressor is not None:
+                val_data = self.covariate_regressor.transform(val_data)
             val_data = self.preprocess(val_data, is_train=False)
 
         if time_limit is not None:
@@ -279,7 +279,7 @@ class AbstractTimeSeriesModel(AbstractModel):
     @property
     def allowed_hyperparameters(self) -> List[str]:
         """List of hyperparameters allowed by the model."""
-        return ["target_scaler", "covariates_regressor"]
+        return ["target_scaler", "covariate_regressor"]
 
     def _create_target_scaler(self) -> Optional[LocalTargetScaler]:
         """Create a LocalTargetScaler object based on the value of the `target_scaler` hyperparameter."""
@@ -290,28 +290,28 @@ class AbstractTimeSeriesModel(AbstractModel):
         else:
             return None
 
-    def _create_covariates_regressor(self) -> Optional[CovariateRegressor]:
-        """Create a CovariatesRegressor object based on the value of the `covariates_regressor` hyperparameter."""
-        covariates_regressor = self._get_model_params().get("covariates_regressor")
-        if covariates_regressor is not None:
+    def _create_covariate_regressor(self) -> Optional[CovariateRegressor]:
+        """Create a CovariateRegressor object based on the value of the `covariate_regressor` hyperparameter."""
+        covariate_regressor = self._get_model_params().get("covariate_regressor")
+        if covariate_regressor is not None:
             if len(self.metadata.known_covariates + self.metadata.static_features) == 0:
                 logger.debug(
-                    "Skipping CovariatesRegressor since the dataset contains no covariates or static features."
+                    "Skipping CovariateRegressor since the dataset contains no covariates or static features."
                 )
                 return None
             else:
-                if isinstance(covariates_regressor, str):
-                    return CovariateRegressor(covariates_regressor, target=self.target, metadata=self.metadata)
-                elif isinstance(covariates_regressor, CovariateRegressor):
+                if isinstance(covariate_regressor, str):
+                    return CovariateRegressor(covariate_regressor, target=self.target, metadata=self.metadata)
+                elif isinstance(covariate_regressor, CovariateRegressor):
                     logger.warning(
-                        "Using a custom CovariatesRegressor object is experimental functionality that may break in the future!"
+                        "Using a custom CovariateRegressor object is experimental functionality that may break in the future!"
                     )
-                    covariates_regressor.target = self.target
-                    covariates_regressor.metadata = self.metadata
-                    return covariates_regressor
+                    covariate_regressor.target = self.target
+                    covariate_regressor.metadata = self.metadata
+                    return covariate_regressor
                 else:
                     raise ValueError(
-                        f"Invalid value for covariates_regressor {covariates_regressor} of type {type(covariates_regressor)}"
+                        f"Invalid value for covariate_regressor {covariate_regressor} of type {type(covariate_regressor)}"
                     )
         else:
             return None
@@ -371,18 +371,18 @@ class AbstractTimeSeriesModel(AbstractModel):
         """
         if self.target_scaler is not None:
             data = self.target_scaler.fit_transform(data)
-        if self.covariates_regressor is not None:
-            data = self.covariates_regressor.fit_transform(data)
+        if self.covariate_regressor is not None:
+            data = self.covariate_regressor.fit_transform(data)
 
         data = self.preprocess(data, is_train=False)
         known_covariates = self.preprocess_known_covariates(known_covariates)
 
-        # FIXME: Set self.covariates_regressor=None so to avoid copying it across processes during _predict
+        # FIXME: Set self.covariate_regressor=None so to avoid copying it across processes during _predict
         # FIXME: The clean solution is to convert all methods executed in parallel to @classmethod
-        covariates_regressor = self.covariates_regressor
-        self.covariates_regressor = None
+        covariate_regressor = self.covariate_regressor
+        self.covariate_regressor = None
         predictions = self._predict(data=data, known_covariates=known_covariates, **kwargs)
-        self.covariates_regressor = covariates_regressor
+        self.covariate_regressor = covariate_regressor
 
         # "0.5" might be missing from the quantiles if self is a wrapper (MultiWindowBacktestingModel or ensemble)
         if "0.5" in predictions.columns:
@@ -391,14 +391,14 @@ class AbstractTimeSeriesModel(AbstractModel):
             if self.must_drop_median:
                 predictions = predictions.drop("0.5", axis=1)
 
-        if self.covariates_regressor is not None:
+        if self.covariate_regressor is not None:
             if known_covariates is None:
                 forecast_index = get_forecast_horizon_index_ts_dataframe(
                     data, prediction_length=self.prediction_length, freq=self.freq
                 )
                 known_covariates = pd.DataFrame(index=forecast_index, dtype="float32")
 
-            predictions = self.covariates_regressor.inverse_transform(
+            predictions = self.covariate_regressor.inverse_transform(
                 predictions,
                 known_covariates=known_covariates,
                 static_features=data.static_features,

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -259,7 +259,10 @@ class AbstractTimeSeriesModel(AbstractModel):
 
         self.covariates_regressor = self._create_covariates_regressor()
         if self.covariates_regressor is not None:
-            train_data = self.covariates_regressor.fit_transform(train_data, time_limit=time_limit)
+            train_data = self.covariates_regressor.fit_transform(
+                train_data,
+                time_limit=time_limit * 0.5 if time_limit is not None else time_limit,
+            )
 
         train_data = self.preprocess(train_data, is_train=True)
         if self._get_tags()["can_use_val_data"] and val_data is not None:
@@ -288,9 +291,11 @@ class AbstractTimeSeriesModel(AbstractModel):
             return None
 
     def _create_covariates_regressor(self) -> Optional[CovariatesRegressor]:
-        covariates_regressor_name = self._get_model_params().get("covariates_regressor")
-        if covariates_regressor_name is not None:
-            return CovariatesRegressor(covariates_regressor_name, target=self.target, metadata=self.metadata)
+        covariates_regressor = self._get_model_params().get("covariates_regressor")
+        if isinstance(covariates_regressor, str):
+            return CovariatesRegressor(covariates_regressor, target=self.target, metadata=self.metadata)
+        elif isinstance(covariates_regressor, CovariatesRegressor):
+            return covariates_regressor
         else:
             return None
 

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -324,12 +324,6 @@ class AbstractTimeSeriesModel(AbstractModel):
                 "as hyperparameters when initializing or use `hyperparameter_tune` instead."
             )
 
-    def _maybe_unscale_data(self, data: TimeSeriesDataFrame) -> TimeSeriesDataFrame:
-        return data
-
-    def _maybe_unscale_predictions(self, predictions: TimeSeriesDataFrame) -> TimeSeriesDataFrame:
-        return predictions
-
     def predict(
         self,
         data: Union[TimeSeriesDataFrame, Dict[str, TimeSeriesDataFrame]],

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -5,6 +5,8 @@ import time
 from contextlib import nullcontext
 from typing import Dict, List, Optional, Union
 
+import pandas as pd
+
 from autogluon.common import space
 from autogluon.common.loaders import load_pkl
 from autogluon.common.savers import save_pkl
@@ -13,8 +15,10 @@ from autogluon.core.hpo.executors import HpoExecutor, RayHpoExecutor
 from autogluon.core.models import AbstractModel
 from autogluon.timeseries.dataset import TimeSeriesDataFrame
 from autogluon.timeseries.metrics import TimeSeriesScorer, check_get_evaluation_metric
+from autogluon.timeseries.regressor import CovariatesRegressor
 from autogluon.timeseries.transforms import LocalTargetScaler, get_target_scaler_from_name
 from autogluon.timeseries.utils.features import CovariateMetadata
+from autogluon.timeseries.utils.forecast import get_forecast_horizon_index_ts_dataframe
 from autogluon.timeseries.utils.warning_filters import disable_stdout, warning_filter
 
 from .model_trial import model_trial, skip_hpo
@@ -208,7 +212,11 @@ class AbstractTimeSeriesModel(AbstractModel):
         return info
 
     def fit(
-        self, train_data: TimeSeriesDataFrame, val_data: Optional[TimeSeriesDataFrame] = None, **kwargs
+        self,
+        train_data: TimeSeriesDataFrame,
+        val_data: Optional[TimeSeriesDataFrame] = None,
+        time_limit: Optional[float] = None,
+        **kwargs,
     ) -> "AbstractTimeSeriesModel":
         """Fit timeseries model.
 
@@ -243,22 +251,32 @@ class AbstractTimeSeriesModel(AbstractModel):
         model: AbstractTimeSeriesModel
             The fitted model object
         """
+        start_time = time.monotonic()
         self.initialize(**kwargs)
         self.target_scaler = self._create_target_scaler()
         if self.target_scaler is not None:
             train_data = self.target_scaler.fit_transform(train_data)
 
+        self.covariates_regressor = self._create_covariates_regressor()
+        if self.covariates_regressor is not None:
+            train_data = self.covariates_regressor.fit_transform(train_data, time_limit=time_limit)
+
         train_data = self.preprocess(train_data, is_train=True)
         if self._get_tags()["can_use_val_data"] and val_data is not None:
             if self.target_scaler is not None:
                 val_data = self.target_scaler.transform(val_data)
+            if self.covariates_regressor is not None:
+                val_data = self.covariates_regressor.transform(val_data)
             val_data = self.preprocess(val_data, is_train=False)
-        return super().fit(train_data=train_data, val_data=val_data, **kwargs)
+
+        if time_limit is not None:
+            time_limit = time_limit - (time.monotonic() - start_time)
+        return super().fit(train_data=train_data, val_data=val_data, time_limit=time_limit, **kwargs)
 
     @property
     def allowed_hyperparameters(self) -> List[str]:
         """List of hyperparameters allowed by the model."""
-        return ["target_scaler"]
+        return ["target_scaler", "covariates_regressor"]
 
     def _create_target_scaler(self) -> Optional[LocalTargetScaler]:
         """Create a LocalTargetScaler object based on the value of the `target_scaler` hyperparameter."""
@@ -266,6 +284,13 @@ class AbstractTimeSeriesModel(AbstractModel):
         target_scaler_type = self._get_model_params().get("target_scaler")
         if target_scaler_type is not None:
             return get_target_scaler_from_name(target_scaler_type, target=self.target)
+        else:
+            return None
+
+    def _create_covariates_regressor(self) -> Optional[CovariatesRegressor]:
+        covariates_regressor_name = self._get_model_params().get("covariates_regressor")
+        if covariates_regressor_name is not None:
+            return CovariatesRegressor(covariates_regressor_name, target=self.target, metadata=self.metadata)
         else:
             return None
 
@@ -324,17 +349,38 @@ class AbstractTimeSeriesModel(AbstractModel):
         """
         if self.target_scaler is not None:
             data = self.target_scaler.fit_transform(data)
+        if self.covariates_regressor is not None:
+            if self.covariates_regressor.refit_during_predict:
+                data = self.covariates_regressor.fit_transform(data)
+            else:
+                data = self.covariates_regressor.transform(data)
 
         data = self.preprocess(data, is_train=False)
         known_covariates = self.preprocess_known_covariates(known_covariates)
+
+        # FIXME: Avoid copying covariates_regressor across processes if self._predict uses joblib.
+        # FIXME: The clean solution is to convert all methods executed in parallel to @classmethod
+        covariates_regressor = self.covariates_regressor
+        self.covariates_regressor = None
         predictions = self._predict(data=data, known_covariates=known_covariates, **kwargs)
-        logger.debug(f"Predicting with model {self.name}")
+        self.covariates_regressor = covariates_regressor
+
         # "0.5" might be missing from the quantiles if self is a wrapper (MultiWindowBacktestingModel or ensemble)
         if "0.5" in predictions.columns:
             if self.eval_metric.optimized_by_median:
                 predictions["mean"] = predictions["0.5"]
             if self.must_drop_median:
                 predictions = predictions.drop("0.5", axis=1)
+
+        if self.covariates_regressor is not None:
+            if known_covariates is None:
+                forecast_index = get_forecast_horizon_index_ts_dataframe(
+                    data, prediction_length=self.prediction_length, freq=self.freq
+                )
+                known_covariates = pd.DataFrame(index=forecast_index, dtype="float32")
+            predictions = self.covariates_regressor.inverse_transform(
+                predictions, known_covariates=known_covariates, static_features=data.static_features
+            )
 
         if self.target_scaler is not None:
             predictions = self.target_scaler.inverse_transform(predictions)

--- a/timeseries/src/autogluon/timeseries/models/chronos/model.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/model.py
@@ -219,7 +219,8 @@ class ChronosModel(AbstractTimeSeriesModel):
         return minimum_resources
 
     def load_model_pipeline(self, context_length: Optional[int] = None):
-        from .pipeline import OptimizedChronosPipeline
+        # from .pipeline import OptimizedChronosPipeline
+        from chronos import ForecastPipeline
 
         gpu_available = self._is_gpu_available()
 
@@ -232,12 +233,12 @@ class ChronosModel(AbstractTimeSeriesModel):
 
         device = self.device or ("cuda" if gpu_available else "cpu")
 
-        pipeline = OptimizedChronosPipeline.from_pretrained(
+        pipeline = ForecastPipeline.from_pretrained(
             self.model_path,
             device_map=device,
-            optimization_strategy=self.optimization_strategy,
+            # optimization_strategy=self.optimization_strategy,
             torch_dtype=self.torch_dtype,
-            context_length=context_length or self.context_length,
+            # context_length=context_length or self.context_length,
         )
 
         self.model_pipeline = pipeline
@@ -297,6 +298,7 @@ class ChronosModel(AbstractTimeSeriesModel):
 
         with warning_filter(all_warnings=True):
             import torch
+            from chronos import ForecastType
 
             if self.model_pipeline is None:
                 # load model pipeline to device memory
@@ -310,23 +312,38 @@ class ChronosModel(AbstractTimeSeriesModel):
             )
             self.model_pipeline.model.eval()
             with torch.inference_mode():
-                prediction_samples = [
-                    self.model_pipeline.predict(
-                        batch,
-                        prediction_length=self.prediction_length,
-                        num_samples=self.num_samples,
-                        limit_prediction_length=False,
-                    )
-                    .detach()
-                    .cpu()
-                    .numpy()
-                    for batch in inference_data_loader
-                ]
-
-        samples = np.concatenate(prediction_samples, axis=0).swapaxes(1, 2).reshape(-1, self.num_samples)
-
-        mean = samples.mean(axis=-1, keepdims=True)
-        quantiles = np.quantile(samples, self.quantile_levels, axis=-1).T
+                if self.model_pipeline.forecast_type == ForecastType.SAMPLES:
+                    prediction_samples = [
+                        self.model_pipeline.predict(
+                            batch,
+                            prediction_length=self.prediction_length,
+                            num_samples=self.num_samples,
+                            limit_prediction_length=False,
+                        )
+                        .detach()
+                        .cpu()
+                        .numpy()
+                        for batch in inference_data_loader
+                    ]
+                    samples = np.concatenate(prediction_samples, axis=0).swapaxes(1, 2).reshape(-1, self.num_samples)
+                    mean = samples.mean(axis=-1, keepdims=True)
+                    quantiles = np.quantile(samples, self.quantile_levels, axis=-1).T
+                elif self.model_pipeline.forecast_type == ForecastType.QUANTILES:
+                    # TODO: Handle interpolation for arbitrary quantiles
+                    predictions = [
+                        self.model_pipeline.predict(
+                            batch,
+                            prediction_length=self.prediction_length,
+                            limit_prediction_length=False,
+                        )
+                        .detach()
+                        .cpu()
+                        .numpy()
+                        for batch in inference_data_loader
+                    ]
+                    model_quantiles = self.model_pipeline.quantiles
+                    quantiles = np.concatenate(predictions, axis=0).swapaxes(1, 2).reshape(-1, len(model_quantiles))
+                    mean = quantiles[:, [model_quantiles.index("0.5")]]
 
         df = pd.DataFrame(
             np.concatenate([mean, quantiles], axis=1),

--- a/timeseries/src/autogluon/timeseries/models/chronos/model.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/model.py
@@ -219,8 +219,7 @@ class ChronosModel(AbstractTimeSeriesModel):
         return minimum_resources
 
     def load_model_pipeline(self, context_length: Optional[int] = None):
-        # from .pipeline import OptimizedChronosPipeline
-        from chronos import ForecastPipeline
+        from .pipeline import OptimizedChronosPipeline
 
         gpu_available = self._is_gpu_available()
 
@@ -233,12 +232,12 @@ class ChronosModel(AbstractTimeSeriesModel):
 
         device = self.device or ("cuda" if gpu_available else "cpu")
 
-        pipeline = ForecastPipeline.from_pretrained(
+        pipeline = OptimizedChronosPipeline.from_pretrained(
             self.model_path,
             device_map=device,
-            # optimization_strategy=self.optimization_strategy,
+            optimization_strategy=self.optimization_strategy,
             torch_dtype=self.torch_dtype,
-            # context_length=context_length or self.context_length,
+            context_length=context_length or self.context_length,
         )
 
         self.model_pipeline = pipeline
@@ -298,7 +297,6 @@ class ChronosModel(AbstractTimeSeriesModel):
 
         with warning_filter(all_warnings=True):
             import torch
-            from chronos import ForecastType
 
             if self.model_pipeline is None:
                 # load model pipeline to device memory
@@ -312,38 +310,23 @@ class ChronosModel(AbstractTimeSeriesModel):
             )
             self.model_pipeline.model.eval()
             with torch.inference_mode():
-                if self.model_pipeline.forecast_type == ForecastType.SAMPLES:
-                    prediction_samples = [
-                        self.model_pipeline.predict(
-                            batch,
-                            prediction_length=self.prediction_length,
-                            num_samples=self.num_samples,
-                            limit_prediction_length=False,
-                        )
-                        .detach()
-                        .cpu()
-                        .numpy()
-                        for batch in inference_data_loader
-                    ]
-                    samples = np.concatenate(prediction_samples, axis=0).swapaxes(1, 2).reshape(-1, self.num_samples)
-                    mean = samples.mean(axis=-1, keepdims=True)
-                    quantiles = np.quantile(samples, self.quantile_levels, axis=-1).T
-                elif self.model_pipeline.forecast_type == ForecastType.QUANTILES:
-                    # TODO: Handle interpolation for arbitrary quantiles
-                    predictions = [
-                        self.model_pipeline.predict(
-                            batch,
-                            prediction_length=self.prediction_length,
-                            limit_prediction_length=False,
-                        )
-                        .detach()
-                        .cpu()
-                        .numpy()
-                        for batch in inference_data_loader
-                    ]
-                    model_quantiles = self.model_pipeline.quantiles
-                    quantiles = np.concatenate(predictions, axis=0).swapaxes(1, 2).reshape(-1, len(model_quantiles))
-                    mean = quantiles[:, [model_quantiles.index("0.5")]]
+                prediction_samples = [
+                    self.model_pipeline.predict(
+                        batch,
+                        prediction_length=self.prediction_length,
+                        num_samples=self.num_samples,
+                        limit_prediction_length=False,
+                    )
+                    .detach()
+                    .cpu()
+                    .numpy()
+                    for batch in inference_data_loader
+                ]
+
+        samples = np.concatenate(prediction_samples, axis=0).swapaxes(1, 2).reshape(-1, self.num_samples)
+
+        mean = samples.mean(axis=-1, keepdims=True)
+        quantiles = np.quantile(samples, self.quantile_levels, axis=-1).T
 
         df = pd.DataFrame(
             np.concatenate([mean, quantiles], axis=1),

--- a/timeseries/src/autogluon/timeseries/models/chronos/model.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/model.py
@@ -368,18 +368,3 @@ class ChronosModel(AbstractTimeSeriesModel):
         super().score_and_cache_oof(
             val_data, store_val_score, store_predict_time, time_limit=self.time_limit, **predict_kwargs
         )
-
-    def _maybe_unscale_data(self, data: TimeSeriesDataFrame) -> TimeSeriesDataFrame:
-        if self._get_model_params().get("unscale") and self.target_scaler is not None:
-            target_unscaled = self.target_scaler.inverse_transform(data[[self.target]])
-            data = data.assign(**{self.target: target_unscaled[self.target]})
-        return data
-
-    def _maybe_unscale_predictions(self, predictions: TimeSeriesDataFrame) -> TimeSeriesDataFrame:
-        if self._get_model_params().get("unscale") and self.target_scaler is not None:
-            # Only scale, do not subtract the mean
-            loc = self.target_scaler.loc
-            self.target_scaler.loc = None
-            predictions = self.target_scaler.inverse_transform(predictions)
-            self.target_scaler.loc = loc
-        return predictions

--- a/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
+++ b/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
@@ -113,8 +113,11 @@ class AbstractLocalModel(AbstractTimeSeriesModel):
         local_model_args = {}
         # TODO: Move filtering logic to AbstractTimeSeriesModel
         for key, value in raw_local_model_args.items():
-            if key in self.allowed_hyperparameters:
+            if key in self.allowed_local_model_args:
                 local_model_args[key] = value
+            elif key in self.allowed_hyperparameters:
+                # Quietly ignore params in self.allowed_hyperparameters
+                pass
             else:
                 unused_local_model_args.append(key)
 

--- a/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
+++ b/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
@@ -116,7 +116,7 @@ class AbstractLocalModel(AbstractTimeSeriesModel):
             if key in self.allowed_local_model_args:
                 local_model_args[key] = value
             elif key in self.allowed_hyperparameters:
-                # Quietly ignore params in self.allowed_hyperparameters
+                # Quietly ignore params in self.allowed_hyperparameters - they are used by AbstractTimeSeriesModel
                 pass
             else:
                 unused_local_model_args.append(key)

--- a/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
+++ b/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
@@ -12,10 +12,9 @@ import autogluon.core as ag
 from autogluon.timeseries.dataset.ts_dataframe import TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 from autogluon.timeseries.models.local.abstract_local_model import AbstractLocalModel
+from autogluon.timeseries.regressor import CovariatesRegressor
 from autogluon.timeseries.splitter import AbstractWindowSplitter, ExpandingWindowSplitter
 from autogluon.timeseries.transforms import LocalTargetScaler
-from autogluon.timeseries.regressor import CovariatesRegressor
-
 
 logger = logging.getLogger(__name__)
 

--- a/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
+++ b/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
@@ -12,7 +12,7 @@ import autogluon.core as ag
 from autogluon.timeseries.dataset.ts_dataframe import TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 from autogluon.timeseries.models.local.abstract_local_model import AbstractLocalModel
-from autogluon.timeseries.regressor import CovariatesRegressor
+from autogluon.timeseries.regressor import CovariateRegressor
 from autogluon.timeseries.splitter import AbstractWindowSplitter, ExpandingWindowSplitter
 from autogluon.timeseries.transforms import LocalTargetScaler
 
@@ -90,7 +90,7 @@ class MultiWindowBacktestingModel(AbstractTimeSeriesModel):
         # Do not use scaler in the MultiWindowModel to avoid duplication; it will be created in the inner model
         return None
 
-    def _create_covariates_regressor(self) -> Optional[CovariatesRegressor]:
+    def _create_covariates_regressor(self) -> Optional[CovariateRegressor]:
         # Do not use regressor in the MultiWindowModel to avoid duplication; it will be created in the inner model
         return None
 

--- a/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
+++ b/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
@@ -14,6 +14,8 @@ from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 from autogluon.timeseries.models.local.abstract_local_model import AbstractLocalModel
 from autogluon.timeseries.splitter import AbstractWindowSplitter, ExpandingWindowSplitter
 from autogluon.timeseries.transforms import LocalTargetScaler
+from autogluon.timeseries.regressor import CovariatesRegressor
+
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +89,10 @@ class MultiWindowBacktestingModel(AbstractTimeSeriesModel):
 
     def _create_target_scaler(self) -> Optional[LocalTargetScaler]:
         # Do not use scaler in the MultiWindowModel to avoid duplication; it will be created in the inner model
+        return None
+
+    def _create_covariates_regressor(self) -> Optional[CovariatesRegressor]:
+        # Do not use regressor in the MultiWindowModel to avoid duplication; it will be created in the inner model
         return None
 
     def _fit(

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -293,7 +293,7 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
         df = self._to_data_frame(data, name=name)
         if not pd.api.types.is_numeric_dtype(df[self.target]):
             raise ValueError(f"Target column {name}['{self.target}'] has a non-numeric dtype {df[self.target].dtype}")
-        df[self.target] = df[self.target].astype("float64")
+        df = df.assign(**{self.target: df[self.target].astype("float64")})
         # MultiIndex.is_monotonic_increasing checks if index is sorted by ["item_id", "timestamp"]
         if not df.index.is_monotonic_increasing:
             df = df.sort_index()

--- a/timeseries/src/autogluon/timeseries/regressor.py
+++ b/timeseries/src/autogluon/timeseries/regressor.py
@@ -1,0 +1,82 @@
+from typing import Any, Dict, Optional, Tuple
+import pandas as pd
+from autogluon.core.models import AbstractModel
+from autogluon.tabular.trainer.model_presets.presets import (
+    MODEL_TYPES as TABULAR_MODEL_TYPES,
+)
+from autogluon.timeseries.dataset.ts_dataframe import (
+    ITEMID,
+    TIMESTAMP,
+    TimeSeriesDataFrame,
+)
+from autogluon.timeseries.utils.features import CovariateMetadata
+
+
+class CovariatesRegressor:
+    """Predicts y values from the covariates."""
+
+    def __init__(
+        self,
+        model_name: str = "GBM",
+        model_hyperparameters: Optional[Dict[str, Any]] = None,
+        tabular_eval_metric: str = "mean_absolute_error",
+        refit_during_predict: bool = False,
+        max_num_samples: Optional[int] = 500_000,
+        metadata: Optional[CovariateMetadata] = None,
+        target: str = "target",
+    ):
+        if model_name not in TABULAR_MODEL_TYPES:
+            raise ValueError(
+                f"Tabular model {model_name} not supported. Available models: {list(TABULAR_MODEL_TYPES)}"
+            )
+        self.target = target
+        self.model_type = TABULAR_MODEL_TYPES[model_name]
+        self.model_name = model_name
+        self.model_hyperparameters = model_hyperparameters or {}
+        self.refit_during_predict = refit_during_predict
+        self.tabular_eval_metric = tabular_eval_metric
+        self.max_num_samples = max_num_samples
+        self.model: Optional[AbstractModel] = None
+        self.metadata = metadata or CovariateMetadata()
+
+    def fit(self, data: TimeSeriesDataFrame, time_limit: Optional[float] = None) -> "CovariatesRegressor":
+        tabular_df = self._get_tabular_df(data, static_features=data.static_features)
+        tabular_df = tabular_df.query(f"{self.target}.notnull()")
+        if self.max_num_samples is not None and len(tabular_df) > self.max_num_samples:
+            tabular_df = tabular_df.sample(n=self.max_num_samples)
+        self.model = self._get_tabular_model()
+        self.model.fit(X=tabular_df.drop(columns=[self.target]), y=tabular_df[self.target], time_limit=time_limit)
+        return self
+
+    def transform(self, data: TimeSeriesDataFrame) -> TimeSeriesDataFrame:
+        tabular_df = self._get_tabular_df(data, static_features=data.static_features)
+        y_pred = self.model.predict(X=tabular_df)
+        return data.assign(**{self.target: data[self.target] - y_pred})
+
+    def fit_transform(self, data: TimeSeriesDataFrame, time_limit: Optional[float] = None) -> TimeSeriesDataFrame:
+        return self.fit(data=data, time_limit=time_limit).transform(data=data)
+
+    def inverse_transform(
+        self,
+        predictions: TimeSeriesDataFrame,
+        known_covariates: TimeSeriesDataFrame,
+        static_features: Optional[pd.DataFrame],
+    ) -> TimeSeriesDataFrame:
+        tabular_df = self._get_tabular_df(known_covariates, static_features=static_features)
+        y_pred_future = self.model.predict(X=tabular_df)
+        return predictions.assign(**{col: predictions[col] + y_pred_future for col in predictions.columns})
+
+    def _get_tabular_df(
+        self, data: TimeSeriesDataFrame, static_features: Optional[pd.DataFrame] = None
+    ) -> pd.DataFrame:
+        tabular_df = pd.DataFrame(data).reset_index().drop(columns=[TIMESTAMP] + self.metadata.past_covariates)
+        if static_features is not None:
+            tabular_df = pd.merge(tabular_df, static_features, on=ITEMID)
+        return tabular_df
+
+    def _get_tabular_model(self) -> AbstractModel:
+        return self.model_type(
+            problem_type="regression",
+            hyperparameters=self.model_hyperparameters,
+            eval_metric=self.tabular_eval_metric,
+        )

--- a/timeseries/src/autogluon/timeseries/regressor.py
+++ b/timeseries/src/autogluon/timeseries/regressor.py
@@ -134,7 +134,7 @@ class CovariateRegressor:
         available_columns = [ITEMID] + self.metadata.known_covariates
         if include_target:
             available_columns += [self.target]
-        tabular_df = pd.DataFrame(data).reset_index()[available_columns]
+        tabular_df = pd.DataFrame(data).reset_index()[available_columns].astype({ITEMID: "category"})
         if static_features is not None:
             tabular_df = pd.merge(tabular_df, static_features, on=ITEMID)
         return tabular_df

--- a/timeseries/src/autogluon/timeseries/regressor.py
+++ b/timeseries/src/autogluon/timeseries/regressor.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, Optional, Tuple
+import numpy as np
 import pandas as pd
 from autogluon.core.models import AbstractModel
 from autogluon.tabular.trainer.model_presets.presets import (
@@ -83,10 +84,10 @@ class CovariatesRegressor:
         self,
         known_covariates: TimeSeriesDataFrame,
         static_features: Optional[pd.DataFrame],
-    ) -> pd.DataFrame:
+    ) -> np.ndarray:
         tabular_df = self._get_tabular_df(known_covariates, static_features=static_features)
         y_pred_future = self.model.predict(X=tabular_df)
-        return pd.DataFrame(y_pred_future, index=known_covariates.index, columns=[self.target])
+        return y_pred_future
 
     def _get_tabular_df(
         self, data: TimeSeriesDataFrame, static_features: Optional[pd.DataFrame] = None

--- a/timeseries/src/autogluon/timeseries/regressor.py
+++ b/timeseries/src/autogluon/timeseries/regressor.py
@@ -79,15 +79,14 @@ class CovariatesRegressor:
     def fit_transform(self, data: TimeSeriesDataFrame, time_limit: Optional[float] = None) -> TimeSeriesDataFrame:
         return self.fit(data=data, time_limit=time_limit).transform(data=data)
 
-    def inverse_transform(
+    def predict(
         self,
-        predictions: TimeSeriesDataFrame,
         known_covariates: TimeSeriesDataFrame,
         static_features: Optional[pd.DataFrame],
-    ) -> TimeSeriesDataFrame:
+    ) -> pd.DataFrame:
         tabular_df = self._get_tabular_df(known_covariates, static_features=static_features)
         y_pred_future = self.model.predict(X=tabular_df)
-        return predictions.assign(**{col: predictions[col] + y_pred_future for col in predictions.columns})
+        return pd.DataFrame(y_pred_future, index=known_covariates.index, columns=[self.target])
 
     def _get_tabular_df(
         self, data: TimeSeriesDataFrame, static_features: Optional[pd.DataFrame] = None

--- a/timeseries/src/autogluon/timeseries/transforms/scaler.py
+++ b/timeseries/src/autogluon/timeseries/transforms/scaler.py
@@ -85,7 +85,7 @@ class LocalMinMaxScaler(LocalTargetScaler):
     def _compute_loc_scale(self, target_series: pd.Series) -> Tuple[pd.Series, pd.Series]:
         stats = target_series.abs().groupby(level=ITEMID, sort=False).agg(["min", "max"])
         scale = (stats["max"] - stats["min"]).clip(lower=self.min_scale)
-        loc = stats["min"] / scale
+        loc = stats["min"]
         return loc, scale
 
 

--- a/timeseries/tests/conftest.py
+++ b/timeseries/tests/conftest.py
@@ -61,3 +61,31 @@ def hf_model_path(tmp_path_factory):
 
         warnings.warn("Could not cache Chronos for test session. Will call Hugging Face directly.")
         yield model_hub_id  # fallback to hub id if no snapshots found
+
+
+@pytest.fixture(scope="module")
+def dummy_hyperparameters(hf_model_path):
+    """Hyperparameters passed to the models during tests to minimize training time."""
+    return {
+        "epochs": 1,
+        "num_batches_per_epoch": 1,
+        "n_jobs": 1,
+        "use_fallback_model": False,
+        "model_path": hf_model_path,
+    }
+
+
+@pytest.fixture(scope="module")
+def df_with_covariates_and_metadata():
+    """Create a TimeSeriesDataFrame with covariates & static features.
+
+    Returns the preprocessed TimeSeriesDataFrame and the respective CovariateMetadata.
+    """
+    from autogluon.timeseries.utils.features import TimeSeriesFeatureGenerator
+
+    from .unittests.common import DATAFRAME_WITH_STATIC_AND_COVARIATES
+
+    data = DATAFRAME_WITH_STATIC_AND_COVARIATES.copy()
+    feat_gen = TimeSeriesFeatureGenerator("target", known_covariates_names=["cov1", "cov2"])
+    data = feat_gen.fit_transform(data)
+    yield data, feat_gen.covariate_metadata

--- a/timeseries/tests/unittests/common.py
+++ b/timeseries/tests/unittests/common.py
@@ -201,6 +201,12 @@ DATAFRAME_WITH_COVARIATES = get_data_frame_with_variable_lengths(
     ITEM_ID_TO_LENGTH, covariates_names=["cov1", "cov2", "cov3"]
 )
 
+DATAFRAME_WITH_STATIC_AND_COVARIATES = get_data_frame_with_variable_lengths(
+    ITEM_ID_TO_LENGTH,
+    covariates_names=["cov1", "cov2", "cov3"],
+    static_features=get_static_features(ITEM_ID_TO_LENGTH.keys(), ["feat1", "feat2", "feat3"]),
+)
+
 
 def dict_equal_primitive(this, that):
     """Compare two dictionaries but consider only primitive values"""

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -518,9 +518,11 @@ def test_when_fit_and_predict_called_then_train_val_and_test_data_is_preprocesse
     else:
         expected_val_data = train_data
     # We need the ugly line break because Python <3.10 does not support parentheses for context managers
-    with mock.patch.object(model, "preprocess") as mock_preprocess, mock.patch.object(
-        model, "_fit"
-    ) as mock_fit, mock.patch.object(model, "_predict") as mock_predict:
+    with (
+        mock.patch.object(model, "preprocess") as mock_preprocess,
+        mock.patch.object(model, "_fit") as mock_fit,
+        mock.patch.object(model, "_predict") as mock_predict,
+    ):
         mock_preprocess.return_value = preprocessed_data
         model.fit(train_data=train_data, val_data=train_data)
         fit_kwargs = mock_fit.call_args[1]

--- a/timeseries/tests/unittests/test_regressor.py
+++ b/timeseries/tests/unittests/test_regressor.py
@@ -1,0 +1,189 @@
+from unittest import mock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from autogluon.timeseries.dataset.ts_dataframe import ITEMID
+from autogluon.timeseries.models import ZeroModel
+from autogluon.timeseries.models.multi_window import MultiWindowBacktestingModel
+from autogluon.timeseries.regressor import CovariateRegressor
+from autogluon.timeseries.utils.features import CovariateMetadata
+
+
+def get_multi_window_zero_model(hyperparameters=None, **kwargs):
+    """Wrap ZeroModel inside MultiWindowBacktestingModel."""
+    if hyperparameters is None:
+        hyperparameters = {"n_jobs": 1, "use_fallback_model": False}
+    model_base_kwargs = {**kwargs, "hyperparameters": hyperparameters}
+    return MultiWindowBacktestingModel(model_base=ZeroModel, model_base_kwargs=model_base_kwargs, **kwargs)
+
+
+REGRESSOR_MODELS = ["LR", "GBM"]
+TESTABLE_MODELS = [ZeroModel, get_multi_window_zero_model]
+
+
+@pytest.fixture(scope="module")
+def get_model_with_regressor(dummy_hyperparameters, df_with_covariates_and_metadata):
+    """Used as get_model_with_regressor(model_cls, covariate_regressor, extra_hyperparameters)"""
+
+    def _get_model(model_class, covariate_regressor=None, extra_hyperparameters=None):
+        if extra_hyperparameters is None:
+            extra_hyperparameters = {}
+        data, metadata = df_with_covariates_and_metadata
+        return model_class(
+            freq=data.freq,
+            metadata=metadata,
+            prediction_length=2,
+            hyperparameters={
+                "covariate_regressor": covariate_regressor,
+                **extra_hyperparameters,
+                **dummy_hyperparameters,
+            },
+        )
+
+    return _get_model
+
+
+@pytest.mark.parametrize("model_class", TESTABLE_MODELS)
+@pytest.mark.parametrize("refit_during_predict", [True, False])
+def test_when_refit_during_predict_is_true_then_regressor_is_trained_during_predict(
+    model_class, get_model_with_regressor, df_with_covariates_and_metadata, refit_during_predict
+):
+    df, metadata = df_with_covariates_and_metadata
+    regressor = CovariateRegressor("LR", refit_during_predict=refit_during_predict)
+    model = get_model_with_regressor(model_class, regressor)
+    model.fit(train_data=df)
+    past, known_covariates = df.get_model_inputs_for_scoring(
+        model.prediction_length, known_covariates_names=metadata.known_covariates
+    )
+    with mock.patch("autogluon.timeseries.regressor.CovariateRegressor.fit", wraps=regressor.fit) as mock_fit:
+        model.predict(past, known_covariates)
+        if refit_during_predict:
+            mock_fit.assert_called()
+        else:
+            mock_fit.assert_not_called()
+
+
+def test_when_model_is_used_with_regressor_then_regressor_methods_are_called_the_expected_number_of_times(
+    df_with_covariates_and_metadata, get_model_with_regressor
+):
+    df, metadata = df_with_covariates_and_metadata
+    model = get_model_with_regressor(ZeroModel, "LR")
+    past, known_covariates = df.get_model_inputs_for_scoring(
+        model.prediction_length, known_covariates_names=metadata.known_covariates
+    )
+    model.initialize()
+    regressor = model.covariate_regressor
+    with mock.patch("autogluon.timeseries.regressor.CovariateRegressor.fit", wraps=regressor.fit) as mock_fit:
+        with mock.patch(
+            "autogluon.timeseries.regressor.CovariateRegressor.transform", wraps=regressor.transform
+        ) as mock_transform:
+            with mock.patch(
+                "autogluon.timeseries.regressor.CovariateRegressor.inverse_transform",
+                wraps=regressor.inverse_transform,
+            ) as mock_inverse_transform:
+                model.fit(train_data=df)
+                model.predict(past, known_covariates)
+    assert mock_fit.call_count == 1
+    assert mock_transform.call_count == 2
+    assert mock_inverse_transform.call_count == 1
+
+
+@pytest.mark.parametrize("model_class", TESTABLE_MODELS)
+@pytest.mark.parametrize("include_past_covariates", [True, False])
+def test_when_data_contains_no_known_covariates_or_static_features_then_regressor_is_not_used(
+    model_class, include_past_covariates, df_with_covariates_and_metadata
+):
+    df, metadata_full = df_with_covariates_and_metadata
+    if include_past_covariates:
+        metadata = CovariateMetadata(
+            past_covariates_cat=metadata_full.covariates_cat, past_covariates_real=metadata_full.covariates_real
+        )
+    else:
+        metadata = CovariateMetadata()
+    model = model_class(freq=df.freq, metadata=metadata, hyperparameters={"covariate_regressor": "LR"})
+    model.fit(train_data=df)
+    assert model.covariate_regressor is None
+
+
+def test_when_regressor_is_used_then_tabular_df_contains_correct_features(
+    df_with_covariates_and_metadata, get_model_with_regressor
+):
+    df, metadata = df_with_covariates_and_metadata
+    model = get_model_with_regressor(ZeroModel, "LR")
+    with mock.patch("autogluon.tabular.models.LinearModel.fit") as mock_lr_fit:
+        try:
+            model.fit(train_data=df)
+        except KeyError:
+            # Ignore KeyError produced by mock
+            pass
+        features = mock_lr_fit.call_args[1]["X"].columns
+    assert set(features) == set(metadata.static_features + metadata.known_covariates + [ITEMID])
+
+
+def test_when_target_scaler_and_regressor_are_used_then_regressor_receives_scaled_data_as_input(
+    df_with_covariates_and_metadata, get_model_with_regressor
+):
+    df, metadata = df_with_covariates_and_metadata
+    model = get_model_with_regressor(ZeroModel, "LR", extra_hyperparameters={"target_scaler": "min_max"})
+    model.fit(train_data=df)
+    past, known_covariates = df.get_model_inputs_for_scoring(
+        model.prediction_length, known_covariates_names=metadata.known_covariates
+    )
+    regressor = model.covariate_regressor
+    with mock.patch(
+        "autogluon.timeseries.regressor.CovariateRegressor.fit_transform", wraps=regressor.fit_transform
+    ) as mock_transform:
+        model.predict(past, known_covariates)
+
+    input_data_stats = mock_transform.call_args[0][0][model.target].groupby(ITEMID).agg(["min", "max"])
+    assert np.allclose(input_data_stats["min"], 0)
+    assert np.allclose(input_data_stats["max"], 1)
+
+
+@pytest.mark.parametrize("model_class", TESTABLE_MODELS)
+def test_when_covariate_regressor_used_then_residuals_are_subtracted_before_forecaster_fits(
+    model_class,
+    df_with_covariates_and_metadata,
+    dummy_hyperparameters,
+):
+    df, _ = df_with_covariates_and_metadata
+    # Shift the mean of each item; assert that the shift is removed by the regressor before model receives the data
+    df["target"] += pd.Series([10, 20, 30, 40], index=df.item_ids)
+    df["covariate"] = np.ones(len(df))
+    df.static_features = None
+    metadata = CovariateMetadata(known_covariates_real=["covariate"])
+    model = model_class(
+        freq=df.freq,
+        metadata=metadata,
+        hyperparameters={"covariate_regressor": "LR", **dummy_hyperparameters},
+    )
+    with mock.patch("autogluon.timeseries.models.ZeroModel._fit") as mock_fit:
+        try:
+            model.fit(train_data=df)
+        except AttributeError:
+            # Ignore AttributeError produced by mock
+            pass
+    input_data_mean = mock_fit.call_args[1]["train_data"][model.target].groupby(ITEMID).mean()
+    assert np.allclose(input_data_mean, 0, atol=2.0)
+
+
+def test_when_validation_fraction_is_set_then_tabular_model_uses_val_data(df_with_covariates_and_metadata):
+    df, metadata = df_with_covariates_and_metadata
+    regressor = CovariateRegressor("LR", validation_fraction=0.1)
+    regressor.metadata = metadata
+    with mock.patch("autogluon.tabular.models.LinearModel.fit") as mock_lr_fit:
+        regressor.fit(df)
+    assert mock_lr_fit.call_args[1]["X_val"] is not None
+    assert mock_lr_fit.call_args[1]["y_val"] is not None
+
+
+def test_when_validation_fraction_is_none_then_tabular_model_doesnt_use_val_data(df_with_covariates_and_metadata):
+    df, metadata = df_with_covariates_and_metadata
+    regressor = CovariateRegressor("LR", validation_fraction=None)
+    regressor.metadata = metadata
+    with mock.patch("autogluon.tabular.models.LinearModel.fit") as mock_lr_fit:
+        regressor.fit(df)
+    assert mock_lr_fit.call_args[1]["X_val"] is None
+    assert mock_lr_fit.call_args[1]["y_val"] is None

--- a/timeseries/tests/unittests/test_regressor.py
+++ b/timeseries/tests/unittests/test_regressor.py
@@ -19,7 +19,6 @@ def get_multi_window_zero_model(hyperparameters=None, **kwargs):
     return MultiWindowBacktestingModel(model_base=ZeroModel, model_base_kwargs=model_base_kwargs, **kwargs)
 
 
-REGRESSOR_MODELS = ["LR", "GBM"]
 TESTABLE_MODELS = [ZeroModel, get_multi_window_zero_model]
 
 


### PR DESCRIPTION
*Issue #, if available:*
Fixes #3508

*Description of changes:*
- Add an option to fit a tabular regression model on the covariates & forecasting on the residuals of the tabular models. The relevant logic is incapsulated into the `CovariateRegressor` object.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
