### PR TITLE
[timeseries] Change Chronos-Bolt model aliases

### DIFF
--- a/timeseries/src/autogluon/timeseries/configs/presets_configs.py
+++ b/timeseries/src/autogluon/timeseries/configs/presets_configs.py
@@ -12,19 +12,19 @@ TIMESERIES_PRESETS_CONFIGS = dict(
     fast_training={"hyperparameters": "very_light"},
     # Chronos-Bolt models
     bolt_tiny={
-        "hyperparameters": {"Chronos": {"model_path": "bolt-tiny"}},
+        "hyperparameters": {"Chronos": {"model_path": "bolt_tiny"}},
         "skip_model_selection": True,
     },
     bolt_mini={
-        "hyperparameters": {"Chronos": {"model_path": "bolt-mini"}},
+        "hyperparameters": {"Chronos": {"model_path": "bolt_mini"}},
         "skip_model_selection": True,
     },
     bolt_small={
-        "hyperparameters": {"Chronos": {"model_path": "bolt-small"}},
+        "hyperparameters": {"Chronos": {"model_path": "bolt_small"}},
         "skip_model_selection": True,
     },
     bolt_base={
-        "hyperparameters": {"Chronos": {"model_path": "bolt-base"}},
+        "hyperparameters": {"Chronos": {"model_path": "bolt_base"}},
         "skip_model_selection": True,
     },
     # Original Chronos models

--- a/timeseries/src/autogluon/timeseries/models/chronos/model.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/model.py
@@ -67,10 +67,10 @@ MODEL_ALIASES = {
     "small": "autogluon/chronos-t5-small",
     "base": "autogluon/chronos-t5-base",
     "large": "autogluon/chronos-t5-large",
-    "bolt-tiny": "autogluon/chronos-bolt-tiny",
-    "bolt-mini": "autogluon/chronos-bolt-mini",
-    "bolt-small": "autogluon/chronos-bolt-small",
-    "bolt-base": "autogluon/chronos-bolt-base",
+    "bolt_tiny": "autogluon/chronos-bolt-tiny",
+    "bolt_mini": "autogluon/chronos-bolt-mini",
+    "bolt_small": "autogluon/chronos-bolt-small",
+    "bolt_base": "autogluon/chronos-bolt-base",
 }
 
 
@@ -109,7 +109,7 @@ class ChronosModel(AbstractTimeSeriesModel):
         compatible model name on HuggingFace Hub or a local path to a model directory. Original
         Chronos models (i.e., ``autogluon/chronos-t5-{model_size}``) can be specified with aliases
         ``tiny``, ``mini`` , ``small``, ``base``, and ``large``. Chronos-Bolt models can be specified
-        with ``bolt-mini``, ``bolt-small``, and ``bolt-base``.
+        with ``bolt_tiny``, ``bolt_mini``, ``bolt_small``, and ``bolt_base``.
     batch_size : int, default = 16
         Size of batches used during inference
     num_samples : int, default = 20

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -134,7 +134,7 @@ def get_default_hps(key):
             "RecursiveTabular": {},
             "DirectTabular": {},
             "TemporalFusionTransformer": {},
-            "Chronos": {"model_path": "bolt-small"},
+            "Chronos": {"model_path": "bolt_small"},
         },
         "light_inference": {
             "SeasonalNaive": {},
@@ -157,11 +157,11 @@ def get_default_hps(key):
             "Chronos": [
                 {
                     "ag_args": {"name_suffix": "ZeroShot"},
-                    "model_path": "bolt-base",
+                    "model_path": "bolt_base",
                 },
                 {
                     "ag_args": {"name_suffix": "FineTuned"},
-                    "model_path": "bolt-small",
+                    "model_path": "bolt_small",
                     "fine_tune": True,
                     "target_scaler": "standard",
                     "covariate_regressor": {"model_name": "CAT", "model_hyperparameters": {"iterations": 1_000}},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Currently, there is an inconsistency between the preset names (e.g., `bolt_small`) and model aliases (e.g., `"Chronos": {"model_path": "bolt-small"}`. This PR changes the aliases for bolt models to `bolt_size` instead of `bolt-size` to be consistent with the preset names. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
