### PR TITLE
[timeseries] fix in conftest

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -131,7 +131,7 @@ class AbstractTimeSeriesModel(AbstractModel):
     def __repr__(self) -> str:
         return self.name
 
-    def save(self, path: str | None = None, verbose=True) -> str:
+    def save(self, path: Optional[str] = None, verbose=True) -> str:
         # Save self._oof_predictions as a separate file, not model attribute
         if self._oof_predictions is not None:
             save_pkl.save(

--- a/timeseries/tests/conftest.py
+++ b/timeseries/tests/conftest.py
@@ -10,6 +10,13 @@ _HF_HUB_DEPENDENCIES = [
 ]
 
 
+def download_and_cache_hf_hub_dependencies():
+    from transformers import AutoModel
+
+    for dependency in _HF_HUB_DEPENDENCIES:
+        _ = AutoModel.from_pretrained(dependency)
+
+
 def pytest_addoption(parser):
     parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
 
@@ -45,14 +52,7 @@ def pytest_sessionstart():
     transformers, then the models cannot be downloaded and cached. If it is set after importing transformers,
     HF will have cached HF_HUB_OFFLINE=0 already and the updated environment variable will not take effect.
     """
-
-    def download_and_cache():
-        from transformers import AutoModel
-
-        for dependency in _HF_HUB_DEPENDENCIES:
-            _ = AutoModel.from_pretrained(dependency)
-
-    process = multiprocessing.Process(target=download_and_cache)
+    process = multiprocessing.Process(target=download_and_cache_hf_hub_dependencies)
     process.start()
     process.join()
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

#4773 broke time series platform tests because of how multiprocessing handles function pickling. This fixes that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
