### PR TITLE
Fix TabPFN dependency

### DIFF
--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -49,8 +49,8 @@ extras_require = {
         "fastai>=2.3.1,<2.9",  # <{N+1} upper cap, where N is the latest released minor version
     ],
     "tabpfn": [
-        # versions below 2.0.2 are broken (or yanked)
-        "tabpfn>=0.1.11,<2.1",  # <{N+1} upper cap, where N is the latest released minor version
+        # versions below 0.1.11 are yanked, not compatible with >=2.0.0 yet
+        "tabpfn>=0.1.11,<2.0",  # after v2 compatibility is ensured, should be <{N+1} upper cap, where N is the latest released minor version
     ],
     "tabpfnmix": [
         "torch",  # version range defined in `core/_setup_utils.py`


### PR DESCRIPTION
autogluon.tabular is not yet adapted to the overhaul of tabpfn to v2

*Issue #, if available:* 5118

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
