### PR TITLE
[timeseries] Add support for `horizon_weight` in time series forecasting metrics

### DIFF
--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -3,6 +3,7 @@ import reprlib
 import time
 from typing import Any, Dict, List, Literal, Optional, Type, Union
 
+import numpy as np
 import pandas as pd
 
 from autogluon.core.learner import AbstractLearner
@@ -30,6 +31,7 @@ class TimeSeriesLearner(AbstractLearner):
         trainer_type: Type[TimeSeriesTrainer] = TimeSeriesTrainer,
         eval_metric: Union[str, TimeSeriesScorer, None] = None,
         eval_metric_seasonal_period: Optional[int] = None,
+        horizon_weight: Optional[np.ndarray] = None,
         prediction_length: int = 1,
         cache_predictions: bool = True,
         ensemble_model_type: Optional[Type] = None,
@@ -38,6 +40,7 @@ class TimeSeriesLearner(AbstractLearner):
         super().__init__(path_context=path_context)
         self.eval_metric: TimeSeriesScorer = check_get_evaluation_metric(eval_metric)
         self.eval_metric_seasonal_period = eval_metric_seasonal_period
+        self.horizon_weight = horizon_weight
         self.trainer_type = trainer_type
         self.target = target
         self.known_covariates_names = [] if known_covariates_names is None else known_covariates_names
@@ -83,6 +86,7 @@ class TimeSeriesLearner(AbstractLearner):
                 prediction_length=self.prediction_length,
                 eval_metric=self.eval_metric,
                 eval_metric_seasonal_period=self.eval_metric_seasonal_period,
+                horizon_weight=self.horizon_weight,
                 target=self.target,
                 quantile_levels=self.quantile_levels,
                 verbosity=kwargs.get("verbosity", 2),

