### PR TITLE
use slash command arg for pr-sha

### DIFF
--- a/.github/workflows/slash_command_dispatch.yml
+++ b/.github/workflows/slash_command_dispatch.yml
@@ -9,20 +9,21 @@ jobs:
     steps:
       - name: Get PR SHA
         id: sha
-        uses: actions/github-script@v4
+        uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |
-            const { owner, repo, number } = context.issue;
-            const pr = await github.pulls.get({
-              owner,
-              repo,
-              pull_number: number,
-            });
-            return pr.data.head.sha
+            const body = context.payload.comment.body.trim();
+            const commandRegex = /^\/platform_tests\s+([a-f0-9]{40})$/;
+            const match = body.match(commandRegex);
+            if (!match) {
+              throw new Error("Invalid command format. Please provide a full 40-character SHA as an argument.");
+            }
+            console.log(`Extracted SHA: "${match[1]}"`);
+            return match[1];
       - name: Get PR number
         id: pr_number
-        uses: actions/github-script@v4
+        uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR fixes a security concern that /platform_tests might pick up a malicious commit sent within the very brief timing gap between when a maintainer sends out `/platform_tests` comment, and when the action dequeues and picks up the new malicious commit sha because it currently checks out the PR sha automatically. With this PR, it requires the maintainer to supply the commit sha in the slash command, and avoids the potential risk of running a malicious commit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
