### PR TITLE
[Tabular] Add mem opt simulation artifact support

### DIFF
--- a/common/src/autogluon/common/utils/simulation_utils.py
+++ b/common/src/autogluon/common/utils/simulation_utils.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from typing import Any, Dict, Tuple
 
+import numpy as np
 import pandas as pd
 
 
@@ -66,8 +67,37 @@ def convert_simulation_artifacts_to_tabular_predictions_dict(
                     "label",
                 ]:
                     aggregated_ground_truth[task_name][fold][k] = zeroshot_metadata[k]
-            for k in ["pred_proba_dict_val", "pred_proba_dict_test"]:
+            ordered_class_labels_transformed = aggregated_ground_truth[task_name][fold]["ordered_class_labels_transformed"]
+            pred_proba_tuples = [
+                ("pred_proba_dict_val", "y_val", "y_val_idx"),
+                ("pred_proba_dict_test", "y_test", "y_test_idx"),
+            ]
+            for (k, ground_truth_key, ground_truth_idx_key) in pred_proba_tuples:
+                ground_truth_idx = zeroshot_metadata.get(ground_truth_idx_key, None)
+
+                if ground_truth_idx is not None:
+                    ground_truth_np = zeroshot_metadata[ground_truth_key]
+                    assert isinstance(ground_truth_np, np.ndarray)
+                    assert isinstance(ground_truth_idx, np.ndarray)
+                    # memory opt variant in np.ndarray format, convert to pandas
+                    if len(ground_truth_np.shape) == 1:
+                        ground_truth_pd = pd.Series(data=ground_truth_np, index=ground_truth_idx, name=zeroshot_metadata["label"])
+                    else:
+                        ground_truth_pd = pd.DataFrame(data=ground_truth_np, index=ground_truth_idx, columns=ordered_class_labels_transformed)
+                    aggregated_ground_truth[task_name][fold][ground_truth_key] = ground_truth_pd
+                ground_truth = aggregated_ground_truth[task_name][fold][ground_truth_key]
+                assert isinstance(ground_truth, (pd.Series, pd.DataFrame))
                 for m, pred_proba in zeroshot_metadata[k].items():
+                    if isinstance(pred_proba, np.ndarray):
+                        if len(pred_proba.shape) == 1:
+                            if ordered_class_labels_transformed is not None:
+                                assert len(ordered_class_labels_transformed) == 2
+                                series_name = ordered_class_labels_transformed[1]
+                            else:
+                                series_name = ground_truth.name
+                            pred_proba = pd.Series(data=pred_proba, index=ground_truth.index, name=series_name)
+                        else:
+                            pred_proba = pd.DataFrame(data=pred_proba, index=ground_truth.index, columns=ordered_class_labels_transformed)
                     if aggregated_ground_truth[task_name][fold]["problem_type"] == "binary":
                         if isinstance(pred_proba, pd.DataFrame):
                             assert len(pred_proba.columns) == 2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add mem opt simulation artifact support, necessary for upcoming TabArena
- Mem opt simulation artifact is up to 4x smaller than non-optimized artifact.
- Tests pass locally

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
