### PR TITLE
[timeseries] Bump GluonTS lower bound to 0.16

### DIFF
--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     "pytorch_lightning",  # version range defined in `core/_setup_utils.py`
     "transformers[sentencepiece]",  # version range defined in `core/_setup_utils.py`
     "accelerate",  # version range defined in `core/_setup_utils.py`
-    "gluonts>=0.15.0,<0.17",
+    "gluonts>=0.16.0,<0.17",
     "networkx",  # version range defined in `core/_setup_utils.py`
     "statsforecast>=1.7.0,<1.8",
     "mlforecast==0.13.4",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Increase the lower bound for GluonTS to 0.16.0 since 0.15.* does not provide covariates support for PatchTST (which results in model crashing).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
