### PR TITLE
Adopt ag_model_register

### DIFF
--- a/tabular/src/autogluon/tabular/configs/config_helper.py
+++ b/tabular/src/autogluon/tabular/configs/config_helper.py
@@ -9,7 +9,7 @@ from autogluon.core.scheduler import scheduler_factory
 from autogluon.features import AutoMLPipelineFeatureGenerator
 from autogluon.tabular.configs.hyperparameter_configs import hyperparameter_config_dict
 from autogluon.tabular.configs.presets_configs import tabular_presets_dict
-from autogluon.tabular.trainer.model_presets.presets import MODEL_TYPES
+from autogluon.tabular.register import ag_model_register
 
 
 class FeatureGeneratorBuilder:
@@ -107,6 +107,10 @@ class ConfigBuilder:
     def __init__(self):
         self.config = {}
 
+    def _valid_keys(self):
+        valid_keys = [m for m in ag_model_register.keys if m not in ["ENS_WEIGHTED", "SIMPLE_ENS_WEIGHTED"]]
+        return valid_keys
+
     def presets(self, presets: Union[str, list, dict]) -> ConfigBuilder:
         """
         List of preset configurations for various arguments in `fit()`. Can significantly impact predictive accuracy, memory-footprint, and inference latency of trained models, and various other properties of the returned `predictor`.
@@ -137,7 +141,7 @@ class ConfigBuilder:
         return self
 
     def hyperparameters(self, hyperparameters: Union[str, dict]) -> ConfigBuilder:
-        valid_keys = [m for m in MODEL_TYPES.keys() if m not in ["ENS_WEIGHTED", "SIMPLE_ENS_WEIGHTED"]]
+        valid_keys = self._valid_keys()
         valid_str_values = list(hyperparameter_config_dict.keys())
         if isinstance(hyperparameters, str):
             assert hyperparameters in hyperparameter_config_dict, f"{hyperparameters} is not one of the valid presets {valid_str_values}"
@@ -270,7 +274,7 @@ class ConfigBuilder:
         Useful when a particular model type such as 'KNN' or 'custom' is not desired but altering the `hyperparameters` dictionary is difficult or time-consuming.
             Example: To exclude both 'KNN' and 'custom' models, specify `excluded_model_types=['KNN', 'custom']`.
         """
-        valid_keys = [m for m in MODEL_TYPES.keys() if m not in ["ENS_WEIGHTED", "SIMPLE_ENS_WEIGHTED"]]
+        valid_keys = self._valid_keys()
         if not isinstance(models, list):
             models = [models]
         for model in models:
