### PR TITLE
[timeseries] Fix incorrect scale of the quantile forecast for RecursiveTabular

### DIFF
--- a/timeseries/src/autogluon/timeseries/metrics/point.py
+++ b/timeseries/src/autogluon/timeseries/metrics/point.py
@@ -8,7 +8,7 @@ import pandas as pd
 from autogluon.timeseries import TimeSeriesDataFrame
 
 from .abstract import TimeSeriesScorer
-from .utils import _in_sample_abs_seasonal_error, _in_sample_squared_seasonal_error
+from .utils import in_sample_abs_seasonal_error, in_sample_squared_seasonal_error
 
 logger = logging.getLogger(__name__)
 
@@ -232,7 +232,7 @@ class MASE(TimeSeriesScorer):
     def save_past_metrics(
         self, data_past: TimeSeriesDataFrame, target: str = "target", seasonal_period: int = 1, **kwargs
     ) -> None:
-        self._past_abs_seasonal_error = _in_sample_abs_seasonal_error(
+        self._past_abs_seasonal_error = in_sample_abs_seasonal_error(
             y_past=data_past[target], seasonal_period=seasonal_period
         )
 
@@ -292,7 +292,7 @@ class RMSSE(TimeSeriesScorer):
     def save_past_metrics(
         self, data_past: TimeSeriesDataFrame, target: str = "target", seasonal_period: int = 1, **kwargs
     ) -> None:
-        self._past_squared_seasonal_error = _in_sample_squared_seasonal_error(
+        self._past_squared_seasonal_error = in_sample_squared_seasonal_error(
             y_past=data_past[target], seasonal_period=seasonal_period
         )
 

--- a/timeseries/src/autogluon/timeseries/metrics/quantile.py
+++ b/timeseries/src/autogluon/timeseries/metrics/quantile.py
@@ -6,7 +6,7 @@ import pandas as pd
 from autogluon.timeseries.dataset.ts_dataframe import TimeSeriesDataFrame
 
 from .abstract import TimeSeriesScorer
-from .utils import _in_sample_abs_seasonal_error
+from .utils import in_sample_abs_seasonal_error
 
 
 class WQL(TimeSeriesScorer):
@@ -85,7 +85,7 @@ class SQL(TimeSeriesScorer):
     def save_past_metrics(
         self, data_past: TimeSeriesDataFrame, target: str = "target", seasonal_period: int = 1, **kwargs
     ) -> None:
-        self._past_abs_seasonal_error = _in_sample_abs_seasonal_error(
+        self._past_abs_seasonal_error = in_sample_abs_seasonal_error(
             y_past=data_past[target], seasonal_period=seasonal_period
         )
 

--- a/timeseries/src/autogluon/timeseries/metrics/utils.py
+++ b/timeseries/src/autogluon/timeseries/metrics/utils.py
@@ -7,12 +7,12 @@ def _get_seasonal_diffs(*, y_past: pd.Series, seasonal_period: int = 1) -> pd.Se
     return y_past.groupby(level=ITEMID, sort=False).diff(seasonal_period).abs()
 
 
-def _in_sample_abs_seasonal_error(*, y_past: pd.Series, seasonal_period: int = 1) -> pd.Series:
+def in_sample_abs_seasonal_error(*, y_past: pd.Series, seasonal_period: int = 1) -> pd.Series:
     """Compute seasonal naive forecast error (predict value from seasonal_period steps ago) for each time series."""
     seasonal_diffs = _get_seasonal_diffs(y_past=y_past, seasonal_period=seasonal_period)
     return seasonal_diffs.groupby(level=ITEMID, sort=False).mean().fillna(1.0)
 
 
-def _in_sample_squared_seasonal_error(*, y_past: pd.Series, seasonal_period: int = 1) -> pd.Series:
+def in_sample_squared_seasonal_error(*, y_past: pd.Series, seasonal_period: int = 1) -> pd.Series:
     seasonal_diffs = _get_seasonal_diffs(y_past=y_past, seasonal_period=seasonal_period)
     return seasonal_diffs.pow(2.0).groupby(level=ITEMID, sort=False).mean().fillna(1.0)

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -404,8 +404,8 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
         residuals_std_per_timestep = self._residuals_std_per_item.reindex(repeated_item_ids)
         # Use in-sample seasonal error in for items not seen during fit
         items_not_seen_during_fit = residuals_std_per_timestep.index[residuals_std_per_timestep.isna()].unique()
-        if len(items_not_seen_during_fit):
-            scale_for_new_items = np.sqrt(
+        if len(items_not_seen_during_fit) > 0:
+            scale_for_new_items: pd.Series = np.sqrt(
                 in_sample_squared_seasonal_error(y_past=past_target.loc[items_not_seen_during_fit])
             )
             residuals_std_per_timestep = residuals_std_per_timestep.fillna(scale_for_new_items)

--- a/timeseries/tests/unittests/test_metrics.py
+++ b/timeseries/tests/unittests/test_metrics.py
@@ -21,7 +21,7 @@ from gluonts.model.forecast import QuantileForecast
 
 from autogluon.timeseries import TimeSeriesPredictor
 from autogluon.timeseries.metrics import AVAILABLE_METRICS, DEFAULT_METRIC_NAME, check_get_evaluation_metric
-from autogluon.timeseries.metrics.utils import _in_sample_abs_seasonal_error, _in_sample_squared_seasonal_error
+from autogluon.timeseries.metrics.utils import in_sample_abs_seasonal_error, in_sample_squared_seasonal_error
 from autogluon.timeseries.models.gluonts.abstract_gluonts import AbstractGluonTSModel
 
 from .common import DUMMY_TS_DATAFRAME, get_data_frame_with_item_index, get_prediction_for_df
@@ -225,7 +225,7 @@ def test_given_historic_data_not_cached_when_scoring_then_exception_is_raised(ev
 
 def test_when_eval_metric_seasonal_period_is_longer_than_ts_then_abs_seasonal_error_is_set_to_1():
     seasonal_period = max(DUMMY_TS_DATAFRAME.num_timesteps_per_item())
-    naive_error_per_item = _in_sample_abs_seasonal_error(
+    naive_error_per_item = in_sample_abs_seasonal_error(
         y_past=DUMMY_TS_DATAFRAME["target"], seasonal_period=seasonal_period
     )
     assert (naive_error_per_item == 1.0).all()
@@ -233,7 +233,7 @@ def test_when_eval_metric_seasonal_period_is_longer_than_ts_then_abs_seasonal_er
 
 def test_when_eval_metric_seasonal_period_is_longer_than_ts_then_squared_seasonal_error_is_set_to_1():
     seasonal_period = max(DUMMY_TS_DATAFRAME.num_timesteps_per_item())
-    naive_error_per_item = _in_sample_squared_seasonal_error(
+    naive_error_per_item = in_sample_squared_seasonal_error(
         y_past=DUMMY_TS_DATAFRAME["target"], seasonal_period=seasonal_period
     )
     assert (naive_error_per_item == 1.0).all()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix a regression caused by the new scaler logic in `RecursiveTabularModel` introduced in #4460
- Make `_in_sample_abs_seasonal_error` and `_in_sample_squared_seasonal_error` public methods


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
