### PR TITLE
[timeseries] Do not ignore __init__ files with ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [tool.ruff]
 line-length = 119
-target-version = "py310"
-extend-exclude = ["__init__.py"]
+target-version = "py39"
 lint.ignore = [
     "E501",  # Line too long
     "E731",  # Do not assign a `lambda` expression, use a `def`
@@ -39,6 +38,8 @@ lint.isort.known-third-party = [
     "nlpaug",
     "nltk",
 ]
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]  # Unused imports in __init__.py files
 
 
 [tool.codespell]
@@ -48,6 +49,7 @@ ignore-words-list = 'mape,ans,2st,fo,nd,te,fpr,coo,rouge,SME,NoES'
 
 
 [tool.pyright]
+pythonVersion = "3.9"
 include = [
     "timeseries/src/"
 ]

--- a/timeseries/src/autogluon/timeseries/metrics/__init__.py
+++ b/timeseries/src/autogluon/timeseries/metrics/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from pprint import pformat
 from typing import Any, Dict, Optional, Sequence, Type, Union
 
@@ -9,6 +10,8 @@ from .point import MAE, MAPE, MASE, MSE, RMSE, RMSLE, RMSSE, SMAPE, WAPE, WCD
 from .quantile import SQL, WQL
 
 __all__ = [
+    "TimeSeriesScorer",
+    "check_get_evaluation_metric",
     "MAE",
     "MAPE",
     "MASE",

--- a/timeseries/src/autogluon/timeseries/models/chronos/pipeline/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/pipeline/__init__.py
@@ -1,7 +1,6 @@
+from .base import BaseChronosPipeline, ForecastType
 from .chronos import ChronosPipeline
 from .chronos_bolt import ChronosBoltPipeline
-from .base import BaseChronosPipeline, ForecastType
-
 
 __all__ = [
     "BaseChronosPipeline",

--- a/timeseries/src/autogluon/timeseries/models/ensemble/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/ensemble/__init__.py
@@ -1,3 +1,3 @@
 from .abstract import AbstractTimeSeriesEnsembleModel
+from .basic import PerformanceWeightedEnsemble, SimpleAverageEnsemble
 from .greedy import GreedyEnsemble
-from .basic import SimpleAverageEnsemble, PerformanceWeightedEnsemble

--- a/timeseries/src/autogluon/timeseries/transforms/__init__.py
+++ b/timeseries/src/autogluon/timeseries/transforms/__init__.py
@@ -1,2 +1,2 @@
 from .covariate_scaler import CovariateScaler, get_covariate_scaler
-from .target_scaler import TargetScaler, get_target_scaler 
+from .target_scaler import TargetScaler, get_target_scaler


### PR DESCRIPTION
*Issue #, if available:* Related to #5097

There are a few arguably incorrect configuration options in our `pyproject.toml` that resulted in issues such as #5097. This PR fixes this misconfiguration.

*Description of changes:*
- Set target Python version to 3.9 for `ruff` and `pyright`.
- Do not completely ignore `__init__.py` files with ruff. Only remove complaints about the unused imports (F401) and perform the other checks.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
