### PR TITLE
[timeseries] Fix minor CovariateRegressor bugs

### DIFF
--- a/timeseries/src/autogluon/timeseries/regressor.py
+++ b/timeseries/src/autogluon/timeseries/regressor.py
@@ -37,7 +37,7 @@ class CovariateRegressor:
         Metadata object describing the covariates available in the dataset.
     target : str
         Name of the target column.
-    validation_frac : float, optional
+    validation_fraction : float, optional
         Fraction of observations that are reserved as the validation set during training (starting from the end of each
         time series).
     fit_time_fraction: float
@@ -45,6 +45,10 @@ class CovariateRegressor:
         will be reserved for prediction.
 
         If the estimated prediction time exceeds `(1 - fit_time_fraction) * time_limit`, the regressor will be disabled.
+    include_static_features: bool
+        If True, static features will be included as features for the regressor.
+    include_item_id: bool
+        If True, item_id will be included as a categorical feature for the regressor.
     """
 
     def __init__(
@@ -58,6 +62,8 @@ class CovariateRegressor:
         target: str = "target",
         validation_fraction: Optional[float] = 0.1,
         fit_time_fraction: float = 0.5,
+        include_static_features: bool = True,
+        include_item_id: bool = False,
     ):
         if model_name not in TABULAR_MODEL_TYPES:
             raise ValueError(
@@ -72,9 +78,11 @@ class CovariateRegressor:
         self.max_num_samples = max_num_samples
         self.validation_fraction = validation_fraction
         self.fit_time_fraction = fit_time_fraction
+        self.include_static_features = include_static_features
+        self.include_item_id = include_item_id
 
         self.model: Optional[AbstractModel] = None
-        self.disabled_due_to_time_limit = False
+        self.disabled_during_inference = False
         self.metadata = metadata or CovariateMetadata()
 
     def is_fit(self) -> bool:
@@ -87,18 +95,21 @@ class CovariateRegressor:
         tabular_df = tabular_df.query(f"{self.target}.notnull()")
 
         median_ts_length = data.num_timesteps_per_item().median()
+        features_to_drop = [self.target]
+        if not self.include_item_id:
+            features_to_drop += [ITEMID]
         if self.validation_fraction is not None:
             grouped_df = tabular_df.groupby(ITEMID, observed=False, sort=False)
             val_size = max(int(self.validation_fraction * median_ts_length), 1)
             train_df = self._subsample_df(grouped_df.head(-val_size))
             val_df = self._subsample_df(grouped_df.tail(val_size))
-            X = train_df.drop(columns=[self.target])
+            X = train_df.drop(columns=features_to_drop)
             y = train_df[self.target]
-            X_val = val_df.drop(columns=[self.target])
+            X_val = val_df.drop(columns=features_to_drop)
             y_val = val_df[self.target]
         else:
             tabular_df = self._subsample_df(tabular_df)
-            X = tabular_df.drop(columns=[self.target])
+            X = tabular_df.drop(columns=features_to_drop)
             y = tabular_df[self.target]
             X_val = None
             y_val = None
@@ -110,27 +121,35 @@ class CovariateRegressor:
                 "ag_args_fit": {"predict_1_batch_size": 10000},  # needed to compute predict_1_time
             },
             eval_metric=self.tabular_eval_metric,
+            # Has no effect since the model won't be saved to disk.
+            # We provide path to avoid https://github.com/autogluon/autogluon/issues/4832
+            path="",
         )
         if time_limit is not None:
             time_limit_fit = self.fit_time_fraction * (time_limit - (time.monotonic() - start_time))
         else:
             time_limit_fit = None
-        self.model.fit(X=X, y=y, X_val=X_val, y_val=y_val, time_limit=time_limit_fit, **kwargs)
+        # Don't fit if all features are constant to avoid autogluon.core.utils.exceptions.NoValidFeatures
+        if (X.nunique() <= 1).all():
+            logger.warning("\tDisabling the covariate_regressor since all features are constant.")
+            self.disabled_during_inference = True
+        else:
+            self.model.fit(X=X, y=y, X_val=X_val, y_val=y_val, time_limit=time_limit_fit, **kwargs)
 
-        if time_limit is not None:
-            time_left = time_limit - (time.monotonic() - start_time)
-            assert self.model.predict_1_time is not None
-            estimated_predict_time = self.model.predict_1_time * len(data)
-            if estimated_predict_time > time_left:
-                logger.warning(
-                    f"\tDisabling the covariate_regressor since {estimated_predict_time=:.1f} exceeds {time_left=:.1f}."
-                )
-                self.disabled_due_to_time_limit = True
+            if time_limit is not None:
+                time_left = time_limit - (time.monotonic() - start_time)
+                assert self.model.predict_1_time is not None
+                estimated_predict_time = self.model.predict_1_time * len(data)
+                if estimated_predict_time > time_left:
+                    logger.warning(
+                        f"\tDisabling the covariate_regressor since {estimated_predict_time=:.1f} exceeds {time_left=:.1f}."
+                    )
+                    self.disabled_during_inference = True
         return self
 
     def transform(self, data: TimeSeriesDataFrame) -> TimeSeriesDataFrame:
         """Subtract the tabular regressor predictions from the target column."""
-        if not self.disabled_due_to_time_limit:
+        if not self.disabled_during_inference:
             y_pred = self._predict(data, static_features=data.static_features)
             data = data.assign(**{self.target: data[self.target] - y_pred})
         return data
@@ -149,7 +168,7 @@ class CovariateRegressor:
         static_features: Optional[pd.DataFrame],
     ) -> TimeSeriesDataFrame:
         """Add the tabular regressor predictions to the target column."""
-        if not self.disabled_due_to_time_limit:
+        if not self.disabled_during_inference:
             y_pred = self._predict(known_covariates, static_features=static_features)
             predictions = predictions.assign(**{col: predictions[col] + y_pred for col in predictions.columns})
         return predictions
@@ -158,6 +177,8 @@ class CovariateRegressor:
         """Construct the tabular features matrix and make predictions"""
         assert self.model is not None, "CovariateRegressor must be fit before calling predict."
         tabular_df = self._get_tabular_df(data, static_features=static_features)
+        if not self.include_item_id:
+            tabular_df = tabular_df.drop(columns=[ITEMID])
         return self.model.predict(X=tabular_df)
 
     def _get_tabular_df(
@@ -171,7 +192,7 @@ class CovariateRegressor:
         if include_target:
             available_columns += [self.target]
         tabular_df = pd.DataFrame(data).reset_index()[available_columns].astype({ITEMID: "category"})
-        if static_features is not None:
+        if static_features is not None and self.include_static_features:
             tabular_df = pd.merge(tabular_df, static_features, on=ITEMID)
         return tabular_df
 

--- a/timeseries/tests/unittests/test_regressor.py
+++ b/timeseries/tests/unittests/test_regressor.py
@@ -216,7 +216,7 @@ def test_when_not_enough_time_is_left_to_predict_then_regressor_is_disabled(df_w
     with mock.patch("autogluon.tabular.models.CatBoostModel.predict", side_effect=predict_with_sleep):
         regressor.fit(df, time_limit=5)
 
-    assert regressor.disabled_during_inference
+    assert regressor.disabled
 
 
 @pytest.mark.parametrize("use_fit_transform", [True, False])
@@ -227,7 +227,7 @@ def test_when_regressor_is_disabled_then_data_is_not_modified_during_transform(
     df, metadata = df_with_covariates_and_metadata
     regressor = CovariateRegressor("LR", **MODEL_HPS, metadata=metadata, refit_during_predict=refit_during_predict)
     regressor.fit(df)
-    regressor.disabled_during_inference = True
+    regressor.disabled = True
     if use_fit_transform:
         df_out = regressor.fit_transform(df)
     else:
@@ -252,5 +252,5 @@ def test_when_all_features_are_constant_then_regressor_is_not_fit():
     )
     regressor = CovariateRegressor("LR", **MODEL_HPS, metadata=metadata)
     regressor.fit(df)
-    assert regressor.disabled_during_inference
+    assert regressor.disabled
     assert not regressor.model.is_fit()

--- a/timeseries/tests/unittests/test_regressor.py
+++ b/timeseries/tests/unittests/test_regressor.py
@@ -11,6 +11,8 @@ from autogluon.timeseries.models.multi_window import MultiWindowBacktestingModel
 from autogluon.timeseries.regressor import CovariateRegressor
 from autogluon.timeseries.utils.features import CovariateMetadata
 
+from .common import DUMMY_TS_DATAFRAME
+
 
 def get_multi_window_zero_model(hyperparameters=None, **kwargs):
     """Wrap ZeroModel inside MultiWindowBacktestingModel."""
@@ -108,11 +110,21 @@ def test_when_data_contains_no_known_covariates_or_static_features_then_regresso
     assert model.covariate_regressor is None
 
 
+@pytest.mark.parametrize("include_static_features", [True, False])
+@pytest.mark.parametrize("include_item_id", [True, False])
 def test_when_regressor_is_used_then_tabular_df_contains_correct_features(
-    df_with_covariates_and_metadata, get_model_with_regressor
+    df_with_covariates_and_metadata,
+    get_model_with_regressor,
+    include_static_features,
+    include_item_id,
 ):
     df, metadata = df_with_covariates_and_metadata
-    model = get_model_with_regressor(ZeroModel, "LR")
+    regressor = CovariateRegressor(
+        model_name="LR",
+        include_static_features=include_static_features,
+        include_item_id=include_item_id,
+    )
+    model = get_model_with_regressor(ZeroModel, regressor)
     with mock.patch("autogluon.tabular.models.LinearModel.fit") as mock_lr_fit:
         try:
             model.fit(train_data=df)
@@ -120,7 +132,12 @@ def test_when_regressor_is_used_then_tabular_df_contains_correct_features(
             # Ignore KeyError produced by mock
             pass
         features = mock_lr_fit.call_args[1]["X"].columns
-    assert set(features) == set(metadata.static_features + metadata.known_covariates + [ITEMID])
+    expected_features = metadata.known_covariates
+    if include_item_id:
+        expected_features += [ITEMID]
+    if include_static_features:
+        expected_features += metadata.static_features
+    assert set(features) == set(expected_features)
 
 
 def test_when_target_scaler_and_regressor_are_used_then_regressor_receives_scaled_data_as_input(
@@ -152,9 +169,9 @@ def test_when_covariate_regressor_used_then_residuals_are_subtracted_before_fore
     df, _ = df_with_covariates_and_metadata
     # Shift the mean of each item; assert that the shift is removed by the regressor before model receives the data
     df["target"] += pd.Series([10, 20, 30, 40], index=df.item_ids)
-    df["covariate"] = np.ones(len(df))
+    df["covariate"] = df.index.get_level_values(ITEMID).astype("category")
     df.static_features = None
-    metadata = CovariateMetadata(known_covariates_real=["covariate"])
+    metadata = CovariateMetadata(known_covariates_cat=["covariate"])
     model = model_class(
         freq=df.freq,
         metadata=metadata,
@@ -199,7 +216,7 @@ def test_when_not_enough_time_is_left_to_predict_then_regressor_is_disabled(df_w
     with mock.patch("autogluon.tabular.models.CatBoostModel.predict", side_effect=predict_with_sleep):
         regressor.fit(df, time_limit=5)
 
-    assert regressor.disabled_due_to_time_limit
+    assert regressor.disabled_during_inference
 
 
 @pytest.mark.parametrize("use_fit_transform", [True, False])
@@ -210,9 +227,30 @@ def test_when_regressor_is_disabled_then_data_is_not_modified_during_transform(
     df, metadata = df_with_covariates_and_metadata
     regressor = CovariateRegressor("LR", **MODEL_HPS, metadata=metadata, refit_during_predict=refit_during_predict)
     regressor.fit(df)
-    regressor.disabled_due_to_time_limit = True
+    regressor.disabled_during_inference = True
     if use_fit_transform:
         df_out = regressor.fit_transform(df)
     else:
         df_out = regressor.transform(df)
     assert df_out is df
+
+
+def test_when_all_features_are_constant_then_regressor_is_not_fit():
+    df = DUMMY_TS_DATAFRAME.copy()
+    df["cov1"] = [0.0] * len(df)
+    df["cov2"] = ["a"] * len(df)
+    df.static_features = pd.DataFrame(
+        {"static1": [0.0] * df.num_items, "static2": ["a"] * df.num_items}, index=df.item_ids
+    )
+    df["cov2"] = df["cov2"].astype("category")
+    df.static_features["static2"] = df.static_features["static2"].astype("category")
+    metadata = CovariateMetadata(
+        known_covariates_real=["cov1"],
+        known_covariates_cat=["cov2"],
+        static_features_real=["static1"],
+        static_features_cat=["static2"],
+    )
+    regressor = CovariateRegressor("LR", **MODEL_HPS, metadata=metadata)
+    regressor.fit(df)
+    assert regressor.disabled_during_inference
+    assert not regressor.model.is_fit()


### PR DESCRIPTION
*Issue #, if available:*
- Fixes #4832
- Fixes #4846

*Description of changes:*
- Add optional arguments `include_static_features` and `include_item_id` to CovariateRegressor that control whether these features are used by the regressor.
- Fix a bug where an empty folder was created during creation of the regression model by the covariate regressor
- Fix a bug where the regressor would fail if all features it receives are constant

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
