### PR TITLE
[Install] Update UV installation instructions and add dedicated UV tabs

### DIFF
--- a/docs/install-cpu-pip.md
+++ b/docs/install-cpu-pip.md
@@ -1,5 +1,5 @@
 ```console
 pip install -U pip
 pip install -U setuptools wheel
-pip install autogluon
+pip install autogluon --extra-index-url https://download.pytorch.org/whl/cpu
 ```

--- a/docs/install-cpu-pip.md
+++ b/docs/install-cpu-pip.md
@@ -1,10 +1,5 @@
 ```console
 pip install -U pip
 pip install -U setuptools wheel
-
-# CPU version of pytorch has smaller footprint - see installation instructions in
-# pytorch documentation - https://pytorch.org/get-started/locally/
-pip install torch==2.4.1+cpu torchvision==0.19.1+cpu --index-url https://download.pytorch.org/whl/cpu
-
 pip install autogluon
 ```

--- a/docs/install-cpu-pip.md
+++ b/docs/install-cpu-pip.md
@@ -1,11 +1,10 @@
 ```console
 pip install -U pip
 pip install -U setuptools wheel
-pip install -U uv
 
 # CPU version of pytorch has smaller footprint - see installation instructions in
 # pytorch documentation - https://pytorch.org/get-started/locally/
-uv pip install torch==2.4.1+cpu torchvision==0.19.1+cpu --index-url https://download.pytorch.org/whl/cpu
+pip install torch==2.4.1+cpu torchvision==0.19.1+cpu --index-url https://download.pytorch.org/whl/cpu
 
-uv pip install autogluon
+pip install autogluon
 ```

--- a/docs/install-cpu-source.md
+++ b/docs/install-cpu-source.md
@@ -1,11 +1,4 @@
 ```console
-pip install -U pip
-pip install -U setuptools wheel
-
-# CPU version of pytorch has smaller footprint - see installation instructions in
-# pytorch documentation - https://pytorch.org/get-started/locally/
-pip install torch==2.4.1+cpu torchvision==0.19.1+cpu --index-url https://download.pytorch.org/whl/cpu
-
 git clone https://github.com/autogluon/autogluon
 cd autogluon && ./full_install.sh
 ```

--- a/docs/install-cpu-source.md
+++ b/docs/install-cpu-source.md
@@ -1,11 +1,10 @@
 ```console
 pip install -U pip
 pip install -U setuptools wheel
-pip install -U uv
 
 # CPU version of pytorch has smaller footprint - see installation instructions in
 # pytorch documentation - https://pytorch.org/get-started/locally/
-uv pip install torch==2.4.1+cpu torchvision==0.19.1+cpu --index-url https://download.pytorch.org/whl/cpu
+pip install torch==2.4.1+cpu torchvision==0.19.1+cpu --index-url https://download.pytorch.org/whl/cpu
 
 git clone https://github.com/autogluon/autogluon
 cd autogluon && ./full_install.sh

--- a/docs/install-cpu-source.md
+++ b/docs/install-cpu-source.md
@@ -1,4 +1,6 @@
 ```console
+pip install uv
+python -m uv pip install -U torch torchvision --extra-index-url https://download.pytorch.org/whl/cpu
 git clone https://github.com/autogluon/autogluon
 cd autogluon && ./full_install.sh
 ```

--- a/docs/install-cpu-uv.md
+++ b/docs/install-cpu-uv.md
@@ -2,9 +2,6 @@
 # Install UV package installer (faster than pip)
 pip install -U uv
 
-# CPU version of pytorch
-python -m uv pip install torch==2.4.1+cpu torchvision==0.19.1+cpu --index-url https://download.pytorch.org/whl/cpu
-
 # Install AutoGluon
 python -m uv pip install autogluon
 ```

