### PR TITLE
Refactor TabularDataset

### DIFF
--- a/common/src/autogluon/common/__init__.py
+++ b/common/src/autogluon/common/__init__.py
@@ -1,3 +1,4 @@
+from .dataset import TabularDataset
 from .features.feature_metadata import FeatureMetadata
 from .utils.log_utils import _add_stream_handler
 from .utils.log_utils import fix_logging_if_kaggle as __fix_logging_if_kaggle

--- a/common/src/autogluon/common/dataset.py
+++ b/common/src/autogluon/common/dataset.py
@@ -5,21 +5,19 @@ from .loaders import load_pd
 __all__ = ["TabularDataset"]
 
 
-# FIXME: Add unit tests
-class TabularDataset(pd.DataFrame):
+class TabularDataset:
     """
     A dataset in tabular format (with rows = samples, columns = features/variables).
-    This object returns a pandas DataFrame when initialized and all existing pandas methods can be applied to it.
+    This class returns a :class:`pd.DataFrame` when initialized and all existing pandas methods can be applied to it.
     For full list of methods/attributes, see pandas Dataframe documentation: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html
+
+    The purpose of this class is to provide an easy-to-use shorthand for loading a pandas DataFrame to use in AutoGluon.
 
     Parameters
     ----------
-    data : :class:`pd.DataFrame` or str
+    data : str, :class:`pd.DataFrame`, :class:`np.ndarray`, Iterable, or dict
         If str, path to data file (CSV or Parquet format).
-        If you already have your data in a :class:`pd.DataFrame`, you can specify it here.
-
-    Note: In addition to these attributes, `TabularDataset` also shares all the same attributes and methods of a pandas Dataframe.
-    For a detailed list, see:  https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html
+        If you already have your data in a :class:`pd.DataFrame`, you can specify it here. In this case, the same DataFrame will be returned with no changes.
 
     Examples
     --------
@@ -32,7 +30,7 @@ class TabularDataset(pd.DataFrame):
     >>> assert type(train_data) == type(train_data_pd)  # True
     """
 
-    def __new__(cls, data, **kwargs):
+    def __new__(cls, data, **kwargs) -> pd.DataFrame:
         if isinstance(data, str):
             data = load_pd.load(data)
         return pd.DataFrame(data, **kwargs)

--- a/common/src/autogluon/common/dataset.py
+++ b/common/src/autogluon/common/dataset.py
@@ -1,13 +1,11 @@
 import pandas as pd
 
-from .utils.loaders import load_pd
+from .loaders import load_pd
 
 __all__ = ["TabularDataset"]
 
 
 # FIXME: Add unit tests
