### PR TITLE
Improve CatBoost and XGBoost memory estimates

### DIFF
--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -99,6 +99,8 @@ class LGBModel(AbstractModel):
             Scales roughly by 5100*num_features*num_leaves bytes
             For 10000 features and 128 num_leaves, the histogram would be 6.5 GB.
         """
+        if hyperparameters is None:
+            hyperparameters = {}
         num_classes = num_classes if num_classes else 1  # num_classes could be None after initialization if it's a regression problem
         data_mem_usage = get_approximate_df_mem_usage(X).sum()
         data_mem_usage_bytes = data_mem_usage * 5 + data_mem_usage / 4 * num_classes  # TODO: Extremely crude approximation, can be vastly improved

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -147,6 +147,8 @@ class RFModel(AbstractModel):
         num_classes: int = 1,
         **kwargs,
     ) -> int:
+        if hyperparameters is None:
+            hyperparameters = {}
         n_estimators_final = hyperparameters.get("n_estimators", 300)
         if isinstance(n_estimators_final, int):
             n_estimators_minimum = min(40, n_estimators_final)

--- a/tabular/src/autogluon/tabular/models/xgboost/callbacks.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/callbacks.py
@@ -147,7 +147,7 @@ class EarlyStoppingCustom(EarlyStopping):
 
         model_size_memory_ratio = estimated_model_size_mb / available_mb
 
-        if (model_size_memory_ratio > 1.0) or (available_mb < 512):
+        if (model_size_memory_ratio > 0.75) or (available_mb < 512):
             logger.warning("Warning: Large XGB model size may cause OOM error if training continues")
             logger.warning(f"Available Memory: {available_mb} MB")
             logger.warning(f"Estimated XGB model size: {estimated_model_size_mb} MB")


### PR DESCRIPTION
*Issue #, if available:*

Resolves #4930 

*Description of changes:*

- Improve CatBoost and XGBoost memory estimates to make out-of-memory errors rarer.
- CatBoost previously underestimated the histogram size with depth<7
- XGBoost previously underestimated the memory size for multiclass tasks and in some cases could go OOM at the end of fit during bagging if the model artifacts are large. Now we early stop due to memory earlier and account for the eventual model size in estimating memory.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
