### PR TITLE
[timeseries] Fix HPO for Chronos models

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -656,7 +656,9 @@ class AbstractTimeSeriesModel(TimeSeriesModelBase, TimeSeriesTunable, ABC):
 
     def get_params(self) -> dict:
         """Get the constructor parameters required for cloning this model object"""
-        hyperparameters = self.get_hyperparameters().copy()
+        # We only use the user-provided hyperparameters for cloning. We cannot use the output of get_hyperparameters()
+        # since it may contain search spaces that won't be converted to concrete values during HPO
+        hyperparameters = self._hyperparameters.copy()
         if self._extra_ag_args:
             hyperparameters[AG_ARGS_FIT] = self._extra_ag_args.copy()
 

--- a/timeseries/src/autogluon/timeseries/models/chronos/model.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/model.py
@@ -196,8 +196,9 @@ class ChronosModel(AbstractTimeSeriesModel):
         name = name if name is not None else "Chronos"
         if not isinstance(model_path_input, Space):
             # we truncate the name to avoid long path errors on Windows
-            model_path_safe = str(model_path_input).replace("/", "__").replace(os.path.sep, "__")[-50:]
-            name += f"[{model_path_safe}]"
+            model_path_suffix = "[" + str(model_path_input).replace("/", "__").replace(os.path.sep, "__")[-50:] + "]"
+            if model_path_suffix not in name:
+                name += model_path_suffix
 
         super().__init__(
             path=path,

--- a/timeseries/tests/unittests/models/chronos/test_model.py
+++ b/timeseries/tests/unittests/models/chronos/test_model.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 import torch
 
+from autogluon.common import space
 from autogluon.core.utils.exceptions import TimeLimitExceeded
 from autogluon.timeseries import TimeSeriesPredictor
 from autogluon.timeseries.models import ChronosModel
@@ -457,3 +458,18 @@ def test_fine_tune_shuffle_buffer_size_is_used(chronos_model_path, shuffle_buffe
             pass
 
         assert chronos_ft_dataset_shuffle.call_args.args[0] == shuffle_buffer_size
+
+
+def test_when_search_spaces_provided_then_model_can_hpo():
+    model = ChronosModel(
+        hyperparameters={
+            "model_path": CHRONOS_BOLT_MODEL_PATH,
+            "fine_tune": True,
+            "fine_tune_steps": space.Categorical(1, 2),
+        }
+    )
+    hpo_models, analysis = model.hyperparameter_tune(
+        train_data=DUMMY_TS_DATAFRAME, val_data=DUMMY_TS_DATAFRAME, time_limit=10
+    )
+    assert len(hpo_models) >= 1
+    assert analysis["best_reward"] > float("-inf")


### PR DESCRIPTION
*Issue #, if available:* Among other things, fixes #4876

*Description of changes:*
On the current `master` branch, the HPO is broken for Chronos models (both with and without `tuning_data` provided to `predictor.fit`). This is caused by two issues:
1. Problems with the model name and path described in #4876 (this only kicks in if `tuning_data` is provided to `predictor.fit`)
2. Bug in `AbstractTimeSeriesModel.get_params` that returned all HP values during cloning (including the instantiated default hyperparameter values), instead of just returning the user-provided HPs.

This PR fixes both of these issues.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
