### PR TITLE
[timeseries] add tests for concrete methods in AbstractTimeSeriesModel

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -183,18 +183,12 @@ class AbstractTimeSeriesModel(AbstractModel):
     def _get_default_auxiliary_params(self) -> dict:
         # TODO: refine to values that are absolutely necessary
         return dict(
-            # Ratio of memory usage allowed by the model. Values > 1.0 have an increased risk of causing OOM errors.
-            # Used in memory checks during model training to avoid OOM errors.
-            max_memory_usage_ratio=1.0,
             # ratio of given time_limit to use during fit(). If time_limit == 10 and max_time_limit_ratio=0.3,
             # time_limit would be changed to 3.
             max_time_limit_ratio=self.default_max_time_limit_ratio,
             # max time_limit value during fit(). If the provided time_limit is greater than this value, it will be
             # replaced by max_time_limit. Occurs after max_time_limit_ratio is applied.
             max_time_limit=None,
-            # min time_limit value during fit(). If the provided time_limit is less than this value, it will be replaced
-            # by min_time_limit. Occurs after max_time_limit is applied.
-            min_time_limit=0,
         )
 
     def initialize(self, **kwargs) -> dict:
@@ -357,15 +351,11 @@ class AbstractTimeSeriesModel(AbstractModel):
         original_time_limit = time_limit
         max_time_limit_ratio = self.params_aux["max_time_limit_ratio"]
         max_time_limit = self.params_aux["max_time_limit"]
-        min_time_limit = self.params_aux["min_time_limit"]
 
         time_limit *= max_time_limit_ratio
 
         if max_time_limit is not None:
             time_limit = min(time_limit, max_time_limit)
-
-        if min_time_limit is not None:
-            time_limit = max(time_limit, min_time_limit)
 
         if original_time_limit != time_limit:
             time_limit_og_str = f"{original_time_limit:.2f}s" if original_time_limit is not None else "None"
@@ -374,8 +364,7 @@ class AbstractTimeSeriesModel(AbstractModel):
                 f"\tTime limit adjusted due to model hyperparameters: "
                 f"{time_limit_og_str} -> {time_limit_str} "
                 f"(ag.max_time_limit={max_time_limit}, "
