### PR TITLE
fix: account for distributed training in learning rate schedule

### DIFF
--- a/multimodal/src/autogluon/multimodal/optim/lit_module.py
+++ b/multimodal/src/autogluon/multimodal/optim/lit_module.py
@@ -139,7 +139,7 @@ class LitModule(pl.LightningModule):
             - ia3, ia3_bias, ia3_norm (adds vector that scales activations by learned vectors, in combination with either bit_fit or norm_fit)
             - None (do not use efficient finetuning strategies)
         track_grad_norm
-            Track the p-norm of gradients during training. May be set to ‘inf’ infinity-norm.
+            Track the p-norm of gradients during training. May be set to 'inf'  infinity-norm.
             If using Automatic Mixed Precision (AMP), the gradients will be unscaled before logging them.
 
         """
@@ -485,12 +485,14 @@ class LitModule(pl.LightningModule):
                     len(self.trainer.datamodule.train_dataloader())
                     * self.trainer.max_epochs
                     // accumulate_grad_batches
+                    // self.trainer.num_devices  # Account for distributed training
                 )
                 logger.debug(
                     f"len(trainer.datamodule.train_dataloader()): {len(self.trainer.datamodule.train_dataloader())}"
                 )
                 logger.debug(f"trainer.max_epochs: {self.trainer.max_epochs}")
                 logger.debug(f"accumulate_grad_batches: {accumulate_grad_batches}")
+                logger.debug(f"num_devices: {self.trainer.num_devices}")
         else:
             max_steps = self.trainer.max_steps
 


### PR DESCRIPTION
*Issue #, if available:*
#4966 

*Description of changes:*
When using multiple GPUs, the learning rate schedule was incorrectly calculated because `max_steps` didn't account for distributed training. This caused: 
- Warmup period to be longer than intended 
- Learning rate to not decay to 0 as expected

The fix divides `max_steps` by `num_devices` to properly scale the schedule for distributed training. 
This ensures: 
- Correct warmup period (e.g. 10% of actual total steps) 
- Proper cosine decay reaching 0 at the end of training

Learning Rate Prior to the fix with 4 GPUs:
![Screenshot 2025-04-01 at 2 38 25 PM](https://github.com/user-attachments/assets/777827d6-2fc2-4fe3-8bb2-7064367e2323)


Learning Rate Post to the fix with 4 GPUs:
![Screenshot 2025-04-01 at 2 39 03 PM](https://github.com/user-attachments/assets/f67da46a-d4f5-40af-8cfc-927c43663492)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
