### PR TITLE
[tabular] Fix weights_only=False torch warnings

### DIFF
--- a/tabular/src/autogluon/tabular/models/fastainn/callbacks.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/callbacks.py
@@ -113,4 +113,4 @@ class AgSaveModelCallback(TrackerCallback):
 
     def after_fit(self, **kwargs):
         if not self.every_epoch:
-            self.learn.load(f"{self.fname}", with_opt=self.with_opt)
+            self.learn.load(f"{self.fname}", with_opt=self.with_opt, weights_only=False)   # nosec B614

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -350,6 +350,7 @@ class NNFastAiTabularModel(AbstractModel):
 
         callbacks = [save_callback, early_stopping]
 
+        # TODO: Optimize by using io.BytesIO() instead of temp_dir for checkpointing?
         with make_temp_directory() as temp_dir:
             with self.model.no_bar():
                 with self.model.no_logging():
@@ -365,7 +366,7 @@ class NNFastAiTabularModel(AbstractModel):
                     self.model.fit_one_cycle(epochs, params["lr"], cbs=callbacks)
 
                     # Load the best one and export it
-                    self.model = self.model.load(fname)
+                    self.model = self.model.load(fname, weights_only=False)  # nosec B614
 
                     if objective_func_name == "log_loss":
                         eval_result = self.model.validate(dl=dls.valid)[0]

--- a/tabular/src/autogluon/tabular/models/tabpfnmix/tabpfnmix_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnmix/tabpfnmix_model.py
@@ -282,7 +282,7 @@ class TabPFNMixModel(AbstractModel):
 
         if model._weights_saved:
             import torch
-            model.model.trainer.model = torch.load(model.weights_path, weights_only=False)
+            model.model.trainer.model = torch.load(model.weights_path, weights_only=False)  # nosec B614
             model._weights_saved = False
         return model
 

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1734,7 +1734,7 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
                         f"Disabling decision threshold calibration for metric `accuracy` due to having "
                         f"fewer than {min_val_rows_for_calibration} rows of validation data for calibration, "
                         f"to avoid overfitting ({num_rows_val_for_calibration} rows)."
-                        f"\n\t`accuracy` is generally not improved through threshold calibration "
+                        f"\n\t`accuracy` is generally not improved through threshold calibration. "
                         f"Force calibration via specifying `calibrate_decision_threshold=True`.",
                     )
             elif calibrate_decision_threshold:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Torch 2.4+ added a warning if no `weights_only` parameter is specified in `torch.load` calls.

- Set `weights_only` parameter for NN_TORCH, FASTAI, and TABPFNMIX models to avoid warning.
- Switched to using `io.BytesIO` instead of a disk file for caching model checkpoints during training for NN_TORCH, which should be faster and won't leave a unnecessary file on disk in case of a crash during fit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