-                f"ag.max_time_limit_ratio={max_time_limit_ratio}, "
-                f"ag.min_time_limit={min_time_limit})",
+                f"ag.max_time_limit_ratio={max_time_limit_ratio}"
             )
 
         return time_limit

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -182,7 +182,7 @@ def get_preset_models(
     freq: Optional[str],
     prediction_length: int,
     path: str,
-    eval_metric: str | TimeSeriesScorer,
+    eval_metric: Union[str, TimeSeriesScorer],
     eval_metric_seasonal_period: Optional[int],
     hyperparameters: Union[str, Dict, None],
     hyperparameter_tune: bool,

--- a/timeseries/tests/unittests/models/test_abstract.py
+++ b/timeseries/tests/unittests/models/test_abstract.py
@@ -1,11 +1,10 @@
-import itertools
-from typing import Optional, Tuple
+from typing import Optional
 from unittest import mock
 
 import pandas as pd
 import pytest
 
-from autogluon.core.constants import AG_ARGS_FIT
+from autogluon.core.constants import AG_ARGS_FIT, REFIT_FULL_SUFFIX
 from autogluon.core.utils.exceptions import TimeLimitExceeded
 from autogluon.timeseries import TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
@@ -17,28 +16,15 @@ from ..common import get_data_frame_with_item_index
 class ConcreteTimeSeriesModel(AbstractTimeSeriesModel):
     """A dummy model that predicts 42s, implemented according to the custom model
     tutorial [1].
-    
+
     References
     ----------
     .. [1] https://auto.gluon.ai/dev/tutorials/timeseries/advanced/forecasting-custom-model.html#implement-the-custom-model
     """
+
     _supports_known_covariates: bool = True
     _supports_past_covariates: bool = True
     _supports_static_features: bool = True
-
-    def preprocess(
-        self,
-        data: TimeSeriesDataFrame,
-        known_covariates: Optional[TimeSeriesDataFrame] = None,
-        is_train: bool = False,
-        **kwargs,
-    ) -> Tuple[TimeSeriesDataFrame, Optional[TimeSeriesDataFrame]]:
-        """Method that implements model-specific preprocessing logic.
-
-        This method is called on all data that is passed to `_fit` and `_predict` methods.
-        """
-        data = data.fill_missing_values(method="constant", value=42.0)
-        return data, known_covariates
 
     def _fit(
         self,
@@ -63,128 +49,157 @@ class ConcreteTimeSeriesModel(AbstractTimeSeriesModel):
         assert self.dummy_learned_parameters is not None
 
         return TimeSeriesDataFrame(
-            pd.DataFrame(
-                index=self.get_forecast_horizon_index(data), 
-                columns=["mean"] + self.quantile_levels
-            ).fillna(42.0)
+            pd.DataFrame(index=self.get_forecast_horizon_index(data), columns=["mean"] + self.quantile_levels).fillna(
+                42.0
+            )
         )
 
 
-class TestAbstractModelFunctionality:
-    
-    @pytest.fixture(
-        scope="class", 
-        params=list(
-            itertools.product(
-                [["A", "B"], ["C", "D"], ["A"], [0, 1, 2, 3]],
-                [10, 45],
-                ["h", "T", "d"],
-            )
-        ),
+@pytest.fixture(scope="class")
+def train_data():
+    return get_data_frame_with_item_index(["A", "B"], data_length=100, freq="h")
+
+
+def test_when_model_is_initialized_then_key_fields_set_correctly(temp_model_path):
+    model = ConcreteTimeSeriesModel(
+        path=temp_model_path,
+        freq="h",
+        prediction_length=3,
+        quantile_levels=[0.1, 0.9],
+        eval_metric="MAPE",
+        hyperparameters={"some": "params"},
     )
-    def train_data(self, request):
-        index, data_length, freq = request.param
-        return get_data_frame_with_item_index(index, data_length=data_length, freq=freq)
-    
-    @pytest.fixture()
-    def model(self, temp_model_path) -> ConcreteTimeSeriesModel:
-        return ConcreteTimeSeriesModel(path=temp_model_path)
-    
-    def test_when_model_is_initialized_then_key_fields_set_correctly(self, temp_model_path):
-        model = ConcreteTimeSeriesModel(
-            path=temp_model_path,
-            freq="h",
-            prediction_length=3,
-            quantile_levels=[0.1, 0.9],
-            eval_metric="MAPE",
-            hyperparameters={"some": "params"},
-        )
-        
-        assert model.freq == "h"
-        assert model.prediction_length == 3
-        assert tuple(model.quantile_levels) == (0.1, 0.5, 0.9)
-        assert model.eval_metric.name == "MAPE"
-        
-    def test_when_model_receives_median_then_must_not_drop_median_set_to_false(self, temp_model_path):
-        model = ConcreteTimeSeriesModel(
-            path=temp_model_path,
-            quantile_levels=[0.1, 0.5, 0.9],
-        )
-        assert not model.must_drop_median
 
-    def test_when_model_does_not_receive_median_then_must_not_drop_median_set_to_true(self, temp_model_path):
-        model = ConcreteTimeSeriesModel(
-            path=temp_model_path,
-            quantile_levels=[0.1, 0.9],
-        )
-        assert not model.must_drop_median
-    
-    def test_when_model_saved_and_loaded_with_load_oof_then_load_oof_called(self, model):        
-        model.save()
-        with mock.patch.object(model.__class__, "load_oof_predictions") as mock_load_oof:
-            model.__class__.load(model.path, load_oof=True)
-            mock_load_oof.assert_called_once()
+    assert model.freq == "h"
+    assert model.prediction_length == 3
+    assert tuple(model.quantile_levels) == (0.1, 0.5, 0.9)
+    assert model.eval_metric.name == "MAPE"
 
-    def test_when_support_model_covariate_properties_are_accessed_then_their_values_are_correct(self, model):
-        assert model.supports_known_covariates == model.__class__._supports_known_covariates
-        assert model.supports_past_covariates == model.__class__._supports_past_covariates
-        assert model.supports_static_features == model.__class__._supports_static_features
-        
-    def test_when_model_is_initialized_with_ag_args_fit_then_they_are_included_in_get_params(self, train_data, temp_model_path):
-        model = ConcreteTimeSeriesModel(
-            path=temp_model_path,
-            hyperparameters={AG_ARGS_FIT: {"key": "value"}},  # type: ignore
-        )
-        model.fit(train_data=train_data)
-        assert AG_ARGS_FIT in model.get_params()["hyperparameters"]
-        
-    def test_when_model_is_fit_with_time_limit_less_than_zero_then_error_raised(self, train_data, model):
-        with pytest.raises(TimeLimitExceeded):
-            model.fit(train_data=train_data, time_limit=-1)
 
-    @pytest.mark.parametrize(
-        "covariate_regressor_hyperparameter", [
-            "dummy_argument",
-            {"key": "value"},
-        ]
+def test_when_model_receives_median_then_must_not_drop_median_set_to_false(temp_model_path):
+    model = ConcreteTimeSeriesModel(
+        path=temp_model_path,
+        quantile_levels=[0.1, 0.5, 0.9],
     )
-    def test_when_create_covariate_regressor_is_called_then_covariate_regressor_is_constructed(
-        self, 
-        temp_model_path,
-        covariate_regressor_hyperparameter,
-    ):
-        model = ConcreteTimeSeriesModel(
-            path=temp_model_path,
-            hyperparameters={"covariate_regressor": covariate_regressor_hyperparameter},
-            metadata=CovariateMetadata(
-                known_covariates_real=["dummy_column"]
-            )
-        )
-        
-        with mock.patch("autogluon.timeseries.models.abstract.abstract_timeseries_model.CovariateRegressor") as mock_covariate_regressor:
-            model.initialize()  # calls create_covariate_regressor
-            mock_covariate_regressor.assert_called_once()
-            assert mock_covariate_regressor.call_args.kwargs["target"] == model.target
-            assert mock_covariate_regressor.call_args.kwargs["metadata"] is model.metadata
-            if isinstance(covariate_regressor_hyperparameter, dict):
-                assert mock_covariate_regressor.call_args.kwargs["key"] == "value"
-            else:
-                assert mock_covariate_regressor.call_args.args[0] == "dummy_argument"
+    assert not model.must_drop_median
 
-    def test_when_get_memory_size_called_then_memory_size_is_none(self, model):
-        assert model.get_memory_size() is None
-        
-    def test_when_hyperparameter_tune_called_with_empty_search_space_then_skip_hpo_called(
-        self, model: ConcreteTimeSeriesModel, train_data: TimeSeriesDataFrame
-    ):
-        with mock.patch("autogluon.timeseries.models.abstract.abstract_timeseries_model.skip_hpo") as mock_skip_hpo:
-            model.hyperparameter_tune(
-                hyperparameter_tune_kwargs="auto", 
-                hpo_executor=None,
-                train_data=train_data,
-                val_data=train_data,
-            )
-            
-            assert mock_skip_hpo.called
-    
-    # def test_when_time_limit_is_capped_then
+
+def test_when_model_does_not_receive_median_then_must_not_drop_median_set_to_true(temp_model_path):
+    model = ConcreteTimeSeriesModel(
+        path=temp_model_path,
+        quantile_levels=[0.1, 0.9],
+    )
+    assert model.must_drop_median
+
+
+def test_when_model_saved_and_loaded_with_load_oof_then_load_oof_called(temp_model_path):
+    model = ConcreteTimeSeriesModel(path=temp_model_path)
+    model.save()
+    with mock.patch.object(model.__class__, "load_oof_predictions") as mock_load_oof:
+        model.__class__.load(model.path, load_oof=True)
+        mock_load_oof.assert_called_once()
+
+
+def test_when_support_model_covariate_properties_are_accessed_then_their_values_are_correct(temp_model_path):
+    model = ConcreteTimeSeriesModel(path=temp_model_path)
+
+    assert model.supports_known_covariates == model.__class__._supports_known_covariates
+    assert model.supports_past_covariates == model.__class__._supports_past_covariates
+    assert model.supports_static_features == model.__class__._supports_static_features
+
+
+def test_when_model_is_initialized_with_ag_args_fit_then_they_are_included_in_get_params(train_data, temp_model_path):
+    model = ConcreteTimeSeriesModel(
+        path=temp_model_path,
+        hyperparameters={AG_ARGS_FIT: {"key": "value"}},  # type: ignore
+    )
+    model.fit(train_data=train_data)
+    assert AG_ARGS_FIT in model.get_params()["hyperparameters"]
+
+
+@pytest.mark.parametrize(
+    "covariate_regressor_hyperparameter",
+    [
+        "dummy_argument",
+        {"key": "value"},
+    ],
+)
+def test_when_create_covariate_regressor_is_called_then_covariate_regressor_is_constructed(
+    temp_model_path,
+    covariate_regressor_hyperparameter,
+):
+    model = ConcreteTimeSeriesModel(
+        path=temp_model_path,
+        hyperparameters={"covariate_regressor": covariate_regressor_hyperparameter},
+        metadata=CovariateMetadata(known_covariates_real=["dummy_column"]),
+    )
+
+    with mock.patch(
+        "autogluon.timeseries.models.abstract.abstract_timeseries_model.CovariateRegressor"
+    ) as mock_covariate_regressor:
+        model.initialize()  # calls create_covariate_regressor
+        mock_covariate_regressor.assert_called_once()
+        assert mock_covariate_regressor.call_args.kwargs["target"] == model.target
+        assert mock_covariate_regressor.call_args.kwargs["metadata"] is model.metadata
+        if isinstance(covariate_regressor_hyperparameter, dict):
+            assert mock_covariate_regressor.call_args.kwargs["key"] == "value"
+        else:
+            assert mock_covariate_regressor.call_args.args[0] == "dummy_argument"
+
+
+def test_when_hyperparameter_tune_called_with_empty_search_space_then_skip_hpo_called(temp_model_path, train_data):
+    model = ConcreteTimeSeriesModel(path=temp_model_path)
+    with mock.patch("autogluon.timeseries.models.abstract.abstract_timeseries_model.skip_hpo") as mock_skip_hpo:
+        model.hyperparameter_tune(
+            hyperparameter_tune_kwargs="auto",
+            hpo_executor=None,
+            train_data=train_data,
+            val_data=train_data,
+        )
+
+        assert mock_skip_hpo.called
+
+
+def test_when_time_limit_is_capped_with_aux_params_then_time_limit_is_adjusted(temp_model_path, train_data):
+    model = ConcreteTimeSeriesModel(
+        path=temp_model_path,
+        hyperparameters={AG_ARGS_FIT: {"max_time_limit": 5}},
+    )
+    with mock.patch.object(model, "_fit") as mock_internal_fit:
+        model.fit(train_data=train_data, time_limit=10)
+        mock_internal_fit.assert_called_once()
+        assert mock_internal_fit.call_args.kwargs["time_limit"] == 5
+
+
+def test_when_max_time_limit_ratio_is_provided_with_aux_params_then_time_limit_is_adjusted(
+    temp_model_path, train_data
+):
+    model = ConcreteTimeSeriesModel(
+        path=temp_model_path,
+        hyperparameters={AG_ARGS_FIT: {"max_time_limit_ratio": 0.8}},
+    )
+    with mock.patch.object(model, "_fit") as mock_internal_fit:
+        model.fit(train_data=train_data, time_limit=10)
+        mock_internal_fit.assert_called_once()
+        pytest.approx(mock_internal_fit.call_args.kwargs["time_limit"], 0.8 * 10)
+
+
+def test_when_model_is_fit_with_time_limit_less_than_zero_then_error_is_raised(temp_model_path, train_data):
+    model = ConcreteTimeSeriesModel(path=temp_model_path)
+    with pytest.raises(TimeLimitExceeded):
+        model.fit(train_data=train_data, time_limit=-1)
+
+
+def test_when_get_memory_size_called_then_memory_size_is_none(temp_model_path):
+    model = ConcreteTimeSeriesModel(path=temp_model_path)
+    assert model.get_memory_size() is None
+
+
+def test_when_convert_to_refit_full_via_copy_called_then_output_is_correct(temp_model_path, train_data):
+    model = ConcreteTimeSeriesModel(path=temp_model_path)
+    model.fit(train_data=train_data)
+
+    copied_model = model.convert_to_refit_full_via_copy()
+
+    assert isinstance(copied_model, ConcreteTimeSeriesModel)
+    assert copied_model.path == model.path + REFIT_FULL_SUFFIX

--- a/timeseries/tests/unittests/models/test_abstract.py
+++ b/timeseries/tests/unittests/models/test_abstract.py
@@ -55,7 +55,7 @@ class ConcreteTimeSeriesModel(AbstractTimeSeriesModel):
         )
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def train_data():
     return get_data_frame_with_item_index(["A", "B"], data_length=100, freq="h")
 

--- a/timeseries/tests/unittests/models/test_abstract.py
+++ b/timeseries/tests/unittests/models/test_abstract.py
@@ -1,0 +1,89 @@
+import itertools
+from typing import Optional, Tuple
+
+import pandas as pd
+import pytest
+
+from autogluon.timeseries import TimeSeriesDataFrame
+from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
+
+from ..common import get_data_frame_with_item_index
+
+
+class ConcreteTimeSeriesModel(AbstractTimeSeriesModel):
+    """A dummy model that predicts 42s, implemented according to the custom model
+    tutorial [1].
+    
+    References
+    ----------
+    .. [1] https://auto.gluon.ai/dev/tutorials/timeseries/advanced/forecasting-custom-model.html#implement-the-custom-model
+    """
+    _supports_known_covariates: bool = True
+    _supports_past_covariates: bool = True
+    _supports_static_features: bool = True
+
+    def preprocess(
+        self,
+        data: TimeSeriesDataFrame,
+        known_covariates: Optional[TimeSeriesDataFrame] = None,
+        is_train: bool = False,
+        **kwargs,
+    ) -> Tuple[TimeSeriesDataFrame, Optional[TimeSeriesDataFrame]]:
+        """Method that implements model-specific preprocessing logic.
+
+        This method is called on all data that is passed to `_fit` and `_predict` methods.
+        """
+        data = data.fill_missing_values(method="constant", value=42.0)
+        return data, known_covariates
+
+    def _fit(
+        self,
+        train_data: TimeSeriesDataFrame,
+        val_data: Optional[TimeSeriesDataFrame] = None,
+        time_limit: Optional[float] = None,
+        **kwargs,
+    ) -> None:
+        # _fit depends on _get_model_params() to provide parameters for the inner model
+        _ = self._get_model_params()
+
+        # let's do some work
+        self.dummy_learned_parameters = train_data.groupby(level=0).mean().to_dict()
+
+    def _predict(
+        self,
+        data: TimeSeriesDataFrame,
+        known_covariates: Optional[TimeSeriesDataFrame] = None,
+        **kwargs,
+    ) -> TimeSeriesDataFrame:
+        """Predict future target given the historic time series data and the future values of known_covariates."""
+        assert self.dummy_learned_parameters is not None
+
+        return TimeSeriesDataFrame(
+            pd.DataFrame(
+                index=self.get_forecast_horizon_index(data), 
+                columns=["mean"] + self.quantile_levels
+            ).fillna(42.0)
+        )
+
+
+class TestConcreteModelsInitialization:
+    
+    @pytest.fixture(
+        scope="class", 
+        params=list(
+            itertools.product(
+                [["A", "B"], ["C", "D"], ["A"], [0, 1, 2, 3]],
+                [10, 45],
+                ["h", "T", "d"],
+            )
+        ),
+    )
+    def train_data(self, request):
+        index, data_length, freq = request.param
+        return get_data_frame_with_item_index(index, data_length=data_length, freq=freq)
+    
+    def test_models_can_be_initialized(self, train_data, temp_model_path):
+        model = ConcreteTimeSeriesModel(
+            path=temp_model_path, freq=train_data.freq, prediction_length=24
+        )
+        assert isinstance(model, AbstractTimeSeriesModel)

--- a/timeseries/tests/unittests/models/test_abstract.py
+++ b/timeseries/tests/unittests/models/test_abstract.py
@@ -1,11 +1,15 @@
 import itertools
 from typing import Optional, Tuple
+from unittest import mock
 
 import pandas as pd
 import pytest
 
+from autogluon.core.constants import AG_ARGS_FIT
+from autogluon.core.utils.exceptions import TimeLimitExceeded
 from autogluon.timeseries import TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
+from autogluon.timeseries.utils.features import CovariateMetadata
 
 from ..common import get_data_frame_with_item_index
 
@@ -66,7 +70,7 @@ class ConcreteTimeSeriesModel(AbstractTimeSeriesModel):
         )
 
 
-class TestConcreteModelsInitialization:
+class TestAbstractModelFunctionality:
     
     @pytest.fixture(
         scope="class", 
@@ -82,8 +86,105 @@ class TestConcreteModelsInitialization:
         index, data_length, freq = request.param
         return get_data_frame_with_item_index(index, data_length=data_length, freq=freq)
     
-    def test_models_can_be_initialized(self, train_data, temp_model_path):
+    @pytest.fixture()
+    def model(self, temp_model_path) -> ConcreteTimeSeriesModel:
+        return ConcreteTimeSeriesModel(path=temp_model_path)
+    
+    def test_when_model_is_initialized_then_key_fields_set_correctly(self, temp_model_path):
         model = ConcreteTimeSeriesModel(
-            path=temp_model_path, freq=train_data.freq, prediction_length=24
+            path=temp_model_path,
+            freq="h",
+            prediction_length=3,
+            quantile_levels=[0.1, 0.9],
+            eval_metric="MAPE",
+            hyperparameters={"some": "params"},
         )
-        assert isinstance(model, AbstractTimeSeriesModel)
+        
+        assert model.freq == "h"
+        assert model.prediction_length == 3
+        assert tuple(model.quantile_levels) == (0.1, 0.5, 0.9)
+        assert model.eval_metric.name == "MAPE"
+        
+    def test_when_model_receives_median_then_must_not_drop_median_set_to_false(self, temp_model_path):
+        model = ConcreteTimeSeriesModel(
+            path=temp_model_path,
+            quantile_levels=[0.1, 0.5, 0.9],
+        )
+        assert not model.must_drop_median
+
+    def test_when_model_does_not_receive_median_then_must_not_drop_median_set_to_true(self, temp_model_path):
+        model = ConcreteTimeSeriesModel(
+            path=temp_model_path,
+            quantile_levels=[0.1, 0.9],
+        )
+        assert not model.must_drop_median
+    
+    def test_when_model_saved_and_loaded_with_load_oof_then_load_oof_called(self, model):        
+        model.save()
+        with mock.patch.object(model.__class__, "load_oof_predictions") as mock_load_oof:
+            model.__class__.load(model.path, load_oof=True)
+            mock_load_oof.assert_called_once()
+
+    def test_when_support_model_covariate_properties_are_accessed_then_their_values_are_correct(self, model):
+        assert model.supports_known_covariates == model.__class__._supports_known_covariates
+        assert model.supports_past_covariates == model.__class__._supports_past_covariates
+        assert model.supports_static_features == model.__class__._supports_static_features
+        
+    def test_when_model_is_initialized_with_ag_args_fit_then_they_are_included_in_get_params(self, train_data, temp_model_path):
+        model = ConcreteTimeSeriesModel(
+            path=temp_model_path,
+            hyperparameters={AG_ARGS_FIT: {"key": "value"}},  # type: ignore
+        )
+        model.fit(train_data=train_data)
+        assert AG_ARGS_FIT in model.get_params()["hyperparameters"]
+        
+    def test_when_model_is_fit_with_time_limit_less_than_zero_then_error_raised(self, train_data, model):
+        with pytest.raises(TimeLimitExceeded):
+            model.fit(train_data=train_data, time_limit=-1)
+
+    @pytest.mark.parametrize(
+        "covariate_regressor_hyperparameter", [
+            "dummy_argument",
+            {"key": "value"},
+        ]
+    )
+    def test_when_create_covariate_regressor_is_called_then_covariate_regressor_is_constructed(
+        self, 
+        temp_model_path,
+        covariate_regressor_hyperparameter,
+    ):
+        model = ConcreteTimeSeriesModel(
+            path=temp_model_path,
+            hyperparameters={"covariate_regressor": covariate_regressor_hyperparameter},
+            metadata=CovariateMetadata(
+                known_covariates_real=["dummy_column"]
+            )
+        )
+        
+        with mock.patch("autogluon.timeseries.models.abstract.abstract_timeseries_model.CovariateRegressor") as mock_covariate_regressor:
+            model.initialize()  # calls create_covariate_regressor
+            mock_covariate_regressor.assert_called_once()
+            assert mock_covariate_regressor.call_args.kwargs["target"] == model.target
+            assert mock_covariate_regressor.call_args.kwargs["metadata"] is model.metadata
+            if isinstance(covariate_regressor_hyperparameter, dict):
+                assert mock_covariate_regressor.call_args.kwargs["key"] == "value"
+            else:
+                assert mock_covariate_regressor.call_args.args[0] == "dummy_argument"
+
+    def test_when_get_memory_size_called_then_memory_size_is_none(self, model):
+        assert model.get_memory_size() is None
+        
+    def test_when_hyperparameter_tune_called_with_empty_search_space_then_skip_hpo_called(
+        self, model: ConcreteTimeSeriesModel, train_data: TimeSeriesDataFrame
+    ):
+        with mock.patch("autogluon.timeseries.models.abstract.abstract_timeseries_model.skip_hpo") as mock_skip_hpo:
+            model.hyperparameter_tune(
+                hyperparameter_tune_kwargs="auto", 
+                hpo_executor=None,
+                train_data=train_data,
+                val_data=train_data,
+            )
+            
+            assert mock_skip_hpo.called
+    
+    # def test_when_time_limit_is_capped_then


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- increase test coverage of AbstractTimeSeriesModel to ~100%
- fix another type annotation issue
- remove "min_time_limit" from model aux params. i.e., a model may not decide to increase its time limit by itself.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
