### PR TITLE
[timeseries] Gracefully handled corrupted cached predictions

### DIFF
--- a/timeseries/src/autogluon/timeseries/trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer.py
@@ -1107,7 +1107,7 @@ class TimeSeriesTrainer(AbstractTrainer[AbstractTimeSeriesModel]):
         combined_hash = hash_pandas_df(data) + hash_pandas_df(known_covariates) + hash_pandas_df(data.static_features)
         return combined_hash
 
-    def _load_cached_predictions(self) -> dict[str, dict]:
+    def _load_cached_predictions(self) -> dict[str, dict[str, dict[str, Any]]]:
         """Load cached predictions from disk. If loading fails, an empty dictionary is returned."""
         if self._cached_predictions_path.exists():
             try:


### PR DESCRIPTION
*Issue #, if available:* Fixes #4992

*Description of changes:*
- Gracefully handle the cases when loading cached predictions fails (e.g., because of EOFError, FileNotFoundError, UnpicklingError, incorrect keys stored in the cached predictions dicts).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
