### PR TITLE
[timeseries] Fix time_limit when val_data is provided #5046

### DIFF
--- a/timeseries/src/autogluon/timeseries/trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer.py
@@ -361,7 +361,7 @@ class TimeSeriesTrainer(AbstractTrainer[AbstractTimeSeriesModel]):
             model.fit_time = model.fit_time or (fit_end_time - fit_start_time)
 
             if time_limit is not None:
-                time_limit = fit_end_time - fit_start_time
+                time_limit = time_limit - (fit_end_time - fit_start_time)
             if val_data is not None and not self.skip_model_selection:
                 model.score_and_cache_oof(
                     val_data, store_val_score=True, store_predict_time=True, time_limit=time_limit

--- a/timeseries/tests/smoketests/test_all_models.py
+++ b/timeseries/tests/smoketests/test_all_models.py
@@ -216,7 +216,7 @@ def test_all_models_handle_all_pandas_frequencies(freq, hyperparameters):
         use_past_covariates=True,
         start_time="1990-01-01",
     )
-    known_covariates_names = [col for col in train_data if col.startswith("known_")]
+    known_covariates_names = [col for col in train_data.columns if col.startswith("known_")]
 
     predictor = TimeSeriesPredictor(
         target=TARGET_COLUMN,
@@ -238,3 +238,13 @@ def test_all_models_handle_all_pandas_frequencies(freq, hyperparameters):
     future_test_data = test_data.slice_by_timestep(-prediction_length, None)
 
     assert predictions.index.equals(future_test_data.index)
+
+
+def test_when_tuning_data_and_time_limit_are_provided_then_all_models_are_trained():
+    prediction_length = 5
+    hyperparameters = {"Naive": DUMMY_MODEL_HPARAMS, "Average": DUMMY_MODEL_HPARAMS}
+    train_data, test_data = generate_train_and_test_data(prediction_length=prediction_length)
+    predictor = TimeSeriesPredictor(prediction_length=prediction_length, target=TARGET_COLUMN)
+    predictor.fit(train_data, tuning_data=train_data, hyperparameters=hyperparameters, time_limit=120)
+    leaderboard = predictor.leaderboard(test_data)
+    assert_leaderboard_contains_all_models(leaderboard, hyperparameters=hyperparameters)

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -17,7 +17,6 @@ from autogluon.common.loaders import load_pkl
 from autogluon.timeseries.dataset import TimeSeriesDataFrame
 from autogluon.timeseries.models import DeepARModel, ETSModel
 from autogluon.timeseries.models.ensemble.greedy_ensemble import TimeSeriesGreedyEnsemble
-from autogluon.timeseries.splitter import ExpandingWindowSplitter
 from autogluon.timeseries.trainer import TimeSeriesTrainer
 
 from .common import DATAFRAME_WITH_COVARIATES, DUMMY_TS_DATAFRAME, dict_equal_primitive, get_data_frame_with_item_index

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -654,25 +654,3 @@ def test_when_add_ci_to_feature_importance_called_then_confidence_bands_correct(
 
             assert np.isclose(r[lower_ci_name], expected_lower)
             assert np.isclose(r[upper_ci_name], expected_upper)
-
-
-def test_when_val_data_and_time_limit_are_provided_then_models_receive_correct_time_limit(temp_model_path):
-    trainer = TimeSeriesTrainer(
-        path=temp_model_path,
-        prediction_length=3,
-        val_splitter=ExpandingWindowSplitter(prediction_length=3, num_val_windows=0),
-    )
-    data = DUMMY_TS_DATAFRAME.copy()
-    mock_fit = mock.Mock()
-    mock_predict = mock.Mock()
-    with mock.patch.multiple(
-        "autogluon.timeseries.models.local.abstract_local_model.AbstractLocalModel", fit=mock_fit, predict=mock_predict
-    ):
-        trainer.fit(
-            train_data=data,
-            val_data=data,
-            hyperparameters={"Naive": {"n_jobs": 1}, "Average": {"n_jobs": 1}},
-            time_limit=10000,
-        )
-        for call_args in mock_fit.call_args_list + mock_predict.call_args_list:
-            assert call_args[1]["time_limit"] > 1000


### PR DESCRIPTION
*Issue #, if available:* Fixes #5046

*Description of changes:*
- Fix the bug introduced in [#4653](https://github.com/autogluon/autogluon/pull/4653/files#diff-d2a9d7490bd4601b8f3613cfea6c5e37455fb05cc4a025420240a6d47e45de0fR523) that incorrectly set the `time_limit` if `tuning_data` was provided to `predictor.fit()`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
