### PR TITLE
Introducing AutoGluon Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![GitHub license](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
 [![Discord](https://img.shields.io/discord/1043248669505368144?logo=discord&style=flat)](https://discord.gg/wjUmjqAc2N)
 [![Twitter](https://img.shields.io/twitter/follow/autogluon?style=social)](https://twitter.com/autogluon)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20AutoGluon%20Guru-006BFF)](https://gurubase.io/g/autogluon)
 [![Continuous Integration](https://github.com/autogluon/autogluon/actions/workflows/continuous_integration.yml/badge.svg)](https://github.com/autogluon/autogluon/actions/workflows/continuous_integration.yml)
 [![Platform Tests](https://github.com/autogluon/autogluon/actions/workflows/platform_tests-command.yml/badge.svg?event=schedule)](https://github.com/autogluon/autogluon/actions/workflows/platform_tests-command.yml)
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [AutoGluon Guru](https://gurubase.io/g/autogluon) to Gurubase. AutoGluon Guru uses the data from this repo and data from the [docs](https://auto.gluon.ai/stable/index.html) to answer questions by leveraging the LLM.

In this PR, I showcased the "AutoGluon Guru", which highlights that AutoGluon now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable AutoGluon Guru in Gurubase, just let me know that's totally fine.