### PR TITLE
[timeseries] refactor dependencies on AbstractModel

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -96,11 +96,11 @@ class AbstractModel:
 
     def __init__(
         self,
-        path: str = None,
-        name: str = None,
-        problem_type: str = None,
-        eval_metric: Union[str, metrics.Scorer] = None,
-        hyperparameters: dict = None,
+        path: str | None = None,
+        name: str | None = None,
+        problem_type: str | None = None,
+        eval_metric: str | metrics.Scorer | None = None,
+        hyperparameters: dict | None = None,
     ):
         if name is None:
             self.name = self.__class__.__name__
@@ -1176,7 +1176,7 @@ class AbstractModel:
             quantile_levels=self.quantile_levels,
         )
 
-    def save(self, path: str = None, verbose: bool = True) -> str:
+    def save(self, path: str | None = None, verbose: bool = True) -> str:
         """
         Saves the model to disk.
 

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -4,7 +4,7 @@ import os
 import re
 import time
 from contextlib import nullcontext
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
 from typing_extensions import Self
@@ -73,23 +73,9 @@ class AbstractTimeSeriesModel(AbstractModel):
     _covariate_regressor_fit_time_fraction: float = 0.5
     default_max_time_limit_ratio: float = 0.9
 
-    # TODO: refactor "pruned" methods after AbstractModel is refactored
-    predict_proba = None
-    score_with_y_pred_proba = None
-    disk_usage = None  # disk / memory size
-    estimate_memory_usage = None
-    reduce_memory_size = None
-    compute_feature_importance = None  # feature processing and importance
-    get_features = None
-    _apply_conformalization = None
-    _apply_temperature_scaling = None
-    _predict_proba = None
-    _convert_proba_to_unified_form = None
-    _compute_permutation_importance = None
-    _estimate_memory_usage = None
-    _preprocess = None
-    _preprocess_nonadaptive = None
-    _preprocess_set_features = None
+    # TODO: This is a hack to override the AbstractModel method, which the HPO module
+    # also circumvents with an ugly None-check.
+    estimate_memory_usage: Callable = None  # type: ignore
 
     _supports_known_covariates: bool = False
     _supports_past_covariates: bool = False

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -337,12 +337,9 @@ class AbstractTimeSeriesModel(AbstractModel):
                     f"\tWarning: Model has no time left to train, skipping model... (Time Left = {time_limit:.1f}s)"
                 )
                 raise TimeLimitExceeded
-        out = self._fit(**kwargs)
-        if out is None:
-            out = self
-        out = out._post_fit(**kwargs)
-        return out
-    
+        self._fit(**kwargs)
+        return self
+
     def _register_fit_metadata(self, **kwargs):
         """
         Used to track properties of the inputs received during fit, such as if validation data was present.

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -204,7 +204,7 @@ class AbstractTimeSeriesModel(AbstractModel):
         if not self._is_initialized:
             self._init_params_aux()
             self._init_params()
-            self._initialize_covariate_scaler_regressor()
+            self._initialize_transforms()
             self._is_initialized = True
 
         # TODO: remove
@@ -213,12 +213,14 @@ class AbstractTimeSeriesModel(AbstractModel):
 
         return kwargs
 
-    def _initialize_covariate_scaler_regressor(self) -> None:
+    def _initialize_transforms(self) -> None:
         self.target_scaler = self._create_target_scaler()
         self.covariate_scaler = self._create_covariate_scaler()
         self.covariate_regressor = self._create_covariate_regressor()
 
     def get_params(self) -> dict:
+        # TODO: do not extract to AbstractModel if this is only used for getting a
+        # prototype of the object for HPO.
         hyperparameters = self._user_params.copy()
         if self._user_params_aux:
             hyperparameters[AG_ARGS_FIT] = self._user_params_aux.copy()
@@ -368,8 +370,7 @@ class AbstractTimeSeriesModel(AbstractModel):
         if original_time_limit != time_limit:
             time_limit_og_str = f"{original_time_limit:.2f}s" if original_time_limit is not None else "None"
             time_limit_str = f"{time_limit:.2f}s" if time_limit is not None else "None"
-            logger.log(
-                20,
+            logger.debug(
                 f"\tTime limit adjusted due to model hyperparameters: "
                 f"{time_limit_og_str} -> {time_limit_str} "
                 f"(ag.max_time_limit={max_time_limit}, "
@@ -449,7 +450,7 @@ class AbstractTimeSeriesModel(AbstractModel):
         the model training logic, `fit` additionally implements other logic such as keeping
         track of the time limit, etc.
         """
-        # TODO: will not extracted to new AbstractModel
+        # TODO: will not be extracted to new AbstractModel
 
         # TODO: Make the models respect `num_cpus` and `num_gpus` parameters
         raise NotImplementedError

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -213,10 +213,6 @@ class AbstractTimeSeriesModel(AbstractModel):
         )
         return fit_metadata
 
-    def _validate_fit_memory_usage(self, **kwargs):
-        # memory usage handling not implemented for timeseries models
-        pass
-
     def get_params(self) -> dict:
         params = super().get_params()
         params.update(
@@ -338,7 +334,6 @@ class AbstractTimeSeriesModel(AbstractModel):
 
         self._register_fit_metadata(**kwargs)
         self.validate_fit_resources(**kwargs)
-        self._validate_fit_memory_usage(**kwargs)
         if time_limit:
             time_start_fit = time.monotonic()
             time_limit -= time_start_fit - time_start
@@ -607,7 +602,6 @@ class AbstractTimeSeriesModel(AbstractModel):
         kwargs = self.initialize(time_limit=time_limit, **kwargs)
 
         self._register_fit_metadata(**kwargs)
-        self._validate_fit_memory_usage(**kwargs)
 
         kwargs = self._preprocess_fit_resources(
             parallel_hpo=hpo_executor.executor_type == "ray", silent=True, **kwargs

--- a/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
+++ b/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
@@ -218,11 +218,14 @@ class MultiWindowBacktestingModel(AbstractTimeSeriesModel):
     def _get_search_space(self):
         return self.model_base._get_search_space()
 
-    def _initialize(self, **kwargs) -> None:
-        self._init_params_aux()
-        self._init_params()
+    def _initialize_covariate_regressor_scaler(self, **kwargs) -> None:
         # Do not initialize the target_scaler and covariate_regressor in the multi window model!
+        pass
+
+    def initialize(self, **kwargs) -> dict:
+        super().initialize(**kwargs)
         self.model_base.initialize(**kwargs)
+        return kwargs
 
     def _get_hpo_train_fn_kwargs(self, **train_fn_kwargs) -> dict:
         train_fn_kwargs["is_bagged_model"] = True


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- This is the first in a line of PRs refactoring the `AbstractModel`. In this first PR we take care of typing in the `AbstractTimeSeriesModel` and pull in some of the methods that depend on their `super()` implementations. We also mark some methods where signatures do not align with `AbstractModel`, as TODO, for refactoring later. 
- The PR also touches `core` for harmless typing corrections.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
