### PR TITLE
[timeseries] Add weighted cumulative error forecasting metric

### DIFF
--- a/timeseries/src/autogluon/timeseries/metrics/__init__.py
+++ b/timeseries/src/autogluon/timeseries/metrics/__init__.py
@@ -2,11 +2,11 @@ from pprint import pformat
 from typing import Type, Union
 
 from .abstract import TimeSeriesScorer
-from .point import CPE, MAE, MAPE, MASE, MSE, RMSE, RMSLE, RMSSE, SMAPE, WAPE
+from .point import CE, MAE, MAPE, MASE, MSE, RMSE, RMSLE, RMSSE, SMAPE, WAPE
 from .quantile import SQL, WQL
 
 __all__ = [
-    "CPE",
+    "CE",
     "MAE",
     "MAPE",
     "MASE",
@@ -43,7 +43,7 @@ DEPRECATED_METRICS = {
 
 # Experimental metrics that are not yet user facing
 EXPERIMENTAL_METRICS = {
-    "CPE": CPE,
+    "CE": CE,
 }
 
 

--- a/timeseries/src/autogluon/timeseries/metrics/__init__.py
+++ b/timeseries/src/autogluon/timeseries/metrics/__init__.py
@@ -2,11 +2,10 @@ from pprint import pformat
 from typing import Type, Union
 
 from .abstract import TimeSeriesScorer
-from .point import CE, MAE, MAPE, MASE, MSE, RMSE, RMSLE, RMSSE, SMAPE, WAPE
+from .point import MAE, MAPE, MASE, MSE, RMSE, RMSLE, RMSSE, SMAPE, WAPE, WCD
 from .quantile import SQL, WQL
 
 __all__ = [
-    "CE",
     "MAE",
     "MAPE",
     "MASE",
@@ -17,6 +16,7 @@ __all__ = [
     "RMSSE",
     "SQL",
     "WAPE",
+    "WCD",
     "WQL",
 ]
 
@@ -43,7 +43,7 @@ DEPRECATED_METRICS = {
 
 # Experimental metrics that are not yet user facing
 EXPERIMENTAL_METRICS = {
-    "CE": CE,
+    "WCD": WCD,
 }
 
 

--- a/timeseries/src/autogluon/timeseries/metrics/point.py
+++ b/timeseries/src/autogluon/timeseries/metrics/point.py
@@ -362,15 +362,15 @@ class RMSLE(TimeSeriesScorer):
         )
 
 
-class CPE(TimeSeriesScorer):
-    r"""Cumulative path error.
+class CE(TimeSeriesScorer):
+    r"""Cumulative error.
 
     This error measures the discrepancy between the cumulative sum of the forecast and the cumulative sum of the actual
     values.
 
     .. math::
 
-        \operatorname{CPE} = \frac{1}{N} \frac{1}{H} \sum_{i=1}^{N} \sum_{t=T+1}^{T+H} \alpha1 \cdot \max(0, -d_{i, t}) + \alpha2 \cdot \max(0, d_{i, t})
+        \operatorname{CE} = \frac{1}{N} \frac{1}{H} \sum_{i=1}^{N} \sum_{t=T+1}^{T+H} \alpha1 \cdot \max(0, -d_{i, t}) + \alpha2 \cdot \max(0, d_{i, t})
 
     where :math:`d_{i, t}` is the difference between the cumulative predicted value and the cumulative actual value
 

--- a/timeseries/src/autogluon/timeseries/metrics/point.py
+++ b/timeseries/src/autogluon/timeseries/metrics/point.py
@@ -408,4 +408,4 @@ class WCD(TimeSeriesScorer):
         cumsum_pred = self._fast_cumsum(y_pred.to_numpy())
         diffs = cumsum_pred - cumsum_true
         error = diffs * np.where(diffs < 0, -self.alpha, (1 - self.alpha))
-        return self._safemean(error)
+        return 2 * self._safemean(error)

--- a/timeseries/src/autogluon/timeseries/metrics/point.py
+++ b/timeseries/src/autogluon/timeseries/metrics/point.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from typing import Optional
 
 import numpy as np
@@ -359,3 +360,54 @@ class RMSLE(TimeSeriesScorer):
             seasonal_period=seasonal_period,
             **kwargs,
         )
+
+
+class CPE(TimeSeriesScorer):
+    r"""Cumulative path error.
+
+    This error measures the discrepancy between the cumulative sum of the forecast and the cumulative sum of the actual
+    values.
+
+    .. math::
+
+        \operatorname{CPE} = \frac{1}{N} \frac{1}{H} \sum_{i=1}^{N} \sum_{t=T+1}^{T+H} \alpha1 \cdot \max(0, -d_{i, t}) + \alpha2 \cdot \max(0, d_{i, t})
+
+    where :math:`d_{i, t}` is the difference between the cumulative predicted value and the cumulative actual value
+
+    .. math::
+
+        d_{i, t} = \left(\sum_{t=T+1}^t f_{i, t}) - \left(\sum_{t=T+1}^t y_{i, t})
+
+    Parameters
+    ----------
+    alpha1 : float
+        Penalty assigned to underpredictions (when cumulative forecast is below the cumulative actual value).
+    alpha2 : float
+        Penalty assigned to overpredictions (when cumulative forecast is above the cumulative actual value).
+    """
+
+    def __init__(self, alpha1: float = 0.75, alpha2: float = 0.25):
+        self.alpha1 = alpha1
+        self.alpha2 = alpha2
+        self.num_items: Optional[int] = None
+        warnings.warn(
+            f"{self.name} is an experimental metric. Its behavior may change in the future version of AutoGluon."
+        )
+
+    def save_past_metrics(self, data_past: TimeSeriesDataFrame, **kwargs) -> None:
+        self.num_items = data_past.num_items
+
+    def _fast_cumsum(self, y: np.ndarray) -> np.ndarray:
+        """Compute the cumulative sum for each consecutive `prediction_length` items in the array."""
+        y = y.reshape(self.num_items, -1)
+        return np.nancumsum(y, axis=1).ravel()
+
+    def compute_metric(
+        self, data_future: TimeSeriesDataFrame, predictions: TimeSeriesDataFrame, target: str = "target", **kwargs
+    ) -> float:
+        y_true, y_pred = self._get_point_forecast_score_inputs(data_future, predictions, target=target)
+        cumsum_true = self._fast_cumsum(y_true.to_numpy())
+        cumsum_pred = self._fast_cumsum(y_pred.to_numpy())
+        diffs = cumsum_pred - cumsum_true
+        error = diffs * np.where(diffs < 0, -self.alpha1, self.alpha2)
+        return self._safemean(error)

--- a/timeseries/tests/unittests/test_metrics.py
+++ b/timeseries/tests/unittests/test_metrics.py
@@ -20,7 +20,7 @@ from gluonts.model.evaluation import evaluate_forecasts
 from gluonts.model.forecast import QuantileForecast
 
 from autogluon.timeseries import TimeSeriesPredictor
-from autogluon.timeseries.metrics import AVAILABLE_METRICS, CPE, DEFAULT_METRIC_NAME, check_get_evaluation_metric
+from autogluon.timeseries.metrics import AVAILABLE_METRICS, DEFAULT_METRIC_NAME, check_get_evaluation_metric
 from autogluon.timeseries.metrics.utils import _in_sample_abs_seasonal_error, _in_sample_squared_seasonal_error
 from autogluon.timeseries.models.gluonts.abstract_gluonts import AbstractGluonTSModel
 

--- a/timeseries/tests/unittests/test_metrics.py
+++ b/timeseries/tests/unittests/test_metrics.py
@@ -328,9 +328,9 @@ def test_when_better_predictions_passed_to_metric_then_score_improves(metric_nam
     assert good_score > bad_score
 
 
-@pytest.mark.parametrize("metric_name", ["CPE", "cpe"])
+@pytest.mark.parametrize("metric_name", ["CE", "ce"])
 def test_when_experimental_metric_name_used_then_predictor_can_score(metric_name):
     predictor = TimeSeriesPredictor(prediction_length=3, eval_metric=metric_name)
     predictor.fit(DUMMY_TS_DATAFRAME, hyperparameters={"DeepAR": {"epochs": 1, "num_batches_per_epoch": 1}})
     score = predictor.score(DUMMY_TS_DATAFRAME)
-    assert np.isfinite(score["CPE"])
+    assert np.isfinite(score["CE"])

--- a/timeseries/tests/unittests/test_metrics.py
+++ b/timeseries/tests/unittests/test_metrics.py
@@ -328,9 +328,9 @@ def test_when_better_predictions_passed_to_metric_then_score_improves(metric_nam
     assert good_score > bad_score
 
 
-@pytest.mark.parametrize("metric_name", ["CE", "ce"])
+@pytest.mark.parametrize("metric_name", ["WCD", "wcd"])
 def test_when_experimental_metric_name_used_then_predictor_can_score(metric_name):
     predictor = TimeSeriesPredictor(prediction_length=3, eval_metric=metric_name)
     predictor.fit(DUMMY_TS_DATAFRAME, hyperparameters={"DeepAR": {"epochs": 1, "num_batches_per_epoch": 1}})
     score = predictor.score(DUMMY_TS_DATAFRAME)
-    assert np.isfinite(score["CE"])
+    assert np.isfinite(score["WCD"])

--- a/timeseries/tests/unittests/test_metrics.py
+++ b/timeseries/tests/unittests/test_metrics.py
@@ -20,7 +20,7 @@ from gluonts.model.evaluation import evaluate_forecasts
 from gluonts.model.forecast import QuantileForecast
 
 from autogluon.timeseries import TimeSeriesPredictor
-from autogluon.timeseries.metrics import AVAILABLE_METRICS, DEFAULT_METRIC_NAME, check_get_evaluation_metric
+from autogluon.timeseries.metrics import AVAILABLE_METRICS, CPE, DEFAULT_METRIC_NAME, check_get_evaluation_metric
 from autogluon.timeseries.metrics.utils import _in_sample_abs_seasonal_error, _in_sample_squared_seasonal_error
 from autogluon.timeseries.models.gluonts.abstract_gluonts import AbstractGluonTSModel
 
@@ -326,3 +326,11 @@ def test_when_better_predictions_passed_to_metric_then_score_improves(metric_nam
     good_score = eval_metric.score(data, predictions + 1, prediction_length=prediction_length)
     bad_score = eval_metric.score(data, predictions + 50, prediction_length=prediction_length)
     assert good_score > bad_score
+
+
+@pytest.mark.parametrize("metric_name", ["CPE", "cpe"])
+def test_when_experimental_metric_name_used_then_predictor_can_score(metric_name):
+    predictor = TimeSeriesPredictor(prediction_length=3, eval_metric=metric_name)
+    predictor.fit(DUMMY_TS_DATAFRAME, hyperparameters={"DeepAR": {"epochs": 1, "num_batches_per_epoch": 1}})
+    score = predictor.score(DUMMY_TS_DATAFRAME)
+    assert np.isfinite(score["CPE"])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add experimental `WCD` (Weighted Cumulative Discrepancy) forecasting metric


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
