### PR TITLE
[timeseries] Expose static_features in the predictor API

### DIFF
--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -720,7 +720,9 @@ class TimeSeriesPredictor:
 
         if tuning_data is not None:
             # TODO: Allow passing separate static_features to tuning_data?
-            tuning_data = self._check_and_prepare_data_frame(tuning_data, name="tuning_data")
+            tuning_data = self._check_and_prepare_data_frame(
+                tuning_data, static_features=static_features, name="tuning_data"
+            )
             self._check_data_for_evaluation(tuning_data, name="tuning_data")
             logger.info(f"Provided tuning_data has {self._get_dataset_stats(tuning_data)}")
             # TODO: Use num_val_windows to perform multi-window backtests on tuning_data

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -465,10 +465,6 @@ class TimeSeriesPredictor:
             Leaving this argument empty and letting AutoGluon automatically generate the validation set from
             ``train_data`` is a good default.
 
-            If ``known_covariates_names`` were specified when creating the predictor, ``tuning_data`` must also include
-            the columns listed in ``known_covariates_names`` with the covariates values aligned with the target time
-            series.
-
             The names and dtypes of columns in ``tuning_data`` must match the ``train_data``.
 
             If provided data is a pandas.DataFrame, AutoGluon will attempt to convert it to a ``TimeSeriesDataFrame``.

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -813,7 +813,7 @@ class TimeSeriesPredictor:
 
             Must contain a column with name ``item_id`` that matches the item IDs of the time series in ``data``.
 
-            If a path is provided, AutoGluon will attempt to automatically read this file as a pandas.DataFrame.
+            If a Path or a str is provided, AutoGluon will attempt to read this file as a pandas.DataFrame.
         model : str, optional
             Name of the model that you would like to use for prediction. By default, the best model during training
             (with highest validation score) will be used.
@@ -900,6 +900,15 @@ class TimeSeriesPredictor:
 
             If provided data is a pandas.DataFrame, AutoGluon will attempt to convert it to a ``TimeSeriesDataFrame``.
             If a str or a Path is provided, AutoGluon will attempt to load this file.
+        static_features : Union[pd.DataFrame, Path, str], optional
+            An optional data frame describing the metadata of each individual time series that does not change with time.
+
+            If ``static_features`` were provided when training the predictor, ``static_features`` should also be
+            provided to this method.
+
+            Must contain a column with name ``item_id`` that matches the item IDs of the time series in ``data``.
+
+            If a Path or a str is provided, AutoGluon will attempt to read this file as a pandas.DataFrame.
         model : str, optional
             Name of the model that you would like to evaluate. By default, the best model during training
             (with highest validation score) will be used.
@@ -973,6 +982,15 @@ class TimeSeriesPredictor:
 
             If ``data`` is not provided, then validation (tuning) data provided during training (or the held out data used for
             validation if ``tuning_data`` was not explicitly provided ``fit()``) will be used.
+        static_features : Union[pd.DataFrame, Path, str], optional
+            An optional data frame describing the metadata of each individual time series that does not change with time.
+
+            If ``static_features`` were provided when training the predictor, ``static_features`` should also be
+            provided to this method.
+
+            Must contain a column with name ``item_id`` that matches the item IDs of the time series in ``data``.
+
+            If a Path or a str is provided, AutoGluon will attempt to read this file as a pandas.DataFrame.
         model : str, optional
             Name of the model that you would like to evaluate. By default, the best model during training
             (with highest validation score) will be used.
@@ -1249,7 +1267,15 @@ class TimeSeriesPredictor:
 
             If provided data is a pandas.DataFrame, AutoGluon will attempt to convert it to a ``TimeSeriesDataFrame``.
             If a str or a Path is provided, AutoGluon will attempt to load this file.
+        static_features : Union[pd.DataFrame, Path, str], optional
+            An optional data frame describing the metadata of each individual time series that does not change with time.
 
+            If ``static_features`` were provided when training the predictor, ``static_features`` should also be
+            provided to this method.
+
+            Must contain a column with name ``item_id`` that matches the item IDs of the time series in ``data``.
+
+            If a Path or a str is provided, AutoGluon will attempt to read this file as a pandas.DataFrame.
         extra_info : bool, default = False
             If True, the leaderboard will contain an additional column `hyperparameters` with the hyperparameters used
             by each model during training. An empty dictionary `{}` means that the model was trained with default

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -541,7 +541,7 @@ def test_when_fit_receives_only_future_data_as_tuning_data_then_exception_is_rai
     prediction_length = 3
     predictor = TimeSeriesPredictor(path=temp_model_path, prediction_length=prediction_length)
     future_data = DUMMY_TS_DATAFRAME.slice_by_timestep(-prediction_length, None)
-    with pytest.raises(ValueError, match="tuning\_data includes both historic and future data"):
+    with pytest.raises(ValueError, match=r"tuning_data includes both historic and future data"):
         predictor.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}}, tuning_data=future_data)
 
 
@@ -1890,3 +1890,13 @@ def test_when_static_features_are_provided_to_fit_but_not_other_methods_then_exc
     for method in ["evaluate", "leaderboard", "feature_importance", "predict"]:
         with pytest.raises(ValueError, match="must contain static"):
             getattr(predictor, method)(data)
+
+
+def test_when_static_features_are_provided_in_addition_to_existing_then_predictor_can_predict(temp_model_path):
+    data = DATAFRAME_WITH_STATIC_AND_COVARIATES.copy()
+    static_features = data.static_features
+    predictor = TimeSeriesPredictor(path=temp_model_path).fit(
+        train_data=data, static_features=static_features, hyperparameters={"Naive": {"n_jobs": 1}}
+    )
+    predictions = predictor.predict(data, static_features=static_features)
+    assert isinstance(predictions, TimeSeriesDataFrame)


### PR DESCRIPTION
*Issue #, if available:* Addresses #5034 

*Description of changes:*
- Make it possible to provide `static_features` as an attribute to `TimeSeriesPredictor` methods `fit`, `predict`, `evaluate`, `leaderboard`, `feature_importance`.
- Make the docstrings for different predictor methods more concise and consistent.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