-# FIXME: Move to common
-# FIXME: Check dtypes, remove usage of type checks for TabularDataset!
 class TabularDataset(pd.DataFrame):
     """
     A dataset in tabular format (with rows = samples, columns = features/variables).

--- a/common/src/autogluon/common/loaders/load_pd.py
+++ b/common/src/autogluon/common/loaders/load_pd.py
@@ -16,7 +16,6 @@ logger = logging.getLogger(__name__)
 
 # TODO: v1.0 consider renaming function so it isn't 'load'. Consider instead 'load_pd', or something more descriptive.
 # TODO: Add full docstring
-# TODO: Add full docstring for usage within TabularDataset
 def load(
     path,
     delimiter=None,

--- a/common/tests/unittests/test_dataset.py
+++ b/common/tests/unittests/test_dataset.py
@@ -4,10 +4,7 @@ from autogluon.common import TabularDataset
 
 
 def test_tabular_dataset():
-    data = {
-        "col1": [1, 2, 3, 4],
-        "col2": ["a", "b", "b", "c"]
-    }
+    data = {"col1": [1, 2, 3, 4], "col2": ["a", "b", "b", "c"]}
 
     df_1 = pd.DataFrame(data)
     df_2 = TabularDataset(data)

--- a/common/tests/unittests/test_dataset.py
+++ b/common/tests/unittests/test_dataset.py
@@ -1,0 +1,18 @@
+import pandas as pd
+
+from autogluon.common import TabularDataset
+
+
+def test_tabular_dataset():
+    data = {
+        "col1": [1, 2, 3, 4],
+        "col2": ["a", "b", "b", "c"]
+    }
+
+    df_1 = pd.DataFrame(data)
+    df_2 = TabularDataset(data)
+
+    assert isinstance(df_1, pd.DataFrame)
+    assert df_1.equals(df_2)
+    assert type(df_1) == pd.DataFrame
+    assert type(df_1) == type(df_2)

--- a/core/src/autogluon/core/__init__.py
+++ b/core/src/autogluon/core/__init__.py
@@ -1,3 +1,4 @@
+# noinspection PyUnresolvedReferences
 from autogluon.common.dataset import TabularDataset
 from autogluon.common.utils.log_utils import _add_stream_handler
 

--- a/core/src/autogluon/core/__init__.py
+++ b/core/src/autogluon/core/__init__.py
@@ -1,7 +1,7 @@
+from autogluon.common.dataset import TabularDataset
 from autogluon.common.utils.log_utils import _add_stream_handler
 
 from . import constants, metrics
-from .dataset import TabularDataset
 from .version import __version__
 
 _add_stream_handler()

--- a/core/src/autogluon/core/dataset.py
+++ b/core/src/autogluon/core/dataset.py
@@ -5,10 +5,13 @@ from .utils.loaders import load_pd
 __all__ = ["TabularDataset"]
 
 
+# FIXME: Add unit tests
+# FIXME: Move to common
+# FIXME: Check dtypes, remove usage of type checks for TabularDataset!
 class TabularDataset(pd.DataFrame):
     """
     A dataset in tabular format (with rows = samples, columns = features/variables).
-    This object is essentially a pandas DataFrame (with some extra attributes) and all existing pandas methods can be applied to it.
+    This object returns a pandas DataFrame when initialized and all existing pandas methods can be applied to it.
     For full list of methods/attributes, see pandas Dataframe documentation: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html
 
     Parameters
@@ -17,38 +20,21 @@ class TabularDataset(pd.DataFrame):
         If str, path to data file (CSV or Parquet format).
         If you already have your data in a :class:`pd.DataFrame`, you can specify it here.
 
-    Attributes
-    ----------
-    file_path: (str)
-        Path to data file from which this `TabularDataset` was created.
-        None if `data` was a :class:`pd.DataFrame`.
-
     Note: In addition to these attributes, `TabularDataset` also shares all the same attributes and methods of a pandas Dataframe.
     For a detailed list, see:  https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html
 
     Examples
     --------
-    >>> from autogluon.core.dataset import TabularDataset
-    >>> train_data = TabularDataset('https://autogluon.s3.amazonaws.com/datasets/Inc/train.csv')
-    >>> train_data.head(30)
-    >>> train_data.columns
+    >>> import pandas as pd
+    >>> from autogluon.common import TabularDataset
+    >>> train_data = TabularDataset("https://autogluon.s3.amazonaws.com/datasets/Inc/train.csv")
+    >>> train_data_pd = pd.read_csv("https://autogluon.s3.amazonaws.com/datasets/Inc/train.csv")
+    >>> assert isinstance(train_data, pd.DataFrame)  # True
+    >>> assert train_data.equals(train_data_pd)  # True
+    >>> assert type(train_data) == type(train_data_pd)  # True
     """
 
-    _metadata = ["file_path"]  # preserved properties that will be copied to a new instance of TabularDataset
-
-    @property
-    def _constructor(self):
-        return TabularDataset
-
-    @property
-    def _constructor_sliced(self):
-        return pd.Series
-
-    def __init__(self, data, **kwargs):
+    def __new__(cls, data, **kwargs):
         if isinstance(data, str):
-            file_path = data
-            data = load_pd.load(file_path)
-        else:
-            file_path = None
-        super().__init__(data, **kwargs)
-        self.file_path = file_path
+            data = load_pd.load(data)
+        return pd.DataFrame(data, **kwargs)

--- a/core/src/autogluon/core/utils/infer_utils.py
+++ b/core/src/autogluon/core/utils/infer_utils.py
@@ -1,13 +1,17 @@
+import copy
+import time
+
+import numpy as np
 import pandas as pd
 
 
-def get_model_true_infer_speed_per_row_batch(data, *, predictor, batch_size: int = 100000, repeats=1, persist=True, silent=False):
+def get_model_true_infer_speed_per_row_batch(data: pd.DataFrame, *, predictor, batch_size: int = 100000, repeats=1, persist=True, silent=False):
     """
     Get per-model true inference speed per row for a given batch size of data.
 
     Parameters
     ----------
