### PR TITLE
fix: Support Apple Silicon and log it in the system info

### DIFF
--- a/common/src/autogluon/common/utils/resource_utils.py
+++ b/common/src/autogluon/common/utils/resource_utils.py
@@ -39,10 +39,14 @@ class ResourceManager:
         try:
             import torch
 
-            if not torch.cuda.is_available():
-                num_gpus = 0
-            else:
+            if torch.cuda.is_available():
                 num_gpus = torch.cuda.device_count()
+            elif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
+                # Apple Silicon MPS (Metal Performance Shaders) support
+                # Apple Silicon Macs have only one integrated GPU
+                num_gpus = 1
+            else:
+                num_gpus = 0
         except Exception:
             num_gpus = 0
         return num_gpus

--- a/common/src/autogluon/common/utils/resource_utils.py
+++ b/common/src/autogluon/common/utils/resource_utils.py
@@ -41,7 +41,7 @@ class ResourceManager:
 
             if torch.cuda.is_available():
                 num_gpus = torch.cuda.device_count()
-            elif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
+            elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
                 # Apple Silicon MPS (Metal Performance Shaders) support
                 # Apple Silicon Macs have only one integrated GPU
                 num_gpus = 1

--- a/multimodal/src/autogluon/multimodal/utils/log.py
+++ b/multimodal/src/autogluon/multimodal/utils/log.py
@@ -1,8 +1,6 @@
-import datetime
 import logging
-import os
 from contextlib import contextmanager
-from typing import Dict, List, Optional, Tuple, Union
+from typing import List, Optional, Union
 
 import torch
 
@@ -105,7 +103,7 @@ def apply_log_filter(log_filter):
 def on_fit_start_message(path: Optional[str] = None):
     return get_ag_system_info(
         path=path,
-        include_gpu_count=False,
+        include_gpu_count=True,
         include_pytorch=True,
         include_cuda=True,
     )

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -8,7 +8,7 @@ import random
 import time
 import warnings
 from copy import deepcopy
-from typing import Dict, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, Union
 
 import numpy as np
 import pandas as pd
@@ -103,9 +103,14 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
         if num_gpus is not None and num_gpus >= 1:
             if torch.cuda.is_available():
                 device = torch.device("cuda")
-                logger.log(15, "Training on GPU")
+                logger.log(15, "Training on GPU (CUDA)")
                 if num_gpus > 1:
                     logger.warning(f"{self.__class__.__name__} not yet able to use more than 1 GPU. 'num_gpus' is set to >1, but we will be using only 1 GPU.")
+            elif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
+                device = torch.device("mps")
+                logger.log(15, "Training on GPU (MPS - Apple Silicon)")
+                if num_gpus > 1:
+                    logger.warning(f"{self.__class__.__name__} on Apple Silicon can only use 1 GPU (MPS). 'num_gpus' is set to >1, but we will be using only 1 GPU.")
             else:
                 device = torch.device("cpu")
                 logger.log(15, "Training on CPU")


### PR DESCRIPTION
*Issue #, if available:*
#4984 
#3126 

*Description of changes:*

It looks like with the recent upgrade of torch and lightning, we're now utilizing MPS on Apple Silicon devices! I've confirmed it through GPU memory and usage. I've also added this information to the system log to prevent any confusion for users on Apple devices.

```
=================== System Info ===================
AutoGluon Version:  1.3.1b20250527
Python Version:     3.10.16
Operating System:   Darwin
Platform Machine:   arm64
Platform Version:   Darwin Kernel Version 24.5.0: Tue Apr 22 19:54:49 PDT 2025; root:xnu-11417.121.6~2/RELEASE_ARM64_T6000
CPU Count:          10
Pytorch Version:    2.6.0
CUDA Version:       CUDA is not available
GPU Count:          1
Memory Avail:       20.19 GB / 32.00 GB (63.1%)
Disk Space Avail:   118.12 GB / 460.43 GB (25.7%)
===================================================
AutoGluon infers your prediction problem is: 'binary' (because only two unique label-values observed).
	2 unique label values:  [np.int64(0), np.int64(1)]
	If 'binary' is not the correct problem_type, please manually specify the problem_type parameter during Predictor init (You may specify problem_type as one of: ['binary', 'multiclass', 'regression', 'quantile'])

AutoMM starts to create your model. ✨✨✨

To track the learning progress, you can open a terminal and launch Tensorboard:
    ```shell
    # Assume you have installed tensorboard
    tensorboard --logdir /Users/tonyhu/workplace/autogluon/autogluon/docs/tutorials/multimodal/multimodal_prediction/AutogluonModels/ag-20250527_175400
    ```

INFO: Seed set to 0
GPU Count: 1
GPU Count to be Used: 1
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