--- a/docs/install-cpu-uv.md
+++ b/docs/install-cpu-uv.md
@@ -1,0 +1,10 @@
+```console
+# Install UV package installer (faster than pip)
+pip install -U uv
+
+# CPU version of pytorch
+python -m uv pip install torch==2.4.1+cpu torchvision==0.19.1+cpu --index-url https://download.pytorch.org/whl/cpu
+
+# Install AutoGluon
+python -m uv pip install autogluon
+```

--- a/docs/install-cpu-uv.md
+++ b/docs/install-cpu-uv.md
@@ -3,5 +3,5 @@
 pip install -U uv
 
 # Install AutoGluon
-python -m uv pip install autogluon
+python -m uv pip install autogluon --extra-index-url https://download.pytorch.org/whl/cpu
 ```

--- a/docs/install-gpu-pip.md
+++ b/docs/install-gpu-pip.md
@@ -1,7 +1,6 @@
 ```console
 pip install -U pip
 pip install -U setuptools wheel
-pip install -U uv
-uv pip install autogluon
+pip install autogluon
 ```
 

--- a/docs/install-gpu-pip.md
+++ b/docs/install-gpu-pip.md
@@ -1,5 +1,5 @@
 ```console
 pip install -U pip
 pip install -U setuptools wheel
-pip install autogluon --extra-index-url https://download.pytorch.org/whl/cu118
+pip install autogluon
 ```

--- a/docs/install-gpu-pip.md
+++ b/docs/install-gpu-pip.md
@@ -1,6 +1,5 @@
 ```console
 pip install -U pip
 pip install -U setuptools wheel
-pip install autogluon
+pip install autogluon --extra-index-url https://download.pytorch.org/whl/cu118
 ```
-

--- a/docs/install-gpu-source.md
+++ b/docs/install-gpu-source.md
@@ -1,6 +1,4 @@
 ```console
-pip install -U pip
-pip install -U setuptools wheel
 git clone https://github.com/autogluon/autogluon
 cd autogluon && ./full_install.sh
 ```

--- a/docs/install-gpu-uv.md
+++ b/docs/install-gpu-uv.md
@@ -2,9 +2,6 @@
 # Install UV package installer (faster than pip)
 pip install -U uv
 
-# GPU version of pytorch with CUDA support
-python -m uv pip install torch==2.4.1 torchvision==0.19.1 --index-url https://download.pytorch.org/whl/cu118
-
 # Install AutoGluon with GPU support
-python -m uv pip install autogluon
+python -m uv pip install autogluon --extra-index-url https://download.pytorch.org/whl/cu118
 ```

--- a/docs/install-gpu-uv.md
+++ b/docs/install-gpu-uv.md
@@ -3,5 +3,5 @@
 pip install -U uv
 
 # Install AutoGluon with GPU support
-python -m uv pip install autogluon --extra-index-url https://download.pytorch.org/whl/cu118
+python -m uv pip install autogluon
 ```

--- a/docs/install-gpu-uv.md
+++ b/docs/install-gpu-uv.md
@@ -1,0 +1,10 @@
+```console
+# Install UV package installer (faster than pip)
+pip install -U uv
+
+# GPU version of pytorch with CUDA support
+python -m uv pip install torch==2.4.1 torchvision==0.19.1 --index-url https://download.pytorch.org/whl/cu118
+
+# Install AutoGluon with GPU support
+python -m uv pip install autogluon
+```

--- a/docs/install-mac-cpu.md
+++ b/docs/install-mac-cpu.md
@@ -2,5 +2,5 @@
 pip install -U pip
 pip install -U setuptools wheel
 
-pip install autogluon
+pip install autogluon --extra-index-url https://download.pytorch.org/whl/cpu
 ```

--- a/docs/install-mac-cpu.md
+++ b/docs/install-mac-cpu.md
@@ -3,5 +3,5 @@ pip install -U pip
 pip install -U setuptools wheel
 pip install -U uv
 
-uv pip install autogluon
+python -m uv pip install autogluon
 ```

--- a/docs/install-mac-cpu.md
+++ b/docs/install-mac-cpu.md
@@ -1,7 +1,6 @@
 ```console
 pip install -U pip
 pip install -U setuptools wheel
