### PR TITLE
Fix sklearn<1.6 compatibility

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -19,7 +19,7 @@ DEPENDENT_PACKAGES = {
     "boto3": ">=1.10,<2",  # <2 because unlikely to introduce breaking changes in minor releases. >=1.10 because 1.10 is 3 years old, no need to support older
     "numpy": ">=1.25.0,<2.3.0",  # "<{N+3}" upper cap, where N is the latest released minor version, assuming no warnings using N
     "pandas": ">=2.0.0,<2.3.0",  # "<{N+3}" upper cap
-    "scikit-learn": ">=1.6.0,<1.7.0",  # <{N+1} upper cap
+    "scikit-learn": ">=1.4.0,<1.7.0",  # <{N+1} upper cap
     "scipy": ">=1.5.4,<1.16",  # "<{N+2}" upper cap
     "matplotlib": ">=3.7.0,<3.11",  # "<{N+2}" upper cap
     "psutil": ">=5.7.3,<7.1.0",  # Major version cap
@@ -30,7 +30,7 @@ DEPENDENT_PACKAGES = {
     "torch": ">=2.2,<2.7",  # Major version cap, sync with common/src/autogluon/common/utils/try_import.py
     "lightning": ">=2.2,<2.7",  # Major version cap
     "async_timeout": ">=4.0,<6",  # Major version cap
-    "transformers[sentencepiece]": ">=4.38.0,<4.50", # there is a breaking change in 4.50 for model config saving
+    "transformers[sentencepiece]": ">=4.38.0,<4.50",  # there is a breaking change in 4.50 for model config saving
     "accelerate": ">=0.34.0,<2.0",
     "typing-extensions": ">=4.0,<5",
 }

--- a/tabular/src/autogluon/tabular/models/tabular_nn/utils/categorical_encoders.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/utils/categorical_encoders.py
@@ -6,13 +6,14 @@ Unknown categories are returned as None in inverse transforms. Always converts i
 
 import copy
 from numbers import Integral
+from packaging.version import parse as parse_version
 
 import numpy as np
 from scipy import sparse
+from sklearn import __version__ as _sklearn_version
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted
-from sklearn.utils import Tags, InputTags, TargetTags
 
 from autogluon.features.generators import LabelEncoderFeatureGenerator
 
@@ -163,7 +164,10 @@ class _BaseEncoder(BaseEstimator, TransformerMixin):
         """
         if not (hasattr(X, "iloc") and getattr(X, "ndim", 0) == 2):
             # if not a dataframe, do normal check_array validation
-            X_temp = check_array(X, dtype=None, ensure_all_finite=False)
+            if parse_version(_sklearn_version) >= parse_version("1.6.0"):
+                X_temp = check_array(X, dtype=None, ensure_all_finite=False)
+            else:
+                X_temp = check_array(X, dtype=None, force_all_finite=False)
             if not hasattr(X, "dtype") and np.issubdtype(X_temp.dtype, np.str_):
                 X = check_array(X, dtype=object)
             else:
@@ -179,7 +183,10 @@ class _BaseEncoder(BaseEstimator, TransformerMixin):
 
         for i in range(n_features):
             Xi = self._get_feature(X, feature_idx=i)
-            Xi = check_array(Xi, ensure_2d=False, dtype=None, ensure_all_finite=needs_validation)
+            if parse_version(_sklearn_version) >= parse_version("1.6.0"):
+                Xi = check_array(Xi, ensure_2d=False, dtype=None, ensure_all_finite=needs_validation)
+            else:
+                Xi = check_array(Xi, ensure_2d=False, dtype=None, force_all_finite=needs_validation)
             X_columns.append(Xi)
 
         return X_columns, n_samples, n_features
@@ -305,7 +312,7 @@ class _BaseEncoder(BaseEstimator, TransformerMixin):
     def _more_tags(self):
         return {"X_types": ["categorical"]}
 
-    def __sklearn_tags__(self) -> Tags:
+    def __sklearn_tags__(self):
         """
         Returns a Tags object with scikit-learn estimator tags.
 
@@ -317,7 +324,8 @@ class _BaseEncoder(BaseEstimator, TransformerMixin):
         tags : sklearn.utils.Tags
             A Tags object containing all tag information.
         """
-
+        # lazily import to avoid crashing if sklearn<1.6
+        from sklearn.utils import Tags, InputTags, TargetTags
 
         # Create the Tags object with appropriate settings
         tags = Tags(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fix sklearn<1.6 compatibility
- With recent PR #5029, it breaks sklearn<1.6 support. It is important we continue to work on older sklearn versions, as many environments or packages might not support sklearn 1.6+ yet.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
