### PR TITLE
[tabular] Stratify regression tasks via binning

### DIFF
--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -129,13 +129,26 @@ class BaggedEnsembleModel(AbstractModel):
         return self.is_fit() and self.params.get("save_bag_folds", True)
 
     def is_stratified(self) -> bool:
+        """
+        Returns whether to stratify on the label during KFold splits
+        """
         stratify = self.params.get("stratify", "auto")
         if isinstance(stratify, str) and stratify == "auto":
-            return self.problem_type in [BINARY, MULTICLASS, REGRESSION, QUANTILE]
+            return self.problem_type in [
+                BINARY,
+                MULTICLASS,
+
+                # Commented out due to inconclusive results on whether this is helpful when combined with binning
+                # REGRESSION,
+                # QUANTILE,
+            ]
         else:
             return stratify
 
     def is_binned(self) -> bool:
+        """
+        Returns whether to bin the label during stratified KFold splits
+        """
         bin = self.params.get("bin", "auto")
         if isinstance(bin, str) and bin == "auto":
             return self.problem_type in [REGRESSION, QUANTILE]

--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -46,11 +46,25 @@ class CVSplitter:
         stratify: bool = False,
         bin: bool = False,
         n_bins: int | None = None,
-        groups=None,
+        groups: pd.Series = None,
     ):
         """
+        Wrapper around splitter objects to perform KFold splits.
+        Supports regression stratification via the `bin` and `n_bins` argument.
+
         Parameters
         ----------
+        splitter_cls, default None
+            The class to use for splitting.
+            If None, will automatically be determined based off of `stratify`, `groups`, and `n_repeats`.
+        n_splits : int, default 5
+            The number of splits to perform.
+            Ignored if `groups` is specified.
+        n_repeats: int, default 1
+            The number of repeated splits to perform.
+            Ignored if `groups` is specified.
+        random_state : int, default 0
+            The seed to use when splitting the data.
         stratify : bool, default False
             If True, will stratify the splits on `y`.
         bin : bool, default False
@@ -59,6 +73,9 @@ class CVSplitter:
         n_bins : int, default None
             The number of bins to use when `bin` is True.
             If None, defaults to `np.floor(n_samples / n_splits)`.
+        groups : pd.Series, default None
+            If specified, splitter_cls will default to LeaveOneGroupOut.
+
         """
         self.n_splits = n_splits
         self.n_repeats = n_repeats

--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -13,7 +13,8 @@ import pandas as pd
 import scipy.stats
 from numpy.typing import ArrayLike
 from pandas import DataFrame, Series
-from sklearn.model_selection import LeaveOneGroupOut, RepeatedKFold, RepeatedStratifiedKFold, train_test_split
+from sklearn.model_selection import BaseCrossValidator, LeaveOneGroupOut, RepeatedKFold, RepeatedStratifiedKFold, train_test_split
+from sklearn.preprocessing import KBinsDiscretizer
 
 from autogluon.common.utils.resource_utils import ResourceManager
 
@@ -34,12 +35,37 @@ from .miscs import warning_filter
 logger = logging.getLogger(__name__)
 
 
+# TODO: Add binned stratification support for regression in train/val split (non CV)
 class CVSplitter:
-    def __init__(self, splitter_cls=None, n_splits=5, n_repeats=1, random_state=0, stratified=False, groups=None):
+    def __init__(
+        self,
+        splitter_cls=None,
+        n_splits: int = 5,
+        n_repeats: int = 1,
+        random_state: int | None = 0,
+        stratify: bool = False,
+        bin: bool = False,
+        n_bins: int | None = None,
+        groups=None,
+    ):
+        """
+        Parameters
+        ----------
+        stratify : bool, default False
+            If True, will stratify the splits on `y`.
+        bin : bool, default False
+            If True and `stratify` is True, will bin `y` into `n_bins` bins for stratification.
+            Should only be used for regression and quantile tasks.
+        n_bins : int, default None
+            The number of bins to use when `bin` is True.
+            If None, defaults to `np.floor(n_samples / n_splits)`.
+        """
         self.n_splits = n_splits
         self.n_repeats = n_repeats
         self.random_state = random_state
-        self.stratified = stratified
+        self.stratify = stratify
+        self.bin = bin
+        self.n_bins = n_bins
         self.groups = groups
         if splitter_cls is None:
             splitter_cls = self._get_splitter_cls()
@@ -53,13 +79,13 @@ class CVSplitter:
             self.n_splits = num_groups
             splitter_cls = LeaveOneGroupOut
             # pass
-        elif self.stratified:
+        elif self.stratify:
             splitter_cls = RepeatedStratifiedKFold
         else:
             splitter_cls = RepeatedKFold
         return splitter_cls
 
-    def _get_splitter(self, splitter_cls):
+    def _get_splitter(self, splitter_cls) -> BaseCrossValidator:
         if splitter_cls == LeaveOneGroupOut:
             return splitter_cls()
         elif splitter_cls in [RepeatedKFold, RepeatedStratifiedKFold]:
@@ -67,19 +93,38 @@ class CVSplitter:
         else:
             raise AssertionError(f"{splitter_cls} is not supported as a valid `splitter_cls` input to CVSplitter.")
 
