### PR TITLE
[tabular] Fix refit_full crash

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -823,8 +823,8 @@ class AbstractModel:
             self._fit_metadata = self._compute_fit_metadata(**kwargs)
             self._is_fit_metadata_registered = True
 
-    def _compute_fit_metadata(self, X_val: pd.DataFrame = None, X_unlabeled: pd.DataFrame = None, num_cpus: int = None, num_gpus: int = None, **kwargs) -> dict:
-        fit_metadata = dict(val_in_fit=X_val is not None, unlabeled_in_fit=X_unlabeled is not None, num_cpus=num_cpus, num_gpus=num_gpus)
+    def _compute_fit_metadata(self, X: pd.DataFrame = None, X_val: pd.DataFrame = None, X_unlabeled: pd.DataFrame = None, num_cpus: int = None, num_gpus: int = None, **kwargs) -> dict:
+        fit_metadata = dict(num_samples=len(X) if X is not None else None, val_in_fit=X_val is not None, unlabeled_in_fit=X_unlabeled is not None, num_cpus=num_cpus, num_gpus=num_gpus)
         return fit_metadata
 
     def get_fit_metadata(self) -> dict:

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -240,6 +240,66 @@ class BaggedEnsembleModel(AbstractModel):
         _skip_oof: bool = False,
         **kwargs,
     ):
+        """
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            The training data features.
+        y : pd.Series
+            The training data ground truth labels.
+        X_val : pd.DataFrame, default None
+            The validation data features.
+            Ignored by BaggedEnsembleModel.
+        y_val : pd.Series, default None
+            The validation data ground truth labels.
+            Ignored by BaggedEnsembleModel.
+        X_pseudo : pd.DataFrame, default None
+            Pseudo data features.
+            If specified, this data is added to each fold model's training data.
+        y_pseudo : pd.Series, default None
+            Pseudo data ground truth labels.
+            If specified, this data is added to each fold model's training data.
+        k_fold : int | None, default None
+            If int, must be a value >=1. Passing 0 will result in an exception.
+            If >1, will fit with `k_fold` folds per n_repeat.
+                This splits X and y into `k_fold` chunks to fit `k_fold` models, each with `k-1` chunks used for training and the remaining used for validation.
+            If 1, will only fit 1 model using all the training data.
+                This is generally reserved for models which are refits of previously trained bags (along with specifying `_skip_oof=True`).
+                This can also be used for models which support child oof generation (Random Forest, Extra Trees, KNN).
+            If None, defaults to 5 if `groups` is None. Else it will be set based on `groups`.
+        k_fold_start : int, default 0
+            The fold to start fitting on.
+            This allows for fitting only a subset of the bagged ensemble's folds per fit call, if desired.
+        k_fold_end : int, default None
+            The fold to stop fitting on.
+            This allows for fitting only a subset of the bagged ensemble's folds per fit call, if desired.
+            If None, will be set to `k_fold`.
+        n_repeats : int, default 1
+            The number of bagging sets (aka repeats).
+            If 1, will only fit `k_fold` models.
+            If >1, will fit `n_repeats * k_fold` models.
+            For each repeat, will split X and y with an incrementing random seed.
+        n_repeat_start : int, default 0
+            The repeat to start on.
+            This allows for fitting only a subset of the bagged ensemble's repeats per fit call, if desired.
+        groups : pd.Series, default None
+            If specified, will split X and y based on `groups`, with each sample going to a specific group.
+            Overrides `k_fold` and disables `n_repeats>1` if specified.
+        _skip_oof : bool, default False
+            If True, will not calculate the out-of-fold predictions from the fold models.
+            This should be set to True when performing a bagged refit.
+        kwargs : dict,
+            Arguments passed downstream to the fold models.
+
+        Returns
+        -------
+        BaggedEnsembleModel
+            The fitted bagged ensemble model.
+            In most cases this is `self`.
+            If `refit_folds=True`, then instead the refit version of the bagged ensemble is returned.
+
+        """
         use_child_oof = self.params.get("use_child_oof", False)
         if use_child_oof and groups is not None:
             logger.log(20, f"\tForcing `use_child_oof=False` because `groups` is specified")

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -269,6 +269,7 @@ class BaggedEnsembleModel(AbstractModel):
             n_repeat_start=n_repeat_start,
             groups=groups,
             use_child_oof=use_child_oof,
