### PR TITLE
 [tabular] Set calibrate_decision_threshold="auto"

### DIFF
--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -4027,6 +4027,7 @@ class AbstractTrainer:
             y_val_probs = self.get_model_oof(model_name_og)
             y_val = self.load_y().to_numpy()
 
+        y_val_probs_og = y_val_probs
         if self.problem_type == BINARY:
             # Convert one-dimensional array to be in the form of a 2-class multiclass predict_proba output
             y_val_probs = LabelCleanerMulticlassToBinary.convert_binary_proba_to_multiclass_proba(y_val_probs)
@@ -4053,7 +4054,7 @@ class AbstractTrainer:
                 )
             else:
                 # Check that scaling improves performance for the target metric
-                score_without_temp = self.score_with_y_pred_proba(y=y_val, y_pred_proba=y_val_probs, weights=None)
+                score_without_temp = self.score_with_y_pred_proba(y=y_val, y_pred_proba=y_val_probs_og, weights=None)
                 scaled_y_val_probs = apply_temperature_scaling(y_val_probs, temp_scalar, problem_type=self.problem_type, transform_binary_proba=False)
                 score_with_temp = self.score_with_y_pred_proba(y=y_val, y_pred_proba=scaled_y_val_probs, weights=None)
 

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -239,6 +239,16 @@ class AbstractTrainer:
         return self._num_rows_val is not None
 
     @property
