### PR TITLE
Pinned Jinja2 version as pip requirement to the bokeh installation notice

### DIFF
--- a/core/src/autogluon/core/utils/plots.py
+++ b/core/src/autogluon/core/utils/plots.py
@@ -166,7 +166,7 @@ def mousover_plot(
             from bokeh.palettes import Category20
             from bokeh.plotting import ColumnDataSource, figure, output_file, save, show
     except ImportError:
-        warnings.warn('AutoGluon summary plots cannot be created because bokeh is not installed. To see plots, please do: "pip install bokeh==2.0.1"')
+        warnings.warn('AutoGluon summary plots cannot be created because bokeh is not installed. To see plots, please do: "pip install bokeh==2.0.1 Jinja2==3.0.3"')
         return None
 
     n = len(datadict[attr_x])


### PR DESCRIPTION
When calling predictor.fit_summary(), users will receive a warning message that bokeh is not installed and thus no plots can be visualized. The warning message suggests to install bokeh==2.0.1. However this version does not play well with the current Jinja2 version 3.1.4. see https://github.com/holoviz/panel/issues/3260


*Description of changes:*
I added a pinned  Jinja2==3.0.3 to the pip install command

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
