### PR TITLE
[timeseries] Allow using custom distr_output with the TFT model

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -55,7 +55,7 @@ class DeepARModel(AbstractGluonTSModel):
         (if None, defaults to [min(50, (cat+1)//2) for cat in cardinality])
     max_cat_cardinality : int, default = 100
         Maximum number of dimensions to use when one-hot-encoding categorical known_covariates.
-    distr_output : gluonts.torch.distributions.Output, default = QuantileOutput()
+    distr_output : gluonts.torch.distributions.Output, default = StudentTOutput()
         Distribution output object that defines how the model output is converted to a forecast, and how the loss is computed.
     scaling: bool, default = True
         If True, mean absolute scaling will be applied to each *context window* during training & prediction.
@@ -112,7 +112,7 @@ class SimpleFeedForwardModel(AbstractGluonTSModel):
         Number of time units that condition the predictions
     hidden_dimensions: List[int], default = [20, 20]
         Size of hidden layers in the feedforward network
-    distr_output : gluonts.torch.distributions.Output, default = QuantileOutput()
+    distr_output : gluonts.torch.distributions.Output, default = StudentTOutput()
         Distribution output object that defines how the model output is converted to a forecast, and how the loss is computed.
     batch_normalization : bool, default = False
         Whether to use batch normalization
@@ -254,7 +254,7 @@ class DLinearModel(AbstractGluonTSModel):
         Number of time units that condition the predictions
     hidden_dimension: int, default = 20
         Size of hidden layers in the feedforward network
-    distr_output : gluonts.torch.distributions.Output, default = QuantileOutput()
+    distr_output : gluonts.torch.distributions.Output, default = StudentTOutput()
         Distribution output object that defines how the model output is converted to a forecast, and how the loss is computed.
     scaling : {"mean", "std", None}, default = "mean"
         Scaling applied to each *context window* during training & prediction.
@@ -318,7 +318,7 @@ class PatchTSTModel(AbstractGluonTSModel):
         Number of attention heads in the Transformer encoder which must divide d_model.
     num_encoder_layers : int, default = 2
         Number of layers in the Transformer encoder.
-    distr_output : gluonts.torch.distributions.Output, default = QuantileOutput()
+    distr_output : gluonts.torch.distributions.Output, default = StudentTOutput()
         Distribution output object that defines how the model output is converted to a forecast, and how the loss is computed.
     scaling : {"mean", "std", None}, default = "mean"
         Scaling applied to each *context window* during training & prediction.

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -17,14 +17,6 @@ from autogluon.timeseries.utils.datetime import (
 # NOTE: We avoid imports for torch and lightning.pytorch at the top level and hide them inside class methods.
 # This is done to skip these imports during multiprocessing (which may cause bugs)
 
-# FIXME: introduces cpflows dependency. We exclude this model until a future release.
-# from gluonts.torch.model.mqf2 import MQF2MultiHorizonEstimator
-
-# FIXME: DeepNPTS does not implement the GluonTS PyTorch API, and does not use
-# PyTorch Lightning. We exclude this model until a future release.
-# from gluonts.torch.model.deep_npts import DeepNPTSEstimator
-
-
 logger = logging.getLogger(__name__)
 
 

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -63,8 +63,8 @@ class DeepARModel(AbstractGluonTSModel):
         (if None, defaults to [min(50, (cat+1)//2) for cat in cardinality])
     max_cat_cardinality : int, default = 100
         Maximum number of dimensions to use when one-hot-encoding categorical known_covariates.
-    distr_output : gluonts.torch.distributions.DistributionOutput, default = StudentTOutput()
-        Distribution to use to evaluate observations and sample predictions
+    distr_output : gluonts.torch.distributions.Output, default = QuantileOutput()
+        Distribution output object that defines how the model output is converted to a forecast, and how the loss is computed.
     scaling: bool, default = True
         If True, mean absolute scaling will be applied to each *context window* during training & prediction.
         Note that this is different from the `target_scaler` that is applied to the *entire time series*.
@@ -120,8 +120,8 @@ class SimpleFeedForwardModel(AbstractGluonTSModel):
         Number of time units that condition the predictions
     hidden_dimensions: List[int], default = [20, 20]
         Size of hidden layers in the feedforward network
-    distr_output : gluonts.torch.distributions.DistributionOutput, default = StudentTOutput()
-        Distribution to fit.
+    distr_output : gluonts.torch.distributions.Output, default = QuantileOutput()
+        Distribution output object that defines how the model output is converted to a forecast, and how the loss is computed.
     batch_normalization : bool, default = False
         Whether to use batch normalization
     mean_scaling : bool, default = True
@@ -169,6 +169,8 @@ class TemporalFusionTransformerModel(AbstractGluonTSModel):
     ----------------
     context_length : int, default = max(64, 2 * prediction_length)
         Number of past values used for prediction.
+    distr_output : gluonts.torch.distributions.Output, default = QuantileOutput()
+        Distribution output object that defines how the model output is converted to a forecast, and how the loss is computed.
     disable_static_features : bool, default = False
         If True, static features won't be used by the model even if they are present in the dataset.
         If False, static features will be used by the model if they are present in the dataset.
@@ -235,6 +237,10 @@ class TemporalFusionTransformerModel(AbstractGluonTSModel):
             init_kwargs["past_dynamic_cardinalities"] = self.past_feat_dynamic_cat_cardinality
 
         init_kwargs.setdefault("time_features", get_time_features_for_frequency(self.freq))
+
+        # 'distr_output' and 'quantiles' shouldn't be included at the same time (otherwise an exception will be raised)
+        if "distr_output" in init_kwargs:
+            init_kwargs.pop("quantiles", None)
         return init_kwargs
 
 
@@ -256,8 +262,8 @@ class DLinearModel(AbstractGluonTSModel):
         Number of time units that condition the predictions
     hidden_dimension: int, default = 20
         Size of hidden layers in the feedforward network
-    distr_output : gluonts.torch.distributions.DistributionOutput, default = StudentTOutput()
-        Distribution to fit.
+    distr_output : gluonts.torch.distributions.Output, default = QuantileOutput()
+        Distribution output object that defines how the model output is converted to a forecast, and how the loss is computed.
     scaling : {"mean", "std", None}, default = "mean"
         Scaling applied to each *context window* during training & prediction.
         One of ``"mean"`` (mean absolute scaling), ``"std"`` (standardization), ``None`` (no scaling).
@@ -320,8 +326,8 @@ class PatchTSTModel(AbstractGluonTSModel):
         Number of attention heads in the Transformer encoder which must divide d_model.
     num_encoder_layers : int, default = 2
         Number of layers in the Transformer encoder.
-    distr_output : gluonts.torch.distributions.DistributionOutput, default = StudentTOutput()
-        Distribution to fit.
+    distr_output : gluonts.torch.distributions.Output, default = QuantileOutput()
+        Distribution output object that defines how the model output is converted to a forecast, and how the loss is computed.
     scaling : {"mean", "std", None}, default = "mean"
         Scaling applied to each *context window* during training & prediction.
         One of ``"mean"`` (mean absolute scaling), ``"std"`` (standardization), ``None`` (no scaling).


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Make it possible to pass custom `distr_output` to the TFT model. Currently, passing the custom value leads to an exception because specifying both `quantiles` and `distr_output` triggers an assertion during initialization of the TFT model.
- Remove stale TODOs for GluonTS models


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
