### PR TITLE
upgrade CI containers to use PyTorch 2.6.0, with CUDA 12.6 for gpu variants

### DIFF
--- a/CI/batch/docker/Dockerfile.cpu
+++ b/CI/batch/docker/Dockerfile.cpu
@@ -1,4 +1,4 @@
-FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training:2.5.1-cpu-py311-ubuntu22.04-ec2
+FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training:2.6.0-cpu-py312-ubuntu22.04-ec2
 
 RUN apt-get update \
    && apt-get -y upgrade \

--- a/CI/batch/docker/Dockerfile.gpu
+++ b/CI/batch/docker/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training:2.5.1-gpu-py311-cu124-ubuntu22.04-ec2
+FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training:2.6.0-gpu-py312-cu126-ubuntu22.04-ec2
 
 ARG AWSCLI_VER=1.22.45
 

--- a/CI/docker/Dockerfile.cpu-inference
+++ b/CI/docker/Dockerfile.cpu-inference
@@ -1,4 +1,4 @@
-FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-inference:2.5.1-cpu-py311-ubuntu22.04-sagemaker
+FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-inference:2.6.0-cpu-py312-ubuntu22.04-sagemaker
 
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/CI/docker/Dockerfile.cpu-training
+++ b/CI/docker/Dockerfile.cpu-training
@@ -1,4 +1,4 @@
-FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training:2.5.1-cpu-py311-ubuntu22.04-sagemaker
+FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training:2.6.0-cpu-py312-ubuntu22.04-sagemaker
 
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/CI/docker/Dockerfile.gpu-inference
+++ b/CI/docker/Dockerfile.gpu-inference
@@ -1,4 +1,4 @@
-FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-inference:2.5.1-gpu-py311-cu124-ubuntu22.04-sagemaker
+FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-inference:2.6.0-gpu-py312-cu126-ubuntu22.04-sagemaker
 
 RUN apt-get update \
  && apt-get -y upgrade \

--- a/CI/docker/Dockerfile.gpu-training
+++ b/CI/docker/Dockerfile.gpu-training
@@ -1,4 +1,4 @@
-FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com//pytorch-training:2.5.1-gpu-py311-cu124-ubuntu22.04-sagemaker
+FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com//pytorch-training:2.6.0-gpu-py312-cu126-ubuntu22.04-sagemaker
 
 RUN apt-get update \
     && apt-get -y upgrade \


### PR DESCRIPTION
Upgrades the Docker containers to use PyTorch 2.6.0, with CUDA 12.6 for gpu variants.

With the CUDA 12.6 included, expect it to avoid the incompatible cuDNN error seen at https://github.com/autogluon/autogluon/pull/5089#issuecomment-2941166029 when attempting to use PyTorch 2.7 which the gpu wheel is packaged with CUDA 12.6


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
