### PR TITLE
[tabular] Remove outdated macOS Python 3.11 CatBoost restriction for test_tabular.py

### DIFF
--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -62,9 +62,6 @@ def test_tabular():
         subsample_size = 100
         time_limit = 60
 
-    # Catboost > 1.2 is required for python 3.11 but cannot be correctly installed on macos
-    if sys.version_info >= (3, 11) and sys.platform == "darwin":
-        hyperparameters.pop("CAT")
 
     fit_args = {"verbosity": verbosity}
     if hyperparameter_tune_kwargs is not None:


### PR DESCRIPTION
*Issue *
Follow-up to [PR#4685](https://github.com/autogluon/autogluon/pull/4685)

*Description of changes:*
- Remove platform-specific CatBoost restriction from test_tabular.py
- Previously, CatBoost was disabled for macOS + Python >= 3.11 combinations
- This restriction is no longer needed since CatBoost >= 1.2 now supports these environments

The change improves test consistency by:
- Allowing CatBoost to run on all supported platforms
- Relying on version checks rather than platform-specific restrictions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

cc @Innixma @shchur @zhiqiangdon @gradientsky @yinweisu @sxjscience @FANGAreNotGnu @canerturkmen @jwmueller @prateekdesai04 @tonyhoo
