### PR TITLE
[tabular] speed up tests

### DIFF
--- a/core/src/autogluon/core/data/label_cleaner.py
+++ b/core/src/autogluon/core/data/label_cleaner.py
@@ -339,3 +339,9 @@ class LabelCleanerDummy(LabelCleaner):
 
     def _inverse_transform(self, y: Union[Series, DataFrame]) -> Union[Series, DataFrame]:
         return y
+
+    def to_transformed_dtype(self, y: Union[Series, np.ndarray, list]) -> Series:
+        return y
+
+    def to_original_dtype(self, y: Union[Series, np.ndarray, list]) -> Series:
+        return y

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -2499,6 +2499,15 @@ class AbstractModel(ModelBase):
         """
         return {}
 
+    @classmethod
+    def supported_problem_types(cls) -> list[str] | None:
+        """
+        Returns the list of supported problem types.
+        If None is returned, then the model has not specified the supported problem types, and it is unknown which problem types are valid.
+            In this case, all problem types are considered supported and the model will never be filtered out based on problem type.
+        """
+        return None
+
     def _get_default_stopping_metric(self) -> Scorer:
         """
         Returns the default stopping metric to use for early stopping.

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -2486,6 +2486,9 @@ class AbstractModel(ModelBase):
         """
         Dictionary of customization options related to meta properties of the model such as its name, the order it is trained, and the problem types it is valid for.
         """
+        supported_problem_types = cls.supported_problem_types()
+        if supported_problem_types is not None:
+            return {"problem_types": supported_problem_types}
         return {}
 
     @classmethod

--- a/core/src/autogluon/core/models/dummy/dummy_model.py
+++ b/core/src/autogluon/core/models/dummy/dummy_model.py
@@ -40,3 +40,7 @@ class DummyModel(AbstractModel):
         else:
             self.model = model_cls()
         self.model.fit(X=X, y=y)
+
+    @classmethod
+    def supported_problem_types(cls) -> list[str] | None:
+        return ["binary", "multiclass", "regression", "quantile"]

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -235,6 +235,9 @@ class AbstractTabularLearner(AbstractLearner):
                 y_pred = y_pred.values
         else:
             if as_pandas:
+                if len(y_pred) == 0:
+                    # avoid exception due to mismatched shape for empty predict
+                    y_pred = None
                 y_pred = pd.DataFrame(data=y_pred, columns=self.quantile_levels, index=index)
         return y_pred
 

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -345,6 +345,10 @@ class CatBoostModel(AbstractModel):
         return num_cpus, num_gpus
 
     @classmethod
