### PR TITLE
Fix log loss calculation for `MultiModalPredictor.evaluate()`.

### DIFF
--- a/multimodal/src/autogluon/multimodal/utils/metric.py
+++ b/multimodal/src/autogluon/multimodal/utils/metric.py
@@ -18,6 +18,7 @@ from ..constants import (
     F1,
     FEW_SHOT_CLASSIFICATION,
     IOU,
+    LOG_LOSS,
     MAP,
     MATCHING_METRICS,
     MATCHING_METRICS_WITHOUT_PROBLEM_TYPE,

--- a/multimodal/src/autogluon/multimodal/utils/metric.py
+++ b/multimodal/src/autogluon/multimodal/utils/metric.py
@@ -233,6 +233,8 @@ def compute_score(
     metric = get_metric(metric)
     if metric.name in [ROC_AUC, AVERAGE_PRECISION]:
         return metric._sign * metric(metric_data[Y_TRUE], metric_data[Y_PRED_PROB][:, pos_label])
+    elif metric.name in [LOG_LOSS]:
+        return metric._sign * metric(metric_data[Y_TRUE], metric_data[Y_PRED_PROB])
     elif metric.name in [F1]:  # only for binary classification
         return f1_score(metric_data[Y_TRUE], metric_data[Y_PRED], pos_label=pos_label)
     else:


### PR DESCRIPTION
*Description of changes:*

Log loss is calculated using probabilities. The existing implementation instead uses labels. This change corrects the existing implementation to use probabilities.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.