### PR TITLE
[install] Fix full_install.sh to be editable

### DIFF
--- a/full_install.sh
+++ b/full_install.sh
@@ -9,4 +9,4 @@ then
 fi
 
 # Use uv to install packages
-uv pip install -e common/[tests] core/[all,tests] features/ tabular/[all,tests] multimodal/[tests] timeseries/[all,tests] eda/ autogluon/
+uv pip install --refresh -e common/[tests] -e core/[all,tests] -e features/ -e tabular/[all,tests] -e multimodal/[tests] -e timeseries/[all,tests] -e eda/ -e autogluon/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fix full_install.sh to be editable
- Previously only `common` was editable.
- Added `--refresh` to ensure that the install still works across different days due to the date suffix in the version name.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