+    def num_rows_val_for_calibration(self) -> int:
+        """The number of rows available to optimize model calibration"""
+        if self._num_rows_val is not None:
+            return self._num_rows_val
+        elif self.bagged_mode:
+            return self._num_rows_train
+        else:
+            return 0
+
+    @property
     def time_left(self) -> float | None:
         """
         Remaining time left in the fit call.

--- a/docs/tutorials/tabular/tabular-indepth.ipynb
+++ b/docs/tutorials/tabular/tabular-indepth.ipynb
@@ -188,7 +188,7 @@
    "source": [
     "## Model ensembling with stacking/bagging\n",
     "\n",
-    "Beyond hyperparameter-tuning with a correctly-specified evaluation metric, two other methods to boost predictive performance are [bagging and stack-ensembling](https://arxiv.org/abs/2003.06505).  You'll often see performance improve if you specify `num_bag_folds` = 5-10, `num_stack_levels` = 1-3 in the call to `fit()`, but this will increase training times and memory/disk usage."
+    "Beyond hyperparameter-tuning with a correctly-specified evaluation metric, two other methods to boost predictive performance are [bagging and stack-ensembling](https://arxiv.org/abs/2003.06505).  You'll often see performance improve if you specify `num_bag_folds` = 5-10, `num_stack_levels` = 1 in the call to `fit()`, but this will increase training times and memory/disk usage."
    ],
    "metadata": {
     "collapsed": false
@@ -217,9 +217,7 @@
    "cell_type": "markdown",
    "id": "38f61e8d",
    "metadata": {},
-   "source": [
-    "You should not provide `tuning_data` when stacking/bagging, and instead provide all your available data as `train_data` (which AutoGluon will split in more intellgent ways). `num_bag_sets` controls how many times the k-fold bagging process is repeated to further reduce variance (increasing this may further boost accuracy but will substantially increase training times, inference latency, and memory/disk usage). Rather than manually searching for good bagging/stacking values yourself, AutoGluon will automatically select good values for you if you specify `auto_stack` instead:"
-   ]
+   "source": "You should not provide `tuning_data` when stacking/bagging, and instead provide all your available data as `train_data` (which AutoGluon will split in more intellgent ways). `num_bag_sets` controls how many times the k-fold bagging process is repeated to further reduce variance (increasing this may further boost accuracy but will substantially increase training times, inference latency, and memory/disk usage). Rather than manually searching for good bagging/stacking values yourself, AutoGluon will automatically select good values for you if you specify `auto_stack` instead (which is used in the `best_quality` preset):"
   },
   {
    "cell_type": "code",
@@ -228,10 +226,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Lets also specify the \"f1\" metric\n",
-    "predictor = TabularPredictor(label=label, eval_metric='f1', path=save_path).fit(\n",
-    "    train_data, auto_stack=True,cl\n",
-    "    time_limit=30, hyperparameters={'FASTAI': {'num_epochs': 10}, 'GBM': {'num_boost_round': 200}}  # last 2 arguments are for quick demo, omit them in real applications\n",
+    "# Lets also specify the \"balanced_accuracy\" metric\n",
+    "predictor = TabularPredictor(label=label, eval_metric='balanced_accuracy', path=save_path).fit(\n",
+    "    train_data, auto_stack=True,\n",
+    "    calibrate_decision_threshold=False,  # Disabling for demonstration in next section\n",
+    "    hyperparameters={'FASTAI': {'num_epochs': 10}, 'GBM': {'num_boost_round': 200}}  # last 2 arguments are for quick demo, omit them in real applications\n",
     ")\n",
     "predictor.leaderboard(test_data)"
    ]
@@ -245,7 +244,7 @@
     "\n",
     "Major metric score improvements can be achieved in binary classification for metrics such as `\"f1\"` and `\"balanced_accuracy\"` by adjusting the prediction decision threshold via `calibrate_decision_threshold` to a value other than the default 0.5.\n",
     "\n",
-    "Below is an example of the `\"f1\"` score achieved on the test data with and without calibrating the decision threshold:"
+    "Below is an example of the `\"balanced_accuracy\"` score achieved on the test data with and without calibrating the decision threshold:"
    ],
    "metadata": {
     "collapsed": false
@@ -293,9 +292,9 @@
   {
    "cell_type": "markdown",
    "source": [
-    "Notice that calibrating for \"f1\" majorly improved the \"f1\" metric score, as well as the \"balanced_accuracy\" score, it harmed the \"accuracy\" score. Threshold calibration will often result in a tradeoff between performance on different metrics, and the user should keep this in mind.\n",
+    "Notice that calibrating for \"balanced_accuracy\" majorly improved the \"balanced_accuracy\" metric score, but it harmed the \"accuracy\" score. Threshold calibration will often result in a tradeoff between performance on different metrics, and the user should keep this in mind.\n",
     "\n",
-    "Instead of calibrating for \"f1\" specifically, we can calibrate for any metric if we want to maximize the score of that metric:"
+    "Instead of calibrating for \"balanced_accuracy\" specifically, we can calibrate for any metric if we want to maximize the score of that metric:"
    ],
    "metadata": {
     "collapsed": false
@@ -328,6 +327,8 @@
    "cell_type": "markdown",
    "source": [
     "Instead of calibrating the decision threshold post-fit, you can have it automatically occur during the fit call by specifying the fit parameter `predictor.fit(..., calibrate_decision_threshold=True)`.\n",
+    "\n",
+    "Luckily, AutoGluon will automatically apply decision threshold calibration when beneficial, as the default value is `calibrate_decision_threshold=\"auto\"`. We recommend keeping this value as the default in most cases.\n",
     "\n",
     "Additional usage examples are below:"
    ],

--- a/docs/tutorials/tabular/tabular-indepth.ipynb
+++ b/docs/tutorials/tabular/tabular-indepth.ipynb
@@ -230,7 +230,7 @@
    "source": [
     "# Lets also specify the \"f1\" metric\n",
     "predictor = TabularPredictor(label=label, eval_metric='f1', path=save_path).fit(\n",
-    "    train_data, auto_stack=True,\n",
+    "    train_data, auto_stack=True,cl\n",
     "    time_limit=30, hyperparameters={'FASTAI': {'num_epochs': 10}, 'GBM': {'num_boost_round': 200}}  # last 2 arguments are for quick demo, omit them in real applications\n",
     ")\n",
     "predictor.leaderboard(test_data)"

--- a/tabular/src/autogluon/tabular/models/tabular_nn/utils/data_preprocessor.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/utils/data_preprocessor.py
@@ -38,7 +38,7 @@ def create_preprocessor(
         )  # returns 0-n when max_category_levels = n-1. category n is reserved for unknown test-time categories.
         transformers.append(("ordinal", ordinal_transformer, embed_features))
     return ColumnTransformer(
-        transformers=transformers, remainder="passthrough"
+        transformers=transformers, remainder="passthrough", force_int_remainder_cols=False,
     )  # numeric features are processed in the same order as in numeric_features vector, so feature-names remain the same.
 
 

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -699,7 +699,6 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             If "auto", will be set to `not use_bag_holdout`.
             See the documentation of `ds_args` for more information.
         calibrate_decision_threshold : bool | str, default = "auto"
-            [Experimental] This may be removed / changed without warning in a future release.
             If True, will automatically calibrate the decision threshold at the end of fit for calls to `.predict` based on the evaluation metric.
             If "auto", will be set to True if `eval_metric.needs_class=True` and `problem_type="binary"`.
             By default, the decision threshold is `0.5`, however for some metrics such as `f1` and `balanced_accuracy`,

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -408,7 +408,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         fit_full_last_level_weighted_ensemble: bool = True,
         full_weighted_ensemble_additionally: bool = False,
         dynamic_stacking: bool | str = False,
-        calibrate_decision_threshold: bool | str = False,
+        calibrate_decision_threshold: bool | str = "auto",
         num_cpus: int | str = "auto",
         num_gpus: int | str = "auto",
         memory_limit: float | str = "auto",
@@ -698,7 +698,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             time for fitting AutoGluon. This can be adjusted by specifying `ds_args` with different parameters to `fit()`.
             If "auto", will be set to `not use_bag_holdout`.
             See the documentation of `ds_args` for more information.
-        calibrate_decision_threshold : bool | str, default = False
+        calibrate_decision_threshold : bool | str, default = "auto"
             [Experimental] This may be removed / changed without warning in a future release.
             If True, will automatically calibrate the decision threshold at the end of fit for calls to `.predict` based on the evaluation metric.
             If "auto", will be set to True if `eval_metric.needs_class=True` and `problem_type="binary"`.
@@ -1678,7 +1678,30 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
                     f"Disabling decision threshold calibration for metric `precision` to avoid undefined results. "
                     f"Force calibration via specifying `calibrate_decision_threshold=True`.",
                 )
+            elif calibrate_decision_threshold and self.eval_metric.name == "accuracy":
+                num_rows_val_for_calibration = self._trainer.num_rows_val_for_calibration
+                min_val_rows_for_calibration = 10000
+                if num_rows_val_for_calibration < min_val_rows_for_calibration:
+                    calibrate_decision_threshold = False
+                    logger.log(
+                        20,
+                        f"Disabling decision threshold calibration for metric `accuracy` due to having "
+                        f"fewer than {min_val_rows_for_calibration} rows of validation data for calibration ({num_rows_val_for_calibration} rows). "
+                        f"\n\t`accuracy` is generally not improved through threshold calibration "
+                        f"Force calibration via specifying `calibrate_decision_threshold=True`.",
+                    )
             elif calibrate_decision_threshold:
+                num_rows_val_for_calibration = self._trainer.num_rows_val_for_calibration
+                min_val_rows_for_calibration = 20
+                if num_rows_val_for_calibration < min_val_rows_for_calibration:
+                    calibrate_decision_threshold = False
+                    logger.log(
+                        30,
+                        f"Disabling decision threshold calibration for metric `{self.eval_metric.name}` due to having "
+                        f"fewer than {min_val_rows_for_calibration} rows of validation data for calibration ({num_rows_val_for_calibration} rows). "
+                        f"Force calibration via specifying `calibrate_decision_threshold=True`.",
+                    )
+            if calibrate_decision_threshold:
                 logger.log(20, f"Enabling decision threshold calibration (calibrate_decision_threshold='auto', metric is valid, problem_type is 'binary')")
         if calibrate_decision_threshold:
             if self.problem_type != BINARY:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Set `calibrate_decision_threshold="auto"` by default in TabularPredictor, previously `False`.
- This massively improves results on `f1` and `balanced_accuracy` metrics for binary classification.
- Only enable calibrate_decision_threshold for accuracy if >=10000 validation rows, to avoid overfitting
- Only enable calibrate_decision_threshold if >=50 validation rows, to minimize the risk of picking extreme thresholds due to overfitting.
- [Major] Update `calibrate="auto"` to also have minimum validation row requirement.
- `calibrate` min val row for binary = 3000, multiclass = 500, quantile = 1000
- Huge improvements on small datasets for `log_loss` metric, refer to 2nd and 3rd benchmark.
- Update in-depth tutorial
- Fix sklearn warning during NN_TORCH preprocessing

TODO: 

- [x] Benchmark on AutoMLBenchmark (Note: Benchmark shows no major change since AMLB doesn't have any small multiclass datasets, but I think it is save to merge the PR).

## calibrate_decision_threshold Benchmark Results

### AdultIncome dataset (code below):

tl;dr: `accuracy` is not impacted much, but `f1` and `balanced_accuracy` improve massively.

```
train_size=10:
	No Calibration Score: 0.7607	(+- 0.0000) (accuracy)
	   Calibration Score: 0.7607	(+- 0.0000) (accuracy)
train_size=50:
	No Calibration Score: 0.7607	(+- 0.0000) (accuracy)
	   Calibration Score: 0.7607	(+- 0.0000) (accuracy)
train_size=100:
	No Calibration Score: 0.7880	(+- 0.0140) (accuracy)
	   Calibration Score: 0.7880	(+- 0.0140) (accuracy)
train_size=200:
	No Calibration Score: 0.7792	(+- 0.0180) (accuracy)
	   Calibration Score: 0.7785	(+- 0.0190) (accuracy)
train_size=500:
	No Calibration Score: 0.8277	(+- 0.0092) (accuracy)
	   Calibration Score: 0.8323	(+- 0.0063) (accuracy)
train_size=1000:
	No Calibration Score: 0.8408	(+- 0.0052) (accuracy)
	   Calibration Score: 0.8403	(+- 0.0056) (accuracy)
train_size=5000:
	No Calibration Score: 0.8589	(+- 0.0041) (accuracy)
	   Calibration Score: 0.8569	(+- 0.0043) (accuracy)
train_size=10000:
	No Calibration Score: 0.8650	(+- 0.0056) (accuracy)
	   Calibration Score: 0.8650	(+- 0.0055) (accuracy)
train_size=20000:
	No Calibration Score: 0.8721	(+- 0.0014) (accuracy)
	   Calibration Score: 0.8715	(+- 0.0019) (accuracy)
train_size=40000:
	No Calibration Score: 0.8741	(+- 0.0026) (accuracy)
	   Calibration Score: 0.8733	(+- 0.0026) (accuracy)

train_size=10:
	No Calibration Score: 0.5000	(+- 0.0000) (balanced_accuracy)
	   Calibration Score: 0.5000	(+- 0.0000) (balanced_accuracy)
train_size=50:
	No Calibration Score: 0.5000	(+- 0.0000) (balanced_accuracy)
	   Calibration Score: 0.5000	(+- 0.0000) (balanced_accuracy)
train_size=100:
	No Calibration Score: 0.6346	(+- 0.0244) (balanced_accuracy)
	   Calibration Score: 0.6619	(+- 0.0286) (balanced_accuracy)
train_size=200:
	No Calibration Score: 0.6452	(+- 0.0192) (balanced_accuracy)
	   Calibration Score: 0.7024	(+- 0.0223) (balanced_accuracy)
train_size=500:
	No Calibration Score: 0.7230	(+- 0.0170) (balanced_accuracy)
	   Calibration Score: 0.7628	(+- 0.0331) (balanced_accuracy)
train_size=1000:
	No Calibration Score: 0.7434	(+- 0.0085) (balanced_accuracy)
	   Calibration Score: 0.7835	(+- 0.0281) (balanced_accuracy)
train_size=5000:
	No Calibration Score: 0.7800	(+- 0.0047) (balanced_accuracy)
	   Calibration Score: 0.8239	(+- 0.0058) (balanced_accuracy)
train_size=10000:
	No Calibration Score: 0.7869	(+- 0.0054) (balanced_accuracy)
	   Calibration Score: 0.8313	(+- 0.0080) (balanced_accuracy)
train_size=20000:
	No Calibration Score: 0.7956	(+- 0.0033) (balanced_accuracy)
	   Calibration Score: 0.8422	(+- 0.0031) (balanced_accuracy)
train_size=40000:
	No Calibration Score: 0.7987	(+- 0.0022) (balanced_accuracy)
	   Calibration Score: 0.8474	(+- 0.0023) (balanced_accuracy)

train_size=10:
	No Calibration Score: 0.0000	(+- 0.0000) (f1)
	   Calibration Score: 0.0000	(+- 0.0000) (f1)
train_size=50:
	No Calibration Score: 0.0000	(+- 0.0000) (f1)
	   Calibration Score: 0.4194	(+- 0.0410) (f1)
train_size=100:
	No Calibration Score: 0.4303	(+- 0.0566) (f1)
	   Calibration Score: 0.4759	(+- 0.0431) (f1)
train_size=200:
	No Calibration Score: 0.4549	(+- 0.0356) (f1)
	   Calibration Score: 0.5243	(+- 0.0510) (f1)
train_size=500:
	No Calibration Score: 0.5918	(+- 0.0262) (f1)
	   Calibration Score: 0.6047	(+- 0.0432) (f1)
train_size=1000:
	No Calibration Score: 0.6253	(+- 0.0145) (f1)
	   Calibration Score: 0.6421	(+- 0.0151) (f1)
train_size=5000:
	No Calibration Score: 0.6829	(+- 0.0059) (f1)
	   Calibration Score: 0.6952	(+- 0.0111) (f1)
train_size=10000:
	No Calibration Score: 0.6918	(+- 0.0120) (f1)
	   Calibration Score: 0.7107	(+- 0.0128) (f1)
train_size=20000:
	No Calibration Score: 0.7084	(+- 0.0036) (f1)
	   Calibration Score: 0.7233	(+- 0.0056) (f1)
train_size=40000:
	No Calibration Score: 0.7137	(+- 0.0042) (f1)
	   Calibration Score: 0.7303	(+- 0.0034) (f1)
```

Benchmark Code:

```python
from autogluon.tabular import TabularPredictor
from autogluon_benchmark.tasks.task_wrapper import OpenMLTaskWrapper

import numpy as np


if __name__ == '__main__':
    task = OpenMLTaskWrapper.from_name(dataset="adult")
    label = task.label
    problem_type = task.problem_type

    train_size_lst = [10, 50, 100, 200, 500, 1000, 5000, 10000, 20000, 40000]

    for eval_metric in ["accuracy", "balanced_accuracy", "f1"]:
        for train_size in train_size_lst:
            print(f"train_size={train_size}:")
            score_lst = []
            score_cal_lst = []
            for i in range(10):
                train_data, test_data = task.get_train_test_split_combined(fold=0, train_size=train_size, random_state=i)

                predictor = TabularPredictor(label=label, problem_type=problem_type, eval_metric=eval_metric, verbosity=0)
                predictor = predictor.fit(
                    train_data=train_data,
                    hyperparameters={
                        "GBM": {},
                    },
                    calibrate_decision_threshold=False,
                )

                score = predictor.evaluate(test_data, auxiliary_metrics=False)[predictor.eval_metric.name]

                predictor = TabularPredictor(label=label, problem_type=problem_type, eval_metric=eval_metric, verbosity=0)
                predictor = predictor.fit(
                    train_data=train_data,
                    hyperparameters={
                        "GBM": {},
                    },
                    calibrate_decision_threshold=True,
                )

                score_cal = predictor.evaluate(test_data, auxiliary_metrics=False)[predictor.eval_metric.name]

                score_lst.append(score)
                score_cal_lst.append(score_cal)

            print(
                f"\tNo Calibration Score: {np.mean(score_lst):.4f}\t(+- {np.std(score_lst):.4f}) ({eval_metric})\n"
                f"\t   Calibration Score: {np.mean(score_cal_lst):.4f}\t(+- {np.std(score_cal_lst):.4f}) ({eval_metric})"
            )

```

## calibrate Benchmark Results

tl:dr: Massive improvement by disabling calibration for small data sizes, <500 rows for multiclass and <3000 rows for binary

```
binary | adult | calibrate

train_size=10:
	No Calibration Score: -0.5373	(+- 0.0666) (log_loss)
	   Calibration Score: -0.5925	(+- 0.0896) (log_loss)
	Win Cal: 0.15	Tie: 0.0	Win No: 0.85
train_size=20:
	No Calibration Score: -0.4673	(+- 0.0402) (log_loss)
	   Calibration Score: -0.4907	(+- 0.0559) (log_loss)
	Win Cal: 0.10	Tie: 0.0	Win No: 0.9
train_size=50:
	No Calibration Score: -0.4155	(+- 0.0252) (log_loss)
	   Calibration Score: -0.4238	(+- 0.0278) (log_loss)
	Win Cal: 0.25	Tie: 0.0	Win No: 0.75
train_size=100:
	No Calibration Score: -0.3911	(+- 0.0160) (log_loss)
	   Calibration Score: -0.3963	(+- 0.0148) (log_loss)
	Win Cal: 0.30	Tie: 0.0	Win No: 0.7
train_size=200:
	No Calibration Score: -0.3679	(+- 0.0095) (log_loss)
	   Calibration Score: -0.3730	(+- 0.0114) (log_loss)
	Win Cal: 0.15	Tie: 0.0	Win No: 0.85
train_size=500:
	No Calibration Score: -0.3490	(+- 0.0074) (log_loss)
	   Calibration Score: -0.3514	(+- 0.0086) (log_loss)
	Win Cal: 0.25	Tie: 0.0	Win No: 0.75
train_size=1000:
	No Calibration Score: -0.3401	(+- 0.0060) (log_loss)
	   Calibration Score: -0.3410	(+- 0.0060) (log_loss)
	Win Cal: 0.20	Tie: 0.0	Win No: 0.8
train_size=5000:
	No Calibration Score: -0.3262	(+- 0.0047) (log_loss)
	   Calibration Score: -0.3257	(+- 0.0041) (log_loss)
	Win Cal: 0.65	Tie: 0.0	Win No: 0.35
train_size=10000:
	No Calibration Score: -0.3197	(+- 0.0041) (log_loss)
	   Calibration Score: -0.3189	(+- 0.0035) (log_loss)
	Win Cal: 0.80	Tie: 0.0	Win No: 0.2
train_size=20000:
	No Calibration Score: -0.3166	(+- 0.0037) (log_loss)
	   Calibration Score: -0.3153	(+- 0.0030) (log_loss)
	Win Cal: 0.95	Tie: 0.0	Win No: 0.05
train_size=40000:
	No Calibration Score: -0.3149	(+- 0.0037) (log_loss)
	   Calibration Score: -0.3129	(+- 0.0029) (log_loss)
	Win Cal: 1.00	Tie: 0.0	Win No: 0.0

```

```
multiclass | covertype | calibrate

train_size=100:
	No Calibration Score: -0.9067	(+- 0.0343) (log_loss)
	   Calibration Score: -0.9356	(+- 0.0385) (log_loss)
	Win Cal: 0.15	Tie: 0.05	Win No: 0.8
train_size=200:
	No Calibration Score: -0.8327	(+- 0.0221) (log_loss)
	   Calibration Score: -0.8368	(+- 0.0267) (log_loss)
	Win Cal: 0.60	Tie: 0.1	Win No: 0.3
train_size=500:
	No Calibration Score: -0.7484	(+- 0.0112) (log_loss)
	   Calibration Score: -0.7422	(+- 0.0119) (log_loss)
	Win Cal: 0.95	Tie: 0.05	Win No: 0.0
train_size=1000:
	No Calibration Score: -0.6887	(+- 0.0100) (log_loss)
	   Calibration Score: -0.6790	(+- 0.0112) (log_loss)
	Win Cal: 1.00	Tie: 0.0	Win No: 0.0
train_size=5000:
	No Calibration Score: -0.5499	(+- 0.0026) (log_loss)
	   Calibration Score: -0.5295	(+- 0.0040) (log_loss)
	Win Cal: 1.00	Tie: 0.0	Win No: 0.0
train_size=10000:
	No Calibration Score: -0.4886	(+- 0.0024) (log_loss)
	   Calibration Score: -0.4607	(+- 0.0029) (log_loss)
	Win Cal: 1.00	Tie: 0.0	Win No: 0.0
train_size=20000:
	No Calibration Score: -0.4240	(+- 0.0021) (log_loss)
	   Calibration Score: -0.3877	(+- 0.0033) (log_loss)
	Win Cal: 1.00	Tie: 0.0	Win No: 0.0
train_size=40000:
	No Calibration Score: -0.3599	(+- 0.0017) (log_loss)
	   Calibration Score: -0.3152	(+- 0.0029) (log_loss)
	Win Cal: 1.00	Tie: 0.0	Win No: 0.0
```

### Code for calibration

#### adult

```python
from autogluon.tabular import TabularPredictor
from autogluon_benchmark.tasks.task_wrapper import OpenMLTaskWrapper

import numpy as np


if __name__ == '__main__':
    task = OpenMLTaskWrapper.from_name(dataset="adult")
    label = task.label
    problem_type = task.problem_type

    train_size_lst = [10, 20, 50, 100, 200, 500, 1000, 5000, 10000, 20000, 40000]
    # train_size_lst = [2000, 3000]

    for eval_metric in ["log_loss"]:
        for train_size in train_size_lst:
            print(f"train_size={train_size}:")
            score_lst = []
            score_cal_lst = []
            for i in range(20):
                train_data, test_data = task.get_train_test_split_combined(fold=0, train_size=train_size, random_state=i)

                predictor = TabularPredictor(label=label, problem_type=problem_type, eval_metric=eval_metric, verbosity=0)
                predictor = predictor.fit(
                    train_data=train_data,
                    hyperparameters={
                        "RF": {},
                    },
                    num_bag_folds=8,
                    calibrate=False,
                )

                score = predictor.evaluate(test_data, auxiliary_metrics=False)[predictor.eval_metric.name]

                predictor = TabularPredictor(label=label, problem_type=problem_type, eval_metric=eval_metric, verbosity=0)
                predictor = predictor.fit(
                    train_data=train_data,
                    hyperparameters={
                        "RF": {},
                    },
                    num_bag_folds=8,
                    calibrate=True,
                )

                score_cal = predictor.evaluate(test_data, auxiliary_metrics=False)[predictor.eval_metric.name]

                score_lst.append(score)
                score_cal_lst.append(score_cal)

            print(
                f"\tNo Calibration Score: {np.mean(score_lst):.4f}\t(+- {np.std(score_lst):.4f}) ({eval_metric})\n"
                f"\t   Calibration Score: {np.mean(score_cal_lst):.4f}\t(+- {np.std(score_cal_lst):.4f}) ({eval_metric})"
            )

            ties = 0
            win_cal = 0
            win_no = 0
            n_runs = len(score_lst)
            for j in range(n_runs):
                if score_lst[j] == score_cal_lst[j]:
                    ties += 1
                elif score_lst[j] > score_cal_lst[j]:
                    win_no += 1
                else:
                    win_cal += 1
            print(f"\tWin Cal: {win_cal/n_runs:.2f}\tTie: {ties/n_runs}"
                  f"\tWin No: {win_no/n_runs}")

```

#### covertype

```python
from autogluon.tabular import TabularPredictor
from autogluon_benchmark.tasks.task_wrapper import OpenMLTaskWrapper

import numpy as np


if __name__ == '__main__':
    task = OpenMLTaskWrapper.from_name(dataset="covertype")
    label = task.label
    problem_type = task.problem_type

    train_size_lst = [
        # 10, 20, 50,
        100, 200, 500, 1000,
        5000, 10000, 20000, 40000,
    ]

    for eval_metric in ["log_loss"]:
        for train_size in train_size_lst:
            print(f"train_size={train_size}:")
            score_lst = []
            score_cal_lst = []
            for i in range(20):
                train_data, test_data = task.get_train_test_split_combined(fold=0, train_size=train_size, random_state=i)

                predictor = TabularPredictor(label=label, problem_type=problem_type, eval_metric=eval_metric, verbosity=0)
                predictor = predictor.fit(
                    train_data=train_data,
                    hyperparameters={
                        "RF": {},
                    },
                    num_bag_folds=8,
                    calibrate=False,
                )

                score = predictor.evaluate(test_data, auxiliary_metrics=False)[predictor.eval_metric.name]

                predictor = TabularPredictor(label=label, problem_type=problem_type, eval_metric=eval_metric, verbosity=0)
                predictor = predictor.fit(
                    train_data=train_data,
                    hyperparameters={
                        "RF": {},
                    },
                    num_bag_folds=8,
                    calibrate=True,
                )

                score_cal = predictor.evaluate(test_data, auxiliary_metrics=False)[predictor.eval_metric.name]

                score_lst.append(score)
                score_cal_lst.append(score_cal)

            print(
                f"\tNo Calibration Score: {np.mean(score_lst):.4f}\t(+- {np.std(score_lst):.4f}) ({eval_metric})\n"
                f"\t   Calibration Score: {np.mean(score_cal_lst):.4f}\t(+- {np.std(score_cal_lst):.4f}) ({eval_metric})"
            )

            ties = 0
            win_cal = 0
            win_no = 0
            n_runs = len(score_lst)
            for j in range(n_runs):
                if score_lst[j] == score_cal_lst[j]:
                    ties += 1
                elif score_lst[j] > score_cal_lst[j]:
                    win_no += 1
                else:
                    win_cal += 1
            print(f"\tWin Cal: {win_cal/n_runs:.2f}\tTie: {ties/n_runs}"
                  f"\tWin No: {win_no/n_runs}")

```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
