### PR TITLE
Upgrade image to use torch 2.7.1

### DIFF
--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -7,26 +7,6 @@ function setup_build_env {
     python -m pip install ruff
 }
 
-function setup_pytorch_cuda_env {
-    # Use wheel bundled CUDA instead of DLC CUDA with fallback to compatibility check bypass
-    PYTORCH_CUDA_PATH=$(python -c '
-try:
-    import torch
-    torch_cuda_path=torch._C._cuda_getLibPath()
-    print(torch_cuda_path if torch_cuda_path else "")
-except:
-    print("")
-')
-
-    if [ -n "$PYTORCH_CUDA_PATH" ]; then
-        echo "Using PyTorch bundled CUDA libraries from: $PYTORCH_CUDA_PATH"
-        export LD_LIBRARY_PATH=$PYTORCH_CUDA_PATH:$LD_LIBRARY_PATH
-    else
-        echo "Warning: Could not get PyTorch bundled CUDA path. Falling back to PYTORCH_SKIP_CUDNN_COMPATIBILITY_CHECK=1"
-        export PYTORCH_SKIP_CUDNN_COMPATIBILITY_CHECK=1
-    fi
-}
-
 function setup_build_contrib_env {
     python -m pip install --upgrade pip
     python -m pip install -r $(dirname "$0")/../../docs/requirements_doc.txt

--- a/.github/workflow_scripts/test_multimodal.sh
+++ b/.github/workflow_scripts/test_multimodal.sh
@@ -11,17 +11,6 @@ function test_multimodal {
     install_local_packages "common/[tests]" "core/[all,tests]" "features/"
     install_multimodal "[tests]"
 
-    # Use wheel bundled CUDA instead of DLC CUDA with fallback to compatibility check bypass
-    PYTORCH_CUDA_PATH=$(python -c "import torch, sys; torch_cuda_path=''; try: torch_cuda_path=torch._C._cuda_getLibPath(); print(torch_cuda_path if torch_cuda_path else ''); except: print('')")
-    
-    if [ -n "$PYTORCH_CUDA_PATH" ]; then
-        echo "Using PyTorch bundled CUDA libraries from: $PYTORCH_CUDA_PATH"
-        export LD_LIBRARY_PATH=$PYTORCH_CUDA_PATH:$LD_LIBRARY_PATH
-    else
-        echo "Warning: Could not get PyTorch bundled CUDA path. Falling back to PYTORCH_SKIP_CUDNN_COMPATIBILITY_CHECK=1"
-        export PYTORCH_SKIP_CUDNN_COMPATIBILITY_CHECK=1
-    fi
-
     cd multimodal/
     if [ -n "$ADDITIONAL_TEST_ARGS" ]
     then

--- a/.github/workflow_scripts/test_tabular.sh
+++ b/.github/workflow_scripts/test_tabular.sh
@@ -25,17 +25,6 @@ else
     install_multimodal "[tests]"
 fi
 
-# Use wheel bundled CUDA instead of DLC CUDA with fallback to compatibility check bypass
-PYTORCH_CUDA_PATH=$(python -c "import torch, sys; torch_cuda_path=''; try: torch_cuda_path=torch._C._cuda_getLibPath(); print(torch_cuda_path if torch_cuda_path else ''); except: print('')")
-
-if [ -n "$PYTORCH_CUDA_PATH" ]; then
-    echo "Using PyTorch bundled CUDA libraries from: $PYTORCH_CUDA_PATH"
-    export LD_LIBRARY_PATH=$PYTORCH_CUDA_PATH:$LD_LIBRARY_PATH
-else
-    echo "Warning: Could not get PyTorch bundled CUDA path. Falling back to PYTORCH_SKIP_CUDNN_COMPATIBILITY_CHECK=1"
-    export PYTORCH_SKIP_CUDNN_COMPATIBILITY_CHECK=1
-fi
-
 cd tabular/
 if [ -n "$ADDITIONAL_TEST_ARGS" ]
 then

--- a/.github/workflow_scripts/test_tabular.sh
+++ b/.github/workflow_scripts/test_tabular.sh
@@ -24,7 +24,18 @@ else
     install_tabular "[all,tests]"
     install_multimodal "[tests]"
 fi
-setup_pytorch_cuda_env
+
+# Use wheel bundled CUDA instead of DLC CUDA with fallback to compatibility check bypass
+PYTORCH_CUDA_PATH=$(python -c "import torch, sys; torch_cuda_path=''; try: torch_cuda_path=torch._C._cuda_getLibPath(); print(torch_cuda_path if torch_cuda_path else ''); except: print('')")
+
+if [ -n "$PYTORCH_CUDA_PATH" ]; then
+    echo "Using PyTorch bundled CUDA libraries from: $PYTORCH_CUDA_PATH"
+    export LD_LIBRARY_PATH=$PYTORCH_CUDA_PATH:$LD_LIBRARY_PATH
+else
+    echo "Warning: Could not get PyTorch bundled CUDA path. Falling back to PYTORCH_SKIP_CUDNN_COMPATIBILITY_CHECK=1"
+    export PYTORCH_SKIP_CUDNN_COMPATIBILITY_CHECK=1
+fi
+
 cd tabular/
 if [ -n "$ADDITIONAL_TEST_ARGS" ]
 then

--- a/.github/workflow_scripts/test_timeseries.sh
+++ b/.github/workflow_scripts/test_timeseries.sh
@@ -15,17 +15,6 @@ python -m pip install --upgrade pytest-xdist
 
 export PYTHONHASHSEED=0  # for consistency in xdist tests
 
-# Use wheel bundled CUDA instead of DLC CUDA with fallback to compatibility check bypass
-PYTORCH_CUDA_PATH=$(python -c "import torch, sys; torch_cuda_path=''; try: torch_cuda_path=torch._C._cuda_getLibPath(); print(torch_cuda_path if torch_cuda_path else ''); except: print('')")
-
-if [ -n "$PYTORCH_CUDA_PATH" ]; then
-    echo "Using PyTorch bundled CUDA libraries from: $PYTORCH_CUDA_PATH"
-    export LD_LIBRARY_PATH=$PYTORCH_CUDA_PATH:$LD_LIBRARY_PATH
-else
-    echo "Warning: Could not get PyTorch bundled CUDA path. Falling back to PYTORCH_SKIP_CUDNN_COMPATIBILITY_CHECK=1"
-    export PYTORCH_SKIP_CUDNN_COMPATIBILITY_CHECK=1
-fi
-
 cd timeseries/
 if [ "$IS_PLATFORM_TEST" = 1 ]; then
     python -m pytest --junitxml=results.xml --runslow tests  # run platform tests without multiprocessing

--- a/.github/workflow_scripts/test_timeseries.sh
+++ b/.github/workflow_scripts/test_timeseries.sh
@@ -11,10 +11,20 @@ source $(dirname "$0")/env_setup.sh
 setup_build_env
 export CUDA_VISIBLE_DEVICES=0
 install_local_packages "common/[tests]" "core/[all,tests]" "features/" "tabular/[all,tests]" "timeseries/[all,tests]"
-setup_pytorch_cuda_env
 python -m pip install --upgrade pytest-xdist
 
 export PYTHONHASHSEED=0  # for consistency in xdist tests
+
+# Use wheel bundled CUDA instead of DLC CUDA with fallback to compatibility check bypass
+PYTORCH_CUDA_PATH=$(python -c "import torch, sys; torch_cuda_path=''; try: torch_cuda_path=torch._C._cuda_getLibPath(); print(torch_cuda_path if torch_cuda_path else ''); except: print('')")
+
+if [ -n "$PYTORCH_CUDA_PATH" ]; then
+    echo "Using PyTorch bundled CUDA libraries from: $PYTORCH_CUDA_PATH"
+    export LD_LIBRARY_PATH=$PYTORCH_CUDA_PATH:$LD_LIBRARY_PATH
+else
+    echo "Warning: Could not get PyTorch bundled CUDA path. Falling back to PYTORCH_SKIP_CUDNN_COMPATIBILITY_CHECK=1"
+    export PYTORCH_SKIP_CUDNN_COMPATIBILITY_CHECK=1
+fi
 
 cd timeseries/
 if [ "$IS_PLATFORM_TEST" = 1 ]; then

--- a/CI/batch/docker/Dockerfile.cpu
+++ b/CI/batch/docker/Dockerfile.cpu
@@ -1,4 +1,4 @@
-FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training:2.5.1-cpu-py311-ubuntu22.04-ec2
+FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training:2.7.1-cpu-py312-ubuntu22.04-ec2
 
 RUN apt-get update \
    && apt-get -y upgrade \

--- a/CI/batch/docker/Dockerfile.gpu
+++ b/CI/batch/docker/Dockerfile.gpu
@@ -1,6 +1,4 @@
-FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training:2.5.1-gpu-py311-cu124-ubuntu22.04-ec2
-
-ARG AWSCLI_VER=1.22.45
+FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training:2.7.1-gpu-py312-cu128-ubuntu22.04-ec2
 
 RUN apt-get update \
    && apt-get -y upgrade \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This should resolve CI failure for torch upgrade at [here](https://github.com/autogluon/autogluon/actions/runs/15697314474/job/44296695040) which is due to cuDNN imcompataibilty

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
