### PR TITLE
Update tabular tutorial wording

### DIFF
--- a/docs/tutorials/tabular/tabular-indepth.ipynb
+++ b/docs/tutorials/tabular/tabular-indepth.ipynb
@@ -175,9 +175,7 @@
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "In the above example, the predictive performance may be poor because we specified very little training to ensure quick runtimes.  You can call `fit()` multiple times while modifying the above settings to better understand how these choices affect performance outcomes. For example: you can comment out the `train_data.head` command or increase `subsample_size` to train using a larger dataset, increase the `num_epochs` and `num_boost_round` hyperparameters, and increase the `time_limit` (which you should do for all code in these tutorials).  To see more detailed output during the execution of `fit()`, you can also pass in the argument: `verbosity = 3`."
-   ],
+   "source": "In the above example, the predictive performance may be poor because we specified very little training to ensure quick runtimes.  You can call `fit()` multiple times while modifying the above settings to better understand how these choices affect performance outcomes. For example: you can increase `subsample_size` to train using a larger dataset, increase the `num_epochs` and `num_boost_round` hyperparameters, and increase the `time_limit` (which you should do for all code in these tutorials).  To see more detailed output during the execution of `fit()`, you can also pass in the argument: `verbosity=3`.",
    "metadata": {
     "collapsed": false
    },


### PR DESCRIPTION
*Issue #, if available:*

Resolves #3542

*Description of changes:*

Fixes wording in tutorial to not mention commenting out train_data.head

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
