### PR TITLE
[Benchmark] Add PyArrow required by clean scripts

### DIFF
--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -16,6 +16,7 @@ function setup_build_contrib_env {
 
 function setup_benchmark_env {
     pip install -U autogluon.bench
+    pip install pyarrow
     git clone https://github.com/autogluon/autogluon-dashboard.git
     pip install -e ./autogluon-dashboard
     pip install yq


### PR DESCRIPTION
*Description of changes:*
AG-Bench does not install pyarrow by default which breaks the cleaning scripts.
Hence, adding the dependency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