-pip install -U uv
 
-python -m uv pip install autogluon
+pip install autogluon
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -175,7 +175,7 @@ The Conda install may have subtle differences in installed dependencies that cou
     ```{include} install-windows-gpu.md
     ```
 
-    ```{include} install-gpu-pip.md
+    ```{include} install-gpu-uv.md
     ```
     ::::
   

--- a/docs/install.md
+++ b/docs/install.md
@@ -27,6 +27,20 @@ The Conda install may have subtle differences in installed dependencies that cou
   
   :::::
   
+  :::::{tab} UV
+  
+    ::::{tab} CPU
+    ```{include} install-cpu-uv.md
+    ```
+    ::::
+    
+    ::::{tab} GPU
+    ```{include} install-gpu-pip.md
+    ```
+    ::::
+  
+  :::::
+  
   :::::{tab} Conda
   
     ::::{tab} CPU
@@ -71,6 +85,23 @@ The Conda install may have subtle differences in installed dependencies that cou
   
     ::::{tab} GPU
     ```{include} install-mac-nogpu.md
+    ::::
+  
+  :::::
+  
+  :::::{tab} UV
+  
+    ::::{tab} CPU
+    ```{include} install-mac-libomp.md
+    ```
+
+    ```{include} install-cpu-uv.md
+    ```
+    ::::
+  
+    ::::{tab} GPU
+    ```{include} install-mac-nogpu.md
+    ```
     ::::
   
   :::::
@@ -125,6 +156,26 @@ The Conda install may have subtle differences in installed dependencies that cou
     ```
 
 	  ```{include} install-gpu-pip.md 
+    ```
+    ::::
+  
+  :::::
+  
+  :::::{tab} UV
+  
+    ::::{tab} CPU
+    ```{include} install-windows-cpu.md
+    ```
+    
+    ```{include} install-cpu-uv.md
+    ```
+    ::::
+    
+    ::::{tab} GPU
+    ```{include} install-windows-gpu.md
+    ```
+
+    ```{include} install-gpu-pip.md
     ```
     ::::
   
@@ -213,7 +264,7 @@ AutoGluon offers nightly builds that can be installed using the `--pre` argument
 
 ```bash
 pip install -U uv
-uv pip install --pre autogluon
+python -m uv pip install --pre autogluon
 ```
 :::
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -35,7 +35,7 @@ The Conda install may have subtle differences in installed dependencies that cou
     ::::
     
     ::::{tab} GPU
-    ```{include} install-gpu-pip.md
+    ```{include} install-gpu-uv.md
     ```
     ::::
   

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,96 +1,96 @@
 # Installing AutoGluon
 
-:::{note} 
+:::{note}
 
 * AutoGluon requires Python version 3.9, 3.10, 3.11, or 3.12 and is available on Linux, MacOS, and Windows.
