### PR TITLE
[Tabular] Raise on NaN val if raise_on_model_failure=True

### DIFF
--- a/common/src/autogluon/common/loaders/load_json.py
+++ b/common/src/autogluon/common/loaders/load_json.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 
@@ -6,7 +8,7 @@ from ..utils import s3_utils
 logger = logging.getLogger(__name__)
 
 
-def load(path: str, *, verbose=True) -> dict:
+def load(path: str, *, verbose=True) -> dict | list:
     if verbose:
         logger.log(15, "Loading: %s" % path)
     is_s3_path = s3_utils.is_s3_url(path)

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -2322,9 +2322,16 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         boolean, True if model was registered, False if model was found to be invalid and not registered.
         """
         if model.val_score is not None and np.isnan(model.val_score):
-            logger.warning(
-                f"WARNING: {model.name} has a val_score of {model.val_score} (NaN)! This should never happen. The model will not be saved to avoid instability."
+            msg = (
+                f"WARNING: {model.name} has a val_score of {model.val_score} (NaN)! "
+                f"This should never happen. The model will not be saved to avoid instability."
             )
+            if self.raise_on_model_failure:
+                raise AssertionError(
+                    f"{msg} Raising an exception because `raise_on_model_failure={self.raise_on_model_failure}`."
+                )
+            else:
+                logger.warning(msg)
             return False
         # TODO: Add to HPO
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Raise on NaN val if raise_on_model_failure=True
- Improve return type hint for load_json which can return a list or a dict.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
