### PR TITLE
[timeseries] Remove _cached_freq attribute for TimeSeriesDataFrame

### DIFF
--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -446,12 +446,12 @@ class TimeSeriesDataFrame(pd.DataFrame):
 
         self._static_features = value
 
-    def infer_frequency(self, num_items: Optional[int] = 100, raise_if_irregular: bool = False) -> str:
+    def infer_frequency(self, num_items: Optional[int] = None, raise_if_irregular: bool = False) -> str:
         """Infer the time series frequency based on the timestamps of the observations.
 
         Parameters
         ----------
-        num_items : int or None, default = 100
+        num_items : int or None, default = None
             Number of items (individual time series) randomly selected to infer the frequency. Lower values speed up
             the method, but increase the chance that some items with invalid frequency are missed by subsampling.
 
@@ -519,7 +519,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
         Computed using a random subset of the time series for speed. This may sometimes result in incorrectly inferred
         values. For reliable results, use :meth:`~autogluon.timeseries.TimeSeriesDataFrame.infer_frequency`.
         """
-        inferred_freq = self.infer_frequency()
+        inferred_freq = self.infer_frequency(num_items=50)
         return None if inferred_freq == IRREGULAR_TIME_INDEX_FREQSTR else inferred_freq
 
     @property
@@ -1006,8 +1006,6 @@ class TimeSeriesDataFrame(pd.DataFrame):
                 2021-12-31    26.0
         """
         offset = pd.tseries.frequencies.to_offset(freq)
-        if self.freq == offset.freqstr:
-            return self
 
         # We need to aggregate categorical columns separately because .agg("mean") deletes all non-numeric columns
         aggregation = {}

--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -115,16 +115,6 @@ class TimeSeriesDataFrame(pd.DataFrame):
         Number of CPU cores used to process the iterable dataset in parallel. Set to -1 to use all cores. This argument
         is only used when constructing a TimeSeriesDataFrame using format 4 (iterable dataset).
 
-    Attributes
-    ----------
-    freq : str
-        A pandas-compatible string describing the frequency of the time series. For example ``"D"`` for daily data,
-        ``"h"`` for hourly data, etc. This attribute is determined automatically based on the timestamps. For the full
-        list of possible values, see `pandas documentation <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases>`_.
-    num_items : int
-        Number of items (time series) in the data set.
-    item_ids : pd.Index
-        List of unique time series IDs contained in the data set.
     """
 
     index: pd.MultiIndex
@@ -394,6 +384,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
 
     @property
     def item_ids(self) -> pd.Index:
+        """List of unique time series IDs contained in the data set."""
         return self.index.unique(level=ITEMID)
 
     @classmethod
@@ -523,11 +514,17 @@ class TimeSeriesDataFrame(pd.DataFrame):
 
     @property
     def freq(self):
+        """Inferred pandas-compatible frequency of the timestamps in the data frame.
+
+        Computed using a random subset of the time series for speed. This may sometimes result in incorrectly inferred
+        values. For reliable results, use :meth:`~autogluon.timeseries.TimeSeriesDataFrame.infer_frequency`.
+        """
         inferred_freq = self.infer_frequency()
         return None if inferred_freq == IRREGULAR_TIME_INDEX_FREQSTR else inferred_freq
 
     @property
     def num_items(self):
+        """Number of items (time series) in the data set."""
         return len(self.item_ids)
 
     def num_timesteps_per_item(self) -> pd.Series:

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -442,10 +442,7 @@ class AbstractTimeSeriesModel(AbstractModel):
 
         if self.covariate_regressor is not None:
             if known_covariates is None:
