### PR TITLE
[timeseries] Raise informative error message if invalid model name is provided

### DIFF
--- a/timeseries/src/autogluon/timeseries/trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer.py
@@ -752,6 +752,8 @@ class TimeSeriesTrainer(AbstractTrainer[AbstractTimeSeriesModel]):
             if isinstance(model, AbstractTimeSeriesModel):
                 return model.name
             else:
+                if model not in self.get_model_names():
+                    raise KeyError(f"Model '{model}' not found. Available models: {self.get_model_names()}")
                 return model
 
     def predict(

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -1828,3 +1828,11 @@ def test_when_leaky_feature_provided_then_model_with_regressor_achieves_good_acc
     )
     score = predictor.evaluate(test_data, metrics=["RMSE"])["RMSE"]
     assert score > -1.0
+
+
+@pytest.mark.parametrize("method", ["evaluate", "predict", "feature_importance"])
+def test_when_invalid_model_provided_then_informative_error_is_raised(method, temp_model_path):
+    data = DUMMY_TS_DATAFRAME.copy()
+    predictor = TimeSeriesPredictor(path=temp_model_path).fit(data, hyperparameters={"Naive": {}})
+    with pytest.raises(KeyError, match="Available models"):
+        getattr(predictor, method)(data=data, model="InvalidModel")


### PR DESCRIPTION
*Issue #, if available:* Fixes #4973

*Description of changes:*
- Raise an informative error message if a model not present in the trainer is used for prediction. Currently, the error message is very confusing: `networkx.exception.NetworkXError: The node Chronos is not in the digraph`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
