### PR TITLE
upgrade numpy to 2.x with latest catboost release

### DIFF
--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -37,7 +37,7 @@ extras_require = {
         "lightgbm>=4.0,<4.7",  # <{N+1} upper cap, where N is the latest released minor version
     ],
     "catboost": [
-        "numpy>=1.25,<2.0.0",  # TODO support numpy>=2.0.0 once issue resolved https://github.com/catboost/catboost/issues/2671
+        "numpy>=1.25,<2.3.0",
         "catboost>=1.2,<1.3",
     ],
     "xgboost": [

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -44,7 +44,7 @@ extras_require = {
         "xgboost>=2.0,<3.1",  # <{N+1} upper cap, where N is the latest released minor version
     ],
     "fastai": [
-        "spacy<3.8",  # cap for issue https://github.com/explosion/spaCy/issues/13653
+        "spacy<3.9",  # cap for issue https://github.com/explosion/spaCy/issues/13653
         "torch",  # version range defined in `core/_setup_utils.py`
         "fastai>=2.3.1,<2.9",  # <{N+1} upper cap, where N is the latest released minor version
     ],

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -44,7 +44,7 @@ extras_require = {
         "xgboost>=2.0,<3.1",  # <{N+1} upper cap, where N is the latest released minor version
     ],
     "fastai": [
-        "spacy<3.9",  # cap for issue https://github.com/explosion/spaCy/issues/13653
+        "spacy<3.9",
         "torch",  # version range defined in `core/_setup_utils.py`
         "fastai>=2.3.1,<2.9",  # <{N+1} upper cap, where N is the latest released minor version
     ],

--- a/tabular/src/autogluon/tabular/models/tabular_nn/utils/categorical_encoders.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/utils/categorical_encoders.py
@@ -167,7 +167,7 @@ class _BaseEncoder(BaseEstimator, TransformerMixin):
             if parse_version(_sklearn_version) >= parse_version("1.6.0"):
                 X_temp = check_array(X, dtype=None, ensure_all_finite=False)
             else:
-                X_temp = check_array(X, dtype=None, force_all_finite=False)
+                X_temp = check_array(X, dtype=None, ensure_all_finite=False)
             if not hasattr(X, "dtype") and np.issubdtype(X_temp.dtype, np.str_):
                 X = check_array(X, dtype=object)
             else:
@@ -186,7 +186,7 @@ class _BaseEncoder(BaseEstimator, TransformerMixin):
             if parse_version(_sklearn_version) >= parse_version("1.6.0"):
                 Xi = check_array(Xi, ensure_2d=False, dtype=None, ensure_all_finite=needs_validation)
             else:
-                Xi = check_array(Xi, ensure_2d=False, dtype=None, force_all_finite=needs_validation)
+                Xi = check_array(Xi, ensure_2d=False, dtype=None, ensure_all_finite=needs_validation)
             X_columns.append(Xi)
 
         return X_columns, n_samples, n_features


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/catboost/catboost/issues/2671

*Description of changes:*
With the release of catboost 1.2.8 and resolution of the [issue](https://github.com/catboost/catboost/issues/2671), update numpy support on autogluon side

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
