### PR TITLE
[CI] Fix container checkouts incorrect branch

### DIFF
--- a/.github/actions/submit-job/action.yml
+++ b/.github/actions/submit-job/action.yml
@@ -39,8 +39,8 @@ runs:
       run: |
         echo "Start submitting job"
         python ./CI/batch/submit-job.py --job-type ${{ inputs.job-type }}-PUSH \
-                                        --name ${{ inputs.job-name }}-'$SOURCE_REF' \
-                                        --source-ref '$SOURCE_REF' \
+                                        --name "${{ inputs.job-name }}-$SOURCE_REF" \
+                                        --source-ref "$SOURCE_REF" \
                                         --work-dir ${{ inputs.work-dir }} \
                                         --remote https://github.com/'${{ github.repository }}' \
                                         --command "$COMMAND" \


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/autogluon/autogluon/issues/4578

*Description of changes:*
Broke by change https://github.com/autogluon/autogluon/pull/4462

Arg ($SOURCE_REF) submitted to AWS Batch containers is interpreted as string literal during CI `push` action - when commits getting merged into `master` or `stable` branch. 

```
[2024-09-16T22:38:57.563Z] jobId: fe2e76f5-8edc-466a-893b-d33b7b6550a6
[2024-09-16T22:38:57.563Z] jobQueue: CI-GPU
[2024-09-16T22:38:57.563Z] computeEnvironment: CI-GPU-3
[2024-09-16T22:38:57.566Z] Cloning into 'autogluon'...
[2024-09-16T22:38:59.370Z] fatal: couldn't find remote ref $SOURCE_REF
[2024-09-16T22:38:59.374Z] error: pathspec 'working' did not match any file(s) known to git
```

This does not materially affect `master` merge action but does affect `stable` merge because it fails to check out to `stable` branch inside the container where tests or documents are run. Therefore, we are seeing documents built on master instead of `stable` branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
