### PR TITLE
[tabular] Fix .refit_full(train_data_extra)

### DIFF
--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -620,7 +620,8 @@ class BaggedEnsembleModel(AbstractModel):
             # FIXME: Consider use_child_oof with pseudo labels! Need to keep track of indices
             logger.log(15, f"{len(X_pseudo)} extra rows of pseudolabeled data added to training set for {self.name}")
             assert_pseudo_column_match(X=X, X_pseudo=X_pseudo)
-            X_fit = pd.concat([X, X_pseudo], axis=0, ignore_index=True)
+            # Needs .astype(X.dtypes) because pd.concat will convert categorical features to int/float unexpectedly. Need to convert them back to original.
+            X_fit = pd.concat([X, X_pseudo], axis=0, ignore_index=True).astype(X.dtypes)
             y_fit = pd.concat([y, y_pseudo], axis=0, ignore_index=True)
         else:
             X_fit = X

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -2148,8 +2148,9 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         # is required
         if not isinstance(model, BaggedEnsembleModel) and X_pseudo is not None and y_pseudo is not None and X_pseudo.columns.equals(X.columns):
             assert_pseudo_column_match(X=X, X_pseudo=X_pseudo)
-            X_w_pseudo = pd.concat([X, X_pseudo])
-            y_w_pseudo = pd.concat([y, y_pseudo])
+            # Needs .astype(X.dtypes) because pd.concat will convert categorical features to int/float unexpectedly. Need to convert them back to original.
+            X_w_pseudo = pd.concat([X, X_pseudo], ignore_index=True).astype(X.dtypes)
+            y_w_pseudo = pd.concat([y, y_pseudo], ignore_index=True)
             logger.log(15, f"{len(X_pseudo)} extra rows of pseudolabeled data added to training set for {model.name}")
             model_fit_kwargs["X"] = X_w_pseudo
             model_fit_kwargs["y"] = y_w_pseudo

--- a/tabular/tests/unittests/models/advanced/test_refit_full.py
+++ b/tabular/tests/unittests/models/advanced/test_refit_full.py
@@ -1,14 +1,15 @@
 import shutil
 
 from autogluon.tabular import TabularPredictor
+from autogluon.tabular.testing import FitHelper
 
 
-def test_refit_full_train_data_extra(fit_helper):
+def test_refit_full_train_data_extra():
     """
     Verifies that `refit_full(train_data_extra)` works.
     """
     dataset = "adult"  # Need a dataset with categorical features + NaNs in categories
-    train_data, test_data, dataset_info = fit_helper.load_dataset(dataset)
+    train_data, test_data, dataset_info = FitHelper.load_dataset(dataset)
 
     len_train = len(train_data)
     len_test = len(test_data)
@@ -40,12 +41,12 @@ def test_refit_full_train_data_extra(fit_helper):
     shutil.rmtree(predictor.path, ignore_errors=True)
 
 
-def test_refit_full_train_data_extra_bag(fit_helper):
+def test_refit_full_train_data_extra_bag():
     """
     Verifies that `refit_full(train_data_extra)` works when bagging
     """
     dataset = "adult"  # Need a dataset with categorical features + NaNs in categories
-    train_data, test_data, dataset_info = fit_helper.load_dataset(dataset)
+    train_data, test_data, dataset_info = FitHelper.load_dataset(dataset)
 
     len_train = len(train_data)
     len_test = len(test_data)

--- a/tabular/tests/unittests/models/advanced/test_refit_full.py
+++ b/tabular/tests/unittests/models/advanced/test_refit_full.py
@@ -1,0 +1,80 @@
+import shutil
+
+from autogluon.tabular import TabularPredictor
+
+
+def test_refit_full_train_data_extra(fit_helper):
+    """
+    Verifies that `refit_full(train_data_extra)` works.
+    """
+    dataset = "adult"  # Need a dataset with categorical features + NaNs in categories
+    train_data, test_data, dataset_info = fit_helper.load_dataset(dataset)
+
+    len_train = len(train_data)
+    len_test = len(test_data)
+    len_combined = len_train + len_test
+
+    predictor = TabularPredictor(label=dataset_info["label"], problem_type=dataset_info["problem_type"])
+
+    predictor.fit(
+        train_data=train_data,
+        hyperparameters={"NN_TORCH": {"num_epochs": 1}},
+        raise_on_model_failure=True,
+        fit_weighted_ensemble=False,
+    )
+
+    assert len(predictor.model_names()) == 1
+    model_name = predictor.model_names()[0]
+    refit_model_map = predictor.refit_full(train_data_extra=test_data)
+    refit_model_name = refit_model_map[model_name]
+
+    assert len(predictor.model_names()) == 2
+
+    refit_model_info = predictor.model_info(refit_model_name)
+
+    # Ensure refit uses all of train_data and all of train_data_extra
+    assert refit_model_info["num_samples"] == len_combined
+
+    predictor.predict(test_data, model=refit_model_name)
+
+    shutil.rmtree(predictor.path, ignore_errors=True)
+
+
+def test_refit_full_train_data_extra_bag(fit_helper):
+    """
+    Verifies that `refit_full(train_data_extra)` works when bagging
+    """
+    dataset = "adult"  # Need a dataset with categorical features + NaNs in categories
+    train_data, test_data, dataset_info = fit_helper.load_dataset(dataset)
+
+    len_train = len(train_data)
+    len_test = len(test_data)
+    len_combined = len_train + len_test
+
+    predictor = TabularPredictor(label=dataset_info["label"], problem_type=dataset_info["problem_type"])
+
+    predictor.fit(
+        train_data=train_data,
+        hyperparameters={"NN_TORCH": {"num_epochs": 1}},
+        raise_on_model_failure=True,
+        fit_weighted_ensemble=False,
+        num_bag_folds=2,
+        ag_args_ensemble={"fold_fitting_strategy": "sequential_local"},
+    )
+
+    assert len(predictor.model_names()) == 1
+    model_name = predictor.model_names()[0]
+    refit_model_map = predictor.refit_full(train_data_extra=test_data)
+    refit_model_name = refit_model_map[model_name]
+
+    assert len(predictor.model_names()) == 2
+
+    refit_model_info = predictor.model_info(refit_model_name)
+
+    # Ensure refit uses all of train_data and all of train_data_extra
+    assert refit_model_info["num_samples"] == len_train
+    assert refit_model_info["children_info"]["S1F1"]["num_samples"] == len_combined
+
+    predictor.predict(test_data, model=refit_model_name)
+
+    shutil.rmtree(predictor.path, ignore_errors=True)


### PR DESCRIPTION
*Issue #, if available:*

Related: #4941

*Description of changes:*

Fix a bug where refit_full(train_data_extra) fails when categorical features are present. This is because when concating two dataframes with identical dtypes, the dtypes for category features are changed to float/int. This causes downstream errors in models. This PR fixes this by doing `.astype(X.dtypes)` after the concat.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
