### PR TITLE
fix: enable autogluon build on aarch64 platforms

### DIFF
--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -3,6 +3,7 @@
 # This code block is a HACK (!), but is necessary to avoid code duplication. Do NOT alter these lines.
 import importlib.util
 import os
+import platform
 
 from setuptools import setup
 
@@ -64,7 +65,7 @@ tests_require = [
     "onnx>=1.13.0,<1.16.2;platform_system=='Windows'",  # cap at 1.16.1 for issue https://github.com/onnx/onnx/issues/6267
     "onnx>=1.13.0,<1.18.0;platform_system!='Windows'",
     "onnxruntime>=1.17.0,<1.20.0",  # install for gpu system due to https://github.com/autogluon/autogluon/issues/3804
-    "onnxruntime-gpu>=1.17.0,<1.20.0;platform_system!='Darwin'",
+    "onnxruntime-gpu>=1.17.0,<1.20.0;platform_system!='Darwin' and platform_machine!='aarch64'",
     "tensorrt>=8.6.0,<10.3;platform_system=='Linux' and python_version<'3.11'",
 ]
 

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -3,6 +3,7 @@
 # This code block is a HACK (!), but is necessary to avoid code duplication. Do NOT alter these lines.
 import importlib.util
 import os
+import platform
 
 from setuptools import setup
 
@@ -72,7 +73,15 @@ extras_require = {
         # No vowpalwabbit wheel for python 3.11 or above yet
         "vowpalwabbit>=9,<9.10; python_version < '3.11' and sys_platform != 'darwin'",
     ],
-    "skl2onnx": [
+    
+}
+
+is_aarch64 = platform.machine() == 'aarch64'
+is_darwin = sys.platform == 'darwin'
+
+if is_darwin or is_aarch64:
+# For macOS or aarch64, only use CPU version
+    extras_require["skl2onnx"] = [
         "onnx>=1.13.0,<1.16.2;platform_system=='Windows'",  # cap at 1.16.1 for issue https://github.com/onnx/onnx/issues/6267
         "onnx>=1.13.0,<1.18.0;platform_system!='Windows'",
         "skl2onnx>=1.15.0,<1.18.0",
@@ -80,14 +89,15 @@ extras_require = {
         # Therefore, we install onnxruntime explicitly here just for macOS.
         "onnxruntime>=1.17.0,<1.20.0",
     ]
-    if sys.platform == "darwin"
-    else [
+else:
+# For other platforms, include both CPU and GPU versions
+    extras_require["skl2onnx"] = [
         "onnx>=1.13.0,<1.16.2;platform_system=='Windows'",  # cap at 1.16.1 for issue https://github.com/onnx/onnx/issues/6267
         "onnx>=1.13.0,<1.18.0;platform_system!='Windows'",
         "skl2onnx>=1.15.0,<1.18.0", 
         "onnxruntime>=1.17.0,<1.20.0",   # install for gpu system due to https://github.com/autogluon/autogluon/issues/3804
-        "onnxruntime-gpu>=1.17.0,<1.20.0"],
-}
+        "onnxruntime-gpu>=1.17.0,<1.20.0",
+    ]
 
 # TODO: v1.0: Rename `all` to `core`, make `all` contain everything.
 all_requires = []


### PR DESCRIPTION
**Issue:** Build fails on aarch64 due to onnxruntime-gpu dependency

![image](https://github.com/user-attachments/assets/8e48d74e-7486-4b40-ac83-7143fe12ca7b)
 


**Fix**: Exclude onnxruntime-gpu on aarch64 platforms to fix build issues

The autogluon build process was failing on aarch64 platforms due to onnxruntime-gpu package incompatibility. 

This PR:
- Modified platform-specific ONNX dependencies by updates tabular/setup.py & multimodal/setup.py
- Falls back to CPU-only onnxruntime on aarch64 and Darwin platforms
- Maintains GPU support on compatible platforms (x86_64/Windows/Linux)

This change allows autogluon to build successfully on aarch64 while maintaining existing functionality on other platforms.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

cc @Innixma @shchur @zhiqiangdon @gradientsky @yinweisu @sxjscience @FANGAreNotGnu @canerturkmen @jwmueller @prateekdesai04 @tonyhoo 