### PR TITLE
Increase tabpfn version min

### DIFF
--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -52,7 +52,8 @@ extras_require = {
         "fastai>=2.3.1,<2.8",  # <{N+1} upper cap, where N is the latest released minor version
     ],
     "tabpfn": [
-        "tabpfn>=0.1,<0.2",  # <{N+1} upper cap, where N is the latest released minor version
+        # versions below 0.1.11 are broken
+        "tabpfn>=0.1.11,<0.2",  # <{N+1} upper cap, where N is the latest released minor version
     ],
     "tabpfnmix": [
         "torch",  # version range defined in `core/_setup_utils.py`


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Increase tabpfn version min as lower versions are broken after the TabPFN v2 release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
