### PR TITLE
[timeseries] Fix FutureWarning in leaderboard and evaluate methods

### DIFF
--- a/timeseries/src/autogluon/timeseries/trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer.py
@@ -809,7 +809,6 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
         return self._get_eval_metric(metric).score(
             data=data,
             predictions=predictions,
-            prediction_length=self.prediction_length,
             target=self.target,
         )
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix `FutureWarnings` produced by `leaderboard` and `evaluate` methods in the `TimeSeriesPredictor` (see e.g., https://auto.gluon.ai/stable/tutorials/timeseries/forecasting-quick-start.html#evaluating-the-performance-of-different-models). This happens because we forgot to update the code in light of a deprecation introduced in #5084.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