+    def supported_problem_types(cls) -> list[str] | None:
+        return ["binary", "multiclass", "regression", "quantile", "softclass"]
+
+    @classmethod
     def _class_tags(cls):
         return {
             "can_estimate_memory_usage_static": True,

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -650,6 +650,10 @@ class NNFastAiTabularModel(AbstractModel):
         return minimum_resources
 
     @classmethod
+    def supported_problem_types(cls) -> list[str] | None:
+        return ["binary", "multiclass", "regression", "quantile"]
+
+    @classmethod
     def _class_tags(cls):
         return {"can_estimate_memory_usage_static": True}
 

--- a/tabular/src/autogluon/tabular/models/knn/knn_model.py
+++ b/tabular/src/autogluon/tabular/models/knn/knn_model.py
@@ -74,7 +74,6 @@ class KNNModel(AbstractModel):
         default_ag_args = super()._get_default_ag_args()
         extra_ag_args = {
             "valid_stacker": False,
-            "problem_types": [BINARY, MULTICLASS, REGRESSION],
         }
         default_ag_args.update(extra_ag_args)
         return default_ag_args
@@ -263,6 +262,10 @@ class KNNModel(AbstractModel):
         num_cpus = ResourceManager.get_cpu_count()
         num_gpus = 0
         return num_cpus, num_gpus
+
+    @classmethod
+    def supported_problem_types(cls) -> list[str] | None:
+        return ["binary", "multiclass", "regression"]
 
     @classmethod
     def _class_tags(cls):

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -528,6 +528,10 @@ class LGBModel(AbstractModel):
         num_gpus = 0
         return num_cpus, num_gpus
 
+    @classmethod
+    def supported_problem_types(cls) -> list[str] | None:
+        return ["binary", "multiclass", "regression", "quantile", "softclass"]
+
     @property
     def _features(self):
         return self._features_internal_list

--- a/tabular/src/autogluon/tabular/models/lr/lr_model.py
+++ b/tabular/src/autogluon/tabular/models/lr/lr_model.py
@@ -318,6 +318,10 @@ class LinearModel(AbstractModel):
         return 4 * get_approximate_df_mem_usage(X).sum()
 
     @classmethod
+    def supported_problem_types(cls) -> list[str] | None:
+        return ["binary", "multiclass", "regression"]
+
+    @classmethod
     def _class_tags(cls):
         return {"can_estimate_memory_usage_static": True}
 

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -382,6 +382,10 @@ class RFModel(AbstractModel):
         return default_ag_args_ensemble
 
     @classmethod
+    def supported_problem_types(cls) -> list[str] | None:
+        return ["binary", "multiclass", "regression", "quantile", "softclass"]
+
+    @classmethod
     def _class_tags(cls):
         return {"can_estimate_memory_usage_static": True}
 

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -947,6 +947,10 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
         self.processor = self._compiler.compile(model=(self.processor, self.model), path=self.path, input_types=input_types)
 
     @classmethod
+    def supported_problem_types(cls) -> list[str] | None:
+        return ["binary", "multiclass", "regression", "quantile", "softclass"]
+
+    @classmethod
     def _class_tags(cls):
         return {
             "can_estimate_memory_usage_static": True,

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -10,7 +10,7 @@ from autogluon.common.utils.lite import disable_if_lite_mode
 from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
 from autogluon.common.utils.resource_utils import ResourceManager
 from autogluon.common.utils.try_import import try_import_xgboost
-from autogluon.core.constants import BINARY, MULTICLASS, PROBLEM_TYPES_CLASSIFICATION, REGRESSION, SOFTCLASS
+from autogluon.core.constants import MULTICLASS, PROBLEM_TYPES_CLASSIFICATION, REGRESSION, SOFTCLASS
 from autogluon.core.models import AbstractModel
 from autogluon.core.models._utils import get_early_stopping_rounds
 
@@ -44,15 +44,6 @@ class XGBoostModel(AbstractModel):
 
     def _get_default_searchspace(self):
         return get_default_searchspace(problem_type=self.problem_type, num_classes=self.num_classes)
-
-    @classmethod
-    def _get_default_ag_args(cls) -> dict:
-        default_ag_args = super()._get_default_ag_args()
-        extra_ag_args = {
-            "problem_types": [BINARY, MULTICLASS, REGRESSION, SOFTCLASS],
-        }
-        default_ag_args.update(extra_ag_args)
-        return default_ag_args
 
     def _get_default_auxiliary_params(self) -> dict:
         default_auxiliary_params = super()._get_default_auxiliary_params()
@@ -324,6 +315,10 @@ class XGBoostModel(AbstractModel):
             model.model.load_model(os.path.join(path, "xgb.ubj"))
             model._xgb_model_type = None
         return model
+
+    @classmethod
+    def supported_problem_types(cls) -> list[str] | None:
+        return ["binary", "multiclass", "regression", "softclass"]
 
     @classmethod
     def _class_tags(cls):

--- a/tabular/src/autogluon/tabular/models/xt/xt_model.py
+++ b/tabular/src/autogluon/tabular/models/xt/xt_model.py
@@ -24,3 +24,7 @@ class XTModel(RFModel):
             from sklearn.ensemble import ExtraTreesClassifier
 
             return ExtraTreesClassifier
+
+    @classmethod
+    def supported_problem_types(cls) -> list[str] | None:
+        return ["binary", "multiclass", "regression", "quantile"]

--- a/tabular/tests/conftest.py
+++ b/tabular/tests/conftest.py
@@ -185,6 +185,25 @@ def generate_toy_quantile_10_dataset():
     return train_data, test_data, dataset_info
 
 
+def generate_toy_multiclass_30_dataset():
+    label = "label"
+    train_data = generate_toy_multiclass_n_dataset(n_samples=30, n_features=2, n_classes=3)
+    test_data = train_data
+
+    dataset_info = {
+        "problem_type": MULTICLASS,
+        "label": label,
+    }
+    return train_data, test_data, dataset_info
+
+
+def generate_toy_multiclass_n_dataset(n_samples, n_features, n_classes) -> pd.DataFrame:
+    from sklearn.datasets import make_blobs
+    X, y = make_blobs(centers=n_classes, n_samples=n_samples, n_features=n_features, cluster_std=0.5, random_state=0)
+    data = pd.DataFrame(X)
+    data["label"] = y
+    return data
+
 
 class DatasetLoaderHelper:
     dataset_info_dict = dict(
@@ -234,6 +253,7 @@ class DatasetLoaderHelper:
         toy_multiclass_10=generate_toy_multiclass_10_dataset,
         toy_regression_10=generate_toy_regression_10_dataset,
         toy_quantile_10=generate_toy_quantile_10_dataset,
+        toy_multiclass_30=generate_toy_multiclass_30_dataset,
     )
 
     @staticmethod

--- a/tabular/tests/conftest.py
+++ b/tabular/tests/conftest.py
@@ -127,6 +127,64 @@ def generate_toy_quantile_dataset():
     return train_data, test_data, dataset_info
 
 
+def generate_toy_binary_10_dataset():
+    label = "label"
+    dummy_dataset = {
+        "int": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        label: [0, 0, 1, 1, 0, 0, 1, 1, 0, 0],
+    }
+
+    dataset_info = {
+        "problem_type": BINARY,
+        "label": label,
+    }
+
+    train_data = pd.DataFrame(dummy_dataset)
+    test_data = train_data
+    return train_data, test_data, dataset_info
+
+
+def generate_toy_multiclass_10_dataset():
+    label = "label"
+    dummy_dataset = {
+        "int": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        label: [0, 0, 1, 1, 2, 2, 0, 0, 1, 1],
+    }
+
+    dataset_info = {
+        "problem_type": MULTICLASS,
+        "label": label,
+    }
+
+    train_data = pd.DataFrame(dummy_dataset)
+    test_data = train_data
+    return train_data, test_data, dataset_info
+
+
+def generate_toy_regression_10_dataset():
+    label = "label"
+    dummy_dataset = {
+        "int": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        label: [0.1, 0.9, 1.1, 1.9, 0.2, 0.8, 1.2, 1.8, -0.1, 0.7],
+    }
+
+    dataset_info = {
+        "problem_type": REGRESSION,
+        "label": label,
+    }
+
+    train_data = pd.DataFrame(dummy_dataset)
+    test_data = train_data
+    return train_data, test_data, dataset_info
+
+
+def generate_toy_quantile_10_dataset():
+    train_data, test_data, dataset_info = generate_toy_regression_10_dataset()
+    dataset_info["problem_type"] = QUANTILE
+    dataset_info["init_kwargs"] = {"quantile_levels": [0.25, 0.5, 0.75]}
+    return train_data, test_data, dataset_info
+
+
 
 class DatasetLoaderHelper:
     dataset_info_dict = dict(
@@ -172,6 +230,10 @@ class DatasetLoaderHelper:
         toy_multiclass=generate_toy_multiclass_dataset,
         toy_regression=generate_toy_regression_dataset,
         toy_quantile=generate_toy_quantile_dataset,
+        toy_binary_10=generate_toy_binary_10_dataset,
+        toy_multiclass_10=generate_toy_multiclass_10_dataset,
+        toy_regression_10=generate_toy_regression_10_dataset,
+        toy_quantile_10=generate_toy_quantile_10_dataset,
     )
 
     @staticmethod
@@ -349,6 +411,10 @@ class FitHelper:
         if delete_directory:
             shutil.rmtree(save_path, ignore_errors=True)  # Delete AutoGluon output directory to ensure runs' information has been removed.
         return predictor
+
+    @staticmethod
+    def load_dataset(name: str, directory_prefix: str = "./datasets/") -> tuple[pd.DataFrame, pd.DataFrame, dict]:
+        return DatasetLoaderHelper.load_dataset(name=name, directory_prefix=directory_prefix)
 
     @staticmethod
     def fit_dataset(train_data, init_args, fit_args, sample_size=None, min_cls_count_train=1, scikit_api=False) -> TabularPredictor:

--- a/tabular/tests/conftest.py
+++ b/tabular/tests/conftest.py
@@ -242,6 +242,7 @@ class FitHelper:
         use_test_data=False,
         use_test_for_val=False,
         raise_on_model_failure: bool | None = None,
+        deepcopy_fit_args: bool = True,
     ) -> TabularPredictor:
         if compiler_configs is None:
             compiler_configs = {}
@@ -272,7 +273,8 @@ class FitHelper:
             assert PathConverter._is_absolute(path=init_args["path"])
         save_path = init_args["path"]
 
-        fit_args = copy.deepcopy(fit_args)
+        if deepcopy_fit_args:
+            fit_args = copy.deepcopy(fit_args)
         if use_test_data:
             fit_args["test_data"] = test_data
             if use_test_for_val:

--- a/tabular/tests/unittests/calibrate/test_calibrate.py
+++ b/tabular/tests/unittests/calibrate/test_calibrate.py
@@ -4,21 +4,21 @@ def test_calibrate_binary(fit_helper):
         hyperparameters={"GBM": {}},
         calibrate=True,
     )
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
 
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, sample_size=100)
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
 
 
 def test_calibrate_binary_bag(fit_helper):
     """Tests that calibrate=True doesn't crash in binary w/ bagging"""
     fit_args = dict(
-        hyperparameters={"GBM": {}},
+        hyperparameters={"GBM": {"ag_args_ensemble": {"fold_fitting_strategy": "sequential_local"}}},
         calibrate=True,
         num_bag_folds=3,
     )
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
 
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, sample_size=100)
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
 
 
 def test_calibrate_multiclass(fit_helper):
@@ -27,21 +27,21 @@ def test_calibrate_multiclass(fit_helper):
         hyperparameters={"GBM": {}},
         calibrate=True,
     )
-    dataset_name = "covertype_small"
+    dataset_name = "toy_multiclass"
 
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, sample_size=100)
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
 
 
 def test_calibrate_multiclass_bag(fit_helper):
     """Tests that calibrate=True doesn't crash in multiclass w/ bagging"""
     fit_args = dict(
-        hyperparameters={"GBM": {}},
+        hyperparameters={"GBM": {"ag_args_ensemble": {"fold_fitting_strategy": "sequential_local"}}},
         calibrate=True,
         num_bag_folds=3,
     )
-    dataset_name = "covertype_small"
+    dataset_name = "toy_multiclass"
 
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, sample_size=100)
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
 
 
 def test_calibrate_quantile(fit_helper):
@@ -50,20 +50,18 @@ def test_calibrate_quantile(fit_helper):
         hyperparameters={"RF": {}},
         calibrate=True,
     )
-    dataset_name = "ames"
-    init_args = dict(problem_type="quantile", quantile_levels=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
+    dataset_name = "toy_quantile"
 
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, init_args=init_args, sample_size=100)
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
 
 
 def test_calibrate_quantile_bag(fit_helper):
     """Tests that calibrate=True doesn't crash in quantile w/ bagging"""
     fit_args = dict(
-        hyperparameters={"RF": {}},
+        hyperparameters={"RF": {"ag_args_ensemble": {"fold_fitting_strategy": "sequential_local"}}},
         calibrate=True,
         num_bag_folds=3,
     )
-    dataset_name = "ames"
-    init_args = dict(problem_type="quantile", quantile_levels=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
+    dataset_name = "toy_quantile"
 
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, init_args=init_args, sample_size=100)
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)

--- a/tabular/tests/unittests/callbacks/test_callbacks.py
+++ b/tabular/tests/unittests/callbacks/test_callbacks.py
@@ -17,7 +17,7 @@ def test_early_stopping_callback(fit_helper):
     )
     dataset_name = "adult"
 
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=3, refit_full=False)
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=3, refit_full=False, deepcopy_fit_args=False)
 
     assert callback.model_best == "LightGBM"
     assert callback.infer_limit is not None
@@ -41,7 +41,7 @@ def test_early_stopping_callback_v2(fit_helper):
     )
     dataset_name = "adult"
 
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=6, refit_full=False)
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=6, refit_full=False, deepcopy_fit_args=False)
 
     assert callback.model_best == "Dummy_BAG_L1"
     assert callback.score_best == 0.76