+            skip_oof=_skip_oof,
         )
         if k_fold_end is None:
             k_fold_end = k_fold
@@ -384,6 +385,7 @@ class BaggedEnsembleModel(AbstractModel):
         n_repeat_start: int,
         groups: pd.Series | None,
         use_child_oof: bool,
+        skip_oof: bool,
     ):
         if groups is not None:
             if self._n_repeats_finished != 0:
@@ -419,7 +421,7 @@ class BaggedEnsembleModel(AbstractModel):
                 f"\tTo enable this logic, `{self._child_type.__name__}._predict_proba_oof` must be implemented "
                 f"and `tags['valid_oof'] = True` must be set in `{self._child_type.__name__}._more_tags`."
             )
-        if k_fold == 1 and not use_child_oof and not self._get_tags().get("can_get_oof_from_train", False):
+        if k_fold == 1 and not skip_oof and not use_child_oof and not self._get_tags().get("can_get_oof_from_train", False):
             logger.log(
                 30,
                 f"\tWARNING: Fitting bagged model with `k_fold=1`, "

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -4701,7 +4701,7 @@ def _detached_refit_single_full(
             stack_name=REFIT_FULL_NAME,
             hyperparameter_tune_kwargs=None,
             feature_prune=False,
-            k_fold=0,
+            k_fold=1,
             n_repeats=1,
             ensemble_type=type(model),
             refit_full=True,

--- a/tabular/tests/unittests/models/test_lightgbm.py
+++ b/tabular/tests/unittests/models/test_lightgbm.py
@@ -77,6 +77,18 @@ def test_lightgbm_quantile_model(model_fit_helper):
     )
 
 
+def test_lightgbm_binary_bagged(fit_helper):
+    """Additionally tests that all binary metrics work, and verifies that bagged refit works correctly"""
+    fit_args = dict(
+        hyperparameters={LGBModel: {"ag_args_ensemble": {"fold_fitting_strategy": "sequential_local"}}},
+        num_bag_folds=2,
+    )
+    dataset_name = "adult"
+    extra_metrics = list(METRICS[BINARY])
+
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics)
+
+
 def test_lightgbm_binary_with_calibrate_decision_threshold(fit_helper):
     """Tests that calibrate_decision_threshold works and does not make the validation score worse on the given metric"""
     fit_args = dict(

--- a/tabular/tests/unittests/models/test_rf.py
+++ b/tabular/tests/unittests/models/test_rf.py
@@ -35,6 +35,17 @@ def test_rf_quantile(fit_helper):
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, init_args=init_args)
 
 
+def test_rf_binary_bagged(fit_helper):
+    """Additionally verifies that bagged refit works correctly"""
+    fit_args = dict(
+        hyperparameters={RFModel: {}},
+        num_bag_folds=2,
+    )
+    dataset_name = "adult"
+
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
+
+
 def test_rf_binary_compile_onnx(fit_helper):
     fit_args = dict(
         hyperparameters={RFModel: {}},


### PR DESCRIPTION
*Issue #, if available:*

Resolves #4869 

*Description of changes:*

For the 1.2 release, I refactored the sanity checks in BaggedEnsembleModel, and as part of it, I made it raise an exception if called with `k_fold=0`, as previously we passed both `k_fold=0` and `k_fold=1` to mean the same thing (doing refit_full). However, this actually made refit_full fail to work for models anymore. This wasn't caught in our unit tests because the fallback mechanism which uses the first fold model in case of an error made the unit tests continue to pass.

I've fixed the issue by passing `k_fold=1` instead of `k_fold=0` during refit_full.

I've also added a docstring to clarify this behavior in BaggedEnsembleModel, and a unit test to verify that it is working correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
