### PR TITLE
[CI] Schedule benchmark everday

### DIFF
--- a/.github/workflows/benchmark_master.yml
+++ b/.github/workflows/benchmark_master.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
   schedule:
-    - cron: '00 09 * * SUN' #  UTC 9:00(2:00 PST Time) every Sunday
+    - cron: '00 02 * * *' #  UTC 2:00 AM every day
 
 env:
   AG_BRANCH_NAME: master


### PR DESCRIPTION
*Description of changes:*
Scheduling benchmark daily until v1.2. 
Will merge post AMLB and AG-Bench fixes.
Pending PRs to merge before his PR is merged - 
1. https://github.com/autogluon/autogluon-bench/pull/108
2. https://github.com/openml/automlbenchmark/pull/643
3. Until [2] is merged we are using https://github.com/autogluon/autogluon/pull/4603
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
