### PR TITLE
[tabular] Add predictor.model_hyperparameters()

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -1632,9 +1632,7 @@ class AbstractModel:
         path = self.path_root
         problem_type = self.problem_type
         eval_metric = self.eval_metric
-        hyperparameters = self._user_params.copy()
-        if self._user_params_aux:
-            hyperparameters[AG_ARGS_FIT] = self._user_params_aux.copy()
+        hyperparameters = self.get_hyperparameters_init()
 
         args = dict(
             path=path,
@@ -1645,6 +1643,20 @@ class AbstractModel:
         )
 
         return args
+
+    def get_hyperparameters_init(self) -> dict:
+        """
+
+        Returns
+        -------
+        hyperparameters: dict
+            The dictionary of user specified hyperparameters for the model.
+
+        """
+        hyperparameters = self._user_params.copy()
+        if self._user_params_aux:
+            hyperparameters[AG_ARGS_FIT] = self._user_params_aux.copy()
+        return hyperparameters
 
     def convert_to_template(self):
         """
@@ -2227,7 +2239,7 @@ class AbstractModel:
         # TODO: Report errors?
         shutil.rmtree(path=model_path, ignore_errors=True)
 
-    def get_info(self) -> dict:
+    def get_info(self, include_feature_metadata: bool = True) -> dict:
         """
         Returns a dictionary of numerous fields describing the model.
         """
@@ -2243,6 +2255,7 @@ class AbstractModel:
             "predict_time": self.predict_time,
             "val_score": self.val_score,
             "hyperparameters": self.params,
+            "hyperparameters_user": self.get_hyperparameters_init(),
             "hyperparameters_fit": self.params_trained,  # TODO: Explain in docs that this is for hyperparameters that differ in final model from original hyperparameters, such as epochs (from early stopping)
             "hyperparameters_nondefault": self.nondefault_params,
             AG_ARGS_FIT: self.get_params_aux_info(),
@@ -2260,6 +2273,8 @@ class AbstractModel:
         }
         if self._is_fit_metadata_registered:
             info.update(self._fit_metadata)
+        if not include_feature_metadata:
+            info.pop("feature_metadata")
         return info
 
     def get_params_aux_info(self) -> dict:

--- a/core/src/autogluon/core/models/ensemble/stacker_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/stacker_ensemble_model.py
@@ -309,8 +309,8 @@ class StackerEnsembleModel(BaggedEnsembleModel):
             model = model_type.load(model_path)
         return model
 
-    def get_info(self):
-        info = super().get_info()
+    def get_info(self, **kwargs):
+        info = super().get_info(**kwargs)
         stacker_info = dict(
             num_base_models=len(self.base_model_names),
             base_model_names=self.base_model_names,

--- a/core/src/autogluon/core/models/greedy_ensemble/greedy_weighted_ensemble_model.py
+++ b/core/src/autogluon/core/models/greedy_ensemble/greedy_weighted_ensemble_model.py
@@ -111,8 +111,8 @@ class GreedyWeightedEnsembleModel(AbstractModel):
         model_weight_dict = {self.base_model_names[i]: self.weights_[i] for i in range(num_models)}
         return model_weight_dict
 
-    def get_info(self):
-        info = super().get_info()
+    def get_info(self, **kwargs):
+        info = super().get_info(**kwargs)
         info["model_weights"] = self._get_model_weights()
         return info
 

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -3793,6 +3793,80 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
         self._assert_is_fit("info")
         return self._learner.get_info(include_model_info=True, include_model_failures=True)
 
+    def model_info(self, model: str) -> dict:
+        """
+        Returns metadata information about the given model.
+        Equivalent output to `predictor.info()["model_info"][model]`
+
+        Parameters
+        ----------
+        model: str
+            The name of the model to get info for.
+
+        Returns
+        -------
+        model_info: dict
+            Model info dictionary
+
+        """
+        return self._trainer.get_model_info(model=model)
+
+    # TODO: Add entire `hyperparameters` dict method for multiple models (including stack ensemble)
+    # TODO: Add unit test
+    def model_hyperparameters(
+        self,
+        model: str,
+        include_ag_args_ensemble: bool = True,
+        output_format: Literal["user", "all"] = "user",
+    ) -> dict:
+        """
+        Returns the hyperparameters of a given model.
+
+        Parameters
+        ----------
+        model: str
+            The name of the model to get hyperparameters for.
+        include_ag_args_ensemble: bool, default True
+            If True, includes the ag_args_ensemble parameters if they exist (for example, when bagging is enabled).
+        output_format: {"user", "all"}, default "user"
+            If "user", returns the same hyperparameters specified by the user (only non-defaults).
+            If "all", returns all hyperparameters used by the model (including default hyperparameters not specified by the user)
+            Regardless of the output_format, they both are functionally equivalent if passed to AutoGluon.
+
+        Returns
+        -------
+        model_hyperparameters: dict
+            Dictionary of model hyperparameters.
+            Equivalent to the model_hyperparameters specified by the user for this model in:
+                `predictor.fit(..., hyperparameters={..., model_key: [..., model_hyperparameters]})`
+
+        """
+        # TODO: Move logic into trainer?
+        info_model = self.model_info(model=model)
+        if output_format == "user":
+            if "bagged_info" in info_model:
+                hyperparameters = info_model["bagged_info"]["child_hyperparameters_user"].copy()
+                if include_ag_args_ensemble and info_model["hyperparameters_user"]:
+                    hyperparameters["ag_args_ensemble"] = info_model["hyperparameters_user"]
+            else:
+                hyperparameters = info_model["hyperparameters_user"]
+        elif output_format == "all":
+            if "bagged_info" in info_model:
+                hyperparameters = info_model["bagged_info"]["child_hyperparameters"].copy()
+                if info_model["bagged_info"]["child_ag_args_fit"]:
+                    hyperparameters["ag_args_fit"] = info_model["bagged_info"]["child_ag_args_fit"]
+                if include_ag_args_ensemble:
+                    bag_hyperparameters = info_model["hyperparameters"].copy()
+                    if info_model["ag_args_fit"]:
+                        bag_hyperparameters["ag_args_fit"] = info_model["ag_args_fit"]
+                    if bag_hyperparameters:
+                        hyperparameters["ag_args_ensemble"] = bag_hyperparameters
+            else:
+                hyperparameters = info_model["hyperparameters"]
+        else:
+            raise ValueError(f"output_format={output_format} is unknown!")
+        return hyperparameters
+
     # TODO: Add data argument
     # TODO: Add option to disable OOF generation of newly fitted models
     # TODO: Move code logic to learner/trainer


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding extra features to better support TabRepo 2.0:

- Add `predictor.model_hyperparameters(model)`
- Add `predictor.model_info(model)`
- Add `include_feature_metadata` boolean to `model.get_info()`, as `feature_metadata` is dependent on AutoGluon unlike all other outputs of `get_info` which are python native types.

TODO:
- [x] Add unit test for holdout
- [x] Add unit test for bagging
- [ ] (Stretch) Add `predictor.export_hyperparameters(models)` to return a usable `hyperparameters` dict that can be passed into a new `predictor.fit(... hyperparameters=hyperparameters)` call to reproduce a given AutoGluon stack architecture on new tasks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
