### PR TITLE
Fix NLTK tagger path in download function

### DIFF
--- a/multimodal/src/autogluon/multimodal/data/trivial_augmenter.py
+++ b/multimodal/src/autogluon/multimodal/data/trivial_augmenter.py
@@ -206,7 +206,7 @@ def set_image_augmentation_space():
 
 def download_nltk():
     try:
-        nltk.data.find("tagger/averaged_perceptron_tagger")
+        nltk.data.find("taggers/averaged_perceptron_tagger")
     except LookupError:
         nltk.download("averaged_perceptron_tagger", quiet=True)
     try:


### PR DESCRIPTION
*Issue #, if available:* fix #4967

*Description of changes:*
fix typo in download_nltk function. Which always caused downloading of averaged_perceptron_tagger

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
