### PR TITLE
[timeseries] Fix ensemble weights format for printing

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/ensemble/greedy.py
+++ b/timeseries/src/autogluon/timeseries/models/ensemble/greedy.py
@@ -182,5 +182,5 @@ class GreedyEnsemble(AbstractWeightedTimeSeriesEnsembleModel):
             if weight != 0:
                 self.model_to_weight[model_name] = weight
 
-        weights_for_printing = {model: round(weight, 2) for model, weight in self.model_to_weight.items()}
+        weights_for_printing = {model: round(float(weight), 2) for model, weight in self.model_to_weight.items()}
         logger.info(f"\tEnsemble weights: {pprint.pformat(weights_for_printing, width=200)}")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- With `numpy>2.0` the ensemble weights are printed as follows:
    ```
    Ensemble weights: {'Chronos[bolt_small]': np.float64(0.74), 'DirectTabular': np.float64(0.04), 'ETS': np.float64(0.02), 'RecursiveTabular': np.float64(0.19)}
    ```
    This PR ensures that the weights are displayed as floats (and not np.float64 dtype).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