--- a/timeseries/src/autogluon/timeseries/metrics/__init__.py
+++ b/timeseries/src/autogluon/timeseries/metrics/__init__.py
@@ -102,5 +102,5 @@ def check_get_horizon_weight(horizon_weight: list[float] | None, prediction_leng
         raise ValueError(f"At least some values in horizon_weight must be > 0 (got {horizon_weight})")
     if not np.isfinite(horizon_weight_np).all():
         raise ValueError(f"All horizon_weight values must be finite (got {horizon_weight})")
-    horizon_weight_np = horizon_weight_np / (horizon_weight_np.sum() / prediction_length)
+    horizon_weight_np = horizon_weight_np * prediction_length / horizon_weight_np.sum()
     return horizon_weight_np

--- a/timeseries/src/autogluon/timeseries/metrics/__init__.py
+++ b/timeseries/src/autogluon/timeseries/metrics/__init__.py
@@ -98,5 +98,5 @@ def check_get_horizon_weight(horizon_weight: list[float] | None, prediction_leng
         raise ValueError(f"At least some values in horizon_weight must be > 0 (got {horizon_weight})")
     if not np.isfinite(horizon_weight_np).all():
         raise ValueError(f"All horizon_weight values must be finite (got {horizon_weight})")
-    horizon_weight_np = horizon_weight_np / (horizon_weight_np.sum() * prediction_length)
+    horizon_weight_np = horizon_weight_np / (horizon_weight_np.sum() / prediction_length)
     return horizon_weight_np

--- a/timeseries/src/autogluon/timeseries/metrics/__init__.py
+++ b/timeseries/src/autogluon/timeseries/metrics/__init__.py
@@ -85,10 +85,14 @@ def check_get_horizon_weight(horizon_weight: None, prediction_length: int) -> No
 def check_get_horizon_weight(horizon_weight: list[float], prediction_length: int) -> np.ndarray: ...
 
 def check_get_horizon_weight(horizon_weight: list[float] | None, prediction_length: int) -> Optional[np.ndarray]:
+    """Convert horizon_weight to a non-negative numpy array that sums up to prediction_length.
+
+    Raises an exception if horizon_weight has an invalid shape or contains invalid values.
+    """
     if horizon_weight is None:
         return None
     horizon_weight_np = np.array(list(horizon_weight), dtype=np.float64)
-    if len(horizon_weight_np) != prediction_length:
+    if horizon_weight_np.shape != (prediction_length,):
         raise ValueError(
             f"horizon_weight must have length equal to {prediction_length=} (got {len(horizon_weight)=})"
         )

--- a/timeseries/src/autogluon/timeseries/metrics/__init__.py
+++ b/timeseries/src/autogluon/timeseries/metrics/__init__.py
@@ -1,5 +1,8 @@
 from pprint import pformat
-from typing import Type, Union
+from typing import Optional, Type, Union, overload
+
+import numpy as np
+import numpy.typing as npt
 
 from .abstract import TimeSeriesScorer
 from .point import MAE, MAPE, MASE, MSE, RMSE, RMSLE, RMSSE, SMAPE, WAPE, WCD
@@ -75,3 +78,25 @@ def check_get_evaluation_metric(
             f"(received eval_metric = {eval_metric} of type {type(eval_metric)})"
         )
     return scorer
+
+@overload
+def check_get_horizon_weight(horizon_weight: None, prediction_length: int) -> None: ...
+@overload
+def check_get_horizon_weight(horizon_weight: list[float], prediction_length: int) -> np.ndarray: ...
+
+def check_get_horizon_weight(horizon_weight: list[float] | None, prediction_length: int) -> Optional[np.ndarray]:
+    if horizon_weight is None:
+        return None
+    horizon_weight_np = np.array(list(horizon_weight), dtype=np.float64)
+    if len(horizon_weight_np) != prediction_length:
+        raise ValueError(
+            f"horizon_weight must have length equal to {prediction_length=} (got {len(horizon_weight)=})"
+        )
+    if not (horizon_weight_np >= 0).all():
+        raise ValueError(f"All values in horizon_weight must be >= 0 (got {horizon_weight})")
+    if not horizon_weight_np.sum() > 0:
+        raise ValueError(f"At least some values in horizon_weight must be > 0 (got {horizon_weight})")
+    if not np.isfinite(horizon_weight_np).all():
+        raise ValueError(f"All horizon_weight values must be finite (got {horizon_weight})")
+    horizon_weight_np = horizon_weight_np / (horizon_weight_np.sum() * prediction_length)
+    return horizon_weight_np

--- a/timeseries/src/autogluon/timeseries/metrics/abstract.py
+++ b/timeseries/src/autogluon/timeseries/metrics/abstract.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd

--- a/timeseries/src/autogluon/timeseries/metrics/abstract.py
+++ b/timeseries/src/autogluon/timeseries/metrics/abstract.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -69,6 +69,7 @@ class TimeSeriesScorer:
         prediction_length: int = 1,
         target: str = "target",
         seasonal_period: Optional[int] = None,
+        horizon_weight: Optional[np.ndarray] = None,
         **kwargs,
     ) -> float:
         seasonal_period = get_seasonality(data.freq) if seasonal_period is None else seasonal_period
@@ -92,6 +93,8 @@ class TimeSeriesScorer:
                     data_future=data_future,
                     predictions=predictions,
                     target=target,
+                    prediction_length=prediction_length,
+                    horizon_weight=horizon_weight,
                     **kwargs,
                 )
         finally:
@@ -105,6 +108,8 @@ class TimeSeriesScorer:
         data_future: TimeSeriesDataFrame,
         predictions: TimeSeriesDataFrame,
         target: str = "target",