-                forecast_index = get_forecast_horizon_index_ts_dataframe(
-                    data, prediction_length=self.prediction_length, freq=self.freq
-                )
-                known_covariates = pd.DataFrame(index=forecast_index, dtype="float32")
+                known_covariates = pd.DataFrame(index=self.get_forecast_horizon_index(data), dtype="float32")
 
             predictions = self.covariate_regressor.inverse_transform(
                 predictions,
@@ -456,6 +453,10 @@ class AbstractTimeSeriesModel(AbstractModel):
         if self.target_scaler is not None:
             predictions = self.target_scaler.inverse_transform(predictions)
         return predictions
+
+    def get_forecast_horizon_index(self, data: TimeSeriesDataFrame) -> pd.MultiIndex:
+        """For each item in the dataframe, get timestamps for the next `prediction_length` time steps into the future."""
+        return get_forecast_horizon_index_ts_dataframe(data, prediction_length=self.prediction_length, freq=self.freq)
 
     def _predict(
         self,

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -19,7 +19,6 @@ from autogluon.timeseries.utils.datetime import (
     get_seasonality,
     get_time_features_for_frequency,
 )
-from autogluon.timeseries.utils.forecast import get_forecast_horizon_index_ts_dataframe
 from autogluon.timeseries.utils.warning_filters import warning_filter
 
 from .utils import MLF_ITEMID, MLF_TARGET, MLF_TIMESTAMP
@@ -519,7 +518,7 @@ class DirectTabularModel(AbstractMLForecastModel):
         if known_covariates is not None:
             data_future = known_covariates.copy()
         else:
-            future_index = get_forecast_horizon_index_ts_dataframe(data, self.prediction_length, freq=self.freq)
+            future_index = self.get_forecast_horizon_index(data)
             data_future = pd.DataFrame(columns=[self.target], index=future_index, dtype="float32")
         # MLForecast raises exception of target contains NaN. We use inf as placeholder, replace them by NaN afterwards
         data_future[self.target] = float("inf")
@@ -652,7 +651,7 @@ class RecursiveTabularModel(AbstractMLForecastModel):
         if self._max_ts_length is not None:
             new_df = self._shorten_all_series(new_df, self._max_ts_length)
         if known_covariates is None:
-            future_index = get_forecast_horizon_index_ts_dataframe(data, self.prediction_length, freq=self.freq)
+            future_index = self.get_forecast_horizon_index(data)
             known_covariates = pd.DataFrame(columns=[self.target], index=future_index, dtype="float32")
         X_df = self._to_mlforecast_df(known_covariates, data.static_features, include_target=False)
         # If both covariates & static features are missing, set X_df = None to avoid exception from MLForecast

--- a/timeseries/src/autogluon/timeseries/models/chronos/model.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/model.py
@@ -11,7 +11,6 @@ import pandas as pd
 from autogluon.common.loaders import load_pkl
 from autogluon.timeseries.dataset.ts_dataframe import TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
-from autogluon.timeseries.utils.forecast import get_forecast_horizon_index_ts_dataframe
 from autogluon.timeseries.utils.warning_filters import disable_duplicate_logs, warning_filter
 
 logger = logging.getLogger("autogluon.timeseries.models.chronos")
@@ -631,7 +630,7 @@ class ChronosModel(AbstractTimeSeriesModel):
                 axis=1,
             ),
             columns=["mean"] + [str(q) for q in self.quantile_levels],
-            index=get_forecast_horizon_index_ts_dataframe(data, self.prediction_length, freq=self.freq),
+            index=self.get_forecast_horizon_index(data),
         )
 
         return TimeSeriesDataFrame(df)

--- a/timeseries/src/autogluon/timeseries/models/chronos/pipeline/utils.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/pipeline/utils.py
@@ -253,7 +253,6 @@ class ChronosInferenceDataset:
         assert context_length > 0
         self.context_length = context_length
         self.target_array = target_df[target_column].to_numpy(dtype=np.float32)
