### PR TITLE
[CI] fix timeseries platform tests

### DIFF
--- a/.github/workflow_scripts/test_timeseries.sh
+++ b/.github/workflow_scripts/test_timeseries.sh
@@ -15,6 +15,7 @@ python -m pip install --upgrade pytest-xdist
 
 export PYTHONHASHSEED=0  # for consistency in xdist tests
 
+cd timeseries/
 if [ "$IS_PLATFORM_TEST" = 1 ]; then
     python -m pytest --junitxml=results.xml --runslow tests  # run platform tests without multiprocessing
 else

--- a/.github/workflow_scripts/test_timeseries.sh
+++ b/.github/workflow_scripts/test_timeseries.sh
@@ -2,7 +2,9 @@
 
 set -ex
 
-ADDITIONAL_TEST_ARGS=$1
+while getopts ":-:" opt; do
+  [ "$opt" = "-" ] && [ "${OPTARG}" = "is-platform-test" ] && IS_PLATFORM_TEST=1
+done
 
 source $(dirname "$0")/env_setup.sh
 
@@ -11,12 +13,10 @@ export CUDA_VISIBLE_DEVICES=0
 install_local_packages "common/[tests]" "core/[all,tests]" "features/" "tabular/[all,tests]" "timeseries/[all,tests]"
 python -m pip install --upgrade pytest-xdist
 
-export PYTHONHASHSEED=0
+export PYTHONHASHSEED=0  # for consistency in xdist tests
 
-cd timeseries/
-if [ -n "$ADDITIONAL_TEST_ARGS" ]
-then
-    python -m pytest --junitxml=results.xml --runslow "$ADDITIONAL_TEST_ARGS" --numprocesses 4 tests
+if [ "$IS_PLATFORM_TEST" = 1 ]; then
+    python -m pytest --junitxml=results.xml --runslow tests  # run platform tests without multiprocessing
 else
     python -m pytest --junitxml=results.xml --runslow --numprocesses 4 tests
 fi

--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -260,7 +260,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install --channel conda-forge pygraphviz
-          chmod +x ./.github/workflow_scripts/test_timeseries.sh && ./.github/workflow_scripts/test_timeseries.sh "-m not gpu" "true"
+          chmod +x ./.github/workflow_scripts/test_timeseries.sh && ./.github/workflow_scripts/test_timeseries.sh --is-platform-test
 
   install:
     needs: setup


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

#4828 started causing time series platform tests to fail. This disables xdist in platform tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
