### PR TITLE
[timeseries] Fix redundant scaler and regressor initialization for MultiWindowBacktestingModel

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -217,9 +217,9 @@ class TimeSeriesModelBase(ModelBase, ABC):
         )
         self.val_score: Optional[float] = None  # Score with eval_metric (Validation data)
 
-        self.target_scaler: Optional[TargetScaler] = None
-        self.covariate_scaler: Optional[CovariateScaler] = None
-        self.covariate_regressor: Optional[CovariateRegressor] = None
+        self.target_scaler: Optional[TargetScaler]
+        self.covariate_scaler: Optional[CovariateScaler]
+        self.covariate_regressor: Optional[CovariateRegressor]
         self._initialize_transforms_and_regressor()
 
     def __repr__(self) -> str:

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -217,9 +217,9 @@ class TimeSeriesModelBase(ModelBase, ABC):
         )
         self.val_score: Optional[float] = None  # Score with eval_metric (Validation data)
 
-        self.target_scaler: Optional[TargetScaler]
-        self.covariate_scaler: Optional[CovariateScaler]
-        self.covariate_regressor: Optional[CovariateRegressor]
+        self.target_scaler: Optional[TargetScaler] = None
+        self.covariate_scaler: Optional[CovariateScaler] = None
+        self.covariate_regressor: Optional[CovariateRegressor] = None
         self._initialize_transforms_and_regressor()
 
     def __repr__(self) -> str:

--- a/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
+++ b/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
@@ -218,7 +218,7 @@ class MultiWindowBacktestingModel(AbstractTimeSeriesModel):
     def _get_search_space(self):
         return self.model_base._get_search_space()
 
-    def _initialize_covariate_regressor_scaler(self, **kwargs) -> None:
+    def _initialize_transforms_and_regressor(self, **kwargs) -> None:
         # Do not initialize the target_scaler and covariate_regressor in the multi window model!
         pass
 

--- a/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
+++ b/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
@@ -220,7 +220,9 @@ class MultiWindowBacktestingModel(AbstractTimeSeriesModel):
 
     def _initialize_transforms_and_regressor(self, **kwargs) -> None:
         # Do not initialize the target_scaler and covariate_regressor in the multi window model!
-        pass
+        self.target_scaler = None
+        self.covariate_scaler = None
+        self.covariate_regressor = None
 
     def _get_hpo_train_fn_kwargs(self, **train_fn_kwargs) -> dict:
         train_fn_kwargs["is_bagged_model"] = True

--- a/timeseries/tests/unittests/models/common.py
+++ b/timeseries/tests/unittests/models/common.py
@@ -129,8 +129,8 @@ def get_multi_window_deepar(hyperparameters=None, **kwargs):
     """Wrap DeepAR inside MultiWindowBacktestingModel."""
     if hyperparameters is None:
         hyperparameters = {"max_epochs": 1, "num_batches_per_epoch": 1}
-    model_base_kwargs = {**kwargs, "hyperparameters": hyperparameters}
-    return MultiWindowBacktestingModel(model_base=DeepARModel, model_base_kwargs=model_base_kwargs, **kwargs)
+    model_base = DeepARModel(hyperparameters=hyperparameters, **kwargs)
+    return MultiWindowBacktestingModel(model_base=model_base, hyperparameters=hyperparameters, **kwargs)
 
 
 def patch_constructor(


### PR DESCRIPTION
*Issue #, if available:* Fixes #4999

*Description of changes:*
- The method `_initialize_covariate_regressor_scaler` in `MultiWindowBacktestingModel` did not actually overload the method `_initialize_transforms_and_regressor` in `AbstractTimeSeriesModel`. Because of this, the scaler / regressor object was created twice in multi window models. 
- This bug went unnoticed because of another bug in the `get_multi_window_deepar` method in the tests. The initialization was done differently from what actually happened when we trained a `MultiWindowBacktestingModel` during training.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
