### PR TITLE
Fix infer_frequency

### DIFF
--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -490,7 +490,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
                 except ValueError:
                     inferred_freq = None
                 else:
-                    inferred_freq = candidate_freq
+                    inferred_freq = candidate_freq.freqstr
             return inferred_freq
 
         freq_for_each_item = index_df.groupby(ITEMID, sort=False).agg(get_freq)[TIMESTAMP]


### PR DESCRIPTION
*Issue #, if available:* fixes #4990

*Description of changes:* This PR fixes `infer_frequency` to ensure that the `get_freq` function returns either `None` or a `freqstr` and NOT an `Offset`. This was the core issues causing problems with the MWE in #4990. Before and after shown below.

**Code**:

```py
from autogluon.timeseries import TimeSeriesDataFrame, TimeSeriesPredictor

data = TimeSeriesDataFrame.from_path(
    "https://autogluon.s3.amazonaws.com/datasets/timeseries/grocery_sales/test.csv",
)
# Create an irregularly sampled dataframe
data_irreg = data.iloc[[1, 2, 31, 34, 62, 63, 64, 65, 66, 67, 68, 69, 70]]
predictor = TimeSeriesPredictor(prediction_length=1, freq="W", target="unit_sales")
predictor.fit(
    data_irreg,
    hyperparameters={"Croston": {}},
    skip_model_selection=True,
    refit_full=True,
)
print(predictor.leaderboard(data_irreg))
```
NOTE: Code is a small modification of the MWE in #4990 to ensure that each time series has at least 2 items. 