+        prediction_length: int = 1,
+        horizon_weight: Optional[np.ndarray] = None,
         **kwargs,
     ) -> float:
         """Internal method that computes the metric for given forecast & actual data.
@@ -121,6 +126,11 @@ class TimeSeriesScorer:
             columns corresponding to each of the quantile levels. Must have the same index as ``data_future``.
         target : str, default = "target"
             Name of the column in ``data_future`` that contains the target time series.
+        prediction_length : int, default = 1
+            Length of the forecast horizon in time steps.
+        horizon_weight : np.ndarray, optional
+            Weight assigned to each time step in the forecast horizon when computing the metric. If provided, this list
+            must contain `prediction_length` non-negative values, with `sum(horizon_weight) = prediction_length`.
 
         Returns
         -------

--- a/timeseries/src/autogluon/timeseries/metrics/point.py
+++ b/timeseries/src/autogluon/timeseries/metrics/point.py
@@ -149,6 +149,7 @@ class WAPE(TimeSeriesScorer):
     - not sensitive to outliers
     - prefers models that accurately estimate the median
 
+    If `horizon_weight` is provided, both the errors and the target time series in the denominator will be re-weighted.
 
     References
     ----------

--- a/timeseries/src/autogluon/timeseries/metrics/point.py
+++ b/timeseries/src/autogluon/timeseries/metrics/point.py
@@ -1,6 +1,6 @@
 import logging
 import warnings
-from typing import List, Optional
+from typing import Optional
 
 import numpy as np
 import pandas as pd

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -8,6 +8,7 @@ import time
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
+import numpy as np
 import pandas as pd
 from typing_extensions import Self
 
@@ -59,6 +60,9 @@ class TimeSeriesModelBase(ModelBase, ABC):
     eval_metric_seasonal_period : int, optional
         Seasonal period used to compute some evaluation metrics such as mean absolute scaled error (MASE). Defaults to
         ``None``, in which case the seasonal period is computed based on the data frequency.
+    horizon_weight : np.ndarray, optional
+        Weight assigned to each time step in the forecast horizon when computing the metric. If provided, this list
+        must contain `prediction_length` non-negative values, with `sum(horizon_weight) = prediction_length`.
     hyperparameters : dict, default = None
         Hyperparameters that will be used by the model (can be search spaces instead of fixed values).
         If None, model defaults are used. This is identical to passing an empty dictionary.
@@ -88,6 +92,7 @@ class TimeSeriesModelBase(ModelBase, ABC):
         quantile_levels: Sequence[float] = (0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9),
         eval_metric: Union[str, TimeSeriesScorer, None] = None,
         eval_metric_seasonal_period: Optional[int] = None,
+        horizon_weight: Optional[np.ndarray] = None,
     ):
         self.name = name or re.sub(r"Model$", "", self.__class__.__name__)
 
@@ -104,6 +109,7 @@ class TimeSeriesModelBase(ModelBase, ABC):
 
         self.eval_metric: TimeSeriesScorer = check_get_evaluation_metric(eval_metric)
         self.eval_metric_seasonal_period = eval_metric_seasonal_period
+        self.horizon_weight = horizon_weight
         self.target: str = target
         self.covariate_metadata = covariate_metadata or CovariateMetadata()
 
@@ -322,6 +328,7 @@ class TimeSeriesModelBase(ModelBase, ABC):
             prediction_length=self.prediction_length,
             target=self.target,
             seasonal_period=self.eval_metric_seasonal_period,
+            horizon_weight=self.horizon_weight,
         )
 
     def score(self, data: TimeSeriesDataFrame, metric: Optional[str] = None) -> float:  # type: ignore

--- a/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
+++ b/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
@@ -28,6 +28,7 @@ class TimeSeriesEnsembleSelection(EnsembleSelection):
         prediction_length: int = 1,
         target: str = "target",
         eval_metric_seasonal_period: Optional[int] = None,
+        horizon_weight: Optional[np.ndarray] = None,
         **kwargs,
     ):
         super().__init__(
@@ -43,6 +44,7 @@ class TimeSeriesEnsembleSelection(EnsembleSelection):
         self.prediction_length = prediction_length
         self.target = target
         self.eval_metric_seasonal_period = eval_metric_seasonal_period
+        self.horizon_weight = horizon_weight
 
     def _fit(
         self,
@@ -90,7 +92,11 @@ class TimeSeriesEnsembleSelection(EnsembleSelection):
             dummy_pred[list(dummy_pred.columns)] = y_pred_proba[window_idx]
             # We use scorer.compute_metric instead of scorer.score to avoid repeated calls to scorer.save_past_metrics
             metric_value = self.scorer_per_window[window_idx].compute_metric(
-                data_future, dummy_pred, target=self.target
+                data_future,
+                dummy_pred,
+                target=self.target,
+                prediction_length=self.prediction_length,
+                horizon_weight=self.horizon_weight,
             )
             total_score += metric.sign * metric_value
         avg_score = total_score / len(self.data_future_per_window)
@@ -123,6 +129,7 @@ class TimeSeriesGreedyEnsemble(AbstractTimeSeriesEnsembleModel):
             prediction_length=self.prediction_length,
             target=self.target,
             eval_metric_seasonal_period=self.eval_metric_seasonal_period,
+            horizon_weight=self.horizon_weight,
         )
         ensemble_selection.fit(
             predictions=list(predictions_per_window.values()),

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -4,6 +4,8 @@ import re
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Type, Union
 
+import numpy as np
+
 from autogluon.common import space
 from autogluon.core import constants
 from autogluon.timeseries.metrics import TimeSeriesScorer
@@ -184,6 +186,7 @@ def get_preset_models(
     path: str,
     eval_metric: Union[str, TimeSeriesScorer],
     eval_metric_seasonal_period: Optional[int],
+    horizon_weight: Optional[np.ndarray],
     hyperparameters: Union[str, Dict, None],
     hyperparameter_tune: bool,
     covariate_metadata: CovariateMetadata,
@@ -262,6 +265,7 @@ def get_preset_models(
                 eval_metric=eval_metric,
                 eval_metric_seasonal_period=eval_metric_seasonal_period,
                 covariate_metadata=covariate_metadata,
+                horizon_weight=horizon_weight,
                 hyperparameters=model_hps,
                 **kwargs,
             )

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -99,7 +99,7 @@ class TimeSeriesPredictor:
         AutoGluon will automatically normalize the weights so that they sum up to `prediction_length`. By default, all
         time steps in the forecast horizon have the same weight, which is equivalent to setting `horizon_weight = [1] * prediction_length`.
 
-        This parameter only affect model selection and ensemble construction; it has no effect on the loss function of
+        This parameter only affects model selection and ensemble construction; it has no effect on the loss function of
         the individual forecasting models.
     known_covariates_names: List[str], optional
         Names of the covariates that are known in advance for all time steps in the forecast horizon. These are also

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -24,7 +24,7 @@ from autogluon.timeseries import __version__ as current_ag_version
 from autogluon.timeseries.configs import TIMESERIES_PRESETS_CONFIGS
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TimeSeriesDataFrame
 from autogluon.timeseries.learner import TimeSeriesLearner
-from autogluon.timeseries.metrics import TimeSeriesScorer, check_get_evaluation_metric
+from autogluon.timeseries.metrics import TimeSeriesScorer, check_get_evaluation_metric, check_get_horizon_weight
 from autogluon.timeseries.splitter import ExpandingWindowSplitter
 from autogluon.timeseries.trainer import TimeSeriesTrainer
 from autogluon.timeseries.utils.forecast import make_future_data_frame
@@ -93,6 +93,14 @@ class TimeSeriesPredictor:
     eval_metric_seasonal_period : int, optional
         Seasonal period used to compute some evaluation metrics such as mean absolute scaled error (MASE). Defaults to
         ``None``, in which case the seasonal period is computed based on the data frequency.
+    horizon_weight : List[float], optional
+        Weight assigned to each time step in the forecast horizon when computing the `eval_metric`. If provided, this
+        must be a list with `prediction_length` non-negative values, where at least some values are greater than zero.
+        AutoGluon will automatically normalize the weights so that they sum up to `prediction_length`. By default, all
+        time steps in the forecast horizon have the same weight, which is equivalent to setting `horizon_weight = [1] * prediction_length`.
+
+        This parameter only affect model selection and ensemble construction; it has no effect on the loss function of
+        the individual forecasting models.
     known_covariates_names: List[str], optional
         Names of the covariates that are known in advance for all time steps in the forecast horizon. These are also
         known as dynamic features, exogenous variables, additional regressors or related time series. Examples of such
@@ -144,6 +152,7 @@ class TimeSeriesPredictor:
         freq: Optional[str] = None,
         eval_metric: Union[str, TimeSeriesScorer, None] = None,
         eval_metric_seasonal_period: Optional[int] = None,
+        horizon_weight: list[float] | None = None,
         path: Optional[Union[str, Path]] = None,
         verbosity: int = 2,
         log_to_file: bool = True,
@@ -189,6 +198,7 @@ class TimeSeriesPredictor:
             self.freq = std_freq
         self.eval_metric = check_get_evaluation_metric(eval_metric)
         self.eval_metric_seasonal_period = eval_metric_seasonal_period
+        self.horizon_weight = check_get_horizon_weight(horizon_weight, prediction_length=self.prediction_length)
         if quantile_levels is None:
             quantile_levels = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
         self.quantile_levels = sorted(quantile_levels)
@@ -196,6 +206,7 @@ class TimeSeriesPredictor:
             path_context=self.path,
             eval_metric=eval_metric,
             eval_metric_seasonal_period=eval_metric_seasonal_period,
+            horizon_weight=self.horizon_weight,
             target=self.target,
             known_covariates_names=self.known_covariates_names,
             prediction_length=self.prediction_length,

--- a/timeseries/src/autogluon/timeseries/trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer.py
@@ -47,6 +47,7 @@ class TimeSeriesTrainer(AbstractTrainer[AbstractTimeSeriesModel]):
         prediction_length: int = 1,
         eval_metric: Union[str, TimeSeriesScorer, None] = None,
         eval_metric_seasonal_period: Optional[int] = None,
+        horizon_weight: Optional[np.ndarray] = None,
         save_data: bool = True,
         skip_model_selection: bool = False,
         enable_ensemble: bool = True,
@@ -88,6 +89,7 @@ class TimeSeriesTrainer(AbstractTrainer[AbstractTimeSeriesModel]):
 
         self.eval_metric: TimeSeriesScorer = check_get_evaluation_metric(eval_metric)
         self.eval_metric_seasonal_period = eval_metric_seasonal_period
+        self.horizon_weight = horizon_weight
         if val_splitter is None:
             val_splitter = ExpandingWindowSplitter(prediction_length=self.prediction_length)
         assert isinstance(val_splitter, AbstractWindowSplitter), "val_splitter must be of type AbstractWindowSplitter"
@@ -571,6 +573,7 @@ class TimeSeriesTrainer(AbstractTrainer[AbstractTimeSeriesModel]):
             name=self._get_ensemble_model_name(),
             eval_metric=self.eval_metric,
             eval_metric_seasonal_period=self.eval_metric_seasonal_period,
+            horizon_weight=self.horizon_weight,
             target=self.target,
             prediction_length=self.prediction_length,
             path=self.path,
@@ -793,6 +796,7 @@ class TimeSeriesTrainer(AbstractTrainer[AbstractTimeSeriesModel]):
             prediction_length=self.prediction_length,
             target=self.target,
             seasonal_period=self.eval_metric_seasonal_period,
+            horizon_weight=self.horizon_weight,
         )
 
     def score(
@@ -1254,6 +1258,7 @@ class TimeSeriesTrainer(AbstractTrainer[AbstractTimeSeriesModel]):
             path=self.path,
             eval_metric=self.eval_metric,
             eval_metric_seasonal_period=self.eval_metric_seasonal_period,
+            horizon_weight=self.horizon_weight,
             prediction_length=self.prediction_length,
             freq=freq,
             hyperparameters=hyperparameters,

--- a/timeseries/tests/unittests/test_metrics.py
+++ b/timeseries/tests/unittests/test_metrics.py
@@ -387,6 +387,22 @@ def test_when_horizon_weight_is_non_uniform_then_metric_value_changes(metric_cls
     assert orig_score != weighted_score
 
 
+@pytest.mark.parametrize(
+    "input_horizon_weight, normalized_horizon_weight",
+    [
+        [[1], [1]],
+        [[1, 3], [0.5, 1.5]],
+        [[0, 0, 1], [0, 0, 3]],
+    ],
+)
+def test_when_horizon_weight_is_checked_then_values_are_normalized(input_horizon_weight, normalized_horizon_weight):
+    checked_horizon_weight = check_get_horizon_weight(
+        input_horizon_weight, prediction_length=len(input_horizon_weight)
+    )
+    assert isinstance(checked_horizon_weight, np.ndarray)
+    assert np.allclose(checked_horizon_weight, normalized_horizon_weight)
+
+
 @pytest.fixture(scope="module")
 def partially_matching_predictions():
     # For each item, the error equals zero for the first two time steps, and the error is positive for the remainder

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -1873,7 +1873,7 @@ def test_when_make_future_data_frame_output_is_used_to_set_the_known_covariates_
     assert isinstance(predictions, TimeSeriesDataFrame)
 
 
-def test_when_horizon_weight_is_provided_to_predictor_then_eval_metric_receives_weight_during_computation(
+def test_when_horizon_weight_is_provided_to_predictor_then_eval_metric_receives_weight_during_training(
     temp_model_path,
 ):
     predictor = TimeSeriesPredictor(

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -1871,3 +1871,16 @@ def test_when_make_future_data_frame_output_is_used_to_set_the_known_covariates_
     known_covariates["foo"] = range(len(known_covariates))
     predictions = predictor.predict(data, known_covariates)
     assert isinstance(predictions, TimeSeriesDataFrame)
+
+
+def test_when_horizon_weight_is_provided_to_predictor_then_eval_metric_receives_weight_during_computation(
+    temp_model_path,
+):
+    predictor = TimeSeriesPredictor(
+        prediction_length=3, horizon_weight=[0, 4, 4], path=temp_model_path, eval_metric="MASE"
+    )
+    with mock.patch("autogluon.timeseries.metrics.point.MASE.compute_metric") as mock_mase:
+        mock_mase.return_value = 0.4
+        predictor.fit(DUMMY_TS_DATAFRAME, hyperparameters=DUMMY_HYPERPARAMETERS)
+        for call_args in mock_mase.call_args_list:
+            assert np.allclose(call_args[1]["horizon_weight"], np.array([0, 1.5, 1.5]))

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -1882,5 +1882,7 @@ def test_when_horizon_weight_is_provided_to_predictor_then_eval_metric_receives_
     with mock.patch("autogluon.timeseries.metrics.point.MASE.compute_metric") as mock_mase:
         mock_mase.return_value = 0.4
         predictor.fit(DUMMY_TS_DATAFRAME, hyperparameters=DUMMY_HYPERPARAMETERS)
+        predictor.evaluate(DUMMY_TS_DATAFRAME)
+        predictor.leaderboard(DUMMY_TS_DATAFRAME)
         for call_args in mock_mase.call_args_list:
             assert np.allclose(call_args[1]["horizon_weight"], np.array([0, 1.5, 1.5]))


### PR DESCRIPTION
*Issue #, if available:* #4852

*Description of changes:*
- Add an optional argument `horizon_weight: list[float] | None` to the `TimeSeriesPredictor` and all forecasting metrics that allows assigning custom weights to each time step in the forecast horizon when computing the metric. 
- When computing all metrics, we create an array of raw error values of shape `[num_items, prediction_length]`. We then multiply this array with `horizon_weight.reshape[1, prediction_length]`, before applying the final aggregation step. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