- 
-* The AutoGluon library comes pre-installed in all releases of [Amazon SageMaker Distribution](https://github.com/aws/sagemaker-distribution). For more information, refer to the dropdown [AutoGluon in Amazon SageMaker Studio](#dropdown-sagemaker) in this page. 
+
+* The AutoGluon library comes pre-installed in all releases of [Amazon SageMaker Distribution](https://github.com/aws/sagemaker-distribution). For more information, refer to the dropdown [AutoGluon in Amazon SageMaker Studio](#dropdown-sagemaker) in this page.
 
 We recommend most users to install via pip. The pip install of AutoGluon is the version we actively benchmark and test on.
-The Conda install may have subtle differences in installed dependencies that could impact performance and stability, and we recommend trying pip if you run into issues with Conda. 
+The Conda install may have subtle differences in installed dependencies that could impact performance and stability, and we recommend trying pip if you run into issues with Conda.
 
 :::
 
 ::::::{tab} Linux
 
   :::::{tab} Pip
-  
+
     ::::{tab} CPU
     ```{include} install-cpu-pip.md
     ```
     ::::
-    
+
     ::::{tab} GPU
     ```{include} install-gpu-pip.md
     ```
     ::::
-  
+
   :::::
-  
+
   :::::{tab} UV
-  
+
     ::::{tab} CPU
     ```{include} install-cpu-uv.md
     ```
     ::::
-    
+
     ::::{tab} GPU
     ```{include} install-gpu-uv.md
     ```
     ::::
-  
+
   :::::
-  
+
   :::::{tab} Conda
-  
+
     ::::{tab} CPU
     ```{include} install-conda-full.md
     ```
     ::::
-    
+
     ::::{tab} GPU
     ```{include} install-linux-conda-gpu.md
     ```
     ::::
-  
+
   :::::
-  
+
   :::::{tab} Source
-  
+
     ::::{tab} CPU
     ```{include} install-cpu-source.md
     ```
     ::::
-    
+
     ::::{tab} GPU
     ```{include} install-gpu-source.md
     ```
     ::::
-  
+
   :::::
-  
+
 ::::::
 
 ::::::{tab} Mac
 
   :::::{tab} Pip
-  
+
     ::::{tab} CPU
     ```{include} install-mac-libomp.md
     ```
 
     ```{include} install-mac-cpu.md
-    ``` 
+    ```
     ::::
-  
+
     ::::{tab} GPU
     ```{include} install-mac-nogpu.md
     ::::
-  
+
   :::::
-  
+
   :::::{tab} UV
-  
+
     ::::{tab} CPU
     ```{include} install-mac-libomp.md
     ```
@@ -98,30 +98,30 @@ The Conda install may have subtle differences in installed dependencies that cou
     ```{include} install-cpu-uv.md
     ```
     ::::
-  
+
     ::::{tab} GPU
     ```{include} install-mac-nogpu.md
     ```
     ::::
-  
+
   :::::
-  
+
   :::::{tab} Conda
-  
+
     ::::{tab} CPU
     ```{include} install-mac-conda.md
     ```
     ::::
-  
+
     ::::{tab} GPU
     ```{include} install-mac-nogpu.md
     ```
     ::::
-  
+
   :::::
-  
+
   :::::{tab} Source
-  
+
     ::::{tab} CPU
     ```{include} install-mac-libomp.md
     ```
@@ -129,12 +129,12 @@ The Conda install may have subtle differences in installed dependencies that cou
     ```{include} install-mac-cpu-source.md
     ```
     ::::
-    
+
     ::::{tab} GPU
     ```{include} install-mac-nogpu.md
     ```
     ::::
-  
+
   :::::
 
 ::::::
@@ -142,35 +142,35 @@ The Conda install may have subtle differences in installed dependencies that cou
 ::::::{tab} Windows
 
   :::::{tab} Pip
-  
+
     ::::{tab} CPU
     ```{include} install-windows-cpu.md
     ```
-    
-	  ```{include} install-cpu-pip.md 
+
+	  ```{include} install-cpu-pip.md
     ```
     ::::
-    
+
     ::::{tab} GPU
     ```{include} install-windows-gpu.md
     ```
 
-	  ```{include} install-gpu-pip.md 
+	  ```{include} install-gpu-pip.md
     ```
     ::::
-  
+
   :::::
-  
+
   :::::{tab} UV
-  
+
     ::::{tab} CPU
     ```{include} install-windows-cpu.md
     ```
-    
+
     ```{include} install-cpu-uv.md
     ```
     ::::
-    
+
     ::::{tab} GPU
     ```{include} install-windows-gpu.md
     ```
@@ -178,25 +178,25 @@ The Conda install may have subtle differences in installed dependencies that cou
     ```{include} install-gpu-uv.md
     ```
     ::::
-  
+
   :::::
-  
+
   :::::{tab} Conda
-  
+
     ::::{tab} CPU
     ```{include} install-conda-full.md
     ```
     ::::
-    
+
     ::::{tab} GPU
     ```{include} install-windows-conda-gpu.md
     ```
     ::::
-  
+
   :::::
-  
+
   :::::{tab} Source
-  
+
     ::::{tab} CPU
     ```{include} install-windows-cpu.md
     ```
@@ -204,7 +204,7 @@ The Conda install may have subtle differences in installed dependencies that cou
     ```{include} install-cpu-source.md
     ```
     ::::
-    
+
     ::::{tab} GPU
     ```{include} install-windows-gpu.md
     ```
@@ -212,7 +212,7 @@ The Conda install may have subtle differences in installed dependencies that cou
     ```{include} install-gpu-source.md
     ```
     ::::
-  
+
   :::::
 
 ::::::
@@ -227,10 +227,10 @@ The Conda install may have subtle differences in installed dependencies that cou
 
 :::{dropdown} AutoGluon in Amazon SageMaker Studio
 
-[Amazon SageMaker Distribution](https://github.com/aws/sagemaker-distribution) is the docker environment for data science used as the default image of [JupyterLab](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-updated-jl.html) notebook instances and [Code Editor](https://docs.aws.amazon.com/sagemaker/latest/dg/code-editor.html) in [Amazon SageMaker Studio](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-updated.html).  The AutoGluon library comes pre-installed in all releases of Amazon SageMaker Distribution. SageMaker Studio users can access AutoGluon's automation capabilities without needing to install anything additional. 
+[Amazon SageMaker Distribution](https://github.com/aws/sagemaker-distribution) is the docker environment for data science used as the default image of [JupyterLab](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-updated-jl.html) notebook instances and [Code Editor](https://docs.aws.amazon.com/sagemaker/latest/dg/code-editor.html) in [Amazon SageMaker Studio](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-updated.html).  The AutoGluon library comes pre-installed in all releases of Amazon SageMaker Distribution. SageMaker Studio users can access AutoGluon's automation capabilities without needing to install anything additional.
 
 
-To find the AutoGluon and PyTorch versions available in a SageMaker Distribution image, refer to the [RELEASE.md](https://github.com/aws/sagemaker-distribution/blob/main/build_artifacts/v1/v1.4/v1.4.2/RELEASE.md) file for your image version in the SageMaker Distribution GitHub repository. 
+To find the AutoGluon and PyTorch versions available in a SageMaker Distribution image, refer to the [RELEASE.md](https://github.com/aws/sagemaker-distribution/blob/main/build_artifacts/v1/v1.4/v1.4.2/RELEASE.md) file for your image version in the SageMaker Distribution GitHub repository.
 
 :::
 
@@ -240,7 +240,7 @@ To build AutoGluon from source for the purposes of testing a pull-request, you c
 This process is useful if you are a code reviewer or want to test if a PR fixes a bug you have reported.
 
 In this example, we are using [this PR](https://github.com/autogluon/autogluon/pull/2944).
-It is from the user `innixma` and the PR branch is called `accel_preprocess_bool`. 
+It is from the user `innixma` and the PR branch is called `accel_preprocess_bool`.
 This information is provided in the PR page directly under the title of the PR (where it says `into autogluon:master from Innixma:accel_preprocess_bool`).
 
 ```bash
@@ -298,4 +298,3 @@ If you encounter issues after installing AutoGluon, try restarting the notebook 
 If you encounter installation issues not covered here, please create a [GitHub issue](https://github.com/autogluon/autogluon/issues).
 
 :::
-


### PR DESCRIPTION
## Issue #, if available:*

Issue #4593

## Description of changes:
1. Added dedicated UV installation tabs for all platforms (Linux/Mac/Windows)
2. Fixed virtual environment installation issues by:
   - Using `python -m uv pip install` instead of `uv pip install`
   - Creating separate UV-specific installation files
3. Cleaned up installation files:
   - Removed UV installer from non-UV installation methods (pip, source)
   - Created dedicated install-cpu-uv.md and install-gpu-uv.md
   - Updated nightly build instructions to use correct UV command format



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.