```
Frequency 'W' stored as 'W-SUN'
Beginning AutoGluon training...
AutoGluon will save models to '/Users/ansarnd/Documents/repos/autogluon/AutogluonModels/ag-20250417_202258'
=================== System Info ===================
AutoGluon Version:  1.2.1b20250417
Python Version:     3.11.12
Operating System:   Darwin
Platform Machine:   arm64
Platform Version:   Darwin Kernel Version 24.3.0: Thu Jan  2 20:24:16 PST 2025; root:xnu-11215.81.4~3/RELEASE_ARM64_T6000
CPU Count:          10
GPU Count:          0
Memory Avail:       8.57 GB / 32.00 GB (26.8%)
Disk Space Avail:   162.71 GB / 460.43 GB (35.3%)
===================================================

Fitting with arguments:
{'enable_ensemble': True,
 'eval_metric': WQL,
 'freq': 'W-SUN',
 'hyperparameters': {'Croston': {}},
 'known_covariates_names': [],
 'num_val_windows': 1,
 'prediction_length': 1,
 'quantile_levels': [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
 'random_seed': 123,
 'refit_every_n_windows': 1,
 'refit_full': True,
 'skip_model_selection': True,
 'target': 'unit_sales',
 'verbosity': 2}

train_data with frequency 'IRREG' has been resampled to frequency 'W-SUN'.
Provided train_data has 15 rows (NaN fraction=13.3%), 3 time series. Median time series length is 4 (min=2, max=9). 

Provided data contains following columns:
        target: 'unit_sales'
        past_covariates:
                categorical:        []
                continuous (float): ['scaled_price', 'promotion_email']

AutoGluon will ignore following non-numeric/non-informative columns:
        ignored covariates:      ['promotion_homepage']

To learn how to fix incorrectly inferred types, please see documentation for TimeSeriesPredictor.fit

AutoGluon will gauge predictive performance using evaluation metric: 'WQL'
        This metric's sign has been flipped to adhere to being higher_is_better. The metric score can be multiplied by -1 to get the metric value.
===================================================

Starting training. Start time is 2025-04-17 22:23:03
Models that will be trained: ['Croston']
Training timeseries model Croston. 
        0.01    s     = Training runtime
Training complete. Models trained: ['Croston']
Total runtime: 0.02 s
Best model: Croston
        WARNING: refit_full functionality for TimeSeriesPredictor is experimental and is not yet supported by all models.
Refitting models via `refit_full` using all of the data (combined train and validation)...
        Models trained in this way will have the suffix '_FULL' and have NaN validation score.
        This process is not bound by time_limit, but should take less time than the original `fit` call.
Fitting model: Croston_FULL | Skipping fit via cloning parent ...
Refit complete. Models trained: ['Croston_FULL']
Total runtime: 0.00 s
Updated best model to 'Croston_FULL' (Previously 'Croston'). AutoGluon will default to using 'Croston_FULL' for predict().
data with frequency 'IRREG' has been resampled to frequency 'W-SUN'.
Additional data provided, testing on additional data. Resulting leaderboard will be sorted according to test score (`score_test`).
Model Croston_FULL failed to predict with the following exception:
Traceback (most recent call last):
  File "/Users/ansarnd/Documents/repos/autogluon/timeseries/src/autogluon/timeseries/trainer.py", line 1062, in get_model_pred_dict
    model_pred_dict[model_name] = self._predict_model(
                                  ^^^^^^^^^^^^^^^^^^^^
  File "/Users/ansarnd/Documents/repos/autogluon/timeseries/src/autogluon/timeseries/trainer.py", line 991, in _predict_model
    return model.predict(model_inputs, known_covariates=known_covariates)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ansarnd/Documents/repos/autogluon/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py", line 594, in predict
    predictions = self._predict(data=data, known_covariates=known_covariates, **kwargs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ansarnd/Documents/repos/autogluon/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py", line 185, in _predict
    predictions_df.index = self.get_forecast_horizon_index(data)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ansarnd/Documents/repos/autogluon/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py", line 671, in get_forecast_horizon_index
    make_future_data_frame(data, prediction_length=self.prediction_length, freq=self.freq)
  File "/Users/ansarnd/Documents/repos/autogluon/timeseries/src/autogluon/timeseries/utils/forecast.py", line 48, in make_future_data_frame
    timestamps = np.dstack([last_ts + step * offset for step in range(1, prediction_length + 1)]).ravel()  # type: ignore[operator]
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ansarnd/Documents/repos/autogluon/timeseries/src/autogluon/timeseries/utils/forecast.py", line 48, in <listcomp>
    timestamps = np.dstack([last_ts + step * offset for step in range(1, prediction_length + 1)]).ravel()  # type: ignore[operator]
                                      ~~~~~^~~~~~~~
TypeError: unsupported operand type(s) for *: 'int' and 'NoneType'

Model Croston failed to predict with the following exception:
Traceback (most recent call last):
  File "/Users/ansarnd/Documents/repos/autogluon/timeseries/src/autogluon/timeseries/trainer.py", line 1062, in get_model_pred_dict
    model_pred_dict[model_name] = self._predict_model(
                                  ^^^^^^^^^^^^^^^^^^^^
  File "/Users/ansarnd/Documents/repos/autogluon/timeseries/src/autogluon/timeseries/trainer.py", line 991, in _predict_model
    return model.predict(model_inputs, known_covariates=known_covariates)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ansarnd/Documents/repos/autogluon/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py", line 594, in predict
    predictions = self._predict(data=data, known_covariates=known_covariates, **kwargs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ansarnd/Documents/repos/autogluon/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py", line 185, in _predict
    predictions_df.index = self.get_forecast_horizon_index(data)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ansarnd/Documents/repos/autogluon/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py", line 671, in get_forecast_horizon_index
    make_future_data_frame(data, prediction_length=self.prediction_length, freq=self.freq)
  File "/Users/ansarnd/Documents/repos/autogluon/timeseries/src/autogluon/timeseries/utils/forecast.py", line 48, in make_future_data_frame
    timestamps = np.dstack([last_ts + step * offset for step in range(1, prediction_length + 1)]).ravel()  # type: ignore[operator]
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ansarnd/Documents/repos/autogluon/timeseries/src/autogluon/timeseries/utils/forecast.py", line 48, in <listcomp>
    timestamps = np.dstack([last_ts + step * offset for step in range(1, prediction_length + 1)]).ravel()  # type: ignore[operator]
                                      ~~~~~^~~~~~~~
TypeError: unsupported operand type(s) for *: 'int' and 'NoneType'

Traceback (most recent call last):
  File "/Users/ansarnd/Documents/repos/autogluon/issue.py", line 15, in <module>
    print(predictor.leaderboard(data_irreg))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ansarnd/Documents/repos/autogluon/timeseries/src/autogluon/timeseries/predictor.py", line 1266, in leaderboard
    leaderboard = self._learner.leaderboard(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ansarnd/Documents/repos/autogluon/timeseries/src/autogluon/timeseries/learner.py", line 284, in leaderboard
    return self.load_trainer().leaderboard(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ansarnd/Documents/repos/autogluon/timeseries/src/autogluon/timeseries/trainer.py", line 646, in leaderboard
    model_predictions, pred_time_dict = self.get_model_pred_dict(
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ansarnd/Documents/repos/autogluon/timeseries/src/autogluon/timeseries/trainer.py", line 1087, in get_model_pred_dict
    final_pred_time_dict_total = {model_name: pred_time_dict_total[model_name] for model_name in model_names}
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ansarnd/Documents/repos/autogluon/timeseries/src/autogluon/timeseries/trainer.py", line 1087, in <dictcomp>
    final_pred_time_dict_total = {model_name: pred_time_dict_total[model_name] for model_name in model_names}
                                              ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
KeyError: 'Croston'
```
</details>

