### PR TITLE
Fix XGBoost GPU warnings

### DIFF
--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -40,11 +40,8 @@ extras_require = {
         "numpy>=1.25,<2.0.0",  # TODO support numpy>=2.0.0 once issue resolved https://github.com/catboost/catboost/issues/2671
         "catboost>=1.2,<1.3",
     ],
-    # FIXME: Debug why xgboost 1.6 has 4x+ slower inference on multiclass datasets compared to 1.4
-    #  It is possibly only present on MacOS, haven't tested linux.
-    # XGBoost made API breaking changes in 1.6 with custom metric and callback support, so we don't support older versions.
     "xgboost": [
-        "xgboost>=1.6,<2.2",  # <{N+1} upper cap, where N is the latest released minor version
+        "xgboost>=2.0,<2.2",  # <{N+1} upper cap, where N is the latest released minor version
     ],
     "fastai": [
         "spacy<3.8",  # cap for issue https://github.com/explosion/spaCy/issues/13653

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -147,10 +147,11 @@ class XGBoostModel(AbstractModel):
                 eval_set["test"] = (X_test, y_test)
 
         if num_gpus != 0:
-            params["tree_method"] = "gpu_hist"
-            if "gpu_id" not in params:
-                params["gpu_id"] = 0
-        elif "tree_method" not in params:
+            if "device" not in params:
+                # FIXME: figure out which GPUs are available to this model instead of hardcoding GPU 0.
+                #  Need to update BaggedEnsembleModel
+                params["device"] = "cuda:0"
+        if "tree_method" not in params:
             params["tree_method"] = "hist"
 
         try_import_xgboost()


### PR DESCRIPTION
*Issue #, if available:*

#4859

*Description of changes:*

Gets rid of deprecation warnings when using GPU with XGBoost, as the arguments changed in the XGBoost 2.0 release.

This will also remove support for XGBoost 1.x. We could consider keeping it by having an `if version<2:` logic, but unless XGB 1.x is important for some reason, I'll plan to just drop it for simplicity.

Note that I haven't tested this PR yet, so I don't know if it works properly. Would be good for someone with a GPU machine to sanity check it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
