### PR TITLE
[timeseries] Fix `fused=True` failure in Chronos fine-tuning on CPU

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/chronos/model.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/model.py
@@ -435,6 +435,12 @@ class ChronosModel(AbstractTimeSeriesModel):
             fine_tune_trainer_kwargs = fine_tune_args["fine_tune_trainer_kwargs"]
             fine_tune_trainer_kwargs["disable_tqdm"] = fine_tune_trainer_kwargs.get("disable_tqdm", (verbosity < 3))
             fine_tune_trainer_kwargs["use_cpu"] = str(self.model_pipeline.inner_model.device) == "cpu"
+
+            # TODO: adamw_torch_fused is not supported on CPU in torch <= 2.3. When torch 2.4 becomes the lower bound
+            # this if block can be removed because torch >= 2.4 supports AdamW optimizer with fused=True on CPU
+            if fine_tune_trainer_kwargs["use_cpu"] and fine_tune_trainer_kwargs["optim"] == "adamw_torch_fused":
+                fine_tune_trainer_kwargs["optim"] = "adamw_torch"
+
             output_dir = Path(fine_tune_trainer_kwargs["output_dir"])
 
             if not eval_during_fine_tune:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* This PR fixes a problem that occurs on `torch <= 2.3` when fine-tuning Chronos models on CPU. Since the default optimizer is `adamw_torch_fused`, fine-tuning fails because the fused AdamW optimizer is not supported on `torch <= 2.3`. I tested this using the following snippet. 

```py
import torch

a = torch.rand(42, requires_grad=True)

b = ((a - 1) ** 2).mean()

optim = torch.optim.AdamW([a], fused=True)
optim.zero_grad()
b.backward()
optim.step()
```

It fails with the following error on `torch <= 2.3` but succeeds on `torch >= 2.4`. 

> RuntimeError: `fused=True` requires all the params to be floating point Tensors of supported devices: ['cuda', 'xpu', 'privateuseone'].

The fix in this PR is to default to `adamw_torch` instead of `adamw_torch_fused` when training on CPU. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
