### PR TITLE
Disable callbacks for parallel fit_strategy

### DIFF
--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -2439,7 +2439,7 @@ class AbstractTrainer:
         """
         if self._callback_early_stop:
             return []
-        check_callbacks = k_fold_start == 0 and n_repeat_start == 0
+        check_callbacks = k_fold_start == 0 and n_repeat_start == 0 and not is_ray_worker
         skip_model = False
         if self.callbacks and check_callbacks:
             skip_model, time_limit = self._callbacks_before_fit(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Disable callbacks for parallel fit_strategy
- This ensures that callbacks aren't used when parallel mode is enabled, as callback support in parallel mode is not implemented.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
