### PR TITLE
[timeseries] Update try_import.py by update CatBoost requirement

### DIFF
--- a/common/src/autogluon/common/utils/try_import.py
+++ b/common/src/autogluon/common/utils/try_import.py
@@ -68,19 +68,24 @@ def try_import_ray() -> ModuleType:
 def try_import_catboost():
     try:
         import catboost
+        from pkg_resources import parse_version  # pylint: disable=import-outside-toplevel
+
+        catboost_version = parse_version(catboost.__version__)
+        min_version = "1.2"
+        assert catboost_version >= parse_version(
+            min_version
+        ), f'Currently, we support "catboost>={min_version}". Installed version: "catboost=={catboost.__version__}".'
     except ImportError as e:
-        error_msg = "`import catboost` failed. "
-        if sys.version_info >= (3, 11) and sys.platform == "darwin":
-            error_msg += f"Detected your env as {sys.platform}. Please either downgrade your python version to below 3.11 or move to another platform. Then install via ``pip install autogluon.tabular[catboost]=={__version__}``"
-        else:
-            error_msg += f"A quick tip is to install via `pip install autogluon.tabular[catboost]=={__version__}`."
-        raise ImportError()
+        raise ImportError(
+            "`import catboost` failed. "
+            f"A quick tip is to install via `pip install autogluon.tabular[catboost]=={__version__}`."
+        ) from e
     except ValueError as e:
         raise ImportError(
             "Import catboost failed. Numpy version may be outdated, "
             "Please ensure numpy version >=1.17.0. If it is not, please try 'pip uninstall numpy -y; pip install numpy>=1.17.0' "
             "Detailed info: {}".format(str(e))
-        )
+        ) from e
 
 
 def try_import_lightgbm():

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -37,7 +37,7 @@ extras_require = {
     ],
     "catboost": [
         "numpy>=1.25,<2.0.0",  # TODO support numpy>=2.0.0 once issue resolved https://github.com/catboost/catboost/issues/2671
-        "catboost>=1.1,<1.3",
+        "catboost>=1.2,<1.3",
     ],
     # FIXME: Debug why xgboost 1.6 has 4x+ slower inference on multiclass datasets compared to 1.4
     #  It is possibly only present on MacOS, haven't tested linux.


### PR DESCRIPTION
*Issue*
Related to failing tests on macOS Python >= 3.11
See https://github.com/autogluon/autogluon/actions/runs/12000876469/job/33494689238 and
https://github.com/autogluon/autogluon/actions/runs/12000876469/job/33494690159

*Description of changes:*
- Remove outdated Python 3.11 + macOS compatibility check as CatBoost now supports this configuration
- Add minimum version requirement for CatBoost (>= 1.2)
- Improve error messages and exception handling:
  - Add proper exception chaining using `from e`
  - Include version requirements in error messages
  - Maintain existing numpy-related error handling
- Fix empty ImportError being raised without message

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

cc @Innixma @shchur @zhiqiangdon @gradientsky @yinweisu @sxjscience @FANGAreNotGnu @canerturkmen @jwmueller @prateekdesai04 @tonyhoo