### PR TITLE
[timeseries] Update version ranges for statsforecast & coreforecast

### DIFF
--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -34,7 +34,7 @@ install_requires = [
     "networkx",  # version range defined in `core/_setup_utils.py`
     "statsforecast>=1.7.0,<2.0.1",
     "mlforecast>0.13,<0.14",
-    "utilsforecast>=0.2.3,<0.2.5",  # to prevent breaking changes that propagate through mlforecast's dependency
+    "utilsforecast>=0.2.3,<0.2.11",  # to prevent breaking changes that propagate through mlforecast's dependency
     "coreforecast>=0.0.12,<0.0.16",  # to prevent breaking changes that propagate through mlforecast's dependency
     "fugue>=0.9.0",  # prevent dependency clash with omegaconf
     "tqdm",  # version range defined in `core/_setup_utils.py`

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -32,10 +32,10 @@ install_requires = [
     "accelerate",  # version range defined in `core/_setup_utils.py`
     "gluonts>=0.15.0,<0.17",
     "networkx",  # version range defined in `core/_setup_utils.py`
-    "statsforecast>=1.7.0,<1.8",
-    "mlforecast==0.13.4",
+    "statsforecast>=1.7.0,<2.0.1",
+    "mlforecast>0.13,<0.14",
     "utilsforecast>=0.2.3,<0.2.5",  # to prevent breaking changes that propagate through mlforecast's dependency
-    "coreforecast==0.0.12",  # to prevent breaking changes that propagate through mlforecast's dependency
+    "coreforecast>=0.0.12,<0.0.16",  # to prevent breaking changes that propagate through mlforecast's dependency
     "fugue>=0.9.0",  # prevent dependency clash with omegaconf
     "tqdm",  # version range defined in `core/_setup_utils.py`
     "orjson~=3.9",  # use faster JSON implementation in GluonTS


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Bump version ranges to StatsForecast, MLForecast and coreforecast

These contain no breaking changes so we can safely upgrade.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
