### PR TITLE
[tabular] Fix possible type error in balanced_accuracy

### DIFF
--- a/core/src/autogluon/core/metrics/classification_metrics.py
+++ b/core/src/autogluon/core/metrics/classification_metrics.py
@@ -23,11 +23,7 @@ def balanced_accuracy(solution, prediction):
     if y_type not in ["binary", "multiclass", "multilabel-indicator"]:
         raise ValueError(f"{y_type} is not supported")
 
-    if y_type == "binary":
-        # Do not transform into any multiclass representation
-        pass
-
-    elif y_type == "multiclass":
+    if y_type == "multiclass" or any(isinstance(item, str) for item in prediction):
         n = len(solution)
         unique_sol, encoded_sol = np.unique(solution, return_inverse=True)
         unique_pred, encoded_pred = np.unique(prediction, return_inverse=True)
@@ -41,7 +37,8 @@ def balanced_accuracy(solution, prediction):
         pred_ohe[np.arange(n), map_pred[encoded_pred]] = 1
         solution = sol_ohe
         prediction = pred_ohe
-
+    elif y_type == "binary":
+        pass
     elif y_type == "multilabel-indicator":
         solution = solution.toarray()
         prediction = prediction.toarray()


### PR DESCRIPTION
*Issue #, if available:*
#4590 4590
*Description of changes:*

In a multicategorization problem, predictions will not be converted to onehot to be passed to `balanced_accuracy`.
This causes an error when a test dataset containing only two categories is used in a multiclass task:
1. since it is a multiclass problem, the data will not be transformed before being passed to `balanced_accuracy`
2. since it contains only two categories, `balanced_accuracy` will guess that it is a binary problem and the data will not be transformed
So the data without onehot conversion is passed to the evaluation section

I think this modification may not be perfect, the best way would be to pass the problem type before passing it to the evaluation function, instead of relying on the data to guess.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