@@ -67,7 +67,7 @@ def test_early_stopping_callback_v3(fit_helper):
     )
     dataset_name = "adult"
 
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=3, refit_full=False)
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=3, refit_full=False, deepcopy_fit_args=False)
 
     assert callback.model_best == "Dummy_BAG_L1"
     assert callback.score_best == 0.76
@@ -88,7 +88,7 @@ def test_early_stopping_ensemble_callback(fit_helper):
     )
     dataset_name = "adult"
 
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=4, refit_full=False)
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=4, refit_full=False, deepcopy_fit_args=False)
 
     assert callback.model_best == "LightGBM"
     assert callback.infer_limit is not None
@@ -113,7 +113,7 @@ def test_early_stopping_ensemble_callback_v2(fit_helper):
     )
     dataset_name = "adult"
 
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=9, refit_full=False)
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=9, refit_full=False, deepcopy_fit_args=False)
 
     assert callback.model_best == "Dummy_BAG_L1"
     assert callback.score_best == 0.76
@@ -140,7 +140,7 @@ def test_early_stopping_ensemble_callback_v3(fit_helper):
     )
     dataset_name = "adult"
 
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=5, refit_full=False)
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=5, refit_full=False, deepcopy_fit_args=False)
 
     assert callback.model_best == "Dummy_BAG_L1"
     assert callback.score_best == 0.76

--- a/tabular/tests/unittests/data/test_learning_curves.py
+++ b/tabular/tests/unittests/data/test_learning_curves.py
@@ -18,7 +18,7 @@ def get_default_model_name(model):
 MODELS = [name for name, model in MODEL_TYPES.items() if model._get_class_tags().get("supports_learning_curves", False)]
 PROBLEM_TYPES = [BINARY, MULTICLASS, REGRESSION]
 
-common_args = {"sample_size": 50, "delete_directory": False, "refit_full": False}
+common_args = {"sample_size": 50, "delete_directory": False, "refit_full": False, "raise_on_model_failure": True}
 
 early_stop = 999999
 long_run = 5
@@ -352,9 +352,9 @@ def test_supported_class_tags(learning_curve_supported_class):
 @pytest.fixture()
 def get_dataset_map():
     return {
-        BINARY: "adult",
-        MULTICLASS: "covertype_small",
-        REGRESSION: "ames",
+        BINARY: "toy_binary_10",
+        MULTICLASS: "toy_multiclass_30",
+        REGRESSION: "toy_regression_10",
     }
 
 

--- a/tabular/tests/unittests/edgecases/test_edgecases.py
+++ b/tabular/tests/unittests/edgecases/test_edgecases.py
@@ -14,7 +14,7 @@ def test_no_weighted_ensemble(fit_helper):
         hyperparameters={"DUMMY": {}},
         fit_weighted_ensemble=False,
     )
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
     extra_metrics = list(METRICS[BINARY])
 
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics, expected_model_count=1)
@@ -31,7 +31,7 @@ def test_no_full_last_level_weighted_ensemble(fit_helper):
         num_bag_sets=1,
         ag_args_ensemble={"fold_fitting_strategy": "sequential_local"},
     )
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
     extra_metrics = list(METRICS[BINARY])
 
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics, expected_model_count=4)
@@ -49,7 +49,7 @@ def test_no_full_last_level_weighted_ensemble_additionally(fit_helper):
         num_bag_sets=1,
         ag_args_ensemble={"fold_fitting_strategy": "sequential_local"},
     )
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
     extra_metrics = list(METRICS[BINARY])
 
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics, expected_model_count=4)
@@ -67,7 +67,7 @@ def test_full_last_level_weighted_ensemble_additionally(fit_helper):
         num_bag_sets=1,
         ag_args_ensemble={"fold_fitting_strategy": "sequential_local"},
     )
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
     extra_metrics = list(METRICS[BINARY])
 
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics, expected_model_count=5)
@@ -87,7 +87,7 @@ def test_full_last_level_weighted_ensemble(fit_helper):
         num_bag_sets=1,
         ag_args_ensemble={"fold_fitting_strategy": "sequential_local"},
     )
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
     extra_metrics = list(METRICS[BINARY])
 
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics, expected_model_count=4)
@@ -101,7 +101,7 @@ def test_max_sets(fit_helper):
         num_bag_folds=2,
         num_bag_sets=5,
     )
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
 
     predictor = fit_helper.fit_and_validate_dataset(
         dataset_name=dataset_name,
@@ -124,7 +124,7 @@ def test_num_folds(fit_helper):
         num_bag_folds=7,
         num_bag_sets=2,
     )
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
 
     predictor = fit_helper.fit_and_validate_dataset(
         dataset_name=dataset_name,
@@ -152,7 +152,7 @@ def test_num_folds_hpo(fit_helper):
             "num_trials": 2,
         },
     )
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
 
     predictor = fit_helper.fit_and_validate_dataset(
         dataset_name=dataset_name,
@@ -195,7 +195,7 @@ def test_use_bag_holdout_calibrate(fit_helper):
 def test_num_folds_parallel(fit_helper, capsys):
     """Tests that num_folds_parallel equal to 1 works"""
     fit_args = dict(hyperparameters={"DUMMY": {}}, fit_weighted_ensemble=False, num_bag_folds=2, num_bag_sets=1, ag_args_ensemble=dict(num_folds_parallel=1))
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
 
     predictor = fit_helper.fit_and_validate_dataset(
         dataset_name=dataset_name,
@@ -212,7 +212,7 @@ def test_num_folds_parallel(fit_helper, capsys):
 def test_raises_num_cpus_float(fit_helper):
     """Tests that num_cpus specified as a float raises a TypeError"""
     fit_args = dict(num_cpus=1.0)
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
     with pytest.raises(TypeError, match=r"`num_cpus` must be an int or 'auto'. Found: .*"):
         fit_helper.fit_and_validate_dataset(
             dataset_name=dataset_name,
@@ -225,7 +225,7 @@ def test_raises_num_cpus_float(fit_helper):
 def test_raises_num_cpus_zero(fit_helper):
     """Tests that num_cpus=0 raises a ValueError"""
     fit_args = dict(num_cpus=0)
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
     with pytest.raises(ValueError, match=r"`num_cpus` must be greater than or equal to 1. .*"):
         fit_helper.fit_and_validate_dataset(
             dataset_name=dataset_name,
@@ -238,7 +238,7 @@ def test_raises_num_cpus_zero(fit_helper):
 def test_raises_num_gpus_neg(fit_helper):
     """Tests that num_gpus<0 raises a ValueError"""
     fit_args = dict(num_gpus=-1)
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
     with pytest.raises(ValueError, match=r"`num_gpus` must be greater than or equal to 0. .*"):
         fit_helper.fit_and_validate_dataset(
             dataset_name=dataset_name,
@@ -259,7 +259,7 @@ def test_delay_bag_sets(fit_helper,delay_bag_sets):
         delay_bag_sets=delay_bag_sets,
         ag_args_ensemble={"fold_fitting_strategy":"sequential_local"},
     )
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
 
     predictor = fit_helper.fit_and_validate_dataset(
         dataset_name=dataset_name,

--- a/tabular/tests/unittests/experimental/test_scikit_api.py
+++ b/tabular/tests/unittests/experimental/test_scikit_api.py
@@ -8,7 +8,7 @@ def test_scikit_api_binary(fit_helper):
     fit_args = dict(
         hyperparameters={LGBModel: {}},
     )
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
     extra_metrics = list(METRICS[BINARY])
 
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics, scikit_api=True)
@@ -21,7 +21,7 @@ def test_scikit_api_multiclass(fit_helper):
     )
     extra_metrics = list(METRICS[MULTICLASS])
 
-    dataset_name = "covertype_small"
+    dataset_name = "toy_multiclass"
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics, scikit_api=True)
 
 
@@ -32,5 +32,5 @@ def test_scikit_api_regression(fit_helper):
     )
     extra_metrics = list(METRICS[REGRESSION])
 
-    dataset_name = "ames"
+    dataset_name = "toy_regression"
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics, scikit_api=True)

