### PR TITLE
[AutoMM] Fix Index Typo in Tutorial

### DIFF
--- a/docs/tutorials/multimodal/advanced_topics/index.md
+++ b/docs/tutorials/multimodal/advanced_topics/index.md
@@ -59,7 +59,7 @@
 :::
 
 :::{grid-item-card} AutoMM Problem Types and Evaluation Metrics.
-  :link: advanced_topics/problem_types_and_metrics.html
+  :link: problem_types_and_metrics.html
 
   A comprehensive guide to AutoGluon's supported problem types and their evaluation metrics.
 :::


### PR DESCRIPTION
Current Bug: Can't open metric tutorial in this page: https://auto.gluon.ai/dev/tutorials/multimodal/advanced_topics/index.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
