### PR TITLE
Use pyarrow by default, remove fastparquet

### DIFF
--- a/common/setup.py
+++ b/common/setup.py
@@ -23,6 +23,7 @@ install_requires = (
         # version ranges added in ag.get_dependency_version_ranges()
         "numpy",  # version range defined in `core/_setup_utils.py`
         "pandas",  # version range defined in `core/_setup_utils.py`
+        "pyarrow",  # version range defined in `core/_setup_utils.py`
         "boto3",  # version range defined in `core/_setup_utils.py`
         "psutil",  # version range defined in `core/_setup_utils.py`
         "tqdm",  # version range defined in `core/_setup_utils.py`

--- a/common/src/autogluon/common/loaders/load_pd.py
+++ b/common/src/autogluon/common/loaders/load_pd.py
@@ -132,12 +132,7 @@ def load(
             multiprocessing_method=multiprocessing_method,
         )
     elif format == "parquet":
-        try:
-            # TODO: Deal with extremely strange issue resulting from torch being present in package,
-            #  will cause read_parquet to either freeze or Segmentation Fault when performing multiprocessing
-            df = pd.read_parquet(path, columns=columns_to_keep, engine="fastparquet")
-        except:
-            df = pd.read_parquet(path, columns=columns_to_keep, engine="pyarrow")
+        df = pd.read_parquet(path, columns=columns_to_keep)
         column_count_full = len(df.columns)
     elif format == "csv":
         df = pd.read_csv(

--- a/common/src/autogluon/common/savers/save_pd.py
+++ b/common/src/autogluon/common/savers/save_pd.py
@@ -104,12 +104,7 @@ def save(
         if verbose:
             logger.log(15, "Saved " + str(path) + " | Columns = " + str(column_count) + " | Rows = " + str(row_count))
     elif type == "parquet":
-        try:
-            df.to_parquet(
-                path, compression=compression, engine="fastparquet"
-            )  # TODO: Might be slower than pyarrow in multiprocessing
-        except:
-            df.to_parquet(path, compression=compression, engine="pyarrow")
+        df.to_parquet(path, compression=compression)
         if verbose:
             logger.log(15, "Saved " + str(path) + " | Columns = " + str(column_count) + " | Rows = " + str(row_count))
     elif type == "multipart_s3":

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -19,6 +19,7 @@ DEPENDENT_PACKAGES = {
     "boto3": ">=1.10,<2",  # <2 because unlikely to introduce breaking changes in minor releases. >=1.10 because 1.10 is 3 years old, no need to support older
     "numpy": ">=1.25.0,<2.3.0",  # "<{N+3}" upper cap, where N is the latest released minor version, assuming no warnings using N
     "pandas": ">=2.0.0,<2.3.0",  # "<{N+3}" upper cap
+    "pyarrow": ">=7.0.0,<21.0.0",  #"<{N=1}.0.0" upper cap
     "scikit-learn": ">=1.4.0,<1.7.0",  # <{N+1} upper cap
     "scipy": ">=1.5.4,<1.16",  # "<{N+2}" upper cap
     "matplotlib": ">=3.7.0,<3.11",  # "<{N+2}" upper cap


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Use pyarrow by default, remove fastparquet

This aligns with panda's choice to adopt pyarrow as a required dependency in pandas 3.0: https://pandas.pydata.org/pdeps/0010-required-pyarrow-dependency.html

Additionally, fastparquet has been deprecated by dask, who are the authors of fastparquet and recommend pyarrow: https://stackoverflow.com/a/77844771

Finally, I noticed that loading parquet files from https using `pd.read_parquet` led to different results depending on if fastparquet or pyarrow was used. In the case I observed, pyarrow loaded the parquet file correctly, whereas fastparquet loaded the file incorrectly.

For the pyarrow version ranges, I chose `>=7` as the lower bound to align with pandas 3.0's planned minimum version bound for pyarrow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