--- a/tabular/tests/unittests/models/test_advanced.py
+++ b/tabular/tests/unittests/models/test_advanced.py
@@ -5,7 +5,7 @@ from autogluon.tabular.models.lgb.lgb_model import LGBModel
 
 def test_bagged_predict_children(model_fit_helper):
     fit_args = dict(k_fold=3)
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
     model = BaggedEnsembleModel(
         model_base=LGBModel,
         model_base_kwargs=dict(hyperparameters=dict(num_boost_round=10)),  # Speed up run
@@ -16,7 +16,6 @@ def test_bagged_predict_children(model_fit_helper):
         model=model,
         fit_args=fit_args,
         check_predict_children=True,
-        sample_size=100,
     )
 
 
@@ -43,7 +42,7 @@ def test_resource_constraints(fit_helper, dataset_loader_helper):
             refit_full=True,
         )
 
-        dataset_name = "adult"
+        dataset_name = "toy_binary"
         predictor = fit_helper.fit_and_validate_dataset(
             dataset_name=dataset_name,
             fit_args=fit_args,

--- a/tabular/tests/unittests/models/test_automm.py
+++ b/tabular/tests/unittests/models/test_automm.py
@@ -1,8 +1,13 @@
 import pytest
 
+from autogluon.common.utils.resource_utils import ResourceManager
+
 
 @pytest.mark.gpu
 def test_automm_sts(fit_helper):
+    if ResourceManager.get_gpu_count_torch() == 0:
+        # Skip test if no GPU available
+        pytest.skip("Skip, no GPU available.")
     fit_args = dict(
         hyperparameters={"AG_AUTOMM": {"env.num_workers": 0, "env.num_workers_evaluation": 0}},
     )

--- a/tabular/tests/unittests/models/test_automm.py
+++ b/tabular/tests/unittests/models/test_automm.py
@@ -10,13 +10,14 @@ def test_automm_sts(fit_helper):
         pytest.skip("Skip, no GPU available.")
     fit_args = dict(
         hyperparameters={"AG_AUTOMM": {"env.num_workers": 0, "env.num_workers_evaluation": 0}},
+        time_limit=60,
     )
     dataset_name = "sts"
     fit_helper.fit_and_validate_dataset(
         dataset_name=dataset_name,
         fit_args=fit_args,
-        sample_size=1000,
-        refit_full=True,
+        sample_size=100,
+        refit_full=False,
     )
 
 

--- a/tabular/tests/unittests/models/test_catboost.py
+++ b/tabular/tests/unittests/models/test_catboost.py
@@ -4,41 +4,12 @@ import pytest
 
 from autogluon.tabular.models.catboost.catboost_model import CatBoostModel
 
-
-@pytest.mark.skipif(sys.version_info >= (3, 11) and sys.platform == "darwin", reason="catboost has no wheel for py311 darwin")
-def test_catboost_binary(fit_helper):
-    fit_args = dict(
-        hyperparameters={CatBoostModel: {}},
-    )
-    dataset_name = "adult"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
+toy_model_params = {"iterations": 10}
 
 
 @pytest.mark.skipif(sys.version_info >= (3, 11) and sys.platform == "darwin", reason="catboost has no wheel for py311 darwin")
-def test_catboost_multiclass(fit_helper):
-    fit_args = dict(
-        hyperparameters={CatBoostModel: {}},
-    )
-    dataset_name = "covertype_small"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
+def test_catboost(fit_helper):
+    model_cls = CatBoostModel
+    model_hyperparameters = toy_model_params
 
-
-@pytest.mark.skipif(sys.version_info >= (3, 11) and sys.platform == "darwin", reason="catboost has no wheel for py311 darwin")
-def test_catboost_regression(fit_helper):
-    fit_args = dict(
-        hyperparameters={CatBoostModel: {}},
-        time_limit=10,  # CatBoost trains for a very long time on ames (many iterations)
-    )
-    dataset_name = "ames"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
-
-
-@pytest.mark.skipif(sys.version_info >= (3, 11) and sys.platform == "darwin", reason="catboost has no wheel for py311 darwin")
-def test_catboost_quantile(fit_helper):
-    fit_args = dict(
-        hyperparameters={"CAT": {}},
-        time_limit=10,  # CatBoost trains for a very long time on ames (many iterations)
-    )
-    dataset_name = "ames"
-    init_args = dict(problem_type="quantile", quantile_levels=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, init_args=init_args)
+    fit_helper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters)

--- a/tabular/tests/unittests/models/test_dummy.py
+++ b/tabular/tests/unittests/models/test_dummy.py
@@ -14,9 +14,8 @@ def test_no_models_will_raise(fit_helper, dataset_loader_helper):
         hyperparameters={},
     )
 
-    dataset_name = "adult"
-    directory_prefix = "./datasets/"
-    train_data, test_data, dataset_info = dataset_loader_helper.load_dataset(name=dataset_name, directory_prefix=directory_prefix)
+    dataset_name = "toy_binary"
+    train_data, test_data, dataset_info = dataset_loader_helper.load_dataset(name=dataset_name)
 
     with pytest.raises(RuntimeError):
         fit_helper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
@@ -29,9 +28,8 @@ def test_no_models(fit_helper, dataset_loader_helper):
         raise_on_no_models_fitted=False,
     )
 
-    dataset_name = "adult"
-    directory_prefix = "./datasets/"
-    train_data, test_data, dataset_info = dataset_loader_helper.load_dataset(name=dataset_name, directory_prefix=directory_prefix)
+    dataset_name = "toy_binary"
+    train_data, test_data, dataset_info = dataset_loader_helper.load_dataset(name=dataset_name)
 
     predictor = fit_helper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
 
@@ -54,9 +52,8 @@ def test_no_models_raise(fit_helper, dataset_loader_helper):
         raise_on_no_models_fitted=False,
     )
 
-    dataset_name = "adult"
-    directory_prefix = "./datasets/"
-    train_data, test_data, dataset_info = dataset_loader_helper.load_dataset(name=dataset_name, directory_prefix=directory_prefix)
+    dataset_name = "toy_binary"
+    train_data, test_data, dataset_info = dataset_loader_helper.load_dataset(name=dataset_name)
 
     predictor = fit_helper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
 
@@ -80,7 +77,7 @@ def test_raise_on_model_failure(fit_helper, dataset_loader_helper):
 
     expected_exc_str = "Test Error Message"
 
-    train_data, test_data, dataset_info = dataset_loader_helper.load_dataset(name="adult", directory_prefix="./datasets/")
+    train_data, test_data, dataset_info = dataset_loader_helper.load_dataset(name="toy_binary")
 
     # Force DummyModel to raise an exception when fit.
     fit_args = dict(
@@ -99,10 +96,10 @@ def test_dummy_binary(fit_helper):
     fit_args = dict(
         hyperparameters={DummyModel: {}},
     )
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
     extra_metrics = list(METRICS[BINARY])
 
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics)
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics, refit_full=False)
 
 
 def test_dummy_multiclass(fit_helper):
@@ -112,7 +109,7 @@ def test_dummy_multiclass(fit_helper):
     )
     extra_metrics = list(METRICS[MULTICLASS])
 
-    dataset_name = "covertype_small"
+    dataset_name = "toy_multiclass"
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics)
 
 
@@ -123,7 +120,7 @@ def test_dummy_regression(fit_helper):
     )
     extra_metrics = list(METRICS[REGRESSION])
 
-    dataset_name = "ames"
+    dataset_name = "toy_regression"
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics)
 
 
@@ -131,26 +128,26 @@ def test_dummy_quantile(fit_helper):
     fit_args = dict(
         hyperparameters={"DUMMY": {}},
     )
-    dataset_name = "ames"
+    dataset_name = "toy_regression"
     init_args = dict(problem_type="quantile", quantile_levels=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, init_args=init_args)
 
 
 def test_dummy_binary_model(model_fit_helper):
     fit_args = dict()
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
     model_fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, model=DummyModel(), fit_args=fit_args)
 
 
 def test_dummy_multiclass_model(model_fit_helper):
     fit_args = dict()
-    dataset_name = "covertype_small"
+    dataset_name = "toy_multiclass"
     model_fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, model=DummyModel(), fit_args=fit_args)
 
 
 def test_dummy_regression_model(model_fit_helper):
     fit_args = dict()
