### PR TITLE
Fix specifying None in upload_file prefix

### DIFF
--- a/common/src/autogluon/common/utils/s3_utils.py
+++ b/common/src/autogluon/common/utils/s3_utils.py
@@ -86,7 +86,7 @@ def upload_file(*, file_name: str, bucket: str, prefix: Optional[str] = None):
     import boto3
 
     object_name = os.path.basename(file_name)
-    if len(prefix) == 0:
+    if prefix is not None and len(prefix) == 0:
         prefix = None
     if prefix is not None:
         object_name = prefix + "/" + object_name


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fix specifying None in upload_file prefix causing crash

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
