### PR TITLE
[timeseries] Fix inplace data modification by GluonTS models

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -353,6 +353,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         columns = self.metadata.known_covariates_real
         if self.supports_known_covariates and len(columns) > 0:
             assert "known" in self._real_column_transformers, "Preprocessing pipeline must be fit first"
+            known_covariates = known_covariates.copy()
             known_covariates[columns] = self._real_column_transformers["known"].transform(known_covariates[columns])
         return known_covariates
 

--- a/timeseries/src/autogluon/timeseries/models/local/statsforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/local/statsforecast.py
@@ -129,6 +129,7 @@ class AutoARIMAModel(AbstractProbabilisticStatsForecastModel):
         This significantly speeds up fitting and usually leads to no change in accuracy.
     """
 
+    init_time_in_seconds = 0  # C++ models require no compilation
     allowed_local_model_args = [
         "d",
         "D",
@@ -206,6 +207,7 @@ class ARIMAModel(AbstractProbabilisticStatsForecastModel):
         This significantly speeds up fitting and usually leads to no change in accuracy.
     """
 
+    init_time_in_seconds = 0  # C++ models require no compilation
     allowed_local_model_args = [
         "order",
         "seasonal_order",
@@ -261,6 +263,7 @@ class AutoETSModel(AbstractProbabilisticStatsForecastModel):
         This significantly speeds up fitting and usually leads to no change in accuracy.
     """
 
+    init_time_in_seconds = 0  # C++ models require no compilation
     allowed_local_model_args = [
         "damped",
         "model",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix the bug where GluonTS models would modify known_covariates inplace, affecting other models
- Remove the initialization time for AutoARIMA, AutoETS and ARIMA models


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