-    dataset_name = "ames"
+    dataset_name = "toy_regression"
     model_fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, model=DummyModel(), fit_args=fit_args)
 
 
@@ -163,7 +160,7 @@ def test_dummy_binary_absolute_path(fit_helper):
     path = str(path.resolve())
     init_args = dict(path=path)
 
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
 
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, init_args=init_args, fit_args=fit_args)
 
@@ -177,8 +174,7 @@ def test_dummy_binary_absolute_path_stack(fit_helper):
         num_stack_levels=1,
     )
 
-    dataset_name = "adult"
-
+    dataset_name = "toy_binary"
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=4, path_as_absolute=True)
 
 
@@ -188,5 +184,5 @@ def test_dummy_binary_model_absolute_path(model_fit_helper):
     path = Path(".") / "AG_test"
     path = str(path.resolve())
     model = DummyModel(path=path)
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
     model_fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, model=model, fit_args=fit_args)

--- a/tabular/tests/unittests/models/test_dummy.py
+++ b/tabular/tests/unittests/models/test_dummy.py
@@ -3,8 +3,6 @@ from pathlib import Path
 
 import pytest
 
-from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION
-from autogluon.core.metrics import METRICS
 from autogluon.core.models.dummy.dummy_model import DummyModel
 
 
@@ -91,46 +89,12 @@ def test_raise_on_model_failure(fit_helper, dataset_loader_helper):
     assert str(excinfo.value) == "Test Error Message"
 
 
-def test_dummy_binary(fit_helper):
-    """Additionally tests that all binary metrics work"""
-    fit_args = dict(
-        hyperparameters={DummyModel: {}},
-    )
-    dataset_name = "toy_binary"
-    extra_metrics = list(METRICS[BINARY])
+def test_dummy(fit_helper):
+    model_cls = DummyModel
+    model_hyperparameters = {}
 
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics, refit_full=False)
-
-
-def test_dummy_multiclass(fit_helper):
-    """Additionally tests that all multiclass metrics work"""
-    fit_args = dict(
-        hyperparameters={DummyModel: {}},
-    )
-    extra_metrics = list(METRICS[MULTICLASS])
-
-    dataset_name = "toy_multiclass"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics)
-
-
-def test_dummy_regression(fit_helper):
-    """Additionally tests that all regression metrics work"""
-    fit_args = dict(
-        hyperparameters={DummyModel: {}},
-    )
-    extra_metrics = list(METRICS[REGRESSION])
-
-    dataset_name = "toy_regression"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics)
-
-
-def test_dummy_quantile(fit_helper):
-    fit_args = dict(
-        hyperparameters={"DUMMY": {}},
-    )
-    dataset_name = "toy_regression"
-    init_args = dict(problem_type="quantile", quantile_levels=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, init_args=init_args)
+    """Additionally tests that all metrics work"""
+    fit_helper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters, extra_metrics=True)
 
 
 def test_dummy_binary_model(model_fit_helper):

--- a/tabular/tests/unittests/models/test_image_predictor.py
+++ b/tabular/tests/unittests/models/test_image_predictor.py
@@ -1,11 +1,15 @@
 import pytest
 
 from autogluon.common.features.feature_metadata import FeatureMetadata
+from autogluon.common.utils.resource_utils import ResourceManager
 from autogluon.tabular import TabularPredictor
 
 
 @pytest.mark.gpu
 def test_image_predictor_multiclass(fit_helper):
+    if ResourceManager.get_gpu_count_torch() == 0:
+        # Skip test if no GPU available
+        pytest.skip("Skip, no GPU available.")
     from autogluon.multimodal.utils.misc import shopee_dataset
 
     download_dir = "./automm_shopee_data_multiclass"
@@ -21,6 +25,9 @@ def test_image_predictor_multiclass(fit_helper):
 
 @pytest.mark.gpu
 def test_image_predictor_regression(fit_helper):
+    if ResourceManager.get_gpu_count_torch() == 0:
+        # Skip test if no GPU available
+        pytest.skip("Skip, no GPU available.")
     from autogluon.multimodal.utils.misc import shopee_dataset
 
     download_dir = "./automm_shopee_data_regression"

--- a/tabular/tests/unittests/models/test_knn.py
+++ b/tabular/tests/unittests/models/test_knn.py
@@ -5,4 +5,4 @@ def test_knn(fit_helper):
     model_cls = KNNModel
     model_hyperparameters = {"n_neighbors": 2}
 
-    fit_helper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters, bag="first", refit_full="first")
+    fit_helper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters)

--- a/tabular/tests/unittests/models/test_knn.py
+++ b/tabular/tests/unittests/models/test_knn.py
@@ -1,25 +1,8 @@
 from autogluon.tabular.models.knn.knn_model import KNNModel
 
 
-def test_knn_binary(fit_helper):
-    fit_args = dict(
-        hyperparameters={KNNModel: {}},
-    )
-    dataset_name = "adult"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
+def test_knn(fit_helper):
+    model_cls = KNNModel
+    model_hyperparameters = {"n_neighbors": 2}
 
-
-def test_knn_multiclass(fit_helper):
-    fit_args = dict(
-        hyperparameters={KNNModel: {}},
-    )
-    dataset_name = "covertype_small"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
-
-
-def test_knn_regression(fit_helper):
-    fit_args = dict(
-        hyperparameters={KNNModel: {}},
-    )
-    dataset_name = "ames"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
+    fit_helper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters, bag="first", refit_full="first")

--- a/tabular/tests/unittests/models/test_lightgbm.py
+++ b/tabular/tests/unittests/models/test_lightgbm.py
@@ -9,7 +9,7 @@ def test_lightgbm(fit_helper):
     model_hyperparameters = {}
 
     """Additionally tests that all metrics work"""
-    fit_helper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters, bag="first", refit_full="first", extra_metrics=True)
+    fit_helper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters, extra_metrics=True)
 
 
 def test_lightgbm_binary_model(model_fit_helper):

--- a/tabular/tests/unittests/models/test_lightgbm.py
+++ b/tabular/tests/unittests/models/test_lightgbm.py
@@ -1,51 +1,15 @@
 import numpy as np
 
-from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION
-from autogluon.core.metrics import METRICS
 from autogluon.tabular import TabularPredictor
 from autogluon.tabular.models.lgb.lgb_model import LGBModel
 
 
-def test_lightgbm_binary(fit_helper):
-    """Additionally tests that all binary metrics work"""
-    fit_args = dict(
-        hyperparameters={LGBModel: {}},
-    )
-    dataset_name = "toy_binary"
-    extra_metrics = list(METRICS[BINARY])
+def test_lightgbm(fit_helper):
+    model_cls = LGBModel
+    model_hyperparameters = {}
 
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics)
-
-
-def test_lightgbm_multiclass(fit_helper):
-    """Additionally tests that all multiclass metrics work"""
-    fit_args = dict(
-        hyperparameters={LGBModel: {}},
-    )
-    extra_metrics = list(METRICS[MULTICLASS])
-
-    dataset_name = "toy_multiclass"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics)
-
-
-def test_lightgbm_regression(fit_helper):
-    """Additionally tests that all regression metrics work"""
-    fit_args = dict(
-        hyperparameters={LGBModel: {}},
-    )
-    extra_metrics = list(METRICS[REGRESSION])
-
-    dataset_name = "toy_regression"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics)
-
-
-def test_lightgbm_quantile(fit_helper):
-    fit_args = dict(
-        hyperparameters={"GBM": {}},
-    )
-    dataset_name = "toy_regression"
-    init_args = dict(problem_type="quantile", quantile_levels=[0.25, 0.5, 0.75])
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, init_args=init_args)
+    """Additionally tests that all metrics work"""
+    fit_helper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters, bag="first", refit_full="first", extra_metrics=True)
 
 
 def test_lightgbm_binary_model(model_fit_helper):
@@ -68,7 +32,7 @@ def test_lightgbm_regression_model(model_fit_helper):
 
 def test_lightgbm_quantile_model(model_fit_helper):
     fit_args = dict()
-    dataset_name = "toy_regression"
+    dataset_name = "toy_quantile"
     model_fit_helper.fit_and_validate_dataset(
         dataset_name=dataset_name,
         model=LGBModel(
@@ -77,18 +41,6 @@ def test_lightgbm_quantile_model(model_fit_helper):
         ),
         fit_args=fit_args,
     )