@@ -285,7 +289,7 @@ class ConfigBuilder:
         Useful when only the particular models should be trained such as 'KNN' or 'custom', but altering the `hyperparameters` dictionary is difficult or time-consuming.
             Example: To keep only 'KNN' and 'custom' models, specify `included_model_types=['KNN', 'custom']`.
         """
-        valid_keys = [m for m in MODEL_TYPES.keys() if m not in ["ENS_WEIGHTED", "SIMPLE_ENS_WEIGHTED"]]
+        valid_keys = self._valid_keys()
         if not isinstance(models, list):
             models = [models]
 

--- a/tabular/src/autogluon/tabular/trainer/auto_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/auto_trainer.py
@@ -5,8 +5,9 @@ from autogluon.core.utils import generate_train_test_split
 
 from ..models.lgb.lgb_model import LGBModel
 from .abstract_trainer import AbstractTabularTrainer
-from .model_presets.presets import MODEL_TYPES, get_preset_models
+from .model_presets.presets import get_preset_models
 from .model_presets.presets_distill import get_preset_models_distillation
+from ..register import ag_model_register
 
 logger = logging.getLogger(__name__)
 
@@ -186,4 +187,4 @@ class AutoTrainer(AbstractTabularTrainer):
         return super().compile(model_names=model_names, with_ancestors=with_ancestors, compiler_configs=compiler_configs)
 
     def _get_model_types_map(self) -> dict[str, AbstractModel]:
-        return MODEL_TYPES
+        return ag_model_register.key_to_cls_map()

--- a/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
+++ b/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
@@ -33,30 +33,7 @@ from ...version import __version__
 
 logger = logging.getLogger(__name__)
 
-# TODO: Replace with ag_model_register
-# Problem type specific model priority overrides (will update default values in DEFAULT_MODEL_PRIORITY)
-PROBLEM_TYPE_MODEL_PRIORITY = {
-    MULTICLASS: dict(
-        FASTAI=95,
-    ),
-}
-
-# TODO: Replace with ag_model_register
-DEFAULT_SOFTCLASS_PRIORITY = dict(
-    GBM=100,
-    RF=80,
-    CAT=60,
-    custom=0,
-)
-
 DEFAULT_CUSTOM_MODEL_PRIORITY = 0
-
-# FIXME: Don't do this, use ag_model_register lazily so users can register custom models before calling fit
-DEFAULT_MODEL_PRIORITY = {ag_model_register.key(model_cls): ag_model_register.priority(model_cls) for model_cls in ag_model_register.model_cls_list}
-DEFAULT_MODEL_NAMES = ag_model_register.name_map()
-REGISTERED_MODEL_CLS_LST = ag_model_register.model_cls_list
-MODEL_TYPES = ag_model_register.key_to_cls_map()
-
 
 VALID_AG_ARGS_KEYS = {
     "name",
@@ -122,9 +99,10 @@ def get_preset_models(
         invalid_name_set.update(invalid_model_names)
 
     if default_priorities is None:
-        default_priorities = copy.deepcopy(DEFAULT_MODEL_PRIORITY)
-        if problem_type in PROBLEM_TYPE_MODEL_PRIORITY:
-            default_priorities.update(PROBLEM_TYPE_MODEL_PRIORITY[problem_type])
+        priority_cls_map = ag_model_register.priority_map(problem_type=problem_type)
+        default_priorities = {
+            ag_model_register.key(model_cls): priority for model_cls, priority in priority_cls_map.items()
+        }
 
     level_key = level if level in hyperparameters.keys() else "default"
     if level_key not in hyperparameters.keys() and level_key == "default":
@@ -197,10 +175,11 @@ def clean_model_cfg(model_cfg: dict, model_type=None, ag_args=None, ag_args_ense
     if model_cfg[AG_ARGS]["model_type"] is None:
         raise AssertionError(f"model_type was not specified for model! Model: {model_cfg}")
     model_type = model_cfg[AG_ARGS]["model_type"]
+    model_types = ag_model_register.key_to_cls_map()
     if not inspect.isclass(model_type):
-        if model_type not in MODEL_TYPES:
-            raise AssertionError(f"Unknown model type specified in hyperparameters: '{model_type}'. Valid model types: {list(MODEL_TYPES.keys())}")
-        model_type = MODEL_TYPES[model_type]
+        if model_type not in model_types:
+            raise AssertionError(f"Unknown model type specified in hyperparameters: '{model_type}'. Valid model types: {list(model_types.keys())}")
+        model_type = model_types[model_type]
     elif not issubclass(model_type, AbstractModel):
         logger.warning(
             f"Warning: Custom model type {model_type} does not inherit from {AbstractModel}. This may lead to instability. Consider wrapping {model_type} with an implementation of {AbstractModel}!"
@@ -210,7 +189,7 @@ def clean_model_cfg(model_cfg: dict, model_type=None, ag_args=None, ag_args_ense
     model_cfg[AG_ARGS]["model_type"] = model_type
     model_type_real = model_cfg[AG_ARGS]["model_type"]
     if not inspect.isclass(model_type_real):
-        model_type_real = MODEL_TYPES[model_type_real]
+        model_type_real = model_types[model_type_real]
     default_ag_args = model_type_real._get_default_ag_args()
     if ag_args is not None:
         model_extra_ag_args = ag_args.copy()
@@ -300,10 +279,13 @@ def model_factory(
         invalid_name_set = set()
     model_type = model[AG_ARGS]["model_type"]
     if not inspect.isclass(model_type):
-        model_type = MODEL_TYPES[model_type]
+        model_type = ag_model_register.key_to_cls(model_type)
     name_orig = model[AG_ARGS].get("name", None)
     if name_orig is None:
-        name_main = model[AG_ARGS].get("name_main", DEFAULT_MODEL_NAMES.get(model_type, model_type.__name__))
+        ag_name = model_type.ag_name
+        if ag_name is None:
+            ag_name = model_type.__name__
+        name_main = model[AG_ARGS].get("name_main", ag_name)
         name_prefix = model[AG_ARGS].get("name_prefix", "")
         name_suff = model[AG_ARGS].get("name_suffix", "")
         name_orig = name_prefix + name_main + name_suff
@@ -372,7 +354,6 @@ def get_preset_models_softclass(hyperparameters, invalid_model_names: list = Non
         problem_type=SOFTCLASS,
         eval_metric=soft_log_loss,
         hyperparameters=hyperparameters_standard,
-        default_priorities=DEFAULT_SOFTCLASS_PRIORITY,
         invalid_model_names=invalid_model_names,
         **kwargs,
     )

--- a/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
+++ b/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
@@ -185,7 +185,8 @@ def clean_model_cfg(model_cfg: dict, model_type=None, ag_args=None, ag_args_ense
             f"Warning: Custom model type {model_type} does not inherit from {AbstractModel}. This may lead to instability. Consider wrapping {model_type} with an implementation of {AbstractModel}!"
         )
     else:
-        logger.log(20, f"Custom Model Type Detected: {model_type}")
+        if not ag_model_register.exists(model_type):
+            logger.log(20, f"Custom Model Type Detected: {model_type}")
     model_cfg[AG_ARGS]["model_type"] = model_type
     model_type_real = model_cfg[AG_ARGS]["model_type"]
     if not inspect.isclass(model_type_real):

--- a/tabular/tests/unittests/data/test_learning_curves.py
+++ b/tabular/tests/unittests/data/test_learning_curves.py
@@ -9,14 +9,14 @@ from autogluon.core.metrics import METRICS, get_metric, make_scorer
 from autogluon.tabular import TabularPredictor
 from autogluon.tabular.models import LGBModel, TabularNeuralNetTorchModel, XGBoostModel
 from autogluon.tabular.testing import FitHelper
-from autogluon.tabular.trainer.model_presets.presets import DEFAULT_MODEL_NAMES, MODEL_TYPES
+from autogluon.tabular.register import ag_model_register
 
 
-def get_default_model_name(model):
-    return DEFAULT_MODEL_NAMES[MODEL_TYPES[model]]
+def get_default_model_name(model: str) -> str:
+    return ag_model_register.key_to_cls(model).ag_name
 
-
-MODELS = [name for name, model in MODEL_TYPES.items() if model._get_class_tags().get("supports_learning_curves", False)]
+model_key_to_cls_map = ag_model_register.key_to_cls_map()
+MODELS = [name for name, model in model_key_to_cls_map.items() if model._get_class_tags().get("supports_learning_curves", False)]
 PROBLEM_TYPES = [BINARY, MULTICLASS, REGRESSION]
 
 common_args = {"sample_size": 50, "delete_directory": False, "refit_full": False, "raise_on_model_failure": True}

--- a/timeseries/src/autogluon/timeseries/regressor.py
+++ b/timeseries/src/autogluon/timeseries/regressor.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 
 from autogluon.core.models import AbstractModel
-from autogluon.tabular.trainer.model_presets.presets import MODEL_TYPES as TABULAR_MODEL_TYPES
+from autogluon.tabular.register import ag_model_register as tabular_ag_model_register
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TimeSeriesDataFrame
 from autogluon.timeseries.utils.features import CovariateMetadata
 
@@ -85,12 +85,13 @@ class GlobalCovariateRegressor(CovariateRegressor):
         include_static_features: bool = True,
         include_item_id: bool = False,
     ):
-        if model_name not in TABULAR_MODEL_TYPES:
+        tabular_model_types = tabular_ag_model_register.key_to_cls_map()
+        if model_name not in tabular_model_types:
             raise ValueError(
-                f"Tabular model {model_name} not supported. Available models: {list(TABULAR_MODEL_TYPES)}"
+                f"Tabular model {model_name} not supported. Available models: {list(tabular_model_types)}"
             )
         self.target = target
-        self.model_type = TABULAR_MODEL_TYPES[model_name]
+        self.model_type = tabular_model_types[model_name]
         self.model_name = model_name
         self.model_hyperparameters = model_hyperparameters or {}
         self.refit_during_predict = refit_during_predict


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Adopt ag_model_register in all places to avoid using multiple derivative global variables to track model class metadata.

@shchur I made one edit in timeseries as one of the global variables was used in timeseries. The change should have no impact.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
