### PR TITLE
[timeseries] fix timeseries test_metrics.py failure

### DIFF
--- a/timeseries/tests/unittests/test_metrics.py
+++ b/timeseries/tests/unittests/test_metrics.py
@@ -332,5 +332,5 @@ def test_when_better_predictions_passed_to_metric_then_score_improves(metric_nam
 def test_when_experimental_metric_name_used_then_predictor_can_score(metric_name):
     predictor = TimeSeriesPredictor(prediction_length=3, eval_metric=metric_name)
     predictor.fit(DUMMY_TS_DATAFRAME, hyperparameters={"DeepAR": {"max_epochs": 1, "num_batches_per_epoch": 1}})
-    score = predictor.score(DUMMY_TS_DATAFRAME)
-    assert np.isfinite(score["WCD"])
+    evaluation_results = predictor.evaluate(DUMMY_TS_DATAFRAME)
+    assert np.isfinite(evaluation_results["WCD"])


### PR DESCRIPTION
**Issue**
The Timeseries Platform test is failing.

***Description of changes**:*

Replace deprecated score() with evaluate() in experimental metric test

- Update **test_when_experimental_metric_name_used_then_predictor_can_score** to use evaluate() instead of score()
- Fix test failures caused by deprecated method usage

**Note :** The change addresses ValueError raised when using deprecated score() method that will be removed in version 1.2.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

cc @Innixma @shchur @zhiqiangdon @gradientsky @yinweisu @sxjscience @FANGAreNotGnu @canerturkmen @jwmueller @prateekdesai04 @tonyhoo
