### PR TITLE
add notebook env check for colab and fix the source installation issue

### DIFF
--- a/full_install.sh
+++ b/full_install.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 EDITABLE="true"
+UV_FLAGS=""
 
 while test $# -gt 0
 do
@@ -13,6 +14,28 @@ do
     shift
 done
 
+# Check if we're in a Jupyter/Colab environment
+IN_NOTEBOOK=$(python -c "
+try:
+    import google.colab
+    print('colab')
+except ImportError:
+    try:
+        shell = get_ipython().__class__.__name__
+        if shell == 'ZMQInteractiveShell':  # Jupyter notebook or qtconsole
+            print('jupyter')
+        else:
+            print('no')
+    except (NameError, ImportError):
+        print('no')
+")
+
+# If in Colab or Jupyter, use --system flag with uv
+if [ "$IN_NOTEBOOK" != "no" ]; then
+    echo "Detected $IN_NOTEBOOK environment. Using --system flag with uv."
+    UV_FLAGS="--system"
+fi
+
 # Check if uv is installed
 if ! python -m pip show uv &> /dev/null; then
     echo "uv could not be found. Installing uv..."
@@ -23,15 +46,15 @@ fi
 # TODO: We should simplify this by having a single setup.py at project root, and let user call `pip install -e .`
 if [ "$EDITABLE" == "true" ]; then
   # install common first to avoid bugs with parallelization
-  python -m uv pip install --refresh -e common/[tests]
+  python -m uv pip install --refresh $UV_FLAGS -e common/[tests]
 
   # install the rest
-  python -m uv pip install -e core/[all,tests] -e features/ -e tabular/[all,tests] -e multimodal/[tests] -e timeseries/[all,tests] -e eda/ -e autogluon/
+  python -m uv pip install $UV_FLAGS -e core/[all,tests] -e features/ -e tabular/[all,tests] -e multimodal/[tests] -e timeseries/[all,tests] -e eda/ -e autogluon/
 
 else
   # install common first to avoid bugs with parallelization
-  python -m uv pip install --refresh common/[tests]
+  python -m uv pip install --refresh $UV_FLAGS common/[tests]
 
   # install the rest
-  python -m uv pip install core/[all,tests] features/ tabular/[all,tests] multimodal/[tests] timeseries/[all,tests] eda/ autogluon/
+  python -m uv pip install $UV_FLAGS core/[all,tests] features/ tabular/[all,tests] multimodal/[tests] timeseries/[all,tests] eda/ autogluon/
 fi


### PR DESCRIPTION
*Issue #, if available:*
Fixes #4934

*Description of changes:*

Adds Jupyter/Colab environment detection to the full_install.sh script. When running in Colab or other Jupyter environments, the script automatically adds the `--system` flag to all `uv pip install` commands.

This addresses the issue where AutoGluon installation with `uv pip` was failing in Colab because packages were being installed in a virtual environment not accessible from the notebook's Python kernel. The `--system` flag ensures packages are installed in the system Python path, making them importable in notebook environments.

Colab testing [link](https://colab.research.google.com/drive/16zmGdMylUbLYYVuEgOcEkip8-ah3GH5b?usp=sharing)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.