### PR TITLE
[timeseries] Fix `torch.Tensor.mean` use with incorrect kwargs

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/chronos/pipeline/chronos.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/pipeline/chronos.py
@@ -510,7 +510,7 @@ class ChronosPipeline(BaseChronosPipeline):
             .cpu()
             .swapaxes(1, 2)
         )
-        mean = prediction_samples.mean(axis=-1, keepdims=True)
+        mean = prediction_samples.mean(dim=-1, keepdim=True)
         quantiles = torch.quantile(
             prediction_samples,
             q=torch.tensor(quantile_levels, dtype=prediction_samples.dtype),


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* This PR fixes incorrect use of `axis` and `keepdims` in `torch.Tensor.mean`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
