### PR TITLE
[timeseries] Do not try to compute OOF evaluations for "_FULL" models

### DIFF
--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -1429,17 +1429,17 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
         trainer = self._trainer
         train_data = trainer.load_train_data()
         val_data = trainer.load_val_data()
-        base_models = trainer.get_model_names(level=0)
+        base_model_names = trainer.get_model_names(level=0)
         pred_proba_dict_val: Dict[str, List[TimeSeriesDataFrame]] = {
-            model: trainer._get_model_oof_predictions(model) for model in base_models
-            if "_FULL" not in model
+            model_name: trainer._get_model_oof_predictions(model_name) for model_name in base_model_names
+            if "_FULL" not in model_name
         }
 
         past_data, known_covariates = test_data.get_model_inputs_for_scoring(
             prediction_length=self.prediction_length, known_covariates_names=trainer.metadata.known_covariates
         )
         pred_proba_dict_test: Dict[str, TimeSeriesDataFrame] = trainer.get_model_pred_dict(
-            base_models, data=past_data, known_covariates=known_covariates
+            base_model_names, data=past_data, known_covariates=known_covariates
         )
 
         y_val: List[TimeSeriesDataFrame] = [

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -1431,7 +1431,8 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
         val_data = trainer.load_val_data()
         base_model_names = trainer.get_model_names(level=0)
         pred_proba_dict_val: Dict[str, List[TimeSeriesDataFrame]] = {
-            model_name: trainer._get_model_oof_predictions(model_name) for model_name in base_model_names
+            model_name: trainer._get_model_oof_predictions(model_name)
+            for model_name in base_model_names
             if "_FULL" not in model_name
         }
 

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -1432,6 +1432,7 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
         base_models = trainer.get_model_names(level=0)
         pred_proba_dict_val: Dict[str, List[TimeSeriesDataFrame]] = {
             model: trainer._get_model_oof_predictions(model) for model in base_models
+            if "_FULL" not in model
         }
 
         past_data, known_covariates = test_data.get_model_inputs_for_scoring(


### PR DESCRIPTION
*Description of changes:*
When setting `refit_full=True`, compatible models are re-trained on the full dataset, and the resulting models are saved with a `"_FULL"` suffix in the list of base models. This creates an issue in `predictor._simulation_artifact`, where we simply retrieve the already-computed OOF evaluations of each available model from disk, to be then stored in the `simulation_artifact` dict. These are not available for the `"_FULL"` models, and thus currently the code fails with an error of the form
```
FileNotFoundError: [Errno 2] No such file or directory: '/local/home/user/autogluon/AutogluonModels/ag-20241211_105202/models/DeepAR/DeepAR_FULL/utils/oof.pkl'
```
This PR fixes this issue by skipping any `"_FULL"` model in this step.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
