### PR TITLE
[tabular] Add ag_model_register

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -1022,10 +1022,7 @@ class AbstractModel(ModelBase):
         **kwargs :
             Any additional fit arguments a model supports.
         """
-        if "time_limit" in kwargs and kwargs["time_limit"] is not None:
-            time_start = time.time()
-        else:
-            time_start = None
+        time_start = time.time()
         kwargs = self.initialize(
             **kwargs
         )  # FIXME: This might have to go before self._preprocess_fit_args, but then time_limit might be incorrect in **kwargs init to initialize

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -205,7 +205,7 @@ class AbstractModel(ModelBase):
     ag_key: str | None = None  # set to string value for subclasses for use in AutoGluon
     ag_name: str | None = None  # set to string value for subclasses for use in AutoGluon
     ag_priority: int = 0  # set to int value for subclasses for use in AutoGluon
-    ag_priority_by_problem_type: dict[str, int] = {}
+    ag_priority_by_problem_type: dict[str, int] = {}  # if not set, we fall back to ag_priority
 
     model_file_name = "model.pkl"
     model_info_name = "info.pkl"

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -10,6 +10,7 @@ import pickle
 import sys
 import time
 from abc import ABC, abstractmethod
+from types import MappingProxyType
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -121,7 +122,7 @@ class Tunable(ABC):
         clone the current model.
         """
         pass
-        
+
     @abstractmethod
     def hyperparameter_tune(self, *args, **kwargs) -> tuple:
         pass
@@ -144,7 +145,7 @@ class ModelBase(Taggable, Tunable, ABC):
 
     @abstractmethod
     def get_info(self, *args, **kwargs) -> dict[str, Any]:
-        pass 
+        pass
 
     @abstractmethod
     def fit(self, *args, **kwargs) -> Self:
@@ -205,7 +206,7 @@ class AbstractModel(ModelBase):
     ag_key: str | None = None  # set to string value for subclasses for use in AutoGluon
     ag_name: str | None = None  # set to string value for subclasses for use in AutoGluon
     ag_priority: int = 0  # set to int value for subclasses for use in AutoGluon
-    ag_priority_by_problem_type: dict[str, int] = {}  # if not set, we fall back to ag_priority
+    ag_priority_by_problem_type: dict[str, int] = MappingProxyType({})  # if not set, we fall back to ag_priority. Use MappingProxyType to avoid mutation.
 
     model_file_name = "model.pkl"
     model_info_name = "info.pkl"

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -202,6 +202,10 @@ class AbstractModel(ModelBase):
         Hyperparameters that will be used by the model (can be search spaces instead of fixed values).
         If None, model defaults are used. This is identical to passing an empty dictionary.
     """
+    ag_key: str | None = None  # set to string value for subclasses for use in AutoGluon
+    ag_name: str | None = None  # set to string value for subclasses for use in AutoGluon
+    ag_priority: int = 0  # set to int value for subclasses for use in AutoGluon
+    ag_priority_by_problem_type: dict[str, int] = {}
 
     model_file_name = "model.pkl"
     model_info_name = "info.pkl"
@@ -2624,3 +2628,14 @@ class AbstractModel(ModelBase):
     def fit_num_gpus_child(self) -> float:
         """Number of GPUs used for fitting one model (i.e. a child model)"""
         return self.fit_num_gpus
+
+    @classmethod
+    def get_ag_priority(cls, problem_type: str | None = None) -> int:
+        """
+        Returns the AutoGluon fit priority,
+        defined by `cls.ag_priority` and `cls.ag_priority_by_problem_type`.
+        """
+        if problem_type is None:
+            return cls.ag_priority
+        else:
+            return cls.ag_priority_by_problem_type.get(problem_type, cls.ag_priority)

--- a/core/src/autogluon/core/models/dummy/dummy_model.py
+++ b/core/src/autogluon/core/models/dummy/dummy_model.py
@@ -10,6 +10,8 @@ class DummyModel(AbstractModel):
     A dummy model that ignores input features and predicts only a constant value.
     Useful for tests and calculating worst-case performance.
     """
+    ag_key = "DUMMY"
+    ag_name = "Dummy"
 
     def _get_model_type(self):
         from sklearn.dummy import DummyClassifier, DummyRegressor

--- a/core/src/autogluon/core/models/greedy_ensemble/greedy_weighted_ensemble_model.py
+++ b/core/src/autogluon/core/models/greedy_ensemble/greedy_weighted_ensemble_model.py
@@ -10,6 +10,9 @@ logger = logging.getLogger(__name__)
 
 
 class GreedyWeightedEnsembleModel(AbstractModel):
+    ag_key = "ENS_WEIGHTED"
+    ag_name = "WeightedEnsemble"
+
     def __init__(self, base_model_names=None, model_base=EnsembleSelection, **kwargs):
         super().__init__(**kwargs)
         self.model_base = model_base
@@ -128,6 +131,9 @@ class GreedyWeightedEnsembleModel(AbstractModel):
 
 
 class SimpleWeightedEnsembleModel(GreedyWeightedEnsembleModel):
+    ag_key = "SIMPLE_ENS_WEIGHTED"
+    ag_name = "WeightedEnsemble"
+
     def __init__(self, model_base=SimpleWeightedEnsemble, **kwargs):
         super().__init__(model_base=model_base, **kwargs)
 

--- a/tabular/src/autogluon/tabular/models/automm/automm_model.py
+++ b/tabular/src/autogluon/tabular/models/automm/automm_model.py
@@ -26,6 +26,8 @@ logger = logging.getLogger(__name__)
 
 
 class MultiModalPredictorModel(AbstractModel):
+    ag_key = "AG_AUTOMM"
+    ag_name = "MultiModalPredictor"
     _NN_MODEL_NAME = "automm_model"
 
     def __init__(self, **kwargs):

--- a/tabular/src/autogluon/tabular/models/automm/ft_transformer.py
+++ b/tabular/src/autogluon/tabular/models/automm/ft_transformer.py
@@ -12,6 +12,9 @@ logger = logging.getLogger(__name__)
 
 # TODO: Add unit tests
 class FTTransformerModel(MultiModalPredictorModel):
+    ag_key = "FT_TRANSFORMER"
+    ag_name = "FTTransformer"
+
     def __init__(self, **kwargs):
         """Wrapper of autogluon.multimodal.MultiModalPredictor.
 

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -30,6 +30,12 @@ class CatBoostModel(AbstractModel):
 
     Hyperparameter options: https://catboost.ai/en/docs/references/training-parameters
     """
+    ag_key = "CAT"
+    ag_name = "CatBoost"
+    ag_priority = 70
+    ag_priority_by_problem_type = {
+        SOFTCLASS: 60
+    }
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -2,6 +2,7 @@ import logging
 import math
 import os
 import time
+from types import MappingProxyType
 
 import numpy as np
 import pandas as pd
@@ -33,9 +34,9 @@ class CatBoostModel(AbstractModel):
     ag_key = "CAT"
     ag_name = "CatBoost"
     ag_priority = 70
-    ag_priority_by_problem_type = {
+    ag_priority_by_problem_type = MappingProxyType({
         SOFTCLASS: 60
-    }
+    })
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -8,6 +8,7 @@ import warnings
 from builtins import classmethod
 from functools import partial
 from pathlib import Path
+from types import MappingProxyType
 from typing import Union
 
 import numpy as np
@@ -97,9 +98,9 @@ class NNFastAiTabularModel(AbstractModel):
     ag_priority = 50
     # Increase priority for multiclass since neural networks
     # scale better than trees as a function of n_classes.
