### PR TITLE
Add FastAI 2.8 support

### DIFF
--- a/common/src/autogluon/common/utils/try_import.py
+++ b/common/src/autogluon/common/utils/try_import.py
@@ -131,9 +131,7 @@ def try_import_fastai():
         from pkg_resources import parse_version  # pylint: disable=import-outside-toplevel
 
         fastai_version = parse_version(fastai.__version__)
-        assert parse_version("2.0.0") <= fastai_version, (
-            "Currently, we only support fastai>=2.0.0"
-        )
+        assert parse_version("2.0.0") <= fastai_version, "Currently, we only support fastai>=2.0.0"
 
         # fastai is doing library setup during star imports. These are required for correct library functioning.
         # Local star imports are not possible in-place, so separate helper packages is created

--- a/common/src/autogluon/common/utils/try_import.py
+++ b/common/src/autogluon/common/utils/try_import.py
@@ -131,8 +131,8 @@ def try_import_fastai():
         from pkg_resources import parse_version  # pylint: disable=import-outside-toplevel
 
         fastai_version = parse_version(fastai.__version__)
-        assert parse_version("2.0.0") <= fastai_version < parse_version("2.8"), (
-            "Currently, we only support 2.0.0<=fastai<2.8"
+        assert parse_version("2.0.0") <= fastai_version, (
+            "Currently, we only support fastai>=2.0.0"
         )
 
         # fastai is doing library setup during star imports. These are required for correct library functioning.

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -46,7 +46,7 @@ extras_require = {
     "fastai": [
         "spacy<3.8",  # cap for issue https://github.com/explosion/spaCy/issues/13653
         "torch",  # version range defined in `core/_setup_utils.py`
-        "fastai>=2.3.1,<2.8",  # <{N+1} upper cap, where N is the latest released minor version
+        "fastai>=2.3.1,<2.9",  # <{N+1} upper cap, where N is the latest released minor version
     ],
     "tabpfn": [
         # versions below 2.0.2 are broken (or yanked)


### PR DESCRIPTION
*Issue #, if available:*

Resolves #4987 

*Description of changes:*

- Add FastAI 2.8 support
- Removed upper hard cap on FastAI so users who upgrade in future won't automatically get failures.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
