### PR TITLE
[timeseries] Move covariate scaling logic into a separate class

### DIFF
--- a/docs/tutorials/timeseries/forecasting-model-zoo.md
+++ b/docs/tutorials/timeseries/forecasting-model-zoo.md
@@ -275,7 +275,18 @@ Deep learning models pretrained on large time series datasets, able to perform z
    - `"min_max"` - min-max scaler that converts data into the (0, 1) range, `loc = min(y)`, `scale = max(y) - min(y)`.
    - `None` - no scaling
 
-- **covariate_regressor** *({"LR", "GBM", "CAT", "XGB", None}, default = None)* - If provided, the chosen tabular
+- **covariate_scaler** *({"global", None})* - If provided, the chosen scaling method will be applied to the covariates
+   and static features before fitting the model.
+
+   Such scaling be helpful for deep learning models that assume that the inputs are normalized.
+
+   Available options:
+   - `"global"` - `QuantileTransform` for skewed features, passthrough for boolean features, and `StandardScaler` for the rest of the features
+   - `None` - do not scale the covariates
+
+   By default, this parameter is set to `"global"` for GluonTS models, and `None` for all other models.
+
+- **covariate_regressor** *({"LR", "GBM", "CAT", "XGB", "RF", None}, default = None)* - If provided, the chosen tabular
    regression model will be fit on the known covariates & static features to predict the target column at the same time
    step.
 

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -16,7 +16,12 @@ from autogluon.core.models import AbstractModel
 from autogluon.timeseries.dataset import TimeSeriesDataFrame
 from autogluon.timeseries.metrics import TimeSeriesScorer, check_get_evaluation_metric
 from autogluon.timeseries.regressor import CovariateRegressor
-from autogluon.timeseries.transforms import LocalTargetScaler, get_target_scaler_from_name
+from autogluon.timeseries.transforms import (
+    CovariateScaler,
+    LocalTargetScaler,
+    get_covariate_scaler_from_name,
+    get_target_scaler_from_name,
+)
 from autogluon.timeseries.utils.features import CovariateMetadata
 from autogluon.timeseries.utils.forecast import get_forecast_horizon_index_ts_dataframe
 from autogluon.timeseries.utils.warning_filters import disable_stdout, warning_filter
@@ -130,6 +135,7 @@ class AbstractTimeSeriesModel(AbstractModel):
 
         self._oof_predictions: Optional[List[TimeSeriesDataFrame]] = None
         self.target_scaler: Optional[LocalTargetScaler] = None
+        self.covariate_scaler: Optional[CovariateScaler] = None
         self.covariate_regressor: Optional[CovariateRegressor] = None
 
     def __repr__(self) -> str:
@@ -172,6 +178,7 @@ class AbstractTimeSeriesModel(AbstractModel):
         self._init_params_aux()
         self._init_params()
         self.target_scaler = self._create_target_scaler()
+        self.covariate_scaler = self._create_covariate_scaler()
         self.covariate_regressor = self._create_covariate_regressor()
 
     def _compute_fit_metadata(self, val_data: TimeSeriesDataFrame = None, **kwargs):
@@ -261,6 +268,10 @@ class AbstractTimeSeriesModel(AbstractModel):
 
         if self.target_scaler is not None:
             train_data = self.target_scaler.fit_transform(train_data)