-    data : :class:`TabularDataset` or :class:`pd.DataFrame`
+    data : :class:`pd.DataFrame`
         Table of the data, which is similar to a pandas DataFrame.
         Must contain the label column to be compatible with leaderboard call.
     predictor : TabularPredictor
@@ -31,12 +35,6 @@ def get_model_true_infer_speed_per_row_batch(data, *, predictor, batch_size: int
             'pred_time_test_marginal' is the prediction time needed to predict for this particular model minus dependent model inference times and global preprocessing time.
         time_per_row_transform is the time in seconds per row to do the feature preprocessing.
     """
-    import copy
-    import time
-
-    import numpy as np
-    import pandas as pd
-
     data_batch = copy.deepcopy(data)
     len_data = len(data_batch)
     if len_data == batch_size:
@@ -108,7 +106,7 @@ def get_model_true_infer_speed_per_row_batch_bulk(
 
     Parameters
     ----------
-    data : :class:`TabularDataset` or :class:`pd.DataFrame`
+    data : :class:`pd.DataFrame`
         Table of the data, which is similar to a pandas DataFrame.
         Must contain the label column to be compatible with leaderboard call.
     predictor : TabularPredictor

--- a/docs/tutorials/tabular/advanced/tabular-multilabel.ipynb
+++ b/docs/tutorials/tabular/advanced/tabular-multilabel.ipynb
@@ -108,7 +108,7 @@
     "\n",
     "            Parameters\n",
     "            ----------\n",
-    "            train_data, tuning_data : str or autogluon.tabular.TabularDataset or pd.DataFrame\n",
+    "            train_data, tuning_data : str or pd.DataFrame\n",
     "                See documentation for `TabularPredictor.fit()`.\n",
     "            kwargs :\n",
     "                Arguments passed into the `fit()` call for each TabularPredictor.\n",

--- a/tabular/src/autogluon/tabular/__init__.py
+++ b/tabular/src/autogluon/tabular/__init__.py
@@ -1,4 +1,6 @@
+# noinspection PyUnresolvedReferences
 from autogluon.common.dataset import TabularDataset
+# noinspection PyUnresolvedReferences
 from autogluon.common.features.feature_metadata import FeatureMetadata
 from autogluon.common.utils.log_utils import _add_stream_handler
 

--- a/tabular/src/autogluon/tabular/__init__.py
+++ b/tabular/src/autogluon/tabular/__init__.py
@@ -1,6 +1,6 @@
+from autogluon.common.dataset import TabularDataset
 from autogluon.common.features.feature_metadata import FeatureMetadata
 from autogluon.common.utils.log_utils import _add_stream_handler
-from autogluon.core.dataset import TabularDataset
 
 try:
     from .version import __version__

--- a/tabular/src/autogluon/tabular/predictor/interpretable_predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/interpretable_predictor.py
@@ -111,7 +111,7 @@ class InterpretableTabularPredictor(TabularPredictor):
 
         Parameters
         ----------
-        data : str or :class:`TabularDataset` or :class:`pd.DataFrame`
+        data : str or :class:`pd.DataFrame`
             The data to make predictions for. Should contain same column names as training Dataset and follow same format
             (may contain extra columns that won't be used by Predictor, including the label-column itself).
             If str is passed, `data` will be loaded using the str value as the file path.

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -16,7 +16,7 @@ import numpy as np
 import pandas as pd
 from packaging import version
 
-from autogluon.common import FeatureMetadata
+from autogluon.common import FeatureMetadata, TabularDataset
 from autogluon.common.loaders import load_json
 from autogluon.common.savers import save_json
 from autogluon.common.utils.file_utils import get_directory_size, get_directory_size_per_file
@@ -39,7 +39,6 @@ from autogluon.core.constants import (
     SOFTCLASS,
 )
 from autogluon.core.data.label_cleaner import LabelCleanerMulticlassToBinary
-from autogluon.core.dataset import TabularDataset
 from autogluon.core.metrics import Scorer, get_metric
 from autogluon.core.problem_type import problem_type_info
 from autogluon.core.pseudolabeling.pseudolabeling import filter_ensemble_pseudo, filter_pseudo

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -396,8 +396,8 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
     @apply_presets(tabular_presets_dict, tabular_presets_alias)
     def fit(
         self,
-        train_data,
-        tuning_data=None,
+        train_data: pd.DataFrame | str,
+        tuning_data: pd.DataFrame | str = None,
         time_limit: float = None,
         presets: List[str] | str = None,
         hyperparameters: dict | str = None,
@@ -420,10 +420,10 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
 
         Parameters
         ----------
-        train_data : str or :class:`TabularDataset` or :class:`pd.DataFrame`
-            Table of the training data, which is similar to a pandas DataFrame.
+        train_data : :class:`pd.DataFrame` or str
+            Table of the training data as a pandas DataFrame.
             If str is passed, `train_data` will be loaded using the str value as the file path.
-        tuning_data : str or :class:`TabularDataset` or :class:`pd.DataFrame`, default = None
+        tuning_data : :class:`pd.DataFrame` or str, optional
             Another dataset containing validation data reserved for tuning processes such as early stopping and hyperparameter tuning.
             This dataset should be in the same format as `train_data`.
             If str is passed, `tuning_data` will be loaded using the str value as the file path.
@@ -867,7 +867,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
                     `enable_callbacks` : bool, default = False
                         If True, will perform a deepcopy on the specified user callbacks and enable them during the DyStack call.
                         If False, will not include callbacks in the DyStack call.
-                    `holdout_data`: str or :class:`TabularDataset` or :class:`pd.DataFrame`, default = None
+                    `holdout_data`: str or :class:`pd.DataFrame`, default = None
                         Another dataset containing validation data reserved for detecting stacked overfitting. This dataset should be in the same format as
                         `train_data`. If str is passed, `holdout_data` will be loaded using the str value as the file path.
                         If `holdout_data` is not None, the sub-fit is fit on all of `train_data` and the full fit is fit on all of `train_data` and
@@ -986,8 +986,8 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
                 (which may improve metrics like log_loss) and will train a scalar parameter on the validation set.
                 If True and the problem_type is quantile regression, conformalization will be used to calibrate the Predictor's estimated quantiles
                 (which may improve the prediction interval coverage, and bagging could further improve it) and will compute a set of scalar parameters on the validation set.
-            test_data : str or :class:`TabularDataset` or :class:`pd.DataFrame`, default = None
-                Table of the test data, which is similar to a pandas DataFrame.
+            test_data : str or :class:`pd.DataFrame`, default = None
+                Table of the test data.
                 If str is passed, `test_data` will be loaded using the str value as the file path.
                 NOTE: This test_data is NEVER SEEN by the model during training and, if specified, is only used for logging purposes (i.e. for learning curve generation).
                 This test_data should be treated the same way test data is used in predictor.leaderboard.
@@ -1970,9 +1970,9 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
 
         Parameters:
         -----------
-        unlabeled_data: Extra unlabeled data (could be the test data) to assign pseudolabels to
-            and incorporate as extra training data.
-        max_iter: int, default = 5
+        unlabeled_data: pd.DataFrame
+            Extra unlabeled data (could be the test data) to assign pseudolabels to and incorporate as extra training data.
+        max_iter: int
             Maximum allowed number of iterations, where in each iteration, the data are pseudolabeled
             by the current predictor and the predictor is refit including the pseudolabled data in its training set.
         return_pred_proba: bool, default = False
@@ -2126,7 +2126,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
 
         Parameters
         ----------
-        pseudo_data : str or :class:`TabularDataset` or :class:`pd.DataFrame`
+        pseudo_data : :class:`pd.DataFrame`
             Extra data to incorporate into training. Pre-labeled test data allowed. If no labels
             then pseudo-labeling algorithm will predict and filter out which rows to incorporate into training
         max_iter: int, default = 3
@@ -2231,20 +2231,20 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
 
     def predict(
         self,
-        data: str | TabularDataset | pd.DataFrame,
+        data: pd.DataFrame | str,
         model: str | None = None,
         as_pandas: bool = True,
         transform_features: bool = True,
         *,
         decision_threshold: float | None = None,
-    ):
+    ) -> pd.Series | np.ndarray:
         """
         Use trained models to produce predictions of `label` column values for new data.
 
         Parameters
         ----------
-        data : str or :class:`TabularDataset` or :class:`pd.DataFrame`
-            The data to make predictions for. Should contain same column names as training Dataset and follow same format
+        data : :class:`pd.DataFrame` or str
+            The data to make predictions for. Should contain same column names as training data and follow same format
             (may contain extra columns that won't be used by Predictor, including the label-column itself).
             If str is passed, `data` will be loaded using the str value as the file path.
         model : str (optional)
@@ -2277,19 +2277,19 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
 
     def predict_proba(
         self,
-        data: str | TabularDataset | pd.DataFrame,
+        data: pd.DataFrame | str,
         model: str | None = None,
         as_pandas: bool = True,
         as_multiclass: bool = True,
         transform_features: bool = True,
-    ):
+    ) -> pd.DataFrame | pd.Series | np.ndarray:
         """
         Use trained models to produce predicted class probabilities rather than class-labels (if task is classification).
         If `predictor.problem_type` is regression or quantile, this will raise an AssertionError.
 
         Parameters
         ----------
-        data : str or :class:`TabularDataset` or :class:`pd.DataFrame`
+        data : :class:`pd.DataFrame` or str
             The data to make predictions for. Should contain same column names as training dataset and follow same format
             (may contain extra columns that won't be used by Predictor, including the label-column itself).
             If str is passed, `data` will be loaded using the str value as the file path.
@@ -2381,14 +2381,23 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         """
         return self._learner.is_fit
 
-    def evaluate(self, data, model=None, decision_threshold=None, display: bool = False, auxiliary_metrics=True, detailed_report=False, **kwargs) -> dict:
+    def evaluate(
+        self,
+        data: pd.DataFrame | str,
+        model: str = None,
+        decision_threshold: float = None,
+        display: bool = False,
+        auxiliary_metrics: bool = True,
+        detailed_report: bool = False,
+        **kwargs,
+    ) -> dict:
         """
         Report the predictive performance evaluated over a given dataset.
         This is basically a shortcut for: `pred_proba = predict_proba(data); evaluate_predictions(data[label], pred_proba)`.
 
         Parameters
         ----------
-        data : str or :class:`TabularDataset` or :class:`pd.DataFrame`
+        data : str or :class:`pd.DataFrame`
             This dataset must also contain the `label` with the same column-name as previously specified.
             If str is passed, `data` will be loaded using the str value as the file path.
             If `self.sample_weight` is set and `self.weight_evaluation==True`, then a column with the sample weight name is checked and used for weighted metric evaluation if it exists.
@@ -2498,7 +2507,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
 
     def leaderboard(
         self,
-        data: str | TabularDataset | pd.DataFrame | None = None,
+        data: pd.DataFrame | str | None = None,
         extra_info: bool = False,
         extra_metrics: list | None = None,
         decision_threshold: float | None = None,
@@ -2537,8 +2546,8 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
 
         Parameters
         ----------
-        data : str or :class:`TabularDataset` or :class:`pd.DataFrame` (optional)
-            This Dataset must also contain the label-column with the same column-name as specified during fit().
+        data : str or :class:`pd.DataFrame` (optional)
+            This dataset must also contain the label-column with the same column-name as specified during fit().
             If extra_metrics=None and skip_score=True, then the label column is not required.
             If specified, then the leaderboard returned will contain additional columns 'score_test', 'pred_time_test', and 'pred_time_test_marginal'.
                 'score_test': The score of the model on the 'eval_metric' for the data provided.
@@ -2960,7 +2969,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             decision_threshold=decision_threshold,
         )
 
-    def fit_summary(self, verbosity=3, show_plot=False):
+    def fit_summary(self, verbosity: int = 3, show_plot: bool = False) -> dict:
         """
         Output summary of information about models produced during `fit()`.
         May create various generated summary plots and store them in folder: `predictor.path`.
@@ -3094,7 +3103,13 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             print("*** End of fit() summary ***")
         return results
 
-    def transform_features(self, data=None, model: str = None, base_models: List[str] = None, return_original_features: bool = True) -> pd.DataFrame:
+    def transform_features(
+        self,
+        data: pd.DataFrame | str = None,
+        model: str = None,
+        base_models: list[str] = None,
+        return_original_features: bool = True,
+    ) -> pd.DataFrame:
         """
         Transforms data features through the AutoGluon feature generator.
         This is useful to gain an understanding of how AutoGluon interprets the data features.
@@ -3107,7 +3122,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
 
         Parameters
         ----------
-        data: str or :class:`TabularDataset` or :class:`pd.DataFrame` (optional)
+        data: :class:`pd.DataFrame` or str (optional)
             The data to apply feature transformation to.
             This data does not require the label column.
             If str is passed, `data` will be loaded using the str value as the file path.
@@ -3223,7 +3238,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
 
         Parameters
         ----------
-        data : str or :class:`TabularDataset` or :class:`pd.DataFrame` (optional)
+        data : str or :class:`pd.DataFrame` (optional)
             This data must also contain the label-column with the same column-name as specified during `fit()`.
             If specified, then the data is used to calculate the feature importance scores.
             If str is passed, `data` will be loaded using the str value as the file path.
@@ -3785,7 +3800,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
 
     def calibrate_decision_threshold(
         self,
-        data: str | TabularDataset | pd.DataFrame | None = None,
+        data: pd.DataFrame | str | None = None,
         metric: str | Scorer | None = None,
         model: str = "best",
         decision_thresholds: int | List[float] = 25,
@@ -3805,7 +3820,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
 
         Parameters
         ----------
-        data : Union[str, pd.DataFrame], default = None
+        data : pd.DataFrame or str, optional
             The data to use for calibration. Must contain the label column.
             We recommend to keep this value as None unless you are an advanced user and understand the implications.
             If None, will use internal data such as the holdout validation data or out-of-fold predictions.
@@ -4249,17 +4264,17 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
 
     def distill(
         self,
-        train_data=None,
-        tuning_data=None,
-        augmentation_data=None,
-        time_limit=None,
-        hyperparameters=None,
-        holdout_frac=None,
-        teacher_preds="soft",
-        augment_method="spunge",
-        augment_args={"size_factor": 5, "max_size": int(1e5)},
-        models_name_suffix=None,
-        verbosity=None,
+        train_data: pd.DataFrame | str = None,
+        tuning_data: pd.DataFrame | str = None,
+        augmentation_data: pd.DataFrame = None,
+        time_limit: float = None,
+        hyperparameters: dict | str = None,
+        holdout_frac: float = None,
+        teacher_preds: str = "soft",
+        augment_method: str = "spunge",
+        augment_args: dict = {"size_factor": 5, "max_size": int(1e5)},
+        models_name_suffix: str = None,
+        verbosity: int = None,
     ):
         """
         [EXPERIMENTAL]
@@ -4272,14 +4287,14 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
 
         Parameters
         ----------
-        train_data : str or :class:`TabularDataset` or :class:`pd.DataFrame`, default = None
+        train_data : str or :class:`pd.DataFrame`, default = None
             Same as `train_data` argument of `fit()`.
             If None, the same training data will be loaded from `fit()` call used to produce this Predictor.
-        tuning_data : str or :class:`TabularDataset` or :class:`pd.DataFrame`, default = None
+        tuning_data : str or :class:`pd.DataFrame`, default = None
             Same as `tuning_data` argument of `fit()`.
             If `tuning_data = None` and `train_data = None`: the same training/validation splits will be loaded from `fit()` call used to produce this Predictor,
             unless bagging/stacking was previously used in which case a new training/validation split is performed.
-        augmentation_data : :class:`TabularDataset` or :class:`pd.DataFrame`, default = None
+        augmentation_data : :class:`pd.DataFrame`, default = None
             An optional extra dataset of unlabeled rows that can be used for augmenting the dataset used to fit student models during distillation (ignored if None).
         time_limit : int, default = None
             Approximately how long (in seconds) the distillation process should run for.
@@ -4477,25 +4492,23 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             print(msg + ": " + str(results[key]))
 
     @staticmethod
-    def _get_dataset(data, allow_nan: bool = False):
+    def _get_dataset(data, allow_nan: bool = False) -> pd.DataFrame | None:
         if data is None:
             if allow_nan:
                 return data
             else:
-                raise TypeError("data=None is invalid. data must be a TabularDataset or pandas.DataFrame or str file path to data")
-        elif isinstance(data, TabularDataset):
-            return data
+                raise TypeError("data=None is invalid. data must be a pd.DataFrame or str file path to data")
         elif isinstance(data, pd.DataFrame):
-            return TabularDataset(data)
+            return data
         elif isinstance(data, str):
             return TabularDataset(data)
         elif isinstance(data, pd.Series):
             raise TypeError(
-                "data must be TabularDataset or pandas.DataFrame, not pandas.Series. \
+                "data must be a pd.DataFrame, not pd.Series. \
                    To predict on just single example (ith row of table), use data.iloc[[i]] rather than data.iloc[i]"
             )
         else:
-            raise TypeError("data must be TabularDataset or pandas.DataFrame or str file path to data")
+            raise TypeError("data must be a pd.DataFrame or str file path to data")
 
     def _validate_hyperparameter_tune_kwargs(self, hyperparameter_tune_kwargs, time_limit=None):
         """


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- refactor TabularDataset so that it no longer is a subclass of a pandas DataFrame, but rather *is* a pandas DataFrame.
- This simplifies a lot of logic, such that we only need to consider input types for pandas DataFrame rather than for TabularDataset.
- This also fixes IDE visualizers such as PyCharm which wouldn't properly display TabularDataset because it didn't recognize it as a pandas DataFrame.
- The extra attribute that TabularDataset used to have was never used, so this change is backwards compatible.
- Updated docstrings and type hints in TabularPredictor to remove mention of TabularDataset and cleanup / improve existing type hints.
- Moved TabularDataset from `core` to `common`, since it only depends on pandas and `autogluon.common`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