-        self.freq = target_df.freq
 
         # store pointer to start:end of each time series
         cum_sizes = target_df.num_timesteps_per_item().values.cumsum()

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -24,7 +24,6 @@ from autogluon.tabular.models.tabular_nn.utils.categorical_encoders import (
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP, TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 from autogluon.timeseries.utils.datetime import norm_freq_str
-from autogluon.timeseries.utils.forecast import get_forecast_horizon_index_ts_dataframe
 from autogluon.timeseries.utils.warning_filters import disable_root_logger, warning_filter
 
 # NOTE: We avoid imports for torch and lightning.pytorch at the top level and hide them inside class methods.
@@ -530,7 +529,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
             predicted_targets = self._predict_gluonts_forecasts(data, known_covariates=known_covariates, **kwargs)
             df = self._gluonts_forecasts_to_data_frame(
                 predicted_targets,
-                forecast_index=get_forecast_horizon_index_ts_dataframe(data, self.prediction_length, freq=self.freq),
+                forecast_index=self.get_forecast_horizon_index(data),
             )
         return df
 

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -462,9 +462,6 @@ class TiDEModel(AbstractGluonTSModel):
     disable_known_covariates : bool, default = False
         If True, known covariates won't be used by the model even if they are present in the dataset.
         If False, known covariates will be used by the model if they are present in the dataset.
-    disable_past_covariates : bool, default = False
-        If True, past covariates won't be used by the model even if they are present in the dataset.
-        If False, past covariates will be used by the model if they are present in the dataset.
     feat_proj_hidden_dim : int, default = 4
         Size of the feature projection layer.
     encoder_hidden_dim : int, default = 64

--- a/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
+++ b/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
@@ -12,7 +12,6 @@ from autogluon.core.utils.exceptions import TimeLimitExceeded
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 from autogluon.timeseries.utils.datetime import get_seasonality
-from autogluon.timeseries.utils.forecast import get_forecast_horizon_index_ts_dataframe
 from autogluon.timeseries.utils.warning_filters import warning_filter
 
 logger = logging.getLogger(__name__)
@@ -134,7 +133,7 @@ class AbstractLocalModel(AbstractTimeSeriesModel):
             )
 
         if "seasonal_period" not in local_model_args or local_model_args["seasonal_period"] is None:
-            local_model_args["seasonal_period"] = get_seasonality(train_data.freq)
+            local_model_args["seasonal_period"] = get_seasonality(self.freq)
         self._seasonal_period = local_model_args["seasonal_period"]
 
         self._local_model_args = self._update_local_model_args(local_model_args=local_model_args)
@@ -183,7 +182,7 @@ class AbstractLocalModel(AbstractTimeSeriesModel):
                 f"({fraction_failed_models:.1%}). Fallback model SeasonalNaive was used for these time series."
             )
         predictions_df = pd.concat([pred for pred, _ in predictions_with_flags])
-        predictions_df.index = get_forecast_horizon_index_ts_dataframe(data, self.prediction_length, freq=self.freq)
+        predictions_df.index = self.get_forecast_horizon_index(data)
         return TimeSeriesDataFrame(predictions_df)
 
     def _predict_wrapper(self, time_series: pd.Series, end_time: Optional[float] = None) -> Tuple[pd.DataFrame, bool]:

--- a/timeseries/src/autogluon/timeseries/models/local/statsforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/local/statsforecast.py
@@ -496,7 +496,7 @@ class AbstractConformalizedStatsForecastModel(AbstractStatsForecastModel):
 
 class AutoCESModel(AbstractProbabilisticStatsForecastModel):
     """Forecasting with an Complex Exponential Smoothing model where the model selection is performed using the
-    Akaike Information Criterion.
+    Akaike Information Criterion [Svetunkov2022]_.
 
     Based on `statsforecast.models.AutoCES <https://nixtla.mintlify.app/statsforecast/docs/models/autoces.html>`_.
 

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -283,7 +283,7 @@ class TimeSeriesPredictor:
         if self.freq is None:
             try:
                 # Use all items for inferring the frequency
-                self.freq = df.infer_frequency(num_items=None, raise_if_irregular=True)
+                data_freq = df.infer_frequency(num_items=None, raise_if_irregular=True)
             except ValueError:
                 raise ValueError(
                     f"Frequency of {name} is not provided and cannot be inferred. Please set the expected data "
@@ -291,11 +291,12 @@ class TimeSeriesPredictor:
                     f"the data has a regular time index with `{name}.convert_frequency(freq=...)`"
                 )
             else:
-                self.freq = df.freq
-                logger.info(f"Inferred time series frequency: '{df.freq}'")
+                self.freq = data_freq
+                logger.info(f"Inferred time series frequency: '{data_freq}'")
         else:
-            if df.freq != self.freq:
-                logger.warning(f"{name} with frequency '{df.freq}' has been resampled to frequency '{self.freq}'.")
+            data_freq = df.infer_frequency(num_items=None)
+            if data_freq != self.freq:
+                logger.warning(f"{name} with frequency '{data_freq}' has been resampled to frequency '{self.freq}'.")
                 df = df.convert_frequency(freq=self.freq)
         return df
 

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -278,7 +278,6 @@ class TimeSeriesPredictor:
         # MultiIndex.is_monotonic_increasing checks if index is sorted by ["item_id", "timestamp"]
         if not df.index.is_monotonic_increasing:
             df = df.sort_index()
-            df._cached_freq = None  # in case frequency was incorrectly cached as IRREGULAR_TIME_INDEX_FREQSTR
 
         # Ensure that data has a regular frequency that matches the predictor frequency
         if self.freq is None:

--- a/timeseries/src/autogluon/timeseries/utils/forecast.py
+++ b/timeseries/src/autogluon/timeseries/utils/forecast.py
@@ -18,6 +18,7 @@ def get_forecast_horizon_index_single_time_series(
     return pd.date_range(start=start_ts, periods=prediction_length, freq=freq, name=TIMESTAMP)
 
 
+# TODO: Deprecate this method, add this functionality to `TimeSeriesPredictor`
 def get_forecast_horizon_index_ts_dataframe(
     ts_dataframe: TimeSeriesDataFrame,
     prediction_length: int,

--- a/timeseries/src/autogluon/timeseries/utils/forecast.py
+++ b/timeseries/src/autogluon/timeseries/utils/forecast.py
@@ -23,7 +23,7 @@ def get_forecast_horizon_index_ts_dataframe(
     prediction_length: int,
     freq: Optional[str] = None,
 ) -> pd.MultiIndex:
-    """For each item in the dataframe, get timestamps for the next prediction_length many time steps into the future.
+    """For each item in the dataframe, get timestamps for the next `prediction_length` time steps into the future.
 
     Returns a pandas.MultiIndex, where
     - level 0 ("item_id") contains the same item_ids as the input ts_dataframe.

--- a/timeseries/tests/unittests/common.py
+++ b/timeseries/tests/unittests/common.py
@@ -164,7 +164,6 @@ def get_data_frame_with_variable_lengths(
             columns=["target"],
         )
     )
-    df.freq  # compute _cached_freq
     df.static_features = static_features
     if covariates_names is not None:
         for i, name in enumerate(covariates_names):

--- a/timeseries/tests/unittests/models/test_local.py
+++ b/timeseries/tests/unittests/models/test_local.py
@@ -121,7 +121,9 @@ def test_when_seasonal_period_is_set_to_none_then_inferred_period_is_used(
     expected_seasonal_period,
 ):
     train_data = get_data_frame_with_item_index(["A", "B", "C"], data_length=ts_length, freq=freqstr)
-    model = model_class(path=temp_model_path, prediction_length=3, hyperparameters=hyperparameters)
+    model = model_class(
+        path=temp_model_path, prediction_length=3, hyperparameters=hyperparameters, freq=train_data.freq
+    )
 
     model.fit(train_data=train_data)
     assert get_seasonal_period_from_fitted_local_model(model) == expected_seasonal_period

--- a/timeseries/tests/unittests/test_splitter.py
+++ b/timeseries/tests/unittests/test_splitter.py
@@ -5,12 +5,6 @@ from autogluon.timeseries.splitter import ExpandingWindowSplitter
 from .common import DATAFRAME_WITH_COVARIATES, DATAFRAME_WITH_STATIC, DUMMY_VARIABLE_LENGTH_TS_DATAFRAME
 
 
-def test_when_splitter_splits_then_cached_freq_is_preserved():
-    splitter = ExpandingWindowSplitter(prediction_length=3, num_val_windows=2)
-    for train_fold, val_fold in splitter.split(DUMMY_VARIABLE_LENGTH_TS_DATAFRAME):
-        assert DUMMY_VARIABLE_LENGTH_TS_DATAFRAME._cached_freq == train_fold._cached_freq == val_fold._cached_freq
-
-
 def test_when_splitter_splits_then_underlying_data_is_not_copied():
     splitter = ExpandingWindowSplitter(prediction_length=3, num_val_windows=2)
     original_df = DATAFRAME_WITH_STATIC.copy()

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -917,10 +917,10 @@ def test_given_index_is_irregular_when_convert_frequency_called_then_new_index_h
     assert df_regular.freq == pd.tseries.frequencies.to_offset(freq).freqstr
 
 
-def test_given_index_is_regular_when_convert_frequency_called_then_original_df_is_returned():
+def test_given_index_is_regular_when_convert_frequency_called_the_df_doesnt_change():
     df = SAMPLE_TS_DATAFRAME.copy()
     df_resampled = df.convert_frequency(freq=df.freq)
-    assert df is df_resampled
+    assert df.equals(df_resampled)
 
 
 def test_when_convert_frequency_called_with_different_freq_then_original_df_is_not_modified():

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -277,30 +277,6 @@ def test_when_dataset_constructed_via_constructor_with_freq_then_freq_is_inferre
     assert ts_df.freq == freq
 
 
-@pytest.mark.parametrize("start_time, freq", FREQ_TEST_CASES)
-def test_when_dataset_constructed_via_constructor_with_freq_and_persisted_then_cached_freq_is_persisted(
-    start_time, freq
-):
-    freq = to_supported_pandas_freq(freq)
-    start_period = pd.Period(start_time, freq={"ME": "M"}.get(freq))
-    item_list = ListDataset(
-        [{"target": [1, 2, 3], "start": start_period} for _ in range(3)],  # type: ignore
-        freq=freq,
-    )
-
-    ts_df = TimeSeriesDataFrame(item_list)
-
-    assert ts_df.freq == freq  # call freq once to cache
-
-    with tempfile.TemporaryDirectory() as td:
-        pkl_filename = Path(td) / "temp_pickle.pkl"
-        ts_df.to_pickle(str(pkl_filename))
-
-        read_df = TimeSeriesDataFrame.from_pickle(pkl_filename)
-
-    assert ts_df._cached_freq == freq == read_df._cached_freq
-
-
 IRREGULAR_TIME_INDEXES = [
     [
         ["2020-01-01 00:00:00", "2020-01-01 00:01:00"],
@@ -344,7 +320,7 @@ def test_when_dataset_constructed_with_irregular_timestamps_then_freq_call_retur
 
 
 @pytest.mark.parametrize("irregular_index", IRREGULAR_TIME_INDEXES)
-def test_when_dataset_constructed_with_irregular_timestamps_then_freq_call_caches_irreg_freqstr(
+def test_when_dataset_constructed_with_irregular_timestamps_then_irregular_freqstr_is_inferred(
     irregular_index,
 ):
     df_tuples = []
@@ -355,8 +331,7 @@ def test_when_dataset_constructed_with_irregular_timestamps_then_freq_call_cache
     df = pd.DataFrame(df_tuples, columns=[ITEMID, TIMESTAMP, "target"])
 
     tsdf = TimeSeriesDataFrame.from_data_frame(df)
-    _ = tsdf.freq
-    assert tsdf._cached_freq == IRREGULAR_TIME_INDEX_FREQSTR
+    assert tsdf.infer_frequency() == IRREGULAR_TIME_INDEX_FREQSTR
 
 
 @pytest.mark.parametrize("irregular_index", IRREGULAR_TIME_INDEXES)
@@ -923,7 +898,6 @@ def test_given_index_is_irregular_when_convert_frequency_called_then_result_has_
 
     # Select random rows & reset cached freq
     df_irregular = df_original.iloc[[2, 5, 7, 10, 14, 15, 16, 33]]
-    df_irregular._cached_freq = None
     df_regular = df_irregular.convert_frequency(freq=freq)
     for idx, value in df_regular.iterrows():
         if idx in df_irregular.index:
@@ -938,7 +912,6 @@ def test_given_index_is_irregular_when_convert_frequency_called_then_new_index_h
     df_original = get_data_frame_with_variable_lengths({"B": 15, "A": 20}, freq=freq, covariates_names=["Y", "X"])
 
     df_irregular = df_original.iloc[[2, 5, 7, 10, 14, 15, 16, 33]]
-    df_irregular._cached_freq = None
     assert df_irregular.freq is None
     df_regular = df_irregular.convert_frequency(freq=freq)
     assert df_regular.freq == pd.tseries.frequencies.to_offset(freq).freqstr
@@ -1020,7 +993,6 @@ def test_when_convert_frequency_called_then_categorical_columns_are_preserved(fr
         df_original[col] = np.random.choice(["foo", "bar", "baz"], size=len(df_original))
     # Select random rows & reset cached freq
     df_irregular = df_original.iloc[[2, 5, 7, 10, 14, 15, 16, 33]]
-    df_irregular._cached_freq = None
     df_regular = df_irregular.convert_frequency(freq=freq)
     assert all(col in df_regular.columns for col in cat_columns)
     assert df_regular.freq == pd.tseries.frequencies.to_offset(freq).freqstr

--- a/timeseries/tests/unittests/utils/test_features.py
+++ b/timeseries/tests/unittests/utils/test_features.py
@@ -47,7 +47,6 @@ def test_when_covariates_present_in_data_then_they_are_included_in_metadata(
     assert metadata.static_features_real == static_features_real
 
 
-@pytest.mark.skipif(sys.version_info[:2] <= (3, 8), reason="np.dtypes not available in Python 3.8")
 def test_when_transform_applied_then_numeric_features_are_converted_to_float32():
     data = get_data_frame_with_covariates(covariates_cat=["cov_cat"], static_features_cat=["static_cat"])
 

--- a/timeseries/tests/unittests/utils/test_features.py
+++ b/timeseries/tests/unittests/utils/test_features.py
@@ -1,5 +1,3 @@
-import sys
-
 import numpy as np
 import pandas as pd
 import pytest


### PR DESCRIPTION
*Issue #, if available:*
- The frequency caching mechanism sometimes results in very weird and hard-to-debug situations when an incorrect data frequency is cached even when resampling is applied.

*Description of changes:*
- Originally, we used `data.freq` to infer the data frequency throughout the codebase, so caching this computation made sense. We can safely remove the caching mechanism now since
  1. Currently, we only infer the frequency once when data is passed to the predictor with `data.infer_frequency()`. In the rest of the code, we pass around the `freq` as a string (e.g., setting it as a model attribute).
  2. The new implementation of `data.freq` is much faster than before, so there is minimal overhead.
- Always use all items when inferring the data frequency inside the `TimeSeriesPredictor`.
- Move the method for creating the forecast horizon index into `AbstractTimeSeriesModel.get_forecast_horizon_index` to avoid code duplication across different models.
- Minor documentation fixes:
  - Fixes #4843
  - Fixes #4844


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
