### PR TITLE
[timeseries] Avoid masking the 'scaler' param with the default 'target_scaler' value

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -2,6 +2,7 @@ import logging
 import math
 import os
 import time
+import warnings
 from typing import Any, Callable, Collection, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -190,8 +191,17 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
             target_transforms.append(Differences(differences))
             self._sum_of_differences = sum(differences)
 
+        # TODO: Remove 'scaler' hyperparameter in v2.0.0
         # Support "scaler" for backward compatibility
-        scaler_type = model_params.get("target_scaler", model_params.get("scaler"))
+        if "scaler" in model_params:
+            warnings.warn(
+                f"Hyperparameter 'scaler' for {self.__class__.__name__} has been deprecated "
+                "and will be removed in v2.0. Please use 'target_scaler' instead.",
+                category=FutureWarning,
+            )
+            scaler_type = model_params["scaler"]
+        else:
+            scaler_type = model_params.get("target_scaler")
         if scaler_type is not None:
             self._scaler = MLForecastScaler(scaler_type=scaler_type)
             target_transforms.append(self._scaler)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Prior to v1.3.0, users could set the `scaler` hyperparameter to choose the scaling option in MLForecast models. In v1.3.0, we renamed this hyperparameter to `target_scaler` for consistency with other models. We intended to support the `scaler` hyperparameter as well for backwards compatibility. However, because of a bug in the logic, `scaler` was always shadowed by the default value of the `target_scaler`, so the old parameter name got effectively deprecated. This can result in unexpected performance changes to the users. This PR fixes this problem.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
