### PR TITLE
Fix incorrect reference to positive_class in TabularPredictor constructor

### DIFF
--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -207,7 +207,7 @@ class TabularPredictor:
         learner_kwargs = kwargs.get("learner_kwargs", dict())
         quantile_levels = kwargs.get("quantile_levels", None)
         if positive_class is not None:
-            learner_kwargs["positive_class"] = kwargs["positive_class"]
+            learner_kwargs["positive_class"] = positive_class
 
         self._learner: AbstractTabularLearner = learner_type(
             path_context=path,


### PR DESCRIPTION
Fixes #5114 

*Description of changes:*
This PR fixes a bug in the TabularPredictor constructor where `positive_class` was incorrectly accessed from `kwargs`, causing a KeyError when passed as a named argument. The line:

```python
learner_kwargs["positive_class"] = kwargs["positive_class"]
```
has been corrected to:
```python
learner_kwargs["positive_class"] = positive_class
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