-
-
-def test_lightgbm_binary_bagged(fit_helper):
-    """Additionally tests that all binary metrics work, and verifies that bagged refit works correctly"""
-    fit_args = dict(
-        hyperparameters={LGBModel: {"ag_args_ensemble": {"fold_fitting_strategy": "sequential_local"}}},
-        num_bag_folds=2,
-    )
-    dataset_name = "toy_binary"
-    extra_metrics = list(METRICS[BINARY])
-
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, extra_metrics=extra_metrics)
 
 
 def test_lightgbm_binary_with_calibrate_decision_threshold(fit_helper):
@@ -144,8 +96,7 @@ def test_lightgbm_binary_with_calibrate_decision_threshold_bagged_refit(fit_help
     init_args = dict(eval_metric="f1")
     dataset_name = "toy_binary"
 
-    directory_prefix = "./datasets/"
-    train_data, test_data, dataset_info = dataset_loader_helper.load_dataset(name=dataset_name, directory_prefix=directory_prefix)
+    train_data, test_data, dataset_info = dataset_loader_helper.load_dataset(name=dataset_name)
     label = dataset_info["label"]
     predictor: TabularPredictor = fit_helper.fit_and_validate_dataset(
         dataset_name=dataset_name, init_args=init_args, fit_args=fit_args, delete_directory=False, refit_full=True

--- a/tabular/tests/unittests/models/test_linear.py
+++ b/tabular/tests/unittests/models/test_linear.py
@@ -1,25 +1,8 @@
 from autogluon.tabular.models.lr.lr_model import LinearModel
 
 
-def test_linear_binary(fit_helper):
-    fit_args = dict(
-        hyperparameters={LinearModel: {}},
-    )
-    dataset_name = "adult"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
+def test_linear(fit_helper):
+    model_cls = LinearModel
+    model_hyperparameters = {}
 
-
-def test_linear_multiclass(fit_helper):
-    fit_args = dict(
-        hyperparameters={LinearModel: {}},
-    )
-    dataset_name = "covertype_small"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
-
-
-def test_linear_regression(fit_helper):
-    fit_args = dict(
-        hyperparameters={LinearModel: {}},
-    )
-    dataset_name = "ames"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
+    fit_helper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters)

--- a/tabular/tests/unittests/models/test_rf.py
+++ b/tabular/tests/unittests/models/test_rf.py
@@ -1,82 +1,51 @@
+import copy
+
 from autogluon.tabular.models.rf.rf_model import RFModel
 
-
-# TODO: Consider adding post-test dataset cleanup (not for each test, since they reuse the datasets)
-def test_rf_binary(fit_helper):
-    fit_args = dict(
-        hyperparameters={RFModel: {}},
-    )
-    dataset_name = "adult"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
+toy_model_params = {"n_estimators": 10}
 
 
-def test_rf_multiclass(fit_helper):
-    fit_args = dict(
-        hyperparameters={RFModel: {}},
-    )
-    dataset_name = "covertype_small"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
+def test_rf(fit_helper):
+    model_cls = RFModel
+    model_hyperparameters = toy_model_params
 
-
-def test_rf_regression(fit_helper):
-    fit_args = dict(
-        hyperparameters={RFModel: {}},
-    )
-    dataset_name = "ames"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
-
-
-def test_rf_quantile(fit_helper):
-    fit_args = dict(
-        hyperparameters={"RF": {}},
-    )
-    dataset_name = "ames"
-    init_args = dict(problem_type="quantile", quantile_levels=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, init_args=init_args)
-
-
-def test_rf_binary_bagged(fit_helper):
-    """Additionally verifies that bagged refit works correctly"""
-    fit_args = dict(
-        hyperparameters={RFModel: {}},
-        num_bag_folds=2,
-    )
-    dataset_name = "adult"
-
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
+    fit_helper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters, bag="first", refit_full="first")
 
 
 def test_rf_binary_compile_onnx(fit_helper):
     fit_args = dict(
-        hyperparameters={RFModel: {}},
+        hyperparameters={RFModel: toy_model_params},
     )
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
     compiler_configs = {RFModel: {"compiler": "onnx"}}
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, compile=True, compiler_configs=compiler_configs)
 
 
 def test_rf_binary_compile_onnx_as_ag_arg(fit_helper):
+    model_params = copy.deepcopy(toy_model_params)
+    model_params["ag.compile"] = {"compiler": "onnx"}
+
     fit_args = dict(
-        hyperparameters={RFModel: {"ag.compile": {"compiler": "onnx"}}},
+        hyperparameters={RFModel: model_params},
     )
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
 
 
 def test_rf_multiclass_compile_onnx(fit_helper):
     fit_args = dict(
-        hyperparameters={RFModel: {}},
+        hyperparameters={RFModel: toy_model_params},
     )
-    dataset_name = "covertype_small"
+    dataset_name = "toy_multiclass"
     compiler_configs = {RFModel: {"compiler": "onnx"}}
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, compile=True, compiler_configs=compiler_configs)
 
 
 def test_rf_regression_compile_onnx(fit_helper):
     fit_args = dict(
-        hyperparameters={RFModel: {}},
+        hyperparameters={RFModel: toy_model_params},
     )
-    dataset_name = "ames"
+    dataset_name = "toy_regression"
     compiler_configs = {RFModel: {"compiler": "onnx"}}
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, compile=True, compiler_configs=compiler_configs)
 
@@ -96,9 +65,9 @@ def test_rf_binary_compile_onnx_no_config_bagging(fit_helper):
     run_test = False
     if run_test:
         fit_args = dict(
-            hyperparameters={RFModel: {}},
+            hyperparameters={RFModel: toy_model_params},
             num_bag_folds=2,
         )
-        dataset_name = "adult"
+        dataset_name = "toy_binary"
         compiler_configs = "auto"
         fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, compile=True, compiler_configs=compiler_configs)

--- a/tabular/tests/unittests/models/test_rf.py
+++ b/tabular/tests/unittests/models/test_rf.py
@@ -9,7 +9,7 @@ def test_rf(fit_helper):
     model_cls = RFModel
     model_hyperparameters = toy_model_params
 
-    fit_helper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters, bag="first", refit_full="first")
+    fit_helper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters)
 
 
 def test_rf_binary_compile_onnx(fit_helper):

--- a/tabular/tests/unittests/models/test_tabular_nn.py
+++ b/tabular/tests/unittests/models/test_tabular_nn.py
@@ -1,49 +1,54 @@
+import copy
 import shutil
 
 from autogluon.tabular.models.tabular_nn.torch.tabular_nn_torch import TabularNeuralNetTorchModel
 
+toy_model_params = {"num_epochs": 3}
+
 
 def test_tabular_nn_binary(fit_helper):
     fit_args = dict(
-        hyperparameters={TabularNeuralNetTorchModel: {}},
+        hyperparameters={TabularNeuralNetTorchModel: toy_model_params},
     )
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
 
 
 def test_tabular_nn_multiclass(fit_helper):
     fit_args = dict(
-        hyperparameters={TabularNeuralNetTorchModel: {}},
+        hyperparameters={TabularNeuralNetTorchModel: toy_model_params},
     )
-    dataset_name = "covertype_small"
+    dataset_name = "toy_multiclass"
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
 
 
 def test_tabular_nn_regression(fit_helper):
     fit_args = dict(
-        hyperparameters={TabularNeuralNetTorchModel: {}},
+        hyperparameters={TabularNeuralNetTorchModel: toy_model_params},
         time_limit=20,  # TabularNN trains for a long time on ames
     )
-    dataset_name = "ames"
+    dataset_name = "toy_regression"
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
 
 
 # Testing with bagging to ensure tabularNN work well with ParallelLocalFoldFittingStrategy
 def test_tabular_nn_binary_bagging(fit_helper):