<details><summary>Show After</summary>
```
Frequency 'W' stored as 'W-SUN'
Beginning AutoGluon training...
AutoGluon will save models to '/Users/ansarnd/Documents/repos/autogluon/AutogluonModels/ag-20250417_202457'
=================== System Info ===================
AutoGluon Version:  1.2.1b20250417
Python Version:     3.11.12
Operating System:   Darwin
Platform Machine:   arm64
Platform Version:   Darwin Kernel Version 24.3.0: Thu Jan  2 20:24:16 PST 2025; root:xnu-11215.81.4~3/RELEASE_ARM64_T6000
CPU Count:          10
GPU Count:          0
Memory Avail:       8.45 GB / 32.00 GB (26.4%)
Disk Space Avail:   162.71 GB / 460.43 GB (35.3%)
===================================================

Fitting with arguments:
{'enable_ensemble': True,
 'eval_metric': WQL,
 'freq': 'W-SUN',
 'hyperparameters': {'Croston': {}},
 'known_covariates_names': [],
 'num_val_windows': 1,
 'prediction_length': 1,
 'quantile_levels': [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
 'random_seed': 123,
 'refit_every_n_windows': 1,
 'refit_full': True,
 'skip_model_selection': True,
 'target': 'unit_sales',
 'verbosity': 2}

train_data with frequency 'IRREG' has been resampled to frequency 'W-SUN'.
Provided train_data has 15 rows (NaN fraction=13.3%), 3 time series. Median time series length is 4 (min=2, max=9). 

Provided data contains following columns:
        target: 'unit_sales'
        past_covariates:
                categorical:        []
                continuous (float): ['scaled_price', 'promotion_email']

AutoGluon will ignore following non-numeric/non-informative columns:
        ignored covariates:      ['promotion_homepage']

To learn how to fix incorrectly inferred types, please see documentation for TimeSeriesPredictor.fit

AutoGluon will gauge predictive performance using evaluation metric: 'WQL'
        This metric's sign has been flipped to adhere to being higher_is_better. The metric score can be multiplied by -1 to get the metric value.
===================================================

Starting training. Start time is 2025-04-17 22:25:03
Models that will be trained: ['Croston']
Training timeseries model Croston. 
        0.00    s     = Training runtime
Training complete. Models trained: ['Croston']
Total runtime: 0.01 s
Best model: Croston
        WARNING: refit_full functionality for TimeSeriesPredictor is experimental and is not yet supported by all models.
Refitting models via `refit_full` using all of the data (combined train and validation)...
        Models trained in this way will have the suffix '_FULL' and have NaN validation score.
        This process is not bound by time_limit, but should take less time than the original `fit` call.
Fitting model: Croston_FULL | Skipping fit via cloning parent ...
Refit complete. Models trained: ['Croston_FULL']
Total runtime: 0.00 s
Updated best model to 'Croston_FULL' (Previously 'Croston'). AutoGluon will default to using 'Croston_FULL' for predict().
data with frequency 'IRREG' has been resampled to frequency 'W-SUN'.
Additional data provided, testing on additional data. Resulting leaderboard will be sorted according to test score (`score_test`).
          model  score_test score_val  pred_time_test pred_time_val  fit_time_marginal  fit_order
0  Croston_FULL   -0.620251      None        1.402906          None            0.00319          2
1       Croston   -0.620251      None        3.722209          None            0.00319          1
```

_Multi-hour debugging -> 1 word fix_ 🫠 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
