### PR TITLE
fix: Change multilingual preset to use FP32 to avoid DeBERTa BFloat16…

### DIFF
--- a/multimodal/src/autogluon/multimodal/utils/presets.py
+++ b/multimodal/src/autogluon/multimodal/utils/presets.py
@@ -187,7 +187,7 @@ def default(presets: str = DEFAULT):
             {
                 "model.hf_text.checkpoint_name": "microsoft/mdeberta-v3-base",
                 "optim.top_k": 1,
-                "env.precision": "bf16-mixed",
+                "env.precision": "32",
                 "env.per_gpu_batch_size": 4,
             }
         )


### PR DESCRIPTION
*Issue #, if available:*
#5136 

*Description of changes:*
Change multilingual preset to use FP32 to avoid DeBERTa BFloat16 overflow


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
