### PR TITLE
[timeseries] reorganize gluonts namespace, fix minor typing issue

### DIFF
--- a/timeseries/src/autogluon/timeseries/metrics/abstract.py
+++ b/timeseries/src/autogluon/timeseries/metrics/abstract.py
@@ -240,12 +240,12 @@ class TimeSeriesScorer:
     @overload
     @staticmethod
     def check_get_horizon_weight(
-        horizon_weight: Sequence[float] | np.ndarray, prediction_length: int
+        horizon_weight: Union[Sequence[float], np.ndarray], prediction_length: int
     ) -> npt.NDArray[np.float64]: ...
 
     @staticmethod
     def check_get_horizon_weight(
-        horizon_weight: Sequence[float] | np.ndarray | None, prediction_length: int
+        horizon_weight: Union[Sequence[float], np.ndarray, None], prediction_length: int
     ) -> Optional[npt.NDArray[np.float64]]:
         """Convert horizon_weight to a non-negative numpy array that sums up to prediction_length.
         Raises an exception if horizon_weight has an invalid shape or contains invalid values.

--- a/timeseries/src/autogluon/timeseries/models/chronos/pipeline/utils.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/pipeline/utils.py
@@ -16,7 +16,7 @@ from transformers import TrainerCallback
 from autogluon.common.loaders.load_s3 import download, list_bucket_prefix_suffix_contains_s3
 from autogluon.core.utils.exceptions import TimeLimitExceeded
 from autogluon.timeseries.dataset.ts_dataframe import TimeSeriesDataFrame
-from autogluon.timeseries.models.gluonts.abstract_gluonts import SimpleGluonTSDataset
+from autogluon.timeseries.models.gluonts.abstract import SimpleGluonTSDataset
 
 if TYPE_CHECKING:
     # TODO: fix the underlying reason for this circular import, the pipeline should handle tokenization

--- a/timeseries/src/autogluon/timeseries/models/gluonts/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/__init__.py
@@ -1,4 +1,4 @@
-from .torch.models import (
+from .models import (
     DeepARModel,
     DLinearModel,
     PatchTSTModel,

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract.py
@@ -3,7 +3,7 @@ import os
 import shutil
 from datetime import timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Type, Union, cast, overload
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, Union, cast, overload
 
 import gluonts
 import gluonts.core.settings
@@ -11,7 +11,6 @@ import numpy as np
 import pandas as pd
 from gluonts.core.component import from_hyperparameters
 from gluonts.dataset.common import Dataset as GluonTSDataset
-from gluonts.dataset.field_names import FieldName
 from gluonts.env import env as gluonts_env
 from gluonts.model.estimator import Estimator as GluonTSEstimator
 from gluonts.model.forecast import Forecast, QuantileForecast, SampleForecast
@@ -22,122 +21,20 @@ from autogluon.core.hpo.constants import RAY_BACKEND
 from autogluon.tabular.models.tabular_nn.utils.categorical_encoders import (
     OneHotMergeRaresHandleUnknownEncoder as OneHotEncoder,
 )
-from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP, TimeSeriesDataFrame
+from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
-from autogluon.timeseries.utils.datetime import norm_freq_str
 from autogluon.timeseries.utils.warning_filters import disable_root_logger, warning_filter
 
 if TYPE_CHECKING:
     from gluonts.torch.model.forecast import DistributionForecast
+
+from .dataset import SimpleGluonTSDataset
 
 # NOTE: We avoid imports for torch and lightning.pytorch at the top level and hide them inside class methods.
 # This is done to skip these imports during multiprocessing (which may cause bugs)
 
 logger = logging.getLogger(__name__)
 gts_logger = logging.getLogger(gluonts.__name__)
-
-
-class SimpleGluonTSDataset(GluonTSDataset):
-    """Wrapper for TimeSeriesDataFrame that is compatible with the GluonTS Dataset API."""
-
-    def __init__(
-        self,
-        target_df: TimeSeriesDataFrame,
-        freq: str,
-        target_column: str = "target",
-        feat_static_cat: Optional[np.ndarray] = None,
-        feat_static_real: Optional[np.ndarray] = None,
-        feat_dynamic_cat: Optional[np.ndarray] = None,
-        feat_dynamic_real: Optional[np.ndarray] = None,
-        past_feat_dynamic_cat: Optional[np.ndarray] = None,
-        past_feat_dynamic_real: Optional[np.ndarray] = None,
-        includes_future: bool = False,
-        prediction_length: Optional[int] = None,
-    ):
-        assert target_df is not None
-        # Convert TimeSeriesDataFrame to pd.Series for faster processing
-        self.target_array = target_df[target_column].to_numpy(np.float32)
-        self.feat_static_cat = self._astype(feat_static_cat, dtype=np.int64)
-        self.feat_static_real = self._astype(feat_static_real, dtype=np.float32)
-        self.feat_dynamic_cat = self._astype(feat_dynamic_cat, dtype=np.int64)
-        self.feat_dynamic_real = self._astype(feat_dynamic_real, dtype=np.float32)
-        self.past_feat_dynamic_cat = self._astype(past_feat_dynamic_cat, dtype=np.int64)
-        self.past_feat_dynamic_real = self._astype(past_feat_dynamic_real, dtype=np.float32)
-        self.freq = self._get_freq_for_period(freq)
-
-        # Necessary to compute indptr for known_covariates at prediction time
-        self.includes_future = includes_future
-        self.prediction_length = prediction_length
-
-        # Replace inefficient groupby ITEMID with indptr that stores start:end of each time series
-        item_id_index = target_df.index.get_level_values(ITEMID)
-        indices_sizes = item_id_index.value_counts(sort=False)
-        self.item_ids = indices_sizes.index  # shape [num_items]
-        cum_sizes = indices_sizes.to_numpy().cumsum()
-        self.indptr = np.append(0, cum_sizes).astype(np.int32)
-        self.start_timestamps = target_df.reset_index(TIMESTAMP).groupby(level=ITEMID, sort=False).first()[TIMESTAMP]
-        assert len(self.item_ids) == len(self.start_timestamps)
-
-    @staticmethod
-    def _astype(array: Optional[np.ndarray], dtype: Type[np.generic]) -> Optional[np.ndarray]:
-        if array is None:
-            return None
-        else:
-            return array.astype(dtype)
-
-    @staticmethod
-    def _get_freq_for_period(freq: str) -> str:
-        """Convert freq to format compatible with pd.Period.
-
-        For example, ME freq must be converted to M when creating a pd.Period.
-        """
-        offset = pd.tseries.frequencies.to_offset(freq)
-        assert offset is not None
-        freq_name = norm_freq_str(offset)
-        if freq_name == "SME":
-            # Replace unsupported frequency "SME" with "2W"
-            return "2W"
-        elif freq_name == "bh":
-            # Replace unsupported frequency "bh" with dummy value "Y"
-            return "Y"
-        else:
-            freq_name_for_period = {"YE": "Y", "QE": "Q", "ME": "M"}.get(freq_name, freq_name)
-            return f"{offset.n}{freq_name_for_period}"
-
-    def __len__(self):
-        return len(self.indptr) - 1  # noqa
-
-    def __iter__(self) -> Iterator[Dict[str, Any]]:
-        for j in range(len(self.indptr) - 1):
-            start_idx = self.indptr[j]
-            end_idx = self.indptr[j + 1]
-            # GluonTS expects item_id to be a string
-            ts = {
-                FieldName.ITEM_ID: str(self.item_ids[j]),
-                FieldName.START: pd.Period(self.start_timestamps.iloc[j], freq=self.freq),
-                FieldName.TARGET: self.target_array[start_idx:end_idx],
-            }
-            if self.feat_static_cat is not None:
-                ts[FieldName.FEAT_STATIC_CAT] = self.feat_static_cat[j]
-            if self.feat_static_real is not None:
-                ts[FieldName.FEAT_STATIC_REAL] = self.feat_static_real[j]
-            if self.past_feat_dynamic_cat is not None:
-                ts[FieldName.PAST_FEAT_DYNAMIC_CAT] = self.past_feat_dynamic_cat[start_idx:end_idx].T
-            if self.past_feat_dynamic_real is not None:
-                ts[FieldName.PAST_FEAT_DYNAMIC_REAL] = self.past_feat_dynamic_real[start_idx:end_idx].T
-
-            # Dynamic features that may extend into the future
-            if self.includes_future:
-                assert self.prediction_length is not None, (
-                    "Prediction length must be provided if includes_future is True"
-                )
-                start_idx = start_idx + j * self.prediction_length
-                end_idx = end_idx + (j + 1) * self.prediction_length
-            if self.feat_dynamic_cat is not None:
-                ts[FieldName.FEAT_DYNAMIC_CAT] = self.feat_dynamic_cat[start_idx:end_idx].T
-            if self.feat_dynamic_real is not None:
-                ts[FieldName.FEAT_DYNAMIC_REAL] = self.feat_dynamic_real[start_idx:end_idx].T
-            yield ts
 
 
 class AbstractGluonTSModel(AbstractTimeSeriesModel):

--- a/timeseries/src/autogluon/timeseries/models/gluonts/dataset.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/dataset.py
@@ -1,0 +1,112 @@
+from typing import Any, Dict, Iterator, Optional, Type
+
+import numpy as np
+import pandas as pd
+from gluonts.dataset.common import Dataset as GluonTSDataset
+from gluonts.dataset.field_names import FieldName
+
+from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP, TimeSeriesDataFrame
+from autogluon.timeseries.utils.datetime import norm_freq_str
+
+
+class SimpleGluonTSDataset(GluonTSDataset):
+    """Wrapper for TimeSeriesDataFrame that is compatible with the GluonTS Dataset API."""
+
+    def __init__(
+        self,
+        target_df: TimeSeriesDataFrame,
+        freq: str,
+        target_column: str = "target",
+        feat_static_cat: Optional[np.ndarray] = None,
+        feat_static_real: Optional[np.ndarray] = None,
+        feat_dynamic_cat: Optional[np.ndarray] = None,
+        feat_dynamic_real: Optional[np.ndarray] = None,
+        past_feat_dynamic_cat: Optional[np.ndarray] = None,
+        past_feat_dynamic_real: Optional[np.ndarray] = None,
+        includes_future: bool = False,
+        prediction_length: Optional[int] = None,
+    ):
+        assert target_df is not None
+        # Convert TimeSeriesDataFrame to pd.Series for faster processing
+        self.target_array = target_df[target_column].to_numpy(np.float32)
+        self.feat_static_cat = self._astype(feat_static_cat, dtype=np.int64)
+        self.feat_static_real = self._astype(feat_static_real, dtype=np.float32)
+        self.feat_dynamic_cat = self._astype(feat_dynamic_cat, dtype=np.int64)
+        self.feat_dynamic_real = self._astype(feat_dynamic_real, dtype=np.float32)
+        self.past_feat_dynamic_cat = self._astype(past_feat_dynamic_cat, dtype=np.int64)
+        self.past_feat_dynamic_real = self._astype(past_feat_dynamic_real, dtype=np.float32)
+        self.freq = self._get_freq_for_period(freq)
+
+        # Necessary to compute indptr for known_covariates at prediction time
+        self.includes_future = includes_future
+        self.prediction_length = prediction_length
+
+        # Replace inefficient groupby ITEMID with indptr that stores start:end of each time series
+        item_id_index = target_df.index.get_level_values(ITEMID)
+        indices_sizes = item_id_index.value_counts(sort=False)
+        self.item_ids = indices_sizes.index  # shape [num_items]
+        cum_sizes = indices_sizes.to_numpy().cumsum()
+        self.indptr = np.append(0, cum_sizes).astype(np.int32)
+        self.start_timestamps = target_df.reset_index(TIMESTAMP).groupby(level=ITEMID, sort=False).first()[TIMESTAMP]
+        assert len(self.item_ids) == len(self.start_timestamps)
+
+    @staticmethod
+    def _astype(array: Optional[np.ndarray], dtype: Type[np.generic]) -> Optional[np.ndarray]:
+        if array is None:
+            return None
+        else:
+            return array.astype(dtype)
+
+    @staticmethod
+    def _get_freq_for_period(freq: str) -> str:
+        """Convert freq to format compatible with pd.Period.
+
+        For example, ME freq must be converted to M when creating a pd.Period.
+        """
+        offset = pd.tseries.frequencies.to_offset(freq)
+        assert offset is not None
+        freq_name = norm_freq_str(offset)
+        if freq_name == "SME":
+            # Replace unsupported frequency "SME" with "2W"
+            return "2W"
+        elif freq_name == "bh":
+            # Replace unsupported frequency "bh" with dummy value "Y"
+            return "Y"
+        else:
+            freq_name_for_period = {"YE": "Y", "QE": "Q", "ME": "M"}.get(freq_name, freq_name)
+            return f"{offset.n}{freq_name_for_period}"
+
+    def __len__(self):
+        return len(self.indptr) - 1  # noqa
+
+    def __iter__(self) -> Iterator[Dict[str, Any]]:
+        for j in range(len(self.indptr) - 1):
+            start_idx = self.indptr[j]
+            end_idx = self.indptr[j + 1]
+            # GluonTS expects item_id to be a string
+            ts = {
+                FieldName.ITEM_ID: str(self.item_ids[j]),
+                FieldName.START: pd.Period(self.start_timestamps.iloc[j], freq=self.freq),
+                FieldName.TARGET: self.target_array[start_idx:end_idx],
+            }
+            if self.feat_static_cat is not None:
+                ts[FieldName.FEAT_STATIC_CAT] = self.feat_static_cat[j]
+            if self.feat_static_real is not None:
+                ts[FieldName.FEAT_STATIC_REAL] = self.feat_static_real[j]
+            if self.past_feat_dynamic_cat is not None:
+                ts[FieldName.PAST_FEAT_DYNAMIC_CAT] = self.past_feat_dynamic_cat[start_idx:end_idx].T
+            if self.past_feat_dynamic_real is not None:
+                ts[FieldName.PAST_FEAT_DYNAMIC_REAL] = self.past_feat_dynamic_real[start_idx:end_idx].T
+
+            # Dynamic features that may extend into the future
+            if self.includes_future:
+                assert self.prediction_length is not None, (
+                    "Prediction length must be provided if includes_future is True"
+                )
+                start_idx = start_idx + j * self.prediction_length
+                end_idx = end_idx + (j + 1) * self.prediction_length
+            if self.feat_dynamic_cat is not None:
+                ts[FieldName.FEAT_DYNAMIC_CAT] = self.feat_dynamic_cat[start_idx:end_idx].T
+            if self.feat_dynamic_real is not None:
+                ts[FieldName.FEAT_DYNAMIC_REAL] = self.feat_dynamic_real[start_idx:end_idx].T
+            yield ts

--- a/timeseries/src/autogluon/timeseries/models/gluonts/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/models.py
@@ -7,12 +7,13 @@ from typing import Any, Dict, Type
 
 from gluonts.model.estimator import Estimator as GluonTSEstimator
 
-from autogluon.timeseries.models.gluonts.abstract_gluonts import AbstractGluonTSModel
 from autogluon.timeseries.utils.datetime import (
     get_lags_for_frequency,
     get_seasonality,
     get_time_features_for_frequency,
 )
+
+from .abstract import AbstractGluonTSModel
 
 # NOTE: We avoid imports for torch and lightning.pytorch at the top level and hide them inside class methods.
 # This is done to skip these imports during multiprocessing (which may cause bugs)

--- a/timeseries/tests/unittests/models/common.py
+++ b/timeseries/tests/unittests/models/common.py
@@ -31,7 +31,7 @@ from autogluon.timeseries.models import (
 )
 from autogluon.timeseries.models.abstract.abstract_timeseries_model import AbstractTimeSeriesModel
 from autogluon.timeseries.models.autogluon_tabular.mlforecast import AbstractMLForecastModel
-from autogluon.timeseries.models.gluonts.abstract_gluonts import AbstractGluonTSModel
+from autogluon.timeseries.models.gluonts.abstract import AbstractGluonTSModel
 from autogluon.timeseries.models.local.abstract_local_model import AbstractLocalModel
 from autogluon.timeseries.models.multi_window import MultiWindowBacktestingModel
 

--- a/timeseries/tests/unittests/models/test_gluonts.py
+++ b/timeseries/tests/unittests/models/test_gluonts.py
@@ -116,9 +116,7 @@ def test_when_static_features_present_then_they_are_passed_to_dataset(
 ):
     df, covariate_metadata = df_with_static
     model = gluonts_model_with_static_features_class(covariate_metadata=covariate_metadata, freq=df.freq)
-    with mock.patch(
-        "autogluon.timeseries.models.gluonts.abstract_gluonts.SimpleGluonTSDataset.__init__"
-    ) as patch_dataset:
+    with mock.patch("autogluon.timeseries.models.gluonts.dataset.SimpleGluonTSDataset.__init__") as patch_dataset:
         try:
             model.fit(train_data=df)
         except TypeError:
@@ -169,9 +167,7 @@ def test_when_disable_static_features_set_to_true_then_static_features_are_not_u
     model = gluonts_model_with_static_features_class(
         hyperparameters={"disable_static_features": True}, covariate_metadata=covariate_metadata, freq=df.freq
     )
-    with mock.patch(
-        "autogluon.timeseries.models.gluonts.abstract_gluonts.SimpleGluonTSDataset.__init__"
-    ) as patch_dataset:
+    with mock.patch("autogluon.timeseries.models.gluonts.dataset.SimpleGluonTSDataset.__init__") as patch_dataset:
         try:
             model.fit(train_data=df)
         except TypeError:
@@ -189,9 +185,7 @@ def test_when_known_covariates_present_then_they_are_passed_to_dataset(
 ):
     df, covariate_metadata = df_with_covariates
     model = gluonts_model_with_static_features_class(covariate_metadata=covariate_metadata, freq=df.freq)
-    with mock.patch(
-        "autogluon.timeseries.models.gluonts.abstract_gluonts.SimpleGluonTSDataset.__init__"
-    ) as patch_dataset:
+    with mock.patch("autogluon.timeseries.models.gluonts.dataset.SimpleGluonTSDataset.__init__") as patch_dataset:
         try:
             model.fit(train_data=df)
         except TypeError:
@@ -241,9 +235,7 @@ def test_when_disable_known_covariates_set_to_true_then_known_covariates_are_not
     model = gluonts_model_with_known_covariates_class(
         hyperparameters={"disable_known_covariates": True}, covariate_metadata=covariate_metadata, freq=df.freq
     )
-    with mock.patch(
-        "autogluon.timeseries.models.gluonts.abstract_gluonts.SimpleGluonTSDataset.__init__"
-    ) as patch_dataset:
+    with mock.patch("autogluon.timeseries.models.gluonts.dataset.SimpleGluonTSDataset.__init__") as patch_dataset:
         try:
             model.fit(train_data=df)
         except TypeError:

--- a/timeseries/tests/unittests/test_metrics.py
+++ b/timeseries/tests/unittests/test_metrics.py
@@ -27,7 +27,7 @@ from autogluon.timeseries.metrics import (
     check_get_evaluation_metric,
 )
 from autogluon.timeseries.metrics.utils import in_sample_abs_seasonal_error, in_sample_squared_seasonal_error
-from autogluon.timeseries.models.gluonts.abstract_gluonts import AbstractGluonTSModel
+from autogluon.timeseries.models.gluonts.abstract import AbstractGluonTSModel
 
 from .common import DUMMY_TS_DATAFRAME, get_data_frame_with_item_index, get_prediction_for_df
 


### PR DESCRIPTION


*Issue #, if available:*

- Reorganizes `gluonts` namespace, separating out `dataset` and removing the redundant `torch.*` namespace.
- Fixes minor typing issue (use of pipe instead of Union) in `metrics`.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
