### PR TITLE
[tabular] Fix NN_TORCH batch_size < 8

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -156,12 +156,26 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
 
         return processor_kwargs, optimizer_kwargs, fit_kwargs, loss_kwargs, params
 
-    def _fit(self, X, y, X_val=None, y_val=None, time_limit=None, sample_weight=None, num_cpus=1, num_gpus=0, reporter=None, verbosity=2, **kwargs):
+    def _fit(
+        self,
+        X: pd.DataFrame,
+        y: pd.Series,
+        X_val: pd.DataFrame = None,
+        y_val: pd.Series = None,
+        X_test: pd.DataFrame = None,
+        y_test: pd.Series = None,
+        time_limit: float = None,
+        sample_weight=None,
+        num_cpus: int = 1,
+        num_gpus: float = 0,
+        reporter=None,
+        verbosity: int = 2,
+        **kwargs,
+    ):
         try_import_torch()
         import torch
 
         torch.set_num_threads(num_cpus)
-        from .tabular_torch_dataset import TabularTorchDataset
 
         start_time = time.time()
 
@@ -188,19 +202,20 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
             self.num_dataloading_workers = 0  # TODO: verify 0 is typically faster and uses less memory than 1 in pytorch
         self.num_dataloading_workers = 0  # TODO: >0 crashes on MacOS
         self.max_batch_size = params.pop("max_batch_size", 512)
+
+        train_dataset = self._generate_dataset(X=X, y=y, train_params=processor_kwargs, is_train=True)
+        if X_val is not None and y_val is not None:
+            val_dataset = self._generate_dataset(X=X_val, y=y_val)
+        else:
+            val_dataset = None
+        if X_test is not None and y_test is not None:
+            test_dataset = self._generate_dataset(X=X_test, y=y_test)
+        else:
+            test_dataset = None
+
         batch_size = params.pop("batch_size", None)
         if batch_size is None:
-            if isinstance(X, TabularTorchDataset):
-                batch_size = min(int(2 ** (3 + np.floor(np.log10(len(X))))), self.max_batch_size)
-            else:
-                batch_size = min(int(2 ** (3 + np.floor(np.log10(X.shape[0])))), self.max_batch_size)
-
-        X_test = kwargs.get("X_test", None)
-        y_test = kwargs.get("y_test", None)
-
-        train_dataset = self._generate_dataset(X, y, train_params=processor_kwargs, is_train=True)
-        val_dataset = self._generate_dataset(X_val, y_val)
-        test_dataset = self._generate_dataset(X_test, y_test)
+            batch_size = min(int(2 ** (3 + np.floor(np.log10(len(X))))), self.max_batch_size, len(X))
 
         logger.log(
             15,
@@ -255,16 +270,16 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
 
     def _train_net(
         self,
-        train_dataset,
-        loss_kwargs,
-        batch_size,
-        num_epochs,
-        epochs_wo_improve,
-        val_dataset=None,
-        test_dataset=None,
-        time_limit=None,
+        train_dataset: TabularTorchDataset,
+        loss_kwargs: dict,
+        batch_size: int,
+        num_epochs: int,
+        epochs_wo_improve: int,
+        val_dataset: TabularTorchDataset = None,
+        test_dataset: TabularTorchDataset = None,
+        time_limit: float = None,
         reporter=None,
-        verbosity=2,
+        verbosity: int = 2,
     ):
         import torch
 
@@ -634,7 +649,7 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
         preds_dataset = np.concatenate(preds_dataset, 0)
         return preds_dataset
 
-    def _generate_dataset(self, X: pd.DataFrame, y: pd.Series, train_params: dict = {}, is_train: bool = False):
+    def _generate_dataset(self, X: pd.DataFrame, y: pd.Series, train_params: dict = {}, is_train: bool = False) -> "TabularTorchDataset":
         """
         Generate TabularTorchDataset from X and y.
 
@@ -676,14 +691,11 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
                     use_ngram_features=use_ngram_features,
                 )
         else:
-            if X is not None:
-                if isinstance(X, TabularTorchDataset):
-                    dataset = X
-                else:
-                    X = self.preprocess(X)
-                    dataset = self._process_test_data(df=X, labels=y)
+            if isinstance(X, TabularTorchDataset):
+                dataset = X
             else:
-                dataset = None
+                X = self.preprocess(X)
+                dataset = self._process_test_data(df=X, labels=y)
 
         return dataset
 

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -649,13 +649,13 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
         preds_dataset = np.concatenate(preds_dataset, 0)
         return preds_dataset
 
-    def _generate_dataset(self, X: pd.DataFrame, y: pd.Series, train_params: dict = {}, is_train: bool = False) -> "TabularTorchDataset":
+    def _generate_dataset(self, X: pd.DataFrame | TabularTorchDataset, y: pd.Series, train_params: dict = {}, is_train: bool = False) -> TabularTorchDataset:
         """
         Generate TabularTorchDataset from X and y.
 
         Params:
         -------
-        X: pd.DataFrame
+        X: pd.DataFrame | TabularTorchDataset
             The X data.
         y: pd.Series
             The y data.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes crash that occurs when the number of training samples is < 8 for NeuralNetTorch.

If the number of samples is <8, then NeuralNetTorch will skip doing any training at all because the data loader will only load exactly N samples, where the lowest batch size N is 8. Because N = 8 is greater than the number of training samples, no training occurs.

This PR fixes this by ensuring that batch_size is no larger than len(X), allowing it to be lower than 8.

Additionally, I did logic cleanup and added type hints.

Example code that fails in mainline but works in this PR:

```
from autogluon.tabular import TabularPredictor
from autogluon_benchmark.tasks.task_wrapper import OpenMLTaskWrapper


if __name__ == '__main__':
    task = OpenMLTaskWrapper.from_name(dataset="adult")

    train_data, test_data = task.get_train_test_split_combined(
        fold=0,
        train_size=6,
    )
    label = task.label
    problem_type = task.problem_type

    predictor = TabularPredictor(label=label, problem_type=problem_type, eval_metric="log_loss")

    predictor = predictor.fit(
        train_data=train_data,
        hyperparameters={
            "NN_TORCH": [{}],
        },
    )

    leaderboard = predictor.leaderboard(test_data, display=True)
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
