### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ lint.ignore = [
 ]
 lint.isort.known-first-party = ["autogluon"]
 lint.isort.known-third-party = [
+    "dask", 
     "gluonts",
     "mxnet",
     "networkx",


### PR DESCRIPTION
added dask as known-third-party in pyproject.toml to consider the downloading of dependsncy dask dataframe for needed usecases.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
