### PR TITLE
Deprecate chronos optimization

### DIFF
--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -62,9 +62,8 @@ extras_require = {
     ],
 }
 
-# TODO: add openvino back to "all" after dependency versions are relaxed
-extras_require["all"] = list(set.union(*(set(extras_require[extra]) for extra in ["chronos-onnx"])))
-
+# chronos-openvino and chronos-onnx are deprecated, and will be removed in a future version
+extras_require["all"] = []
 install_requires = ag.get_dependency_version_ranges(install_requires)
 
 if __name__ == "__main__":

--- a/timeseries/src/autogluon/timeseries/models/chronos/model.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/model.py
@@ -136,7 +136,7 @@ class ChronosModel(AbstractTimeSeriesModel):
         Optimization strategy to use for inference on CPUs. If None, the model will use the default implementation.
         If `onnx`, the model will be converted to ONNX and the inference will be performed using ONNX. If ``openvino``,
         inference will be performed with the model compiled to OpenVINO. These optimizations are only available for
-        the original set of Chronos models, and not in Chronos-Bolt where they are not needed. Note that you will need to
+        the original set of Chronos models, and not in Chronos-Bolt where they are not needed. You will need to
         install the appropriate dependencies `optimum[onnxruntime]` or `optimum[openvino,nncf]` for optimizations to work.
         Note that support for optimization strategies is deprecated, and will be removed in a future release. We recommend
         using Chronos-Bolt models for fast inference on the CPU.

--- a/timeseries/src/autogluon/timeseries/models/chronos/model.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/model.py
@@ -136,7 +136,10 @@ class ChronosModel(AbstractTimeSeriesModel):
         Optimization strategy to use for inference on CPUs. If None, the model will use the default implementation.
         If `onnx`, the model will be converted to ONNX and the inference will be performed using ONNX. If ``openvino``,
         inference will be performed with the model compiled to OpenVINO. These optimizations are only available for
-        the original set of Chronos models, and not in Chronos-Bolt where they are not needed.
+        the original set of Chronos models, and not in Chronos-Bolt where they are not needed. Note that you will need to
+        install the appropriate dependencies `optimum[onnxruntime]` or `optimum[openvino,nncf]` for optimizations to work.
+        Note that support for optimization strategies is deprecated, and will be removed in a future release. We recommend
+        using Chronos-Bolt models for fast inference on the CPU.
     torch_dtype : torch.dtype or {"auto", "bfloat16", "float32", "float64"}, default = "auto"
         Torch data type for model weights, provided to ``from_pretrained`` method of Hugging Face AutoModels. If
         original Chronos models are specified and the model size is ``small``, ``base``, or ``large``, the
@@ -202,6 +205,15 @@ class ChronosModel(AbstractTimeSeriesModel):
         self.optimization_strategy: Optional[Literal["onnx", "openvino"]] = hyperparameters.get(
             "optimization_strategy", None
         )
+        if self.optimization_strategy is not None:
+            warnings.warn(
+                (
+                    "optimization_strategy is deprecated and will be removed in a future release. "
+                    "We recommend using Chronos-Bolt models for fast inference on the CPU."
+                ),
+                category=DeprecationWarning,
+                stacklevel=3,
+            )
         self.context_length = hyperparameters.get("context_length")
 
         if self.context_length is not None and self.context_length > self.maximum_context_length:

--- a/timeseries/src/autogluon/timeseries/models/chronos/pipeline/chronos.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/pipeline/chronos.py
@@ -556,7 +556,9 @@ class ChronosPipeline(BaseChronosPipeline):
                     from optimum.onnxruntime import ORTModelForSeq2SeqLM
                 except ImportError:
                     raise ImportError(
-                        "Huggingface Optimum library must be installed with ONNX for using the `onnx` strategy"
+                        "Huggingface Optimum library must be installed with ONNX for using the `onnx` strategy "
+                        "Please try running `pip install optimum[onnxruntime]` or use Chronos-Bolt models for "
+                        "faster performance on the CPU"
                     )
 
                 assert kwargs.pop("device_map", "cpu") in ["cpu", "auto"], "ONNX mode only available on the CPU"
@@ -568,6 +570,8 @@ class ChronosPipeline(BaseChronosPipeline):
                 except ImportError:
                     raise ImportError(
                         "Huggingface Optimum library must be installed with OpenVINO for using the `openvino` strategy"
+                        "Please try running `pip install optimum-intel[openvino,nncf] optimum[openvino,nncf]` or use "
+                        "Chronos-Bolt models for faster performance on the CPU"
                     )
                 with set_loggers_level(regex=r"^optimum.*", level=logging.ERROR):
                     inner_model = OVModelForSeq2SeqLM.from_pretrained(

--- a/timeseries/tests/unittests/models/chronos/test_model.py
+++ b/timeseries/tests/unittests/models/chronos/test_model.py
@@ -70,16 +70,7 @@ TESTABLE_MODELS = [ChronosModel, chronos_with_finetuning, chronos_bolt_model, ch
 
 @pytest.fixture(
     scope="module",
-    params=[
-        {
-            "optimization_strategy": "onnx",
-        },
-        # add openvino tests when they are in core requirements
-        # {
-        #     "optimization_strategy": "openvino",
-        # },
-        *HYPERPARAMETER_DICTS,
-    ],
+    params=HYPERPARAMETER_DICTS,
 )
 def default_chronos_tiny_model(request, chronos_model_path) -> ChronosModel:
     model = ChronosModel(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Deprecates Chronos classic optimization strategies and removes them from extras in setup.py.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
