### PR TITLE
[core] Bump accelerate version to >=0.34,<1.0

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -31,7 +31,7 @@ DEPENDENT_PACKAGES = {
     "lightning": ">=2.2,<2.6",  # Major version cap
     "async_timeout": ">=4.0,<6",  # Major version cap
     "transformers[sentencepiece]": ">=4.38.0,<5",
-    "accelerate": ">=0.32.0,<1.0",
+    "accelerate": ">=0.34.0,<1.0",
 }
 if LITE_MODE:
     DEPENDENT_PACKAGES = {package: version for package, version in DEPENDENT_PACKAGES.items() if package not in ["psutil", "Pillow", "timm"]}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Currently, Chronos fine-tuning fails for `accelerate<0.34` with error `'AdamW' has no attribute 'train'` (see https://github.com/huggingface/transformers/issues/33620#issuecomment-2375857846). This error was fixed in `accelerate-0.34.0`, so we need to raise the lower bound.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
