### PR TITLE
Add `test_version.py`

### DIFF
--- a/common/tests/unittests/test_version.py
+++ b/common/tests/unittests/test_version.py
@@ -1,0 +1,18 @@
+from packaging import version
+
+from autogluon.common import __version__
+
+
+def test_version_has_major_minor_micro():
+    """
+    Verifies that the version contains a major minor and micro version explicitly.
+
+    For example, `__version__ = "1.2"` will fail this test because it does not contain an explicit micro version.
+    """
+    v = version.parse(__version__)
+
+    major = v.major
+    minor = v.minor
+    micro = v.micro
+
+    assert __version__.startswith(f"{major}.{minor}.{micro}")

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -89,8 +89,8 @@ def create_version_file(*, version, submodule):
         version_path = os.path.join(AUTOGLUON_ROOT_PATH, AUTOGLUON, "src", AUTOGLUON, "version.py")
     with open(version_path, "w") as f:
         f.write(f'"""This is the {AUTOGLUON} version file."""\n')
-        f.write("__version__ = '{}'\n".format(version))
-        f.write("__lite__ = {}\n".format(LITE_MODE))
+        f.write(f'\n__version__ = "{version}"\n')
+        f.write(f"__lite__ = {LITE_MODE}\n")
 
 
 def default_setup_args(*, version, submodule):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add `test_version.py` to ensure that we don't accidentally do a release with a version that doesn't include an explicit micro / minor version. For example, we released `1.2` instead of `1.2.0`. While `1.2` is technically valid, it causes issues with some AWS logic such as docker builds that expect an explicit micro version.
- Update the way we create our `version.py` file so the content aligns with the ruff formater. Previously it complained that the version file lacked a newline and should use `"` instead of `'` for string values. This would lead to unnecessary clutter and confusing when users would perform automated linting prior to submitting a PR.

Example of the previous confusing lint message:

```
ruff format --diff "timeseries/"
--- timeseries/src/autogluon/timeseries/version.py
+++ timeseries/src/autogluon/timeseries/version.py
@@ -1,2 +1,3 @@
 """This is the autogluon version file."""
-__version__ = '1.2'
+
+__version__ = "1.2"

1 file would be reformatted, 65 files already formatted

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
