### PR TITLE
[CI Benchmark] Add dependencies for AG Bench 0.4.4

### DIFF
--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -16,10 +16,10 @@ function setup_build_contrib_env {
 
 function setup_benchmark_env {
     pip install -U autogluon.bench
-    pip install pyarrow # TODO: Remove once AG-Bench v0.4.4 is released
     git clone https://github.com/autogluon/autogluon-dashboard.git
     pip install -e ./autogluon-dashboard
     pip install yq
+    pip install s3fs
 }
 
 function setup_hf_model_mirror {


### PR DESCRIPTION
*Description of changes:*
New version of AG Bench requires s3fs to be installed otherwise CI Benchmark fails.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