+    model_params = {"ag_args_ensemble": {"fold_fitting_strategy": "sequential_local"}}
+    model_params.update(toy_model_params)
     fit_args = dict(
-        hyperparameters={TabularNeuralNetTorchModel: {}},
+        hyperparameters={TabularNeuralNetTorchModel: model_params},
         num_bag_folds=2,
         num_bag_sets=1,
     )
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=2, refit_full=False)
 
 
 def test_tabular_nn_binary_compile_onnx(fit_helper):
     fit_args = dict(
-        hyperparameters={TabularNeuralNetTorchModel: {}},
+        hyperparameters={TabularNeuralNetTorchModel: toy_model_params},
     )
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
     compiler_configs = {TabularNeuralNetTorchModel: {"compiler": "onnx"}}
     predictor = fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, compile=True, compiler_configs=compiler_configs)
     from autogluon.tabular.models.tabular_nn.compilers.onnx import TabularNeuralNetTorchOnnxTransformer
@@ -52,10 +57,12 @@ def test_tabular_nn_binary_compile_onnx(fit_helper):
 
 
 def test_tabular_nn_binary_compile_onnx_as_ag_arg(fit_helper):
+    model_params = {"ag.compile": {"compiler": "onnx"}}
+    model_params.update(toy_model_params)
     fit_args = dict(
-        hyperparameters={TabularNeuralNetTorchModel: {"ag.compile": {"compiler": "onnx"}}},
+        hyperparameters={TabularNeuralNetTorchModel: model_params},
     )
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
     predictor = fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, refit_full=True, delete_directory=False)
     from autogluon.tabular.models.tabular_nn.compilers.onnx import TabularNeuralNetTorchOnnxTransformer
 
@@ -66,9 +73,9 @@ def test_tabular_nn_binary_compile_onnx_as_ag_arg(fit_helper):
 
 def test_tabular_nn_multiclass_compile_onnx(fit_helper):
     fit_args = dict(
-        hyperparameters={TabularNeuralNetTorchModel: {}},
+        hyperparameters={TabularNeuralNetTorchModel: toy_model_params},
     )
-    dataset_name = "covertype_small"
+    dataset_name = "toy_multiclass"
     compiler_configs = {TabularNeuralNetTorchModel: {"compiler": "onnx"}}
     predictor = fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, compile=True, compiler_configs=compiler_configs)
     from autogluon.tabular.models.tabular_nn.compilers.onnx import TabularNeuralNetTorchOnnxTransformer
@@ -78,10 +85,10 @@ def test_tabular_nn_multiclass_compile_onnx(fit_helper):
 
 def test_tabular_nn_regression_compile_onnx(fit_helper):
     fit_args = dict(
-        hyperparameters={TabularNeuralNetTorchModel: {}},
+        hyperparameters={TabularNeuralNetTorchModel: toy_model_params},
         time_limit=20,  # TabularNN trains for a long time on ames
     )
-    dataset_name = "ames"
+    dataset_name = "toy_regression"
     compiler_configs = {TabularNeuralNetTorchModel: {"compiler": "onnx"}}
     predictor = fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, compile=True, compiler_configs=compiler_configs)
     from autogluon.tabular.models.tabular_nn.compilers.onnx import TabularNeuralNetTorchOnnxTransformer

--- a/tabular/tests/unittests/models/test_tabular_nn.py
+++ b/tabular/tests/unittests/models/test_tabular_nn.py
@@ -6,42 +6,10 @@ from autogluon.tabular.models.tabular_nn.torch.tabular_nn_torch import TabularNe
 toy_model_params = {"num_epochs": 3}
 
 
-def test_tabular_nn_binary(fit_helper):
-    fit_args = dict(
-        hyperparameters={TabularNeuralNetTorchModel: toy_model_params},
-    )
-    dataset_name = "toy_binary"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
-
-
-def test_tabular_nn_multiclass(fit_helper):
-    fit_args = dict(
-        hyperparameters={TabularNeuralNetTorchModel: toy_model_params},
-    )
-    dataset_name = "toy_multiclass"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
-
-
-def test_tabular_nn_regression(fit_helper):
-    fit_args = dict(
-        hyperparameters={TabularNeuralNetTorchModel: toy_model_params},
-        time_limit=20,  # TabularNN trains for a long time on ames
-    )
-    dataset_name = "toy_regression"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
-
-
-# Testing with bagging to ensure tabularNN work well with ParallelLocalFoldFittingStrategy
-def test_tabular_nn_binary_bagging(fit_helper):
-    model_params = {"ag_args_ensemble": {"fold_fitting_strategy": "sequential_local"}}
-    model_params.update(toy_model_params)
-    fit_args = dict(
-        hyperparameters={TabularNeuralNetTorchModel: model_params},
-        num_bag_folds=2,
-        num_bag_sets=1,
-    )
-    dataset_name = "toy_binary"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, expected_model_count=2, refit_full=False)
+def test_tabular_nn(fit_helper):
+    model_cls = TabularNeuralNetTorchModel
+    model_hyperparameters = copy.deepcopy(toy_model_params)
+    fit_helper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters, bag="first", refit_full="first")
 
 
 def test_tabular_nn_binary_compile_onnx(fit_helper):
@@ -86,7 +54,6 @@ def test_tabular_nn_multiclass_compile_onnx(fit_helper):
 def test_tabular_nn_regression_compile_onnx(fit_helper):
     fit_args = dict(
         hyperparameters={TabularNeuralNetTorchModel: toy_model_params},
-        time_limit=20,  # TabularNN trains for a long time on ames
     )
     dataset_name = "toy_regression"
     compiler_configs = {TabularNeuralNetTorchModel: {"compiler": "onnx"}}

--- a/tabular/tests/unittests/models/test_tabular_nn.py
+++ b/tabular/tests/unittests/models/test_tabular_nn.py
@@ -9,7 +9,7 @@ toy_model_params = {"num_epochs": 3}
 def test_tabular_nn(fit_helper):
     model_cls = TabularNeuralNetTorchModel
     model_hyperparameters = copy.deepcopy(toy_model_params)
-    fit_helper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters, bag="first", refit_full="first")
+    fit_helper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters)
 
 
 def test_tabular_nn_binary_compile_onnx(fit_helper):

--- a/tabular/tests/unittests/models/test_tabular_nn_fastai.py
+++ b/tabular/tests/unittests/models/test_tabular_nn_fastai.py
@@ -7,29 +7,14 @@ from fastai.callback.core import CancelFitException
 from autogluon.tabular.models.fastainn.callbacks import BatchTimeTracker
 from autogluon.tabular.models.fastainn.tabular_nn_fastai import NNFastAiTabularModel
 
-
-def test_tabular_nn_fastai_binary(fit_helper):
-    fit_args = dict(
-        hyperparameters={NNFastAiTabularModel: {}},
-    )
-    dataset_name = "adult"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
+toy_model_params = {"epochs": 3}
 
 
-def test_tabular_nn_fastai_multiclass(fit_helper):
-    fit_args = dict(
-        hyperparameters={NNFastAiTabularModel: {}},
-    )
-    dataset_name = "covertype_small"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
+def test_tabular_nn_fastai(fit_helper):
+    model_cls = NNFastAiTabularModel
+    model_hyperparameters = toy_model_params
 
