### PR TITLE
[features] Fix ZeroDivisionError inside get_approximate_df_mem_usage

### DIFF
--- a/common/src/autogluon/common/utils/pandas_utils.py
+++ b/common/src/autogluon/common/utils/pandas_utils.py
@@ -44,7 +44,7 @@ def get_approximate_df_mem_usage(df: DataFrame, sample_ratio=0.2):
         memory_usage = df.memory_usage()
         if columns_category:
             for column in columns_category:
-                num_categories = len(df[column].cat.categories)
+                num_categories = max(len(df[column].cat.categories), 1)
                 num_categories_sample = math.ceil(sample_ratio * num_categories)
                 sample_ratio_cat = num_categories_sample / num_categories
                 memory_usage[column] = int(

--- a/timeseries/tests/unittests/utils/test_features.py
+++ b/timeseries/tests/unittests/utils/test_features.py
@@ -479,3 +479,16 @@ def test_given_past_features_when_constant_transform_called_then_values_all_equa
     for feature_name in covariate_metadata.static_features:
         transformed_data = transform.transform(data, feature_name)
         assert len(set(transformed_data.static_features[feature_name])) == 1
+
+
+def test_if_categorical_feature_has_all_nan_values_then_feature_generator_works():
+    data = get_data_frame_with_covariates(static_features_cat=["static"], covariates_cat=["past", "known"])
+    data[["past", "known"]] = float("nan")
+    data = data.astype({"past": "category", "known": "category"})
+    data.static_features["static"] = float("nan")
+    data.static_features = data.static_features.astype({"static": "category"})
+    feat_generator = TimeSeriesFeatureGenerator(target="target", known_covariates_names=["known"])
+    transformed_data = feat_generator.fit_transform(data)
+    assert "past" in transformed_data.columns
+    assert "known" in transformed_data.columns
+    assert "static" in transformed_data.static_features.columns


### PR DESCRIPTION
*Issue #, if available:* Fixes #4315

*Description of changes:*
- Currently, if a feature of type `category` contains all-NaN values, `PipelineFeatureGenerator.fit_transform` will raise a `ZeroDivisionError` when trying to estimate the `post_memory_usage`. This PR fixes this issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
