### PR TITLE
[timeseries] Change `evaluation_strategy` to `eval_strategy`

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/chronos/model.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/model.py
@@ -408,6 +408,8 @@ class ChronosModel(AbstractTimeSeriesModel):
         time_limit: Optional[int] = None,
         **kwargs,
     ) -> None:
+        import transformers
+        from packaging import version
         from transformers.trainer import PrinterCallback, Trainer, TrainingArguments
 
         from .pipeline import ChronosBoltPipeline, ChronosPipeline
@@ -495,6 +497,10 @@ class ChronosModel(AbstractTimeSeriesModel):
                 fine_tune_trainer_kwargs["eval_steps"] = None
                 fine_tune_trainer_kwargs["load_best_model_at_end"] = False
                 fine_tune_trainer_kwargs["metric_for_best_model"] = None
+
+            if version.parse(transformers.__version__) >= version.parse("4.46"):
+                # transformers changed the argument name from `evaluation_strategy` to `eval_strategy`
+                fine_tune_trainer_kwargs["eval_strategy"] = fine_tune_trainer_kwargs.pop("evaluation_strategy")
 
             training_args = TrainingArguments(**fine_tune_trainer_kwargs, **pipeline_specific_trainer_kwargs)
             tokenizer_train_dataset = ChronosFineTuningDataset(

--- a/timeseries/tests/unittests/models/chronos/test_model.py
+++ b/timeseries/tests/unittests/models/chronos/test_model.py
@@ -399,7 +399,10 @@ def test_when_eval_during_fine_tune_is_false_then_evaluation_is_turned_off(chron
         except TypeError:
             pass
 
-        assert training_args.call_args.kwargs["evaluation_strategy"] == "no"
+        eval_strategy = training_args.call_args.kwargs.get("eval_strategy") or training_args.call_args.get(
+            "evaluation_strategy"
+        )
+        assert eval_strategy == "no"
         assert training_args.call_args.kwargs["eval_steps"] is None
         assert not training_args.call_args.kwargs["load_best_model_at_end"]
         assert training_args.call_args.kwargs["metric_for_best_model"] is None


### PR DESCRIPTION
*Issue #, if available:* fixes #5018

*Description of changes:* This PR changes the `evaluation_strategy` training argument to `eval_strategy`, if the `transformers` version is greater than or equal to `4.46`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