-
-def test_tabular_nn_fastai_regression(fit_helper):
-    fit_args = dict(
-        hyperparameters={NNFastAiTabularModel: {}},
-    )
-    dataset_name = "ames"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
+    fit_helper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters, bag="first", refit_full="first")
 
 
 __GET_EPOCHS_NUMBER_CASES = {
@@ -53,7 +38,7 @@ def test_get_epochs_number(test_input):
         # batches = (4000/256) + 1 = 16
         # est_epoch_time = 16 * 1.2732 = 20.371
         # time_left:45/est_epoch_time:20.371 = 2
-        model = NNFastAiTabularModel()
+        model = NNFastAiTabularModel(path="", name="")
         assert epochs_expected == model._get_epochs_number(4000, min_batches_count=4, **args)
         if "time_left" in args:
             if args.get("epochs", None) == "auto" and args["batch_size"] * 4 <= 4000:
@@ -73,7 +58,7 @@ __GET_BATCH_SIZE_CASES = {
 def test_get_batch_size_with_bs_provided(test_input):
     args, expected_bs = test_input
     bs, input_size = args["bs"], args["input_size"]
-    model = NNFastAiTabularModel()
+    model = NNFastAiTabularModel(path="", name="")
     model.params["bs"] = bs
     x = np.arange(input_size)
     assert expected_bs == model._get_batch_size(x)

--- a/tabular/tests/unittests/models/test_tabular_nn_fastai.py
+++ b/tabular/tests/unittests/models/test_tabular_nn_fastai.py
@@ -14,7 +14,7 @@ def test_tabular_nn_fastai(fit_helper):
     model_cls = NNFastAiTabularModel
     model_hyperparameters = toy_model_params
 
-    fit_helper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters, bag="first", refit_full="first")
+    fit_helper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters)
 
 
 __GET_EPOCHS_NUMBER_CASES = {

--- a/tabular/tests/unittests/models/test_xgboost.py
+++ b/tabular/tests/unittests/models/test_xgboost.py
@@ -1,33 +1,18 @@
 from autogluon.tabular.models.xgboost.xgboost_model import XGBoostModel
 
-
-def test_xgboost_binary(fit_helper):
-    fit_args = dict(
-        hyperparameters={XGBoostModel: {}},
-    )
-    dataset_name = "adult"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
+toy_model_params = {"n_estimators": 10}
 
 
-def test_xgboost_multiclass(fit_helper):
-    fit_args = dict(
-        hyperparameters={XGBoostModel: {}},
-    )
-    dataset_name = "covertype_small"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
+def test_xgboost(fit_helper):
+    model_cls = XGBoostModel
+    model_hyperparameters = toy_model_params
 
-
-def test_xgboost_regression(fit_helper):
-    fit_args = dict(
-        hyperparameters={XGBoostModel: {}},
-    )
-    dataset_name = "ames"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
+    fit_helper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters)
 
 
 def test_xgboost_binary_enable_categorical(fit_helper):
     fit_args = dict(
         hyperparameters={XGBoostModel: {"enable_categorical": True}},
     )
-    dataset_name = "adult"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
+    dataset_name = "toy_binary"
+    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, refit_full=False)

--- a/tabular/tests/unittests/models/test_xt.py
+++ b/tabular/tests/unittests/models/test_xt.py
@@ -1,52 +1,37 @@
 from autogluon.tabular.models.xt.xt_model import XTModel
 
-
-def test_xt_binary(fit_helper):
-    fit_args = dict(
-        hyperparameters={XTModel: {}},
-    )
-    dataset_name = "adult"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
+toy_model_params = {"n_estimators": 10}
 
 
-def test_xt_multiclass(fit_helper):
-    fit_args = dict(
-        hyperparameters={XTModel: {}},
-    )
-    dataset_name = "covertype_small"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
+def test_xt(fit_helper):
+    model_cls = XTModel
+    model_hyperparameters = toy_model_params
 
-
-def test_xt_regression(fit_helper):
-    fit_args = dict(
-        hyperparameters={XTModel: {}},
-    )
-    dataset_name = "ames"
-    fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
+    fit_helper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters, bag="first", refit_full="first")
 
 
 def test_xt_binary_compile_onnx(fit_helper):
     fit_args = dict(
-        hyperparameters={XTModel: {}},
+        hyperparameters={XTModel: toy_model_params},
     )
-    dataset_name = "adult"
+    dataset_name = "toy_binary"
     compiler_configs = {XTModel: {"compiler": "onnx"}}
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, compile=True, compiler_configs=compiler_configs)
 
 
 def test_xt_multiclass_compile_onnx(fit_helper):
     fit_args = dict(
-        hyperparameters={XTModel: {}},
+        hyperparameters={XTModel: toy_model_params},
     )
-    dataset_name = "covertype_small"
+    dataset_name = "toy_multiclass"
     compiler_configs = {XTModel: {"compiler": "onnx"}}
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, compile=True, compiler_configs=compiler_configs)
 
 
 def test_xt_regression_compile_onnx(fit_helper):
     fit_args = dict(
-        hyperparameters={XTModel: {}},
+        hyperparameters={XTModel: toy_model_params},
     )
     compiler_configs = {XTModel: {"compiler": "onnx"}}
-    dataset_name = "ames"
+    dataset_name = "toy_regression"
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, compile=True, compiler_configs=compiler_configs)

--- a/tabular/tests/unittests/models/test_xt.py
+++ b/tabular/tests/unittests/models/test_xt.py
@@ -7,7 +7,7 @@ def test_xt(fit_helper):
     model_cls = XTModel
     model_hyperparameters = toy_model_params
 
-    fit_helper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters, bag="first", refit_full="first")
+    fit_helper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters)
 
 
 def test_xt_binary_compile_onnx(fit_helper):

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -731,11 +731,13 @@ def run_tabular_benchmarks(fast_benchmark, subsample_size, perf_threshold, seed_
         warnings.warn(w.message)
 
 
-def test_pseudolabeling():
-    datasets = get_benchmark_sets()
-    train_file = "train_data.csv"
-    test_file = "test_data.csv"
-    directory_prefix = "./datasets/"
+def test_pseudolabeling(fit_helper):
+    datasets = [
+        "toy_binary",
+        "toy_multiclass",
+        "toy_regression",
+    ]
+
     hyperparam_setting = {
         "GBM": {"num_boost_round": 10},
         "XGB": {"n_estimators": 10},
@@ -755,23 +757,16 @@ def test_pseudolabeling():
     )
     for idx in range(len(datasets)):
         dataset = datasets[idx]
-        label = dataset["label"]
-        problem_type = dataset["problem_type"]
-        name = dataset["name"]
-        train_data, test_data = load_data(
-            directory_prefix=directory_prefix, train_file=train_file, test_file=test_file, name=dataset["name"], url=dataset["url"]
-        )
+        train_data, test_data, dataset_info = fit_helper.load_dataset(dataset)
+        label = dataset_info["label"]
+        problem_type = dataset_info["problem_type"]
+        name = dataset
 
         print(f"Testing dataset with name: {name}, problem type: {problem_type}")
-
-        train_data = train_data.sample(50, random_state=1)
-        test_data = test_data[test_data[label].notna()]
 
         if problem_type in PROBLEM_TYPES_CLASSIFICATION:
             valid_class_idxes = test_data[label].isin(train_data[label].unique())
             test_data = test_data[valid_class_idxes]
-
-        test_data = test_data.sample(50, random_state=1)
 
         error_msg_og = (
             f"pseudolabel threw an exception during fit, it should have "


### PR DESCRIPTION
*Issue #, if available:*

Same as #4942, moved code to autogluon branch so unit tests work correctly in CI

*Description of changes:*

# Tabular Tests Speedup: 3060s -> 743s (4x speedup)

Massively speed up unit tests for tabular models


- Switch from real datasets to toy synthetic datasets
- Use toy model hyperparameters when faster
- Avoid calling `predictor.info()` for each model fit
- Avoid calling `predictor.leaderboard(..., extra_info=True)` for each model fit
- Only call refit_full for a given model family once, no need to test refit_full on every dataset
- Only test bagging for a given model family once, no need to test bagging on every dataset
- Ensure we test bagging for every model family (previously was inconsistent)
- Ensure we are testing every supported problem_type (previously it was inconsistent)

## Enhancements

- Add classmethod to each model to get the supported problem types

## Speedup

- AutoMM tests: 600s -> 60s
- LightGBM tests: 130s -> 16s 
- Dummy tests: 23s -> 12s
- NeuralNetTorch tests: 140s -> 8s
- NeuralNetFastAI tests: 15s -> 2s
- RandomForest tests: 87s -> 8s
- ExtraTrees tests: 108s -> 7s
- XGBoost tests: 32s -> 4s
- CatBoost tests: 61s -> 3s
- Linear tests: 23s -> 6s
- test_tabular: 233s -> 25s
- test_advanced_functionality: 67s -> 33s
- test_tabularHPO: 199s -> 106s
- test_tabular_parallel_local_bagging: 38s -> 35s
- test_tabular_sequential_local_bagging: 16s -> 8s
- test_calibrate.py: 26s -> 11s
- test_learning_curves.py: 70s -> 40s
- test_pseudolabeling: 68s -> 36s
- test_tabularHPObagstack: 204s -> 51s
- test_tabular_bagstack: 169s -> 6s
- test_tabular_bagstack_use_bag_holdout: 168s -> 6s
- test_sample_weight: 52s -> 15s

## Fixes

- test_tabular_feature_prune wasn't actually testing feature pruning, now it does
- Fixed several bugs with oof predictions on quantile problem type

TODO:

- [ ] Verify categorical, missing value, etc. handling for models (Follow-up, currently still have some tests using real datasets to verify this)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