-    def split(self, X, y):
-        if isinstance(self._splitter, RepeatedStratifiedKFold):
+    def split(self, X: pd.DataFrame, y: pd.Series) -> list[tuple[np.ndarray, np.ndarray]]:
+        splitter = self._splitter
+        if isinstance(splitter, RepeatedStratifiedKFold):
+            if self.bin:
+                if self.n_bins is None:
+                    n_splits = splitter.get_n_splits()
+                    n_samples = len(y)
+
+                    # ensure at least n_splits samples per bin
+                    n_bins = int(np.floor(n_samples / n_splits))
+                else:
+                    n_bins = self.n_bins
+
+                if n_bins > 1:
+                    k_bins_discretizer = KBinsDiscretizer(n_bins=n_bins, encode='ordinal', random_state=self.random_state)
+                    y_bin = k_bins_discretizer.fit_transform(y.to_frame())[:, 0]
+                    y = pd.Series(data=y_bin, index=y.index, name=y.name)
+                else:
+                    # Don't stratify, can't bin!
+                    splitter = self._get_splitter(splitter_cls=RepeatedKFold)
+
             # FIXME: There is a bug in sklearn that causes an incorrect ValueError if performing stratification and all classes have fewer than n_splits samples.
             #  This is hacked by adding a dummy class with n_splits samples, performing the kfold split, then removing the dummy samples from all resulting indices.
             #  This is very inefficient and complicated and ideally should be fixed in sklearn.
             with warning_filter():
                 try:
-                    out = [[train_index, test_index] for train_index, test_index in self._splitter.split(X, y)]
+                    out = [[train_index, test_index] for train_index, test_index in splitter.split(X, y)]
                 except:
                     y_dummy = pd.concat([y, pd.Series([-1] * self.n_splits)], ignore_index=True)
                     X_dummy = pd.concat([X, X.head(self.n_splits)], ignore_index=True)
                     invalid_index = set(list(y_dummy.tail(self.n_splits).index))
-                    out = [[train_index, test_index] for train_index, test_index in self._splitter.split(X_dummy, y_dummy)]
+                    out = [[train_index, test_index] for train_index, test_index in splitter.split(X_dummy, y_dummy)]
                     len_out = len(out)
                     for i in range(len_out):
                         train_index, test_index = out[i]
@@ -87,7 +132,7 @@ class CVSplitter:
                         out[i][1] = [index for index in test_index if index not in invalid_index]
             return out
         else:
-            return [[train_index, test_index] for train_index, test_index in self._splitter.split(X, y, groups=self.groups)]
+            return [[train_index, test_index] for train_index, test_index in splitter.split(X, y, groups=self.groups)]
 
 
 def setup_compute(nthreads_per_trial, ngpus_per_trial):

--- a/core/tests/unittests/models/test_bagged_ensemble_model.py
+++ b/core/tests/unittests/models/test_bagged_ensemble_model.py
@@ -14,7 +14,7 @@ def test_generate_fold_configs():
     n_repeat_start = 2
     n_repeats = 5
 
-    cv_splitter = CVSplitter(n_splits=k_fold, n_repeats=n_repeats, stratified=True, random_state=0)
+    cv_splitter = CVSplitter(n_splits=k_fold, n_repeats=n_repeats, stratify=True, random_state=0)
 
     fold_fit_args_list, n_repeats_started, n_repeats_finished = BaggedEnsembleModel._generate_fold_configs(
         X=X,

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1388,10 +1388,19 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             )
         else:
             # Holdout is false, use (repeated) cross-validation
-            is_stratified = self.problem_type in [REGRESSION, QUANTILE, SOFTCLASS]
+            is_stratified = self.problem_type in [BINARY, MULTICLASS, REGRESSION, QUANTILE]
+            is_binned = self.problem_type in [REGRESSION, QUANTILE]
             self._learner._validate_groups(X=X, X_val=X_val)  # Validate splits before splitting
-            splits = CVSplitter(n_splits=n_folds, n_repeats=n_repeats, groups=self._learner.groups, stratified=is_stratified, random_state=42).split(
-                X=X.drop(self.label, axis=1), y=X[self.label]
+            splits = CVSplitter(
+                n_splits=n_folds,
+                n_repeats=n_repeats,
+                groups=self._learner.groups,
+                stratify=is_stratified,
+                bin=is_binned,
+                random_state=42,
+            ).split(
+                X=X.drop(self.label, axis=1),
+                y=X[self.label]
             )
             n_splits = len(splits)
             logger.info(

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1388,7 +1388,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             )
         else:
             # Holdout is false, use (repeated) cross-validation
-            is_stratified = self.problem_type in [BINARY, MULTICLASS, REGRESSION, QUANTILE]
+            is_stratified = self.problem_type in [BINARY, MULTICLASS]
             is_binned = self.problem_type in [REGRESSION, QUANTILE]
             self._learner._validate_groups(X=X, X_val=X_val)  # Validate splits before splitting
             splits = CVSplitter(


### PR DESCRIPTION
*Issue #, if available:*

Resolves #4453

Resolves #4771

*Description of changes:*

- Stratify regression and quantile tasks via binning when doing cross-validation (such as during bagging)
- Fix bug in dynamic stacking cross-validation mode where stratification was not being done on binary/multiclass, but was being done on other problem_types (opposite of intention).
- Added type hints

- [x] TODO: Benchmark

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
