### PR TITLE
Revert to use jlumbroso/free-disk-space@v1.3.1

### DIFF
--- a/.github/workflows/benchmark_master.yml
+++ b/.github/workflows/benchmark_master.yml
@@ -43,8 +43,7 @@ jobs:
         shell: bash
     steps:
       - name: Free Disk Space (Ubuntu)
-        # uses: jlumbroso/free-disk-space@v1.2.0
-        uses: hirnidrin/free-disk-space@main  # revert back once fix in https://github.com/jlumbroso/free-disk-space/pull/11
+        uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: false
           android: true

--- a/.github/workflows/build_latest_image.yml
+++ b/.github/workflows/build_latest_image.yml
@@ -21,8 +21,7 @@ jobs:
         role-duration-seconds: 3600
         aws-region: us-east-1
     - name: Free Disk Space (Ubuntu)
-      # uses: jlumbroso/free-disk-space@v1.2.0
-      uses: hirnidrin/free-disk-space@main  # revert back once fix in https://github.com/jlumbroso/free-disk-space/pull/11
+      uses: jlumbroso/free-disk-space@v1.3.1
       with:
         tool-cache: false
         android: true
@@ -49,8 +48,7 @@ jobs:
         role-duration-seconds: 3600
         aws-region: us-east-1
     - name: Free Disk Space (Ubuntu)
-      # uses: jlumbroso/free-disk-space@v1.2.0
-      uses: hirnidrin/free-disk-space@main  # revert back once fix in https://github.com/jlumbroso/free-disk-space/pull/11
+      uses: jlumbroso/free-disk-space@v1.3.1
       with:
         tool-cache: false
         android: true
@@ -77,8 +75,7 @@ jobs:
         role-duration-seconds: 3600
         aws-region: us-east-1
     - name: Free Disk Space (Ubuntu)
-      # uses: jlumbroso/free-disk-space@v1.2.0
-      uses: hirnidrin/free-disk-space@main  # revert back once fix in https://github.com/jlumbroso/free-disk-space/pull/11
+      uses: jlumbroso/free-disk-space@v1.3.1
       with:
         tool-cache: false
         android: true
@@ -105,8 +102,7 @@ jobs:
         role-duration-seconds: 3600
         aws-region: us-east-1
     - name: Free Disk Space (Ubuntu)
-      # uses: jlumbroso/free-disk-space@v1.2.0
-      uses: hirnidrin/free-disk-space@main  # revert back once fix in https://github.com/jlumbroso/free-disk-space/pull/11
+      uses: jlumbroso/free-disk-space@v1.3.1
       with:
         tool-cache: false
         android: true


### PR DESCRIPTION
*Issue #, if available:*
In #3466 the free-disk-space action was changed to use a fork to work around some issues, but fixes have since been merged (https://github.com/jlumbroso/free-disk-space/pull/8, https://github.com/jlumbroso/free-disk-space/pull/11).

*Description of changes:*
Changes have been made entirely based on the old comments left in the workflow and the state of the linked issues. I am not familiar with the AutoGluon code base nor the free-disk-space GH action.

Sorry for the git history, did this from the web UI. I assume you squash anyway.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