-    ag_priority_by_problem_type = {
+    ag_priority_by_problem_type = MappingProxyType({
         MULTICLASS: 95,
-    }
+    })
 
     model_internals_file_name = "model-internals.pkl"
 

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -28,7 +28,7 @@ from autogluon.common.features.types import (
 from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
 from autogluon.common.utils.resource_utils import ResourceManager
 from autogluon.common.utils.try_import import try_import_fastai
-from autogluon.core.constants import BINARY, QUANTILE, REGRESSION
+from autogluon.core.constants import BINARY, MULTICLASS, QUANTILE, REGRESSION
 from autogluon.core.hpo.constants import RAY_BACKEND
 from autogluon.core.models import AbstractModel
 from autogluon.core.utils.exceptions import TimeLimitExceeded
@@ -92,6 +92,14 @@ class NNFastAiTabularModel(AbstractModel):
         'early.stopping.min_delta': 0.0001,
         'early.stopping.patience': 10,
     """
+    ag_key = "FASTAI"
+    ag_name = "NeuralNetFastAI"
+    ag_priority = 50
+    # Increase priority for multiclass since neural networks
+    # scale better than trees as a function of n_classes.
+    ag_priority_by_problem_type = {
+        MULTICLASS: 95,
+    }
 
     model_internals_file_name = "model-internals.pkl"
 

--- a/tabular/src/autogluon/tabular/models/fasttext/fasttext_model.py
+++ b/tabular/src/autogluon/tabular/models/fasttext/fasttext_model.py
@@ -21,6 +21,9 @@ logger = logging.getLogger(__name__)
 
 
 class FastTextModel(AbstractModel):
+    ag_key = "FASTTEXT"
+    ag_name = "FastText"
+
     model_bin_file_name = "fasttext.ftz"
 
     def __init__(self, **kwargs):

--- a/tabular/src/autogluon/tabular/models/image_prediction/image_predictor.py
+++ b/tabular/src/autogluon/tabular/models/image_prediction/image_predictor.py
@@ -22,6 +22,8 @@ class ImagePredictorModel(MultiModalPredictorModel):
     Additionally has special null image handling to improve performance in the presence of null images (aka image path of '')
         Note: null handling has not been compared to the built-in null handling of MultimodalPredictor yet.
     """
+    ag_key = "AG_IMAGE_NN"
+    ag_name = "ImagePredictor"
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/tabular/src/autogluon/tabular/models/imodels/imodels_models.py
+++ b/tabular/src/autogluon/tabular/models/imodels/imodels_models.py
@@ -75,6 +75,9 @@ class _IModelsModel(AbstractModel):
 
 
 class RuleFitModel(_IModelsModel):
+    ag_key = "IM_RULEFIT"
+    ag_name = "RuleFit"
+
     def get_model(self):
         try_import_imodels()
         from imodels import RuleFitClassifier, RuleFitRegressor
@@ -86,6 +89,9 @@ class RuleFitModel(_IModelsModel):
 
 
 class GreedyTreeModel(_IModelsModel):
+    ag_key = "IM_GREEDYTREE"
+    ag_name = "GreedyTree"
+
     def get_model(self):
         try_import_imodels()
         from imodels import GreedyTreeClassifier
@@ -98,6 +104,9 @@ class GreedyTreeModel(_IModelsModel):
 
 
 class BoostedRulesModel(_IModelsModel):
+    ag_key = "IM_BOOSTEDRULES"
+    ag_name = "BoostedRules"
+
     def get_model(self):
         try_import_imodels()
         from imodels import BoostedRulesClassifier
@@ -109,6 +118,9 @@ class BoostedRulesModel(_IModelsModel):
 
 
 class HSTreeModel(_IModelsModel):
+    ag_key = "IM_HSTREE"
+    ag_name = "HierarchicalShrinkageTree"
+
     def get_model(self):
         try_import_imodels()
         from imodels import HSTreeClassifierCV, HSTreeRegressorCV
@@ -120,6 +132,9 @@ class HSTreeModel(_IModelsModel):
 
 
 class FigsModel(_IModelsModel):
+    ag_key = "IM_FIGS"
+    ag_name = "Figs"
+
     def get_model(self):
         try_import_imodels()
         from imodels import FIGSClassifier, FIGSRegressor

--- a/tabular/src/autogluon/tabular/models/knn/knn_model.py
+++ b/tabular/src/autogluon/tabular/models/knn/knn_model.py
@@ -22,6 +22,9 @@ class KNNModel(AbstractModel):
     """
     KNearestNeighbors model (scikit-learn): https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KNeighborsClassifier.html
     """
+    ag_key = "KNN"
+    ag_name = "KNeighbors"
+    ag_priority = 100
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -40,6 +40,12 @@ class LGBModel(AbstractModel):
     Extra hyperparameter options:
         ag.early_stop : int, specifies the early stopping rounds. Defaults to an adaptive strategy. Recommended to keep default.
     """
+    ag_key = "GBM"
+    ag_name = "LightGBM"
+    ag_priority = 90
+    ag_priority_by_problem_type = {
+        SOFTCLASS: 100
+    }
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -7,6 +7,7 @@ import random
 import re
 import time
 import warnings
+from types import MappingProxyType
 
 import numpy as np
 import pandas as pd
@@ -43,9 +44,9 @@ class LGBModel(AbstractModel):
     ag_key = "GBM"
     ag_name = "LightGBM"
     ag_priority = 90
-    ag_priority_by_problem_type = {
+    ag_priority_by_problem_type = MappingProxyType({
         SOFTCLASS: 100
-    }
+    })
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/tabular/src/autogluon/tabular/models/lr/lr_model.py
+++ b/tabular/src/autogluon/tabular/models/lr/lr_model.py
@@ -38,6 +38,9 @@ class LinearModel(AbstractModel):
 
         'regression': https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Ridge.html#sklearn.linear_model.Ridge
     """
+    ag_key = "LR"
+    ag_name = "LinearModel"
+    ag_priority = 30
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -30,9 +30,6 @@ class RFModel(AbstractModel):
     ag_key = "RF"
     ag_name = "RandomForest"
     ag_priority = 80
-    ag_priority_by_problem_type = {
-        SOFTCLASS: 80
-    }
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -27,6 +27,12 @@ class RFModel(AbstractModel):
     """
     Random Forest model (scikit-learn): https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html
     """
+    ag_key = "RF"
+    ag_name = "RandomForest"
+    ag_priority = 80
+    ag_priority_by_problem_type = {
+        SOFTCLASS: 80
+    }
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/tabular/src/autogluon/tabular/models/tab_transformer/tab_transformer_model.py
+++ b/tabular/src/autogluon/tabular/models/tab_transformer/tab_transformer_model.py
@@ -40,6 +40,8 @@ class TabTransformerModel(AbstractNeuralNetworkModel):
     and applies them to the use case of tabular data. Specifically, this makes TabTransformer suitable for unsupervised
     training of Tabular data with a subsequent fine-tuning step on labeled data.
     """
+    ag_key = "TRANSF"
+    ag_name = "Transformer"
 
     params_file_name = "tab_trans_params.pth"
 

--- a/tabular/src/autogluon/tabular/models/tabpfn/tabpfn_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfn/tabpfn_model.py
@@ -22,6 +22,9 @@ class TabPFNModel(AbstractModel):
     To use this model, `tabpfn` must be installed.
     To install TabPFN, you can run `pip install autogluon.tabular[tabpfn]` or `pip install tabpfn`.
     """
+    ag_key = "TABPFN"
+    ag_name = "TabPFN"
+    ag_priority = 110
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/tabular/src/autogluon/tabular/models/tabpfnmix/tabpfnmix_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnmix/tabpfnmix_model.py
@@ -35,6 +35,10 @@ class TabPFNMixModel(AbstractModel):
 
     For more information, refer to the `./_internals/README.md` file.
     """
+    ag_key = "TABPFNMIX"
+    ag_name = "TabPFNMix"
+    ag_priority = 45
+
     weights_file_name = "model.pt"
 
     def __init__(self, **kwargs):

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -47,6 +47,9 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
         ag.early_stop : int | str, default = "default"
             Specifies the early stopping rounds. Defaults to an adaptive strategy. Recommended to keep default.
     """
+    ag_key = "NN_TORCH"
+    ag_name = "NeuralNetTorch"
+    ag_priority = 25
 
     # Constants used throughout this class:
     unique_category_str = np.nan  # string used to represent missing values and unknown categories for categorical features.

--- a/tabular/src/autogluon/tabular/models/text_prediction/text_prediction_v1_model.py
+++ b/tabular/src/autogluon/tabular/models/text_prediction/text_prediction_v1_model.py
@@ -19,6 +19,9 @@ logger = logging.getLogger(__name__)
 class TextPredictorModel(MultiModalPredictorModel):
     """MultimodalPredictor that doesn't use image features"""
 
+    ag_key = "AG_TEXT_NN"
+    ag_name = "TextPredictor"
+
     def _get_default_auxiliary_params(self) -> dict:
         default_auxiliary_params = super()._get_default_auxiliary_params()
         extra_auxiliary_params = dict(

--- a/tabular/src/autogluon/tabular/models/vowpalwabbit/vowpalwabbit_model.py
+++ b/tabular/src/autogluon/tabular/models/vowpalwabbit/vowpalwabbit_model.py
@@ -38,6 +38,9 @@ class VowpalWabbitModel(AbstractModel):
     VowpalWabbit Command Line args: https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Command-line-arguments
 
     """
+    ag_key = "VW"
+    ag_name = "VowpalWabbit"
+    ag_priority = 10
 
     model_internals_file_name = "model-internals.pkl"
 

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -27,6 +27,9 @@ class XGBoostModel(AbstractModel):
 
     Hyperparameter options: https://xgboost.readthedocs.io/en/latest/parameter.html
     """
+    ag_key = "XGB"
+    ag_name = "XGBoost"
+    ag_priority = 40
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/tabular/src/autogluon/tabular/models/xt/xt_model.py
+++ b/tabular/src/autogluon/tabular/models/xt/xt_model.py
@@ -10,7 +10,6 @@ class XTModel(RFModel):
     ag_key = "XT"
     ag_name = "ExtraTrees"
     ag_priority = 60
-    ag_priority_by_problem_type = {}
 
     def _get_model_type(self):
         if self.problem_type == REGRESSION:

--- a/tabular/src/autogluon/tabular/models/xt/xt_model.py
+++ b/tabular/src/autogluon/tabular/models/xt/xt_model.py
@@ -7,6 +7,10 @@ class XTModel(RFModel):
     """
     Extra Trees model (scikit-learn): https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.ExtraTreesClassifier.html#sklearn.ensemble.ExtraTreesClassifier
     """
+    ag_key = "XT"
+    ag_name = "ExtraTrees"
+    ag_priority = 60
+    ag_priority_by_problem_type = {}
 
     def _get_model_type(self):
         if self.problem_type == REGRESSION:

--- a/tabular/src/autogluon/tabular/register/__init__.py
+++ b/tabular/src/autogluon/tabular/register/__init__.py
@@ -1,0 +1,2 @@
+from ._model_register import ModelRegister
+from ._ag_model_register import ag_model_register

--- a/tabular/src/autogluon/tabular/register/_ag_model_register.py
+++ b/tabular/src/autogluon/tabular/register/_ag_model_register.py
@@ -1,0 +1,66 @@
+from autogluon.core.models import (
+    DummyModel,
+    GreedyWeightedEnsembleModel,
+    SimpleWeightedEnsembleModel,
+)
+
+from . import ModelRegister
+from ..models import (
+    BoostedRulesModel,
+    CatBoostModel,
+    FastTextModel,
+    FigsModel,
+    FTTransformerModel,
+    GreedyTreeModel,
+    HSTreeModel,
+    ImagePredictorModel,
+    KNNModel,
+    LGBModel,
+    LinearModel,
+    MultiModalPredictorModel,
+    NNFastAiTabularModel,
+    RFModel,
+    RuleFitModel,
+    TabPFNMixModel,
+    TabPFNModel,
+    TabularNeuralNetTorchModel,
+    TextPredictorModel,
+    VowpalWabbitModel,
+    XGBoostModel,
+    XTModel,
+)
+from ..models.tab_transformer.tab_transformer_model import TabTransformerModel
+
+
+# When adding a new model officially to AutoGluon, the model class should be added to the bottom of this list.
+REGISTERED_MODEL_CLS_LST = [
+    RFModel,
+    XTModel,
+    KNNModel,
+    LGBModel,
+    CatBoostModel,
+    XGBoostModel,
+    TabularNeuralNetTorchModel,
+    LinearModel,
+    NNFastAiTabularModel,
+    TabTransformerModel,
+    TextPredictorModel,
+    ImagePredictorModel,
+    MultiModalPredictorModel,
+    FTTransformerModel,
+    TabPFNModel,
+    TabPFNMixModel,
+    FastTextModel,
+    VowpalWabbitModel,
+    GreedyWeightedEnsembleModel,
+    SimpleWeightedEnsembleModel,
+    RuleFitModel,
+    GreedyTreeModel,
+    FigsModel,
+    HSTreeModel,
+    BoostedRulesModel,
+    DummyModel,
+]
+
+# TODO: Replace logic in `autogluon.tabular.trainer.model_presets.presets` with `ag_model_register`
+ag_model_register = ModelRegister(model_cls_list=REGISTERED_MODEL_CLS_LST)

--- a/tabular/src/autogluon/tabular/register/_model_register.py
+++ b/tabular/src/autogluon/tabular/register/_model_register.py
@@ -108,17 +108,6 @@ class ModelRegister:
     def priority_map(self, problem_type: str | None = None) -> dict[Type[AbstractModel], int]:
         return {model_cls: self.priority(model_cls, problem_type=problem_type) for model_cls in self._model_cls_list}
 
-    def key_to_priority_map(self, problem_type: str | None = None) -> dict[str, int]:
-        return {self.key(model_cls): self.priority(model_cls, problem_type=problem_type) for model_cls in self._model_cls_list}
-
-    def key_to_priority(self, key: str, problem_type: str | None = None) -> int:
-        if key not in self.key_to_cls_map():
-            raise ValueError(
-                f"No registered model exists with provided key: {key}"
-                f"\n\tValid keys: {list(self.key_to_cls_map().keys())}"
-            )
-        return self.priority(self.key_to_cls_map()[key], problem_type=problem_type)
-
     def key(self, model_cls: Type[AbstractModel]) -> str:
         assert self.exists(model_cls), f"Model class must be registered: {model_cls}"
         return model_cls.ag_key

--- a/tabular/src/autogluon/tabular/register/_model_register.py
+++ b/tabular/src/autogluon/tabular/register/_model_register.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from typing import Type
+
+import pandas as pd
+
+from autogluon.core.models import AbstractModel
+
+
+# TODO: Move to core? Maybe TimeSeries can re-use?
+# TODO: Use this / refer to this in the custom model tutorial
+# TODO: Add to documentation website
+# TODO: Test register logic in AG
+class ModelRegister:
+    """
+    ModelRegister keeps track of all known model classes to AutoGluon.
+    It can provide information such as:
+        What model classes and keys are valid to specify in an AutoGluon predictor fit call.
+        What a model's name is.
+        What a model's key is (such as the key specified by the user in `hyperparameters` to refer to a specific model type).
+        What a model's priority is (aka which order to fit a list of models).
+
+    Additionally, users can register custom models to AutoGluon so the key is recognized in `hyperparameters` and is treated with the proper priority and name.
+    They can register new models via `ModelRegister.add(model_cls)`.
+
+    Therefore, if a user creates a custom model `MyCustomModel` that inherits from `AbstractModel`, they can set the class attributes in `MyCustomModel`:
+        ag_key: The string key that can be specified in `hyperparameters`. Example: "GBM" for LGBModel
+        ag_name: The string name that is used in logging and accessing the model. Example: "LightGBM" for LGBModel
+        ag_priority: The int priority that is used to order the fitting of models. Higher values will be fit before lower values. Default 0. Example: 90 for LGBModel
+        ag_priority_to_problem_type: A dictionary of problem_type to priority that overrides `ag_priority` if specified for a given problem_type. Optional.
+
+    Then they can say `ag_model_register.add(MyCustomModel)`.
+    Assuming MyCustomModel.ag_key = "MY_MODEL", they can now do:
+    ```
+    predictor.fit(..., hyperparameters={"MY_MODEL": ...})
+    ```
+    """
+    def __init__(self, model_cls_list: list[Type[AbstractModel]] | None = None):
+        if model_cls_list is None:
+            model_cls_list = []
+        assert isinstance(model_cls_list, list)
+        self._model_cls_list = []
+        self._key_to_cls_map = dict()
+        for model_cls in model_cls_list:
+            self.add(model_cls)
+
+    def exists(self, model_cls: Type[AbstractModel]) -> bool:
+        return model_cls in self._model_cls_list
+
+    def add(self, model_cls: Type[AbstractModel]):
+        """
+        Adds `model_cls` to the model register
+        """
+        assert not self.exists(model_cls), f"Cannot add model_cls that is already registered: {model_cls}"
+        if model_cls.ag_key is None:
+            raise AssertionError(
+                f"Cannot add model_cls with `ag_key=None`. "
+                f"Ensure you set class attribute `ag_key` to a string for your model_cls: {model_cls}"
+                f'\n\tFor example, LightGBModel sets `ag_key = "GBM"`'
+            )
+        if model_cls.ag_name is None:
+            raise AssertionError(
+                f"Cannot add model_cls with `ag_name=None`. "
+                f"Ensure you set class attribute `ag_name` to a string for your model_cls: {model_cls}"
+                f'\n\tFor example, LightGBModel sets `ag_name = "LightGBM"`'
+            )
+        assert isinstance(model_cls.ag_key, str)
+        assert isinstance(model_cls.ag_name, str)
+        assert isinstance(model_cls.ag_priority, int)
+        if model_cls.ag_key in self._key_to_cls_map:
+            raise AssertionError(
+                f"Cannot register a model class that shares a model key with an already registered model class."
+                f"\n`model_cls.ag_key` must be unique among registered models:"
+                f"\n\t        New  Class: {model_cls}"
+                f"\n\tConflicting  Class: {self._key_to_cls_map[model_cls.ag_key]}"
+                f"\n\tConflicting ag_key: {model_cls.ag_key}"
+            )
+        self._model_cls_list.append(model_cls)
+        self._key_to_cls_map[model_cls.ag_key] = model_cls
+
+    def remove(self, model_cls: Type[AbstractModel]):
+        """
+        Removes `model_cls` from the model register
+        """
+        assert self.exists(model_cls), f"Cannot remove model_cls that isn't registered: {model_cls}"
+        self._model_cls_list = [m for m in self._model_cls_list if m != model_cls]
+        self._key_to_cls_map.pop(model_cls.ag_key)
+
+    @property
+    def model_cls_list(self) -> list[Type[AbstractModel]]:
+        return self._model_cls_list
+
+    @property
+    def keys(self) -> list[str]:
+        return [self.key(model_cls) for model_cls in self.model_cls_list]
+
+    def key_to_cls_map(self) -> dict[str, Type[AbstractModel]]:
+        return self._key_to_cls_map
+
+    def key_to_cls(self, key: str) -> Type[AbstractModel]:
+        if key not in self._key_to_cls_map:
+            raise ValueError(
+                f"No registered model exists with provided key: {key}"
+                f"\n\tValid keys: {list(self.key_to_cls_map().keys())}"
+            )
+        return self.key_to_cls_map()[key]
+
+    def priority_map(self, problem_type: str | None = None) -> dict[Type[AbstractModel], int]:
+        return {model_cls: self.priority(model_cls, problem_type=problem_type) for model_cls in self._model_cls_list}
+
+    def key_to_priority_map(self, problem_type: str | None = None) -> dict[str, int]:
+        return {self.key(model_cls): self.priority(model_cls, problem_type=problem_type) for model_cls in self._model_cls_list}
+
+    def key_to_priority(self, key: str, problem_type: str | None = None) -> int:
+        if key not in self.key_to_cls_map():
+            raise ValueError(
+                f"No registered model exists with provided key: {key}"
+                f"\n\tValid keys: {list(self.key_to_cls_map().keys())}"
+            )
+        return self.priority(self.key_to_cls_map()[key], problem_type=problem_type)
+
+    def key(self, model_cls: Type[AbstractModel]) -> str:
+        assert self.exists(model_cls), f"Model class must be registered: {model_cls}"
+        return model_cls.ag_key
+
+    def name_map(self) -> dict[Type[AbstractModel], str]:
+        return {model_cls: model_cls.ag_name for model_cls in self._model_cls_list}
+
+    def name(self, model_cls: Type[AbstractModel]) -> str:
+        assert self.exists(model_cls), f"Model class must be registered: {model_cls}"
+        return model_cls.ag_name
+
+    def priority(self, model_cls: Type[AbstractModel], problem_type: str | None = None) -> int:
+        assert self.exists(model_cls), f"Model class must be registered: {model_cls}"
+        return model_cls.get_ag_priority(problem_type=problem_type)
+
+    def docstring(self, model_cls: Type[AbstractModel]) -> str:
+        assert self.exists(model_cls), f"Model class must be registered: {model_cls}"
+        return model_cls.__doc__
+
+    # TODO: Could add a lot of information here to track which features are supported for each model:
+    #  ag.early_stop support
+    #  refit_full support
+    #  GPU support
+    #  etc.
+    def to_frame(self) -> pd.DataFrame:
+        model_classes = self.model_cls_list
+        cls_dict = {}
+        for model_cls in model_classes:
+            print(model_cls.__doc__)
+            cls_dict[self.key(model_cls)] = {
+                "model_cls": model_cls.__name__,
+                "ag_name": self.name(model_cls),
+                "ag_priority": self.priority(model_cls),
+            }
+        df = pd.DataFrame(cls_dict).T
+        df.index.name = "ag_key"
+        return df

--- a/tabular/src/autogluon/tabular/register/_model_register.py
+++ b/tabular/src/autogluon/tabular/register/_model_register.py
@@ -147,7 +147,6 @@ class ModelRegister:
         model_classes = self.model_cls_list
         cls_dict = {}
         for model_cls in model_classes:
-            print(model_cls.__doc__)
             cls_dict[self.key(model_cls)] = {
                 "model_cls": model_cls.__name__,
                 "ag_name": self.name(model_cls),

--- a/tabular/src/autogluon/tabular/register/_model_register.py
+++ b/tabular/src/autogluon/tabular/register/_model_register.py
@@ -7,7 +7,7 @@ import pandas as pd
 from autogluon.core.models import AbstractModel
 
 
-# TODO: Move to core? Maybe TimeSeries can re-use?
+# TODO: Move to core? Maybe TimeSeries can reuse?
 # TODO: Use this / refer to this in the custom model tutorial
 # TODO: Add to documentation website
 # TODO: Test register logic in AG

--- a/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
+++ b/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
@@ -52,7 +52,7 @@ DEFAULT_SOFTCLASS_PRIORITY = dict(
 DEFAULT_CUSTOM_MODEL_PRIORITY = 0
 
 # FIXME: Don't do this, use ag_model_register lazily so users can register custom models before calling fit
-DEFAULT_MODEL_PRIORITY = ag_model_register.key_to_priority_map()
+DEFAULT_MODEL_PRIORITY = {ag_model_register.key(model_cls): ag_model_register.priority(model_cls) for model_cls in ag_model_register.model_cls_list}
 DEFAULT_MODEL_NAMES = ag_model_register.name_map()
 REGISTERED_MODEL_CLS_LST = ag_model_register.model_cls_list
 MODEL_TYPES = ag_model_register.key_to_cls_map()

--- a/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
+++ b/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import inspect
 import logging
@@ -22,70 +24,16 @@ from autogluon.core.constants import (
 )
 from autogluon.core.models import (
     AbstractModel,
-    DummyModel,
-    GreedyWeightedEnsembleModel,
-    SimpleWeightedEnsembleModel,
     StackerEnsembleModel,
 )
 from autogluon.core.trainer.utils import process_hyperparameters
 
-from ...models import (
-    BoostedRulesModel,
-    CatBoostModel,
-    FastTextModel,
-    FigsModel,
-    FTTransformerModel,
-    GreedyTreeModel,
-    HSTreeModel,
-    ImagePredictorModel,
-    KNNModel,
-    LGBModel,
-    LinearModel,
-    MultiModalPredictorModel,
-    NNFastAiTabularModel,
-    RFModel,
-    RuleFitModel,
-    TabPFNMixModel,
-    TabPFNModel,
-    TabularNeuralNetTorchModel,
-    TextPredictorModel,
-    VowpalWabbitModel,
-    XGBoostModel,
-    XTModel,
-)
-from ...models.tab_transformer.tab_transformer_model import TabTransformerModel
+from ...register import ag_model_register
 from ...version import __version__
 
 logger = logging.getLogger(__name__)
 
-# Higher values indicate higher priority, priority dictates the order models are trained for a given level.
-DEFAULT_MODEL_PRIORITY = dict(
-    TABPFN=110,  # highest priority due to its very fast training time
-    KNN=100,
-    GBM=90,
-    RF=80,
-    CAT=70,
-    XT=60,
-    FASTAI=50,
-    TABPFNMIX=45,
-    XGB=40,
-    LR=30,
-    NN_TORCH=25,
-    VW=10,
-    FASTTEXT=0,
-    AG_TEXT_NN=0,
-    AG_IMAGE_NN=0,
-    AG_AUTOMM=0,
-    TRANSF=0,
-    custom=0,
-    # interpretable models
-    IM_RULEFIT=0,
-    IM_GREEDYTREE=0,
-    IM_FIGS=0,
-    IM_HSTREE=0,
-    IM_BOOSTEDRULES=0,
-)
-
+# TODO: Replace with ag_model_register
 # Problem type specific model priority overrides (will update default values in DEFAULT_MODEL_PRIORITY)
 PROBLEM_TYPE_MODEL_PRIORITY = {
     MULTICLASS: dict(
@@ -93,6 +41,7 @@ PROBLEM_TYPE_MODEL_PRIORITY = {
     ),
 }
 
+# TODO: Replace with ag_model_register
 DEFAULT_SOFTCLASS_PRIORITY = dict(
     GBM=100,
     RF=80,
@@ -102,66 +51,11 @@ DEFAULT_SOFTCLASS_PRIORITY = dict(
 
 DEFAULT_CUSTOM_MODEL_PRIORITY = 0
 
-MODEL_TYPES = dict(
-    RF=RFModel,
-    XT=XTModel,
-    KNN=KNNModel,
-    GBM=LGBModel,
-    CAT=CatBoostModel,
-    XGB=XGBoostModel,
-    NN_TORCH=TabularNeuralNetTorchModel,
-    LR=LinearModel,
-    FASTAI=NNFastAiTabularModel,
-    TRANSF=TabTransformerModel,
-    AG_TEXT_NN=TextPredictorModel,
-    AG_IMAGE_NN=ImagePredictorModel,
-    AG_AUTOMM=MultiModalPredictorModel,
-    FT_TRANSFORMER=FTTransformerModel,
-    TABPFN=TabPFNModel,
-    TABPFNMIX=TabPFNMixModel,
-    FASTTEXT=FastTextModel,
-    ENS_WEIGHTED=GreedyWeightedEnsembleModel,
-    SIMPLE_ENS_WEIGHTED=SimpleWeightedEnsembleModel,
-    # interpretable models
-    IM_RULEFIT=RuleFitModel,
-    IM_GREEDYTREE=GreedyTreeModel,
-    IM_FIGS=FigsModel,
-    IM_HSTREE=HSTreeModel,
-    IM_BOOSTEDRULES=BoostedRulesModel,
-    VW=VowpalWabbitModel,
-    DUMMY=DummyModel,
-)
-
-
-# TODO: v1.0 Have this be defined in the model class
-DEFAULT_MODEL_NAMES = {
-    RFModel: "RandomForest",
-    XTModel: "ExtraTrees",
-    KNNModel: "KNeighbors",
-    LGBModel: "LightGBM",
-    CatBoostModel: "CatBoost",
-    XGBoostModel: "XGBoost",
-    TabularNeuralNetTorchModel: "NeuralNetTorch",
-    LinearModel: "LinearModel",
-    NNFastAiTabularModel: "NeuralNetFastAI",
-    TabTransformerModel: "Transformer",
-    TextPredictorModel: "TextPredictor",
-    ImagePredictorModel: "ImagePredictor",
-    MultiModalPredictorModel: "MultiModalPredictor",
-    FTTransformerModel: "FTTransformer",
-    TabPFNModel: "TabPFN",
-    TabPFNMixModel: "TabPFNMix",
-    FastTextModel: "FastText",
-    VowpalWabbitModel: "VowpalWabbit",
-    GreedyWeightedEnsembleModel: "WeightedEnsemble",
-    SimpleWeightedEnsembleModel: "WeightedEnsemble",
-    # Interpretable models
-    RuleFitModel: "RuleFit",
-    GreedyTreeModel: "GreedyTree",
-    FigsModel: "Figs",
-    HSTreeModel: "HierarchicalShrinkageTree",
-    BoostedRulesModel: "BoostedRules",
-}
+# FIXME: Don't do this, use ag_model_register lazily so users can register custom models before calling fit
+DEFAULT_MODEL_PRIORITY = ag_model_register.key_to_priority_map()
+DEFAULT_MODEL_NAMES = ag_model_register.name_map()
+REGISTERED_MODEL_CLS_LST = ag_model_register.model_cls_list
+MODEL_TYPES = ag_model_register.key_to_cls_map()
 
 
 VALID_AG_ARGS_KEYS = {

--- a/tabular/tests/unittests/callbacks/test_callbacks.py
+++ b/tabular/tests/unittests/callbacks/test_callbacks.py
@@ -43,7 +43,7 @@ def test_early_stopping_callback_v2(fit_helper):
 
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=6, refit_full=False)
 
-    assert callback.model_best == "DummyModel_BAG_L1"
+    assert callback.model_best == "Dummy_BAG_L1"
     assert callback.score_best == 0.76
     assert callback.infer_limit is None
 
@@ -69,7 +69,7 @@ def test_early_stopping_callback_v3(fit_helper):
 
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=3, refit_full=False)
 
-    assert callback.model_best == "DummyModel_BAG_L1"
+    assert callback.model_best == "Dummy_BAG_L1"
     assert callback.score_best == 0.76
     assert callback.infer_limit is None
 
@@ -115,7 +115,7 @@ def test_early_stopping_ensemble_callback_v2(fit_helper):
 
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=9, refit_full=False)
 
-    assert callback.model_best == "DummyModel_BAG_L1"
+    assert callback.model_best == "Dummy_BAG_L1"
     assert callback.score_best == 0.76
     assert callback.infer_limit is None
     assert callback.infer_limit_batch_size is None
@@ -142,7 +142,7 @@ def test_early_stopping_ensemble_callback_v3(fit_helper):
 
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=5, refit_full=False)
 
-    assert callback.model_best == "DummyModel_BAG_L1"
+    assert callback.model_best == "Dummy_BAG_L1"
     assert callback.score_best == 0.76
     assert callback.infer_limit is None
     assert callback.infer_limit_batch_size is None

--- a/tabular/tests/unittests/configs/test_config_helper.py
+++ b/tabular/tests/unittests/configs/test_config_helper.py
@@ -5,6 +5,7 @@ from sklearn.feature_extraction.text import CountVectorizer
 from autogluon.features import TextNgramFeatureGenerator
 from autogluon.tabular.configs.config_helper import ConfigBuilder, FeatureGeneratorBuilder
 from autogluon.tabular.models import KNNModel
+from autogluon.tabular.register import ag_model_register
 
 
 def test_presets():
@@ -58,32 +59,11 @@ def test_excluded_model_types_invalid_option():
 
 
 def test_included_model_types():
+    model_keys = ag_model_register.keys
+    model_keys_no_rf = [k for k in model_keys if k not in ["RF", "ENS_WEIGHTED", "SIMPLE_ENS_WEIGHTED"]]
+
     expected_config = dict(
-        excluded_model_types=[
-            "XT",
-            "KNN",
-            "GBM",
-            "CAT",
-            "XGB",
-            "NN_TORCH",
-            "LR",
-            "FASTAI",
-            "TRANSF",
-            "AG_TEXT_NN",
-            "AG_IMAGE_NN",
-            "AG_AUTOMM",
-            "FT_TRANSFORMER",
-            "TABPFN",
-            "TABPFNMIX",
-            "FASTTEXT",
-            "IM_RULEFIT",
-            "IM_GREEDYTREE",
-            "IM_FIGS",
-            "IM_HSTREE",
-            "IM_BOOSTEDRULES",
-            "VW",
-            "DUMMY",
-        ]
+        excluded_model_types=model_keys_no_rf
     )
     actual_config = ConfigBuilder().included_model_types("RF").build()
     assert actual_config == expected_config
@@ -94,31 +74,9 @@ def test_included_model_types():
     actual_config = ConfigBuilder().included_model_types(["RF", "RF"]).build()
     assert actual_config == expected_config
 
+    model_keys_no_lr = [k for k in model_keys_no_rf if k != "LR"]
     expected_config = dict(
-        excluded_model_types=[
-            "XT",
-            "KNN",
-            "GBM",
-            "CAT",
-            "XGB",
-            "NN_TORCH",
-            "FASTAI",
-            "TRANSF",
-            "AG_TEXT_NN",
-            "AG_IMAGE_NN",
-            "AG_AUTOMM",
-            "FT_TRANSFORMER",
-            "TABPFN",
-            "TABPFNMIX",
-            "FASTTEXT",
-            "IM_RULEFIT",
-            "IM_GREEDYTREE",
-            "IM_FIGS",
-            "IM_HSTREE",
-            "IM_BOOSTEDRULES",
-            "VW",
-            "DUMMY",
-        ]
+        excluded_model_types=model_keys_no_lr
     )
     actual_config = ConfigBuilder().included_model_types(["RF", "LR"]).build()
     assert actual_config == expected_config
@@ -127,31 +85,7 @@ def test_included_model_types():
         pass
 
     expected_config = dict(
-        excluded_model_types=[
-            "XT",
-            "KNN",
-            "GBM",
-            "CAT",
-            "XGB",
-            "NN_TORCH",
-            "LR",
-            "FASTAI",
-            "TRANSF",
-            "AG_TEXT_NN",
-            "AG_IMAGE_NN",
-            "AG_AUTOMM",
-            "FT_TRANSFORMER",
-            "TABPFN",
-            "TABPFNMIX",
-            "FASTTEXT",
-            "IM_RULEFIT",
-            "IM_GREEDYTREE",
-            "IM_FIGS",
-            "IM_HSTREE",
-            "IM_BOOSTEDRULES",
-            "VW",
-            "DUMMY",
-        ]
+        excluded_model_types=model_keys_no_rf
     )
     actual_config = ConfigBuilder().included_model_types([CustomKNN, "RF"]).build()
     assert actual_config == expected_config

--- a/tabular/tests/unittests/edgecases/test_edgecases.py
+++ b/tabular/tests/unittests/edgecases/test_edgecases.py
@@ -270,10 +270,10 @@ def test_delay_bag_sets(fit_helper,delay_bag_sets):
     )
 
     # Verify fit order is correct.
-    model_1 = predictor._trainer.load_model('DummyModel_BAG_L1')
+    model_1 = predictor._trainer.load_model('Dummy_BAG_L1')
     max_model_times_1 = max([(Path(model_1.path)/bm).stat().st_mtime_ns for bm in model_1.models])
 
-    model_2 = predictor._trainer.load_model('DummyModel_2_BAG_L1')
+    model_2 = predictor._trainer.load_model('Dummy_2_BAG_L1')
     min_model_times_2 = min([(Path(model_2.path) / bm).stat().st_mtime_ns for bm in model_2.models])
 
     if delay_bag_sets:

--- a/tabular/tests/unittests/models/advanced/test_stack_feature_usage.py
+++ b/tabular/tests/unittests/models/advanced/test_stack_feature_usage.py
@@ -12,7 +12,7 @@ from autogluon.tabular.predictor import TabularPredictor
 def test_stack_feature_usage_binary(fit_helper):
     """Tests that stacker models use base model predictions as features correctly for binary"""
     dataset_name = "adult"
-    expected_ancestors = {"LightGBM_BAG_L1", "DummyModel_BAG_L1"}
+    expected_ancestors = {"LightGBM_BAG_L1", "Dummy_BAG_L1"}
     _fit_predictor_stack_feature_usage(
         dataset_name=dataset_name,
         max_base_models_per_type=1,
@@ -54,7 +54,7 @@ def test_stack_feature_usage_regression(fit_helper):
 def test_stack_feature_usage_binary_all(fit_helper):
     """Tests that stacker models use base model predictions as features correctly for binary"""
     dataset_name = "adult"
-    expected_ancestors = {"LightGBM_BAG_L1", "LightGBM_2_BAG_L1", "KNeighbors_BAG_L1", "DummyModel_BAG_L1"}
+    expected_ancestors = {"LightGBM_BAG_L1", "LightGBM_2_BAG_L1", "KNeighbors_BAG_L1", "Dummy_BAG_L1"}
     _fit_predictor_stack_feature_usage(
         dataset_name=dataset_name,
         max_base_models_per_type=0,  # uncapped

--- a/tabular/tests/unittests/models/test_dummy.py
+++ b/tabular/tests/unittests/models/test_dummy.py
@@ -69,7 +69,7 @@ def test_no_models_raise(fit_helper, dataset_loader_helper):
     model_failures = predictor.model_failures()
     assert len(model_failures) == 1
     model_failures_dict = model_failures.iloc[0].to_dict()
-    assert model_failures_dict["model"] == "DummyModel"
+    assert model_failures_dict["model"] == "Dummy"
     assert model_failures_dict["model_type"] == "DummyModel"
     assert model_failures_dict["exc_type"] == "ValueError"
     assert model_failures_dict["exc_str"] == expected_exc_str

--- a/tabular/tests/unittests/register/test_model_register.py
+++ b/tabular/tests/unittests/register/test_model_register.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+from typing import Type
+
+import pytest
+
+from autogluon.core.models import (
+    AbstractModel,
+    DummyModel,
+    GreedyWeightedEnsembleModel,
+    SimpleWeightedEnsembleModel,
+)
+from autogluon.tabular.register import ag_model_register, ModelRegister
+
+from autogluon.tabular.models import (
+    BoostedRulesModel,
+    CatBoostModel,
+    FastTextModel,
+    FigsModel,
+    FTTransformerModel,
+    GreedyTreeModel,
+    HSTreeModel,
+    ImagePredictorModel,
+    KNNModel,
+    LGBModel,
+    LinearModel,
+    MultiModalPredictorModel,
+    NNFastAiTabularModel,
+    RFModel,
+    RuleFitModel,
+    TabPFNMixModel,
+    TabPFNModel,
+    TabularNeuralNetTorchModel,
+    TextPredictorModel,
+    VowpalWabbitModel,
+    XGBoostModel,
+    XTModel,
+)
+from autogluon.tabular.models.tab_transformer.tab_transformer_model import TabTransformerModel
+
+
+EXPECTED_MODEL_KEYS = {
+    RFModel: "RF",
+    XTModel: "XT",
+    KNNModel: "KNN",
+    LGBModel: "GBM",
+    CatBoostModel: "CAT",
+    XGBoostModel: "XGB",
+    TabularNeuralNetTorchModel: "NN_TORCH",
+    LinearModel: "LR",
+    NNFastAiTabularModel: "FASTAI",
+    TabTransformerModel: "TRANSF",
+    TextPredictorModel: "AG_TEXT_NN",
+    ImagePredictorModel: "AG_IMAGE_NN",
+    MultiModalPredictorModel: "AG_AUTOMM",
+    FTTransformerModel: "FT_TRANSFORMER",
+    TabPFNModel: "TABPFN",
+    TabPFNMixModel: "TABPFNMIX",
+    FastTextModel: "FASTTEXT",
+    VowpalWabbitModel: "VW",
+    GreedyWeightedEnsembleModel: "ENS_WEIGHTED",
+    SimpleWeightedEnsembleModel: "SIMPLE_ENS_WEIGHTED",
+    RuleFitModel: "IM_RULEFIT",
+    GreedyTreeModel: "IM_GREEDYTREE",
+    FigsModel: "IM_FIGS",
+    HSTreeModel: "IM_HSTREE",
+    BoostedRulesModel: "IM_BOOSTEDRULES",
+    DummyModel: "DUMMY",
+}
+
+EXPECTED_MODEL_NAMES = {
+    RFModel: "RandomForest",
+    XTModel: "ExtraTrees",
+    KNNModel: "KNeighbors",
+    LGBModel: "LightGBM",
+    CatBoostModel: "CatBoost",
+    XGBoostModel: "XGBoost",
+    TabularNeuralNetTorchModel: "NeuralNetTorch",
+    LinearModel: "LinearModel",
+    NNFastAiTabularModel: "NeuralNetFastAI",
+    TabTransformerModel: "Transformer",
+    TextPredictorModel: "TextPredictor",
+    ImagePredictorModel: "ImagePredictor",
+    MultiModalPredictorModel: "MultiModalPredictor",
+    FTTransformerModel: "FTTransformer",
+    TabPFNModel: "TabPFN",
+    TabPFNMixModel: "TabPFNMix",
+    FastTextModel: "FastText",
+    VowpalWabbitModel: "VowpalWabbit",
+    GreedyWeightedEnsembleModel: "WeightedEnsemble",
+    SimpleWeightedEnsembleModel: "WeightedEnsemble",
+    RuleFitModel: "RuleFit",
+    GreedyTreeModel: "GreedyTree",
+    FigsModel: "Figs",
+    HSTreeModel: "HierarchicalShrinkageTree",
+    BoostedRulesModel: "BoostedRules",
+    DummyModel: "Dummy",
+}
+
+# Higher values indicate higher priority, priority dictates the order models are trained for a given level.
+EXPECTED_MODEL_PRIORITY = {
+    RFModel: 80,
+    XTModel: 60,
+    KNNModel: 100,
+    LGBModel: 90,
+    CatBoostModel: 70,
+    XGBoostModel: 40,
+    TabularNeuralNetTorchModel: 25,
+    LinearModel: 30,
+    NNFastAiTabularModel: 50,
+    TabTransformerModel: 0,
+    TextPredictorModel: 0,
+    ImagePredictorModel: 0,
+    MultiModalPredictorModel: 0,
+    FTTransformerModel: 0,
+    TabPFNModel: 110,
+    TabPFNMixModel: 45,
+    FastTextModel: 0,
+    VowpalWabbitModel: 10,
+    GreedyWeightedEnsembleModel: 0,
+    SimpleWeightedEnsembleModel: 0,
+    RuleFitModel: 0,
+    GreedyTreeModel: 0,
+    FigsModel: 0,
+    HSTreeModel: 0,
+    BoostedRulesModel: 0,
+    DummyModel: 0,
+}
+
+EXPECTED_MODEL_PRIORITY_BY_PROBLEM_TYPE = {
+    LGBModel: {
+        "softclass": 100,
+    },
+    RFModel: {
+        "softclass": 80,
+    },
+    CatBoostModel: {
+        "softclass": 60,
+    },
+    NNFastAiTabularModel: {
+        "multiclass": 95,
+    },
+}
+
+EXPECTED_REGISTERED_MODEL_CLS_LST = list(EXPECTED_MODEL_NAMES.keys())
+REGISTERED_MODEL_CLS_LST = ag_model_register.model_cls_list
+
+
+@pytest.mark.parametrize(
+    "model_cls",
+    REGISTERED_MODEL_CLS_LST,
+    ids=[c.__name__ for c in REGISTERED_MODEL_CLS_LST],
+)  # noqa
+def test_model_cls_key(model_cls: Type[AbstractModel]):
+    expected_model_key = EXPECTED_MODEL_KEYS[model_cls]
+    assert expected_model_key == model_cls.ag_key
+
+
+def verify_register(model_cls: Type[AbstractModel], model_register: ModelRegister):
+    """
+    Verifies that all methods work as intended in ModelRegister, assuming `model_cls` is already registered.
+    """
+    assert model_register.exists(model_cls)
+    assert model_cls.ag_key == model_register.key(model_cls)
+    assert model_cls.ag_priority == model_register.priority(model_cls)
+
+    assert model_cls in model_register.model_cls_list
+    assert model_cls.ag_key in model_register.keys
+
+    assert model_cls == model_register.key_to_cls(model_register.key(model_cls))
+    key_to_cls_map = model_register.key_to_cls_map()
+    assert model_cls == key_to_cls_map[model_cls.ag_key]
+
+    name_map = model_register.name_map()
+    assert model_cls.ag_name == name_map[model_cls]
+    assert model_cls.ag_name == model_register.name(model_cls)
+
+    priority_map = model_register.priority_map()
+    assert model_cls.ag_priority == priority_map[model_cls]
+    key_to_priority_map = model_register.key_to_priority_map()
+    assert model_cls.ag_priority == key_to_priority_map[model_cls.ag_key]
+    assert model_cls.ag_priority == model_register.key_to_priority(model_cls.ag_key)
+    for problem_type in model_cls.ag_priority_by_problem_type:
+        priority_map_problem_type = model_register.priority_map(problem_type=problem_type)
+        assert model_cls.get_ag_priority(problem_type) == model_register.priority(model_cls, problem_type=problem_type)
+        assert model_cls.get_ag_priority(problem_type) == priority_map_problem_type[model_cls]
+
+
+@pytest.mark.parametrize(
+    "model_cls",
+    REGISTERED_MODEL_CLS_LST,
+    ids=[c.__name__ for c in REGISTERED_MODEL_CLS_LST],
+)  # noqa
+def test_model_register(model_cls: Type[AbstractModel]):
+    """
+    Verifies that all methods work as intended in ModelRegister.
+    """
+    verify_register(model_cls=model_cls, model_register=ag_model_register)
+
+
+def test_model_register_new():
+    """
+    Verifies that all methods work as intended in a new ModelRegister.
+    """
+    model_register_new = ModelRegister()
+
+    assert not model_register_new.exists(RFModel)
+    assert model_register_new.model_cls_list == []
+    assert model_register_new.keys == []
+    assert model_register_new.name_map() == {}
+    assert model_register_new.priority_map() == {}
+
+    model_register_new.add(RFModel)
+    assert model_register_new.model_cls_list == [RFModel]
+    verify_register(model_cls=RFModel, model_register=model_register_new)
+
+    model_register_new.remove(model_cls=RFModel)
+    assert not model_register_new.exists(RFModel)
+    assert model_register_new.model_cls_list == []
+    assert model_register_new.keys == []
+    assert model_register_new.name_map() == {}
+    assert model_register_new.priority_map() == {}
+
+
+def test_no_unknown_model_cls_registered():
+    assert set(ag_model_register.model_cls_list) == set(EXPECTED_REGISTERED_MODEL_CLS_LST)
+
+
+@pytest.mark.parametrize(
+    "model_cls",
+    REGISTERED_MODEL_CLS_LST,
+    ids=[c.__name__ for c in REGISTERED_MODEL_CLS_LST],
+)  # noqa
+def test_model_cls_name(model_cls: Type[AbstractModel]):
+    expected_model_name = EXPECTED_MODEL_NAMES[model_cls]
+    assert expected_model_name == model_cls.ag_name
+
+
+@pytest.mark.parametrize(
+    "model_cls",
+    REGISTERED_MODEL_CLS_LST,
+    ids=[c.__name__ for c in REGISTERED_MODEL_CLS_LST],
+)  # noqa
+def test_model_cls_priority(model_cls: Type[AbstractModel]):
+    expected_model_priority = EXPECTED_MODEL_PRIORITY[model_cls]
+    assert expected_model_priority == model_cls.ag_priority
+
+
+@pytest.mark.parametrize(
+    "model_cls",
+    REGISTERED_MODEL_CLS_LST,
+    ids=[c.__name__ for c in REGISTERED_MODEL_CLS_LST],
+)  # noqa
+def test_model_cls_priority_by_problem_type(model_cls: Type[AbstractModel]):
+    expected_model_priority_by_problem_type = EXPECTED_MODEL_PRIORITY_BY_PROBLEM_TYPE.get(model_cls, {})
+    expected_model_priority_default = EXPECTED_MODEL_PRIORITY[model_cls]
+    assert expected_model_priority_by_problem_type == model_cls.ag_priority_by_problem_type
+    for problem_type in ["binary", "multiclass", "regression", "quantile", "softclass"]:
+        expected_model_priority = expected_model_priority_by_problem_type.get(problem_type, expected_model_priority_default)
+        model_priority = model_cls.get_ag_priority(problem_type=problem_type)
+        assert expected_model_priority == model_priority
+    assert expected_model_priority_default == model_cls.get_ag_priority()
+
+
+def test_model_cls_all_present():
+    assert len(REGISTERED_MODEL_CLS_LST) == len(set(REGISTERED_MODEL_CLS_LST))
+    assert set(EXPECTED_REGISTERED_MODEL_CLS_LST) == set(REGISTERED_MODEL_CLS_LST)
+
+
+def test_model_cls_no_duplicate_keys():
+    keys = set()
+    for c in REGISTERED_MODEL_CLS_LST:
+        if c.ag_key in keys:
+            raise AssertionError(f"Two model classes cannot share the same key: {c.ag_key}")
+        keys.add(c.ag_key)

--- a/tabular/tests/unittests/register/test_model_register.py
+++ b/tabular/tests/unittests/register/test_model_register.py
@@ -131,9 +131,6 @@ EXPECTED_MODEL_PRIORITY_BY_PROBLEM_TYPE = {
     LGBModel: {
         "softclass": 100,
     },
-    RFModel: {
-        "softclass": 80,
-    },
     CatBoostModel: {
         "softclass": 60,
     },
@@ -177,9 +174,6 @@ def verify_register(model_cls: Type[AbstractModel], model_register: ModelRegiste
 
     priority_map = model_register.priority_map()
     assert model_cls.ag_priority == priority_map[model_cls]
-    key_to_priority_map = model_register.key_to_priority_map()
-    assert model_cls.ag_priority == key_to_priority_map[model_cls.ag_key]
-    assert model_cls.ag_priority == model_register.key_to_priority(model_cls.ag_key)
     for problem_type in model_cls.ag_priority_by_problem_type:
         priority_map_problem_type = model_register.priority_map(problem_type=problem_type)
         assert model_cls.get_ag_priority(problem_type) == model_register.priority(model_cls, problem_type=problem_type)

--- a/tabular/tests/unittests/register/test_model_register.py
+++ b/tabular/tests/unittests/register/test_model_register.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from types import MappingProxyType
 from typing import Type
 
 import pytest
@@ -249,6 +250,7 @@ def test_model_cls_priority_by_problem_type(model_cls: Type[AbstractModel]):
     expected_model_priority_by_problem_type = EXPECTED_MODEL_PRIORITY_BY_PROBLEM_TYPE.get(model_cls, {})
     expected_model_priority_default = EXPECTED_MODEL_PRIORITY[model_cls]
     assert expected_model_priority_by_problem_type == model_cls.ag_priority_by_problem_type
+    assert isinstance(model_cls.ag_priority_by_problem_type, MappingProxyType)
     for problem_type in ["binary", "multiclass", "regression", "quantile", "softclass"]:
         expected_model_priority = expected_model_priority_by_problem_type.get(problem_type, expected_model_priority_default)
         model_priority = model_cls.get_ag_priority(problem_type=problem_type)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add `ag_key`, `ag_name` and `ag_priority` class variables to all AbstractModel subclasses.
- Add ag_model_register and ModelRegister to simplify model book keeping and enable registering custom models easily.
- Add 134 unit tests for ModelRegister to ensure matching functionality with mainline.
- This logic will be extremely helpful with making TabRepo 2.0 adoption lightweight.
- Add name for DummyModel -> "Dummy", made relevant unit test changes. Previously it was the only unnamed model.

WIP:
- [ ] Replace logic in `autogluon.tabular.trainer.model_presets.presets` to use `ag_model_register`. I decided not to do that in this PR as it would expand the scope to the point of being hard to review. So I will do this as a follow-up PR.

## Example:

```python
import pandas as pd

from autogluon.core.models import AbstractModel
from autogluon.tabular.register import ag_model_register


class MyCustomModel(AbstractModel):
    ag_key = "MYMODEL"
    ag_name = "MyModel"
    ag_priority = 70


ag_model_register.add(MyCustomModel)
print(f"Class mapped to 'MYMODEL' key: {ag_model_register.key_to_cls(key='MYMODEL')}")

print("Contents of ag_model_register:")
with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):
    print(ag_model_register.to_frame())

```

### Output:

```
Class mapped to 'MYMODEL' key: <class '__main__.MyCustomModel'>
Contents of ag_model_register:
                                       model_cls                    ag_name ag_priority
ag_key                                                                                 
RF                                       RFModel               RandomForest          80
XT                                       XTModel                 ExtraTrees          60
KNN                                     KNNModel                 KNeighbors         100
GBM                                     LGBModel                   LightGBM          90
CAT                                CatBoostModel                   CatBoost          70
XGB                                 XGBoostModel                    XGBoost          40
NN_TORCH              TabularNeuralNetTorchModel             NeuralNetTorch          25
LR                                   LinearModel                LinearModel          30
FASTAI                      NNFastAiTabularModel            NeuralNetFastAI          50
TRANSF                       TabTransformerModel                Transformer           0
AG_TEXT_NN                    TextPredictorModel              TextPredictor           0
AG_IMAGE_NN                  ImagePredictorModel             ImagePredictor           0
AG_AUTOMM               MultiModalPredictorModel        MultiModalPredictor           0
FT_TRANSFORMER                FTTransformerModel              FTTransformer           0
TABPFN                               TabPFNModel                     TabPFN         110
TABPFNMIX                         TabPFNMixModel                  TabPFNMix          45
FASTTEXT                           FastTextModel                   FastText           0
VW                             VowpalWabbitModel               VowpalWabbit          10
ENS_WEIGHTED         GreedyWeightedEnsembleModel           WeightedEnsemble           0
SIMPLE_ENS_WEIGHTED  SimpleWeightedEnsembleModel           WeightedEnsemble           0
IM_RULEFIT                          RuleFitModel                    RuleFit           0
IM_GREEDYTREE                    GreedyTreeModel                 GreedyTree           0
IM_FIGS                                FigsModel                       Figs           0
IM_HSTREE                            HSTreeModel  HierarchicalShrinkageTree           0
IM_BOOSTEDRULES                BoostedRulesModel               BoostedRules           0
DUMMY                                 DummyModel                      Dummy           0
MYMODEL                            MyCustomModel                    MyModel          70
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
