### PR TITLE
[Fix] Resolve AttributeError in LinearModel when using RAPIDS cuML models

### DIFF
--- a/tabular/src/autogluon/tabular/models/_utils/rapids_utils.py
+++ b/tabular/src/autogluon/tabular/models/_utils/rapids_utils.py
@@ -10,7 +10,7 @@ class RapidsModelMixin:
     @classmethod
     def _get_default_ag_args_ensemble(cls, **kwargs) -> dict:
         default_ag_args_ensemble = super()._get_default_ag_args_ensemble(**kwargs)
-        extra_ag_args_ensemble = {"use_child_oof": False}
+        extra_ag_args_ensemble = {"use_child_oof": False, "fold_fitting_strategy": "sequential_local"}
         default_ag_args_ensemble.update(extra_ag_args_ensemble)
         return default_ag_args_ensemble
 

--- a/tabular/src/autogluon/tabular/models/lr/lr_model.py
+++ b/tabular/src/autogluon/tabular/models/lr/lr_model.py
@@ -237,15 +237,13 @@ class LinearModel(AbstractModel):
                 warnings.simplefilter(action="ignore", category=UserWarning)
                 model = model.fit(**fit_args)
             total_iter += model.max_iter
-            # Handle case where n_iter_ is not available (e.g., in RAPIDS implementation)
-            n_iter = getattr(model, 'n_iter_', None)
-            if n_iter is not None:
-                if isinstance(n_iter, int):
-                    total_iter_used += n_iter
+            if model.n_iter_ is not None:
+                if isinstance(model.n_iter_, int):
+                    total_iter_used += model.n_iter_
                 else:
                     try:
                         # FIXME: For some reason this crashes on regression with some versions of scikit-learn.
-                        total_iter_used += n_iter[0]
+                        total_iter_used += model.n_iter_[0]
                     except:
                         pass
             else:

--- a/tabular/src/autogluon/tabular/models/lr/lr_model.py
+++ b/tabular/src/autogluon/tabular/models/lr/lr_model.py
@@ -237,13 +237,15 @@ class LinearModel(AbstractModel):
                 warnings.simplefilter(action="ignore", category=UserWarning)
                 model = model.fit(**fit_args)
             total_iter += model.max_iter
-            if model.n_iter_ is not None:
-                if isinstance(model.n_iter_, int):
-                    total_iter_used += model.n_iter_
+            # Handle case where n_iter_ is not available (e.g., in RAPIDS implementation)
+            n_iter = getattr(model, 'n_iter_', None)
+            if n_iter is not None:
+                if isinstance(n_iter, int):
+                    total_iter_used += n_iter
                 else:
                     try:
                         # FIXME: For some reason this crashes on regression with some versions of scikit-learn.
-                        total_iter_used += model.n_iter_[0]
+                        total_iter_used += n_iter[0]
                     except:
                         pass
             else:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*



### Problem
RAPIDS cuML linear models (LinearRapidsModel) fail during training with an `AttributeError: n_iter_` because they don't expose the `n_iter_` attribute that scikit-learn models provide. This causes the LinearModel base class to crash when trying to access `model.n_iter_` for iteration tracking.

### Root Cause
- RAPIDS cuML models use GPU-optimized algorithms that don't track iterations the same way as scikit-learn
- The `n_iter_` attribute is not available in cuML implementations
- AutoGluon's LinearModel base class assumes all linear models have this attribute

### Solution
Replace direct attribute access with safe `getattr()` calls:
- Use `getattr(model, 'n_iter_', None)` instead of `model.n_iter_`



### Testing
- Verified with RAPIDS cuML lr models
- Confirmed scikit-learn models continue to work as expected
- No regression in existing LinearModel functionality
```from autogluon.tabular.models.knn.knn_rapids_model import KNNRapidsModel
from autogluon.tabular.models.lr.lr_rapids_model import LinearRapidsModel
from autogluon.tabular.models.lr.lr_model import LinearModel
predictor = TabularPredictor(label=label).fit(train_data,
                                              hyperparameters={
        KNNRapidsModel: {},
        LinearRapidsModel: {},
        LinearModel: {},
        
    },
                                              )
                                              
predictor.leaderboard(test_data)
```



| model | score_test | score_val | eval_metric | pred_time_test | pred_time_val | fit_time | pred_time_test_marginal | pred_time_val_marginal | fit_time_marginal | stack_level | can_infer | fit_order |
|-------|------------|-----------|-------------|----------------|---------------|----------|-------------------------|------------------------|-------------------|-------------|-----------|-----------|
| LinearModel | 0.839697 | 0.80 | accuracy | 0.027756 | 0.018365 | 0.644307 | 0.027756 | 0.018365 | 0.644307 | 1 | True | 2 |
| LinearModel_2 | 0.839595 | 0.80 | accuracy | 0.018174 | 0.011734 | 1.089793 | 0.018174 | 0.011734 | 1.089793 | 1 | True | 3 |
| WeightedEnsemble_L2 | 0.829051 | 0.84 | accuracy | 0.034355 | 0.281068 | 8.620535 | 0.001574 | 0.000757 | 0.036132 | 2 | True | 4 |
| KNeighbors | 0.726072 | 0.73 | accuracy | 0.005024 | 0.261946 | 7.940096 | 0.005024 | 0.261946 | 7.940096 | 1 | True | 1 |





                                      

#


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
