### PR TITLE
check cuda.is_available() before cuda.device_count()

### DIFF
--- a/common/src/autogluon/common/utils/resource_utils.py
+++ b/common/src/autogluon/common/utils/resource_utils.py
@@ -38,6 +38,7 @@ class ResourceManager:
     def get_gpu_count_torch() -> int:
         try:
             import torch
+
             if not torch.cuda.is_available():
                 num_gpus = 0
             else:

--- a/common/src/autogluon/common/utils/resource_utils.py
+++ b/common/src/autogluon/common/utils/resource_utils.py
@@ -35,11 +35,13 @@ class ResourceManager:
         return num_gpus
 
     @staticmethod
-    def get_gpu_count_torch():
+    def get_gpu_count_torch() -> int:
         try:
             import torch
-
-            num_gpus = torch.cuda.device_count()
+            if not torch.cuda.is_available():
+                num_gpus = 0
+            else:
+                num_gpus = torch.cuda.device_count()
         except Exception:
             num_gpus = 0
         return num_gpus


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Improvement to first check if cuda is available before trying to get GPU count. On a CPU machine, trying to get GPU count when cuda isn't available leads to warning messages. Better to avoid the warning messages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
