### PR TITLE
Repin accelerate to <2.0 after 1.2.0 release

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -31,7 +31,7 @@ DEPENDENT_PACKAGES = {
     "lightning": ">=2.2,<2.6",  # Major version cap
     "async_timeout": ">=4.0,<6",  # Major version cap
     "transformers[sentencepiece]": ">=4.38.0,<5",
-    "accelerate": ">=0.34.0,<1.0",
+    "accelerate": ">=0.34.0,<2.0",
     "typing-extensions": ">=4.0,<5",
 }
 if LITE_MODE:


### PR DESCRIPTION
*Description of changes:*
Afaik the accelerate pin is the only dependency keeping numpy below 2.0, when installing all autogluon packages.

I did not run any tests yet and am lifting this pin to see what happens.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