+
+        if self.covariate_scaler is not None:
+            train_data, _ = self.covariate_scaler.fit_transform(train_data)
+
         if self.covariate_regressor is not None:
             covariate_regressor_time_limit = (
                 self._covariate_regressor_fit_time_fraction * time_limit if time_limit is not None else None
@@ -279,6 +290,8 @@ class AbstractTimeSeriesModel(AbstractModel):
         if self._get_tags()["can_use_val_data"] and val_data is not None:
             if self.target_scaler is not None:
                 val_data = self.target_scaler.transform(val_data)
+            if self.covariate_scaler is not None:
+                val_data, _ = self.covariate_scaler.transform(val_data)
             if self.covariate_regressor is not None:
                 val_data = self.covariate_regressor.transform(val_data)
             val_data, _ = self.preprocess(val_data, is_train=False)
@@ -298,6 +311,20 @@ class AbstractTimeSeriesModel(AbstractModel):
         target_scaler_type = self._get_model_params().get("target_scaler")
         if target_scaler_type is not None:
             return get_target_scaler_from_name(target_scaler_type, target=self.target)
+        else:
+            return None
+
+    def _create_covariate_scaler(self) -> Optional[CovariateScaler]:
+        """Create a CovariateScaler object based on the value of the `covariate_scaler` hyperparameter."""
+        covariate_scaler_type = self._get_model_params().get("covariate_scaler")
+        if covariate_scaler_type is not None:
+            return get_covariate_scaler_from_name(
+                covariate_scaler_type,
+                metadata=self.metadata,
+                use_static_features=self.supports_static_features,
+                use_known_covariates=self.supports_known_covariates,
+                use_past_covariates=self.supports_past_covariates,
+            )
         else:
             return None
 
@@ -384,6 +411,8 @@ class AbstractTimeSeriesModel(AbstractModel):
         """
         if self.target_scaler is not None:
             data = self.target_scaler.fit_transform(data)
+        if self.covariate_scaler is not None:
+            data, known_covariates = self.covariate_scaler.fit_transform(data, known_covariates)
         if self.covariate_regressor is not None:
             data = self.covariate_regressor.fit_transform(data)
 

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -270,7 +270,7 @@ class AbstractTimeSeriesModel(AbstractModel):
             train_data = self.target_scaler.fit_transform(train_data)
 
         if self.covariate_scaler is not None:
-            train_data, _ = self.covariate_scaler.fit_transform(train_data)
+            train_data = self.covariate_scaler.fit_transform(train_data)
 
         if self.covariate_regressor is not None:
             covariate_regressor_time_limit = (
@@ -291,7 +291,7 @@ class AbstractTimeSeriesModel(AbstractModel):
             if self.target_scaler is not None:
                 val_data = self.target_scaler.transform(val_data)
             if self.covariate_scaler is not None:
-                val_data, _ = self.covariate_scaler.transform(val_data)
+                val_data = self.covariate_scaler.transform(val_data)
             if self.covariate_regressor is not None:
                 val_data = self.covariate_regressor.transform(val_data)
             val_data, _ = self.preprocess(val_data, is_train=False)
@@ -412,7 +412,8 @@ class AbstractTimeSeriesModel(AbstractModel):
         if self.target_scaler is not None:
             data = self.target_scaler.fit_transform(data)
         if self.covariate_scaler is not None:
-            data, known_covariates = self.covariate_scaler.fit_transform(data, known_covariates)
+            data = self.covariate_scaler.fit_transform(data)
+            known_covariates = self.covariate_scaler.transform_known_covariates(data)
         if self.covariate_regressor is not None:
             data = self.covariate_regressor.fit_transform(data)
 

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -413,7 +413,7 @@ class AbstractTimeSeriesModel(AbstractModel):
             data = self.target_scaler.fit_transform(data)
         if self.covariate_scaler is not None:
             data = self.covariate_scaler.fit_transform(data)
-            known_covariates = self.covariate_scaler.transform_known_covariates(data)
+            known_covariates = self.covariate_scaler.transform_known_covariates(known_covariates)
         if self.covariate_regressor is not None:
             data = self.covariate_regressor.fit_transform(data)
 

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -293,7 +293,7 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
         fit_start_time = time.time()
         self._train_target_median = train_data[self.target].median()
         for col in self.metadata.known_covariates_real:
-            if not train_data[col].isin([0, 1]).all():
+            if not set(train_data[col].unique()) == set([0, 1]):
                 self._non_boolean_real_covariates.append(col)
         # TabularEstimator is passed to MLForecast later to include tuning_data
         model_params = self._get_model_params()

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/transforms.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/transforms.py
@@ -13,7 +13,7 @@ from autogluon.timeseries.dataset.ts_dataframe import (
     TIMESTAMP,
     TimeSeriesDataFrame,
 )
-from autogluon.timeseries.transforms.scaler import LocalTargetScaler, get_target_scaler_from_name
+from autogluon.timeseries.transforms.target_scaler import LocalTargetScaler, get_target_scaler_from_name
 
 from .utils import MLF_ITEMID, MLF_TIMESTAMP
 

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -283,6 +283,24 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
 
         self.negative_data = (dataset[self.target] < 0).any()
 
+    def _get_default_params(self):
+        """Gets default parameters for GluonTS estimator initialization that are available after
+        AbstractTimeSeriesModel initialization (i.e., before deferred initialization). Models may
+        override this method to update default parameters.
+        """
+        return {
+            "batch_size": 64,
+            "context_length": min(512, max(10, 2 * self.prediction_length)),
+            "predict_batch_size": 500,
+            "early_stopping_patience": 20,
+            "max_epochs": 100,
+            "lr": 1e-3,
+            "freq": self._dummy_gluonts_freq,
+            "prediction_length": self.prediction_length,
+            "quantiles": self.quantile_levels,
+            "covariate_scaler": "global",
+        }
+
     def _get_model_params(self) -> dict:
         """Gets params that are passed to the inner model."""
         # for backward compatibility with the old GluonTS MXNet API

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -3,7 +3,7 @@ import os
 import shutil
 from datetime import timedelta
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterator, List, Literal, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Type, Union
 
 import gluonts
 import gluonts.core.settings
@@ -15,8 +15,6 @@ from gluonts.dataset.field_names import FieldName
 from gluonts.model.estimator import Estimator as GluonTSEstimator
 from gluonts.model.forecast import Forecast, QuantileForecast, SampleForecast
 from gluonts.model.predictor import Predictor as GluonTSPredictor
-from sklearn.compose import ColumnTransformer
-from sklearn.preprocessing import QuantileTransformer, StandardScaler
 
 from autogluon.common.loaders import load_pkl
 from autogluon.core.hpo.constants import RAY_BACKEND
@@ -186,7 +184,6 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
             **kwargs,
         )
         self.gts_predictor: Optional[GluonTSPredictor] = None
-        self._real_column_transformers: Dict[Literal["known", "past", "static"], ColumnTransformer] = {}
         self._ohe_generator_known: Optional[OneHotEncoder] = None
         self._ohe_generator_past: Optional[OneHotEncoder] = None
         self.callbacks = []
@@ -285,92 +282,6 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
                     self.num_past_feat_dynamic_real += past_feat_dynamic_cat_ohe.shape[1]
 
         self.negative_data = (dataset[self.target] < 0).any()
-
-    def preprocess(
-        self,
-        data: TimeSeriesDataFrame,
-        known_covariates: Optional[TimeSeriesDataFrame] = None,
-        is_train: bool = False,
-        **kwargs,
-    ) -> Tuple[TimeSeriesDataFrame, Optional[TimeSeriesDataFrame]]:
-        # Copy data to avoid SettingWithCopyWarning from pandas
-        data = data.copy()
-        if self.supports_known_covariates and len(self.metadata.known_covariates_real) > 0:
-            columns = self.metadata.known_covariates_real
-            if is_train:
-                self._real_column_transformers["known"] = self._get_transformer_for_columns(data, columns=columns)
-            assert "known" in self._real_column_transformers, "Preprocessing pipeline must be fit first"
-            data[columns] = self._real_column_transformers["known"].transform(data[columns])
-
-            if known_covariates is not None:
-                known_covariates = known_covariates.copy()
-                known_covariates[columns] = self._real_column_transformers["known"].transform(
-                    known_covariates[columns]
-                )
-
-        if self.supports_past_covariates and len(self.metadata.past_covariates_real) > 0:
-            columns = self.metadata.past_covariates_real
-            if is_train:
-                self._real_column_transformers["past"] = self._get_transformer_for_columns(data, columns=columns)
-            assert "past" in self._real_column_transformers, "Preprocessing pipeline must be fit first"
-            data[columns] = self._real_column_transformers["past"].transform(data[columns])
-
-        if self.supports_static_features and len(self.metadata.static_features_real) > 0:
-            columns = self.metadata.static_features_real
-            if is_train:
-                self._real_column_transformers["static"] = self._get_transformer_for_columns(
-                    data.static_features, columns=columns
-                )
-            assert "static" in self._real_column_transformers, "Preprocessing pipeline must be fit first"
-            data.static_features[columns] = self._real_column_transformers["static"].transform(
-                data.static_features[columns]
-            )
-        return data
-
-    def _get_transformer_for_columns(self, df: pd.DataFrame, columns: List[str]) -> Dict[str, str]:
-        """Passthrough bool features, use QuantileTransform for skewed features, and use StandardScaler for the rest.
-
-        The preprocessing logic is similar to the TORCH_NN model from Tabular.
-        """
-        skew_threshold = self._get_model_params().get("proc.skew_threshold", 0.99)
-        bool_features = []
-        skewed_features = []
-        continuous_features = []
-        for col in columns:
-            if df[col].isin([0, 1]).all():
-                bool_features.append(col)
-            elif np.abs(df[col].skew()) > skew_threshold:
-                skewed_features.append(col)
-            else:
-                continuous_features.append(col)
-        transformers = []
-        logger.debug(
-            f"\tbool_features: {bool_features}, continuous_features: {continuous_features}, skewed_features: {skewed_features}"
-        )
-        if continuous_features:
-            transformers.append(("scaler", StandardScaler(), continuous_features))
-        if skewed_features:
-            transformers.append(("skew", QuantileTransformer(output_distribution="normal"), skewed_features))
-        with warning_filter():
-            column_transformer = ColumnTransformer(transformers=transformers, remainder="passthrough").fit(df[columns])
-        return column_transformer
-
-    def _get_default_params(self):
-        """Gets default parameters for GluonTS estimator initialization that are available after
-        AbstractTimeSeriesModel initialization (i.e., before deferred initialization). Models may
-        override this method to update default parameters.
-        """
-        return {
-            "batch_size": 64,
-            "context_length": min(512, max(10, 2 * self.prediction_length)),
-            "predict_batch_size": 500,
-            "early_stopping_patience": 20,
-            "max_epochs": 100,
-            "lr": 1e-3,
-            "freq": self._dummy_gluonts_freq,
-            "prediction_length": self.prediction_length,
-            "quantiles": self.quantile_levels,
-        }
 
     def _get_model_params(self) -> dict:
         """Gets params that are passed to the inner model."""

--- a/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
+++ b/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
@@ -95,10 +95,16 @@ class AbstractLocalModel(AbstractTimeSeriesModel):
             + self.allowed_local_model_args
         )
 
-    def preprocess(self, data: TimeSeriesDataFrame, is_train: bool = False, **kwargs) -> Any:
+    def preprocess(
+        self,
+        data: TimeSeriesDataFrame,
+        known_covariates: Optional[TimeSeriesDataFrame] = None,
+        is_train: bool = False,
+        **kwargs,
+    ) -> Tuple[TimeSeriesDataFrame, Optional[TimeSeriesDataFrame]]:
         if not self._get_tags()["allow_nan"]:
             data = data.fill_missing_values()
-        return data
+        return data, known_covariates
 
     def _fit(self, train_data: TimeSeriesDataFrame, time_limit: Optional[int] = None, **kwargs):
         self._check_fit_params()

--- a/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
+++ b/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
@@ -84,12 +84,6 @@ class MultiWindowBacktestingModel(AbstractTimeSeriesModel):
     def get_minimum_resources(self, is_gpu_available: bool = False) -> bool:
         return self._get_model_base().get_minimum_resources(is_gpu_available)
 
-    def _initialize(self, **kwargs) -> None:
-        self._init_params_aux()
-        self._init_params()
-        # Do not create target_scaler, covariate_scaler and covariate_regressor here!
-        # They will be handled by the base model
-
     def _fit(
         self,
         train_data: TimeSeriesDataFrame,

--- a/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
+++ b/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
@@ -84,6 +84,12 @@ class MultiWindowBacktestingModel(AbstractTimeSeriesModel):
     def get_minimum_resources(self, is_gpu_available: bool = False) -> bool:
         return self._get_model_base().get_minimum_resources(is_gpu_available)
 
+    def _initialize(self, **kwargs) -> None:
+        self._init_params_aux()
+        self._init_params()
+        # Do not create target_scaler, covariate_scaler and covariate_regressor here!
+        # They will be handled by the base model
+
     def _fit(
         self,
         train_data: TimeSeriesDataFrame,

--- a/timeseries/src/autogluon/timeseries/transforms/__init__.py
+++ b/timeseries/src/autogluon/timeseries/transforms/__init__.py
@@ -1,4 +1,9 @@
-from .scaler import (
+from .covariate_scaler import (
+    CovariateScaler,
+    GlobalCovariateScaler,
+    get_covariate_scaler_from_name,
+)
+from .target_scaler import (
     LocalStandardScaler,
     LocalMinMaxScaler,
     LocalMeanAbsScaler,

--- a/timeseries/src/autogluon/timeseries/transforms/covariate_scaler.py
+++ b/timeseries/src/autogluon/timeseries/transforms/covariate_scaler.py
@@ -127,7 +127,7 @@ class GlobalCovariateScaler(CovariateScaler):
         skewed_features = []
         continuous_features = []
         for col in columns:
-            if df[col].isin([0, 1]).all():
+            if set(df[col].unique()) == set([0, 1]):
                 bool_features.append(col)
             elif np.abs(df[col].skew()) > self.skew_threshold:
                 skewed_features.append(col)

--- a/timeseries/src/autogluon/timeseries/transforms/covariate_scaler.py
+++ b/timeseries/src/autogluon/timeseries/transforms/covariate_scaler.py
@@ -22,6 +22,7 @@ class CovariateScaler:
         use_known_covariates: bool = True,
         use_past_covariates: bool = True,
         use_static_features: bool = True,
+        **kwargs,
     ):
         self.metadata = metadata
         self.use_known_covariates = use_known_covariates
@@ -44,6 +45,16 @@ class CovariateScaler:
 
 
 class GlobalCovariateScaler(CovariateScaler):
+    """Applies preprocessing logic similar to tabular's NN_TORCH model to the covariates.
+
+    Performs following preprocessing for real-valued columns:
+    - sklearn.preprocessing.QuantileTransform for skewed features
+    - passthrough (ignore) boolean features
+    - sklearn.preprocessing.StandardScaler for the rest of the features
+
+    Preprocessing is done globally across all items.
+    """
+
     def __init__(
         self,
         metadata: CovariateMetadata,
@@ -139,7 +150,7 @@ AVAILABLE_COVARIATE_SCALERS = {
 }
 
 
-def get_covariate_scaler_from_name(name: Literal["local", "global"], **scaler_kwargs) -> CovariateScaler:
+def get_covariate_scaler_from_name(name: Literal["global"], **scaler_kwargs) -> CovariateScaler:
     if name not in AVAILABLE_COVARIATE_SCALERS:
         raise KeyError(
             f"Covariate scaler type {name} not supported. Available scalers: {list(AVAILABLE_COVARIATE_SCALERS)}"

--- a/timeseries/src/autogluon/timeseries/transforms/covariate_scaler.py
+++ b/timeseries/src/autogluon/timeseries/transforms/covariate_scaler.py
@@ -1,0 +1,147 @@
+import logging
+from typing import Dict, List, Literal, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+from sklearn.compose import ColumnTransformer
+from sklearn.preprocessing import QuantileTransformer, StandardScaler
+
+from autogluon.timeseries.dataset.ts_dataframe import TimeSeriesDataFrame
+from autogluon.timeseries.utils.features import CovariateMetadata
+from autogluon.timeseries.utils.warning_filters import warning_filter
+
+logger = logging.getLogger(__name__)
+
+
+class CovariateScaler:
+    """Preprocesses covariates and static features."""
+
+    def __init__(
+        self,
+        metadata: CovariateMetadata,
+        use_known_covariates: bool = True,
+        use_past_covariates: bool = True,
+        use_static_features: bool = True,
+    ):
+        self.metadata = metadata
+        self.use_known_covariates = use_known_covariates
+        self.use_past_covariates = use_past_covariates
+        self.use_static_features = use_static_features
+
+    def fit_transform(
+        self,
+        data: TimeSeriesDataFrame,
+        known_covariates: Optional[TimeSeriesDataFrame] = None,
+    ) -> Tuple[TimeSeriesDataFrame, Optional[TimeSeriesDataFrame]]:
+        raise NotImplementedError
+
+    def transform(
+        self,
+        data: TimeSeriesDataFrame,
+        known_covariates: Optional[TimeSeriesDataFrame] = None,
+    ) -> Tuple[TimeSeriesDataFrame, Optional[TimeSeriesDataFrame]]:
+        raise NotImplementedError
+
+
+class GlobalCovariateScaler(CovariateScaler):
+    def __init__(
+        self,
+        metadata: CovariateMetadata,
+        use_known_covariates: bool = True,
+        use_past_covariates: bool = True,
+        use_static_features: bool = True,
+        skew_threshold: float = 0.99,
+    ):
+        super().__init__(metadata, use_known_covariates, use_past_covariates, use_static_features)
+        self.skew_threshold = skew_threshold
+        self._column_transformers: Optional[Dict[Literal["known", "past", "static"], ColumnTransformer]] = None
+
+    def is_fit(self) -> bool:
+        return self._column_transformers is not None
+
+    def fit(self, data: TimeSeriesDataFrame) -> "GlobalCovariateScaler":
+        self._column_transformers = {}
+
+        if self.use_known_covariates and len(self.metadata.known_covariates_real) > 0:
+            self._column_transformers["known"] = self._get_transformer_for_columns(
+                data, columns=self.metadata.known_covariates_real
+            )
+        if self.use_past_covariates and len(self.metadata.past_covariates_real) > 0:
+            self._column_transformers["past"] = self._get_transformer_for_columns(
+                data, columns=self.metadata.past_covariates_real
+            )
+        if self.use_static_features and len(self.metadata.static_features_real) > 0:
+            self._column_transformers["static"] = self._get_transformer_for_columns(
+                data.static_features, columns=self.metadata.static_features_real
+            )
+
+    def fit_transform(
+        self, data: TimeSeriesDataFrame, known_covariates: TimeSeriesDataFrame | None = None
+    ) -> Tuple[TimeSeriesDataFrame, Optional[TimeSeriesDataFrame]]:
+        if not self.is_fit():
+            self.fit(data=data)
+        return self.transform(data=data, known_covariates=known_covariates)
+
+    def transform(
+        self, data: TimeSeriesDataFrame, known_covariates: TimeSeriesDataFrame | None = None
+    ) -> Tuple[TimeSeriesDataFrame, Optional[TimeSeriesDataFrame]]:
+        # Copy data to avoid SettingWithCopyWarning from pandas
+        data = data.copy()
+        if "known" in self._column_transformers:
+            columns = self.metadata.known_covariates_real
+            data[columns] = self._column_transformers["known"].transform(data[columns])
+
+            if known_covariates is not None:
+                known_covariates = known_covariates.copy()
+                known_covariates[columns] = self._column_transformers["known"].transform(known_covariates[columns])
+
+        if "past" in self._column_transformers:
+            columns = self.metadata.past_covariates_real
+            data[columns] = self._column_transformers["past"].transform(data[columns])
+
+        if "static" in self._column_transformers:
+            columns = self.metadata.static_features_real
+            data.static_features[columns] = self._column_transformers["static"].transform(
+                data.static_features[columns]
+            )
+        return data, known_covariates
+
+    def _get_transformer_for_columns(self, df: pd.DataFrame, columns: List[str]) -> Dict[str, str]:
+        """Passthrough bool features, use QuantileTransform for skewed features, and use StandardScaler for the rest.
+
+        The preprocessing logic is similar to the TORCH_NN model from Tabular.
+        """
+        bool_features = []
+        skewed_features = []
+        continuous_features = []
+        for col in columns:
+            if df[col].isin([0, 1]).all():
+                bool_features.append(col)
+            elif np.abs(df[col].skew()) > self.skew_threshold:
+                skewed_features.append(col)
+            else:
+                continuous_features.append(col)
+        transformers = []
+        logger.debug(
+            f"\tbool_features: {bool_features}, continuous_features: {continuous_features}, skewed_features: {skewed_features}"
+        )
+        if continuous_features:
+            transformers.append(("scaler", StandardScaler(), continuous_features))
+        if skewed_features:
+            transformers.append(("skew", QuantileTransformer(output_distribution="normal"), skewed_features))
+        with warning_filter():
+            column_transformer = ColumnTransformer(transformers=transformers, remainder="passthrough").fit(df[columns])
+        return column_transformer
+
+
+AVAILABLE_COVARIATE_SCALERS = {
+    "global": GlobalCovariateScaler,
+}
+
+
+def get_covariate_scaler_from_name(name: Literal["local", "global"], **scaler_kwargs) -> CovariateScaler:
+    if name not in AVAILABLE_COVARIATE_SCALERS:
+        raise KeyError(
+            f"Covariate scaler type {name} not supported. Available scalers: {list(AVAILABLE_COVARIATE_SCALERS)}"
+        )
+    return AVAILABLE_COVARIATE_SCALERS[name](**scaler_kwargs)

--- a/timeseries/src/autogluon/timeseries/transforms/covariate_scaler.py
+++ b/timeseries/src/autogluon/timeseries/transforms/covariate_scaler.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Literal, Optional, Tuple
+from typing import Dict, List, Literal, Optional
 
 import numpy as np
 import pandas as pd

--- a/timeseries/src/autogluon/timeseries/transforms/target_scaler.py
+++ b/timeseries/src/autogluon/timeseries/transforms/target_scaler.py
@@ -115,7 +115,7 @@ class LocalRobustScaler(LocalTargetScaler):
         return loc, scale
 
 
-AVAILABLE_SCALERS = {
+AVAILABLE_TARGET_SCALERS = {
     "standard": LocalStandardScaler,
     "mean_abs": LocalMeanAbsScaler,
     "min_max": LocalMinMaxScaler,
@@ -127,6 +127,6 @@ def get_target_scaler_from_name(
     name: Literal["standard", "mean_abs", "min_max", "robust"], **scaler_kwargs
 ) -> LocalTargetScaler:
     """Get LocalTargetScaler object from a string."""
-    if name not in AVAILABLE_SCALERS:
-        raise KeyError(f"Scaler type {name} not supported. Available scalers: {list(AVAILABLE_SCALERS)}")
-    return AVAILABLE_SCALERS[name](**scaler_kwargs)
+    if name not in AVAILABLE_TARGET_SCALERS:
+        raise KeyError(f"Scaler type {name} not supported. Available scalers: {list(AVAILABLE_TARGET_SCALERS)}")
+    return AVAILABLE_TARGET_SCALERS[name](**scaler_kwargs)

--- a/timeseries/tests/unittests/models/test_mlforecast.py
+++ b/timeseries/tests/unittests/models/test_mlforecast.py
@@ -238,7 +238,7 @@ def test_given_train_data_has_nans_when_fit_called_then_nan_rows_removed_from_tr
         hyperparameters={"differences": []},
     )
     model.fit(train_data=data)
-    train_df, val_df = model._generate_train_val_dfs(model.preprocess(data, is_train=True))
+    train_df, val_df = model._generate_train_val_dfs(model.preprocess(data, is_train=True)[0])
     assert len(train_df) + len(val_df) == len(data.dropna())
 
 

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -524,7 +524,7 @@ def test_when_fit_and_predict_called_then_train_val_and_test_data_is_preprocesse
         mock.patch.object(model, "_fit") as mock_fit,
         mock.patch.object(model, "_predict") as mock_predict,
     ):
-        mock_preprocess.return_value = preprocessed_data
+        mock_preprocess.return_value = preprocessed_data, None
         model.fit(train_data=train_data, val_data=train_data)
         fit_kwargs = mock_fit.call_args[1]
         model_train_data = fit_kwargs["train_data"]

--- a/timeseries/tests/unittests/test_transforms.py
+++ b/timeseries/tests/unittests/test_transforms.py
@@ -179,7 +179,7 @@ def test_when_covariate_scaler_is_used_then_original_data_is_not_modified(
 
 def test_when_global_covariate_scaler_is_fit_then_column_transformers_are_created(df_with_covariates_and_metadata):
     df, metadata = df_with_covariates_and_metadata
-    scaler = GlobalCovariateScaler(metadata=metadata)
+    scaler = GlobalCovariateScaler(metadata=metadata, skew_threshold=1e10)
     scaler.fit_transform(df)
     assert scaler.is_fit()
     assert scaler._column_transformers["known"].transformers_[-1][-1] == ["cov2"]

--- a/timeseries/tests/unittests/test_transforms.py
+++ b/timeseries/tests/unittests/test_transforms.py
@@ -170,7 +170,8 @@ def test_when_covariate_scaler_is_used_then_original_data_is_not_modified(
     known_covariates_orig = known_covariates.copy()
     static_features_orig = data.static_features.copy()
 
-    _ = scaler.fit_transform(data=data, known_covariates=known_covariates)
+    scaler.fit_transform(data)
+    scaler.transform_known_covariates(known_covariates)
 
     assert data_orig.equals(data)
     assert known_covariates_orig.equals(known_covariates)
@@ -193,7 +194,7 @@ def test_when_global_covariate_scaler_transforms_then_real_columns_are_standardi
     df, metadata = df_with_covariates_and_metadata
     # ensure that StandardScaler is used for all features by setting large skew_threshold
     scaler = GlobalCovariateScaler(metadata=metadata, skew_threshold=1e10)
-    df_out, _ = scaler.fit_transform(df)
+    df_out = scaler.fit_transform(df)
     assert is_standardized(df_out["cov2"])
     assert is_standardized(df_out.static_features["feat1"])
     assert is_standardized(df_out.static_features["feat3"])

--- a/timeseries/tests/unittests/test_transforms.py
+++ b/timeseries/tests/unittests/test_transforms.py
@@ -1,17 +1,24 @@
 from unittest import mock
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from autogluon.timeseries.models import NaiveModel
-from autogluon.timeseries.transforms.scaler import (
-    AVAILABLE_SCALERS,
+from autogluon.timeseries.transforms.covariate_scaler import (
+    AVAILABLE_COVARIATE_SCALERS,
+    GlobalCovariateScaler,
+    get_covariate_scaler_from_name,
+)
+from autogluon.timeseries.transforms.target_scaler import (
+    AVAILABLE_TARGET_SCALERS,
     LocalMeanAbsScaler,
     LocalMinMaxScaler,
     LocalRobustScaler,
     LocalStandardScaler,
     get_target_scaler_from_name,
 )
+from autogluon.timeseries.utils.features import CovariateMetadata
 
 from .common import DUMMY_TS_DATAFRAME
 from .models.test_models import get_multi_window_deepar
@@ -19,7 +26,7 @@ from .models.test_models import get_multi_window_deepar
 TESTABLE_MODELS = [NaiveModel, get_multi_window_deepar]
 
 
-@pytest.mark.parametrize("scaler_name", AVAILABLE_SCALERS)
+@pytest.mark.parametrize("scaler_name", AVAILABLE_TARGET_SCALERS)
 def test_when_scaler_transforms_then_input_data_is_not_modified(scaler_name):
     scaler = get_target_scaler_from_name(scaler_name)
     data = DUMMY_TS_DATAFRAME.copy()
@@ -29,7 +36,7 @@ def test_when_scaler_transforms_then_input_data_is_not_modified(scaler_name):
     assert not data.equals(data_transformed)
 
 
-@pytest.mark.parametrize("scaler_name", AVAILABLE_SCALERS)
+@pytest.mark.parametrize("scaler_name", AVAILABLE_TARGET_SCALERS)
 def test_when_scaler_transforms_then_no_new_nans_appear(scaler_name):
     scaler = get_target_scaler_from_name(scaler_name)
     data = DUMMY_TS_DATAFRAME.copy()
@@ -37,7 +44,7 @@ def test_when_scaler_transforms_then_no_new_nans_appear(scaler_name):
     assert data.isna().equals(data_transformed.isna())
 
 
-@pytest.mark.parametrize("scaler_name", AVAILABLE_SCALERS)
+@pytest.mark.parametrize("scaler_name", AVAILABLE_TARGET_SCALERS)
 def test_when_inverse_transform_applied_then_output_matches_input(scaler_name):
     scaler = get_target_scaler_from_name(scaler_name)
     data = DUMMY_TS_DATAFRAME.copy()
@@ -65,7 +72,7 @@ def test_when_model_fits_then_fit_transform_called_as_many_times_as_expected(mod
         },
     )
     with mock.patch(
-        "autogluon.timeseries.transforms.scaler.LocalTargetScaler.fit_transform",
+        "autogluon.timeseries.transforms.target_scaler.LocalTargetScaler.fit_transform",
         side_effect=lambda x: x,
     ) as scaler_fit_transform:
         model.fit(train_data=data)
@@ -86,7 +93,7 @@ def test_when_model_predicts_then_fit_transform_called_once(model_class):
     )
     model.fit(train_data=data)
     with mock.patch(
-        "autogluon.timeseries.transforms.scaler.LocalTargetScaler.fit_transform",
+        "autogluon.timeseries.transforms.target_scaler.LocalTargetScaler.fit_transform",
         side_effect=lambda x: x,
     ) as scaler_fit_transform:
         model.predict(data)
@@ -132,3 +139,61 @@ def test_given_no_scaler_name_when_model_fits_then_no_scaler_is_added(hyperparam
     )
     model.fit(train_data=data)
     assert model.target_scaler is None
+
+
+def test_when_global_covariate_scaler_used_then_correct_feature_types_are_detected():
+    covariate_scaler = GlobalCovariateScaler(metadata=CovariateMetadata())
+    N = 500
+    df = pd.DataFrame(
+        {
+            "bool": np.random.choice([0, 1], size=N).astype(float),
+            "skewed": np.random.exponential(size=N),
+            "normal": np.random.normal(size=N),
+        }
+    )
+    pipeline = covariate_scaler._get_transformer_for_columns(df, df.columns)
+    normal_pipeline, skewed_pipeline = pipeline.transformers
+    assert normal_pipeline[-1] == ["normal"]
+    assert skewed_pipeline[-1] == ["skewed"]
+
+
+@pytest.mark.parametrize("scaler_name", AVAILABLE_COVARIATE_SCALERS)
+def test_when_covariate_scaler_is_used_then_original_data_is_not_modified(
+    scaler_name, df_with_covariates_and_metadata
+):
+    df, metadata = df_with_covariates_and_metadata
+    scaler = get_covariate_scaler_from_name(scaler_name, metadata=metadata)
+    data, known_covariates = df.get_model_inputs_for_scoring(
+        prediction_length=2, known_covariates_names=metadata.known_covariates
+    )
+    data_orig = data.copy()
+    known_covariates_orig = known_covariates.copy()
+    static_features_orig = data.static_features.copy()
+
+    _ = scaler.fit_transform(data=data, known_covariates=known_covariates)
+
+    assert data_orig.equals(data)
+    assert known_covariates_orig.equals(known_covariates)
+    assert static_features_orig.equals(data.static_features)
+
+
+def test_when_global_covariate_scaler_is_fit_then_column_transformers_are_created(df_with_covariates_and_metadata):
+    df, metadata = df_with_covariates_and_metadata
+    scaler = GlobalCovariateScaler(metadata=metadata)
+    scaler.fit_transform(df)
+    assert scaler.is_fit()
+    assert scaler._column_transformers["known"].transformers_[-1][-1] == ["cov2"]
+    assert scaler._column_transformers["static"].transformers_[-1][-1] == ["feat1", "feat3"]
+
+
+def test_when_global_covariate_scaler_transforms_then_real_columns_are_standardized(df_with_covariates_and_metadata):
+    def is_standardized(series: pd.Series, atol: float = 1e-2) -> bool:
+        return np.isclose(series.mean(), 0, atol=atol) and np.isclose(series.std(ddof=0), 1, atol=atol)
+
+    df, metadata = df_with_covariates_and_metadata
+    # ensure that StandardScaler is used for all features by setting large skew_threshold
+    scaler = GlobalCovariateScaler(metadata=metadata, skew_threshold=1e10)
+    df_out, _ = scaler.fit_transform(df)
+    assert is_standardized(df_out["cov2"])
+    assert is_standardized(df_out.static_features["feat1"])
+    assert is_standardized(df_out.static_features["feat3"])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Combine methods `preprocess` and `preprocess_known_covariates` into a single method. This simplifies certain types of preprocessing such as converting past_covariates into known_covariates using lags.
- Move GluonTS preprocessing logic into a standalone class `CovariateScaler` that can be used by any `AbstractTimeSeriesModel`
- Extend test coverage for the covariate scaling logic


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
