### PR TITLE
[Tutorial] categorical convert_to_text default value

### DIFF
--- a/docs/tutorials/multimodal/advanced_topics/customization.ipynb
+++ b/docs/tutorials/multimodal/advanced_topics/customization.ipynb
@@ -1604,9 +1604,9 @@
    "source": [
     "```\n",
     "# default used by AutoMM\n",
-    "predictor.fit(hyperparameters={\"data.categorical.convert_to_text\": True})\n",
-    "# turn off the conversion\n",
     "predictor.fit(hyperparameters={\"data.categorical.convert_to_text\": False})\n",
+    "# turn on the conversion\n",
+    "predictor.fit(hyperparameters={\"data.categorical.convert_to_text\": True})\n",
     "```\n"
    ]
   },


### PR DESCRIPTION
Update the documentation to reflect that the default value of `data.categorical.convert_to_text` is set to `False`.

*Issue #, if available:*
see [4678](https://github.com/autogluon/autogluon/issues/4678)

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
