### PR TITLE
[tabular] Add FutureWarning for delete_models dry_run

### DIFF
--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -4257,7 +4257,14 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             reduce_children=reduce_children,
         )
 
-    def delete_models(self, models_to_keep=None, models_to_delete=None, allow_delete_cascade=False, delete_from_disk=True, dry_run=True):
+    def delete_models(
+        self,
+        models_to_keep: str | list[str] | None = None,
+        models_to_delete: str | list[str] | None = None,
+        allow_delete_cascade: bool = False,
+        delete_from_disk: bool = True,
+        dry_run: bool | None = None,
+    ):
         """
         Deletes models from `predictor`.
         This can be helpful to minimize memory usage and disk usage, particularly for model deployment.
@@ -4268,13 +4275,13 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
 
         Parameters
         ----------
-        models_to_keep : str or list, default = None
+        models_to_keep : str or list[str], default = None
             Name of model or models to not delete.
             All models that are not specified and are also not required as a dependency of any model in `models_to_keep` will be deleted.
             Specify `models_to_keep='best'` to keep only the best model and its model dependencies.
             `models_to_delete` must be None if `models_to_keep` is set.
             To see the list of possible model names, use: `predictor.model_names()` or `predictor.leaderboard()`.
-        models_to_delete : str or list, default = None
+        models_to_delete : str or list[str], default = None
             Name of model or models to delete.
             All models that are not specified but depend on a model in `models_to_delete` will also be deleted.
             `models_to_keep` must be None if `models_to_delete` is set.
@@ -4288,10 +4295,19 @@ class TabularPredictor(TabularPredictorDeprecatedMixin):
             WARNING: This deletes the entire directory for the deleted models, and ALL FILES located there.
                 It is highly recommended to first run with `dry_run=True` to understand which directories will be deleted.
         dry_run : bool, default = True
+            WARNING: Starting in v1.4.0 dry_run will default to False.
             If `True`, then deletions don't occur, and logging statements are printed describing what would have occurred.
             Set `dry_run=False` to perform the deletions.
 
         """
+        if dry_run is None:
+            warnings.warn(
+                f"dry_run was not specified for `TabularPredictor.delete_models`. dry_run prior to version 1.4.0 defaults to True. "
+                f"Starting in version 1.4, AutoGluon will default dry_run to False. "
+                f"If you want to maintain the current logic in future versions, explicitly specify `dry_run=True`.",
+                category=FutureWarning,
+            )
+            dry_run = True
         self._assert_is_fit("delete_models")
         if models_to_keep == "best":
             models_to_keep = self.model_best

--- a/tabular/tests/unittests/temporary/test_deprecations.py
+++ b/tabular/tests/unittests/temporary/test_deprecations.py
@@ -1,0 +1,17 @@
+from packaging import version
+
+from autogluon.tabular import __version__
+
+
+def test_tabular_predictor_dry_run_default_false_v140():
+    ag_version = __version__
+    # Delete this test after updating the method for 1.4.0.
+    if version.parse(ag_version) >= version.parse("1.4.0"):
+        # FutureWarning added in v1.3.0
+        # Reasoning: most users probably don't care about dry_run when calling this method,
+        # so it could lead to unintentional bugs / confusing downstream for
+        # users if they aren't aware that they need to set dry_run=False for it to do anything.
+        raise AssertionError(
+            f"Verify that `TabularPredictor.delete_models` dry_run=False "
+            f"is the default starting in v1.4.0. Remove None as an option."
+        )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add FutureWarning for TabularPredictor.delete_models when dry_run is not specified.

The idea is that when users call `delete_models`, it is likely they would prefer for the deletion to occur rather than it being a dry run. It may be hard for users to consistently remember to set `dry_run=False`, so this PR makes it that starting in v1.4.0, dry_run will default to False instead of True.

@shchur I notice that there is no `delete_models` equivalent in TimeSeriesPredictor. Might be something interesting to have in future.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
