### PR TITLE
Platform tests

### DIFF
--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -247,16 +247,6 @@ jobs:
       - name: Checkout repository for nightly test
         if: (github.event_name == 'schedule')
         uses: actions/checkout@v2
-      - name: Free disk space (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          echo "Before cleanup:"
-          df -h
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo apt-get clean
-          docker rmi $(docker image ls -aq) || true
-          echo "After cleanup:"
-          df -h
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:

--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -200,7 +200,6 @@ jobs:
           df -h
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           sudo apt-get clean
-          docker rmi $(docker image ls -aq) || true
           echo "After cleanup:"
           df -h
       - name: Setup Miniconda

--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -52,7 +52,7 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         python: ["3.9", "3.10", "3.11", "3.12"]
-    steps:  
+    steps:
       - name: Checkout repository for PR
         if: (github.event_name == 'workflow_dispatch')
         uses: actions/checkout@v2
@@ -193,6 +193,16 @@ jobs:
       - name: Checkout repository for nightly test
         if: (github.event_name == 'schedule')
         uses: actions/checkout@v2
+      - name: Free disk space (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          echo "Before cleanup:"
+          df -h
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo apt-get clean
+          docker rmi $(docker image ls -aq) || true
+          echo "After cleanup:"
+          df -h
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -238,6 +248,16 @@ jobs:
       - name: Checkout repository for nightly test
         if: (github.event_name == 'schedule')
         uses: actions/checkout@v2
+      - name: Free disk space (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          echo "Before cleanup:"
+          df -h
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo apt-get clean
+          docker rmi $(docker image ls -aq) || true
+          echo "After cleanup:"
+          df -h
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Fix "No space left on device" [errors](https://github.com/autogluon/autogluon/actions/runs/14440463375/job/40489263110) in platform tests CI for tabular modules on Ubuntu runners with python 3.10.

- Added disk cleanup steps before dependency installation for Ubuntu runners
- Removes unnecessary large directories (/usr/share/dotnet, Android libraries, etc.)
- Cleans apt-get cache
- Removes Docker images if present
- Added to both tabular and timeseries workflow jobs
- Frees up ~14GB of disk space (from 67% to 47% disk usage)

* Testing
Successful [run](https://github.com/tonyhoo/autogluon/actions/runs/14455066679)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.