### PR TITLE
[timeseries] prune timeseries unit and smoke tests

### DIFF
--- a/timeseries/tests/smoketests/test_all_models.py
+++ b/timeseries/tests/smoketests/test_all_models.py
@@ -7,7 +7,6 @@ from packaging.version import Version
 
 from autogluon.timeseries import TimeSeriesPredictor
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP, TimeSeriesDataFrame
-from autogluon.timeseries.utils.datetime.seasonality import DEFAULT_SEASONALITIES
 
 TARGET_COLUMN = "custom_target"
 ITEM_IDS = ["Z", "A", "1", "C"]

--- a/timeseries/tests/smoketests/test_all_models.py
+++ b/timeseries/tests/smoketests/test_all_models.py
@@ -139,6 +139,8 @@ def assert_leaderboard_contains_all_models(
     assert len(failed_models) == 0, f"Failed models: {failed_models}"
 
 
+# TODO: Some models, such as local models, do not change behavior when past / known /
+# static features are provided. We could omit them from these tests.
 @pytest.mark.parametrize("use_past_covariates", [True, False])
 @pytest.mark.parametrize("use_known_covariates", [True, False])
 @pytest.mark.parametrize("use_static_features_categorical", [True, False])

--- a/timeseries/tests/smoketests/test_all_models.py
+++ b/timeseries/tests/smoketests/test_all_models.py
@@ -63,7 +63,6 @@ DUMMY_MODEL_HPARAMS = {
 ALL_MODELS = {
     "ADIDA": DUMMY_MODEL_HPARAMS,
     "Average": DUMMY_MODEL_HPARAMS,
-    # "AutoCES": {**DUMMY_MODEL_HPARAMS, "model": "S"},
     "Chronos": {},
     "Croston": DUMMY_MODEL_HPARAMS,
     "DLinear": DUMMY_MODEL_HPARAMS,
@@ -80,7 +79,6 @@ ALL_MODELS = {
     "SeasonalNaive": DUMMY_MODEL_HPARAMS,
     "SimpleFeedForward": DUMMY_MODEL_HPARAMS,
     "TemporalFusionTransformer": DUMMY_MODEL_HPARAMS,
-    # "Theta": DUMMY_MODEL_HPARAMS,  # covered by DynamicOptimizedTheta
     "TiDE": DUMMY_MODEL_HPARAMS,
     "WaveNet": DUMMY_MODEL_HPARAMS,
     "Zero": DUMMY_MODEL_HPARAMS,
@@ -143,11 +141,11 @@ def assert_leaderboard_contains_all_models(
 
 @pytest.mark.parametrize("use_past_covariates", [True, False])
 @pytest.mark.parametrize("use_known_covariates", [True, False])
-@pytest.mark.parametrize("use_static_features_continuous", [True, False])
+@pytest.mark.parametrize("use_static_features_categorical", [True, False])
 def test_all_models_can_handle_all_covariates(
     use_known_covariates,
     use_past_covariates,
-    use_static_features_continuous,
+    use_static_features_categorical,
     all_model_hyperparams,
 ):
     prediction_length = 5
@@ -155,8 +153,8 @@ def test_all_models_can_handle_all_covariates(
         prediction_length=prediction_length,
         use_known_covariates=use_known_covariates,
         use_past_covariates=use_past_covariates,
-        use_static_features_continuous=use_static_features_continuous,
-        use_static_features_categorical=False,
+        use_static_features_continuous=False,
+        use_static_features_categorical=use_static_features_categorical,
     )
 
     known_covariates_names = [col for col in train_data if col.startswith("known_")]
@@ -188,12 +186,12 @@ def test_all_models_can_handle_all_covariates(
         "QE",
         "SME",
         "W",
-        "D",
+        "2D",
         "B",
         "bh",
-        "h",
+        "4h",
         "min",
-        "s",
+        "100s",
     ],
 )
 @pytest.mark.parametrize(

--- a/timeseries/tests/unittests/models/chronos/test_model.py
+++ b/timeseries/tests/unittests/models/chronos/test_model.py
@@ -23,13 +23,7 @@ DATASETS = [DUMMY_TS_DATAFRAME, DATAFRAME_WITH_STATIC, DATAFRAME_WITH_COVARIATES
 GPU_AVAILABLE = torch.cuda.is_available()
 HYPERPARAMETER_DICTS = [
     {
-        "batch_size": 32,
-    },
-    {
         "batch_size": 4,
-    },
-    {
-        "num_samples": 10,
     },
     {
         "context_length": 64,
@@ -39,11 +33,11 @@ HYPERPARAMETER_DICTS = [
     },
     {
         "fine_tune": True,
-        "fine_tune_steps": 10,
+        "fine_tune_steps": 2,
     },
     {
         "fine_tune": True,
-        "fine_tune_steps": 10,
+        "fine_tune_steps": 2,
         "context_length": 64,
     },
 ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR reduces overall test time by ~30%, primarily by 
- reducing the test case grid in smoke tests
- removing expensive but unused local models from smoke and model tests
- removing some Chronos hyperparameter configs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
