### PR TITLE
Make full_install.sh working dir -> script dir

### DIFF
--- a/full_install.sh
+++ b/full_install.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Get the directory of the script
+script_dir=$(dirname "$0")
+
+# Change the current directory to the script's directory
+cd "$script_dir"
+
 EDITABLE="true"
 
 while test $# -gt 0


### PR DESCRIPTION
*Issue #, if available:*

Resolves #4932 

*Description of changes:*

Make `full_install.sh` work when called outside of autogluon's directory.

## Example

This works in mainline:

```
git clone https://github.com/autogluon/autogluon.git
cd autogluon && ./full_install.sh
```

This fails in mainline but succeeds in this PR:

```
git clone https://github.com/autogluon/autogluon.git
./autogluon/full_install.sh
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
