### PR TITLE
update numpy cap, thus 2.3.0 is allowed

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -17,7 +17,7 @@ PYTHON_REQUIRES = ">=3.9, <3.13"
 # Only put packages here that would otherwise appear multiple times across different module's setup.py files.
 DEPENDENT_PACKAGES = {
     "boto3": ">=1.10,<2",  # <2 because unlikely to introduce breaking changes in minor releases. >=1.10 because 1.10 is 3 years old, no need to support older
-    "numpy": ">=1.25.0,<2.3.0",  # "<{N+3}" upper cap, where N is the latest released minor version, assuming no warnings using N
+    "numpy": ">=1.25.0,<2.4.0",  # "<{N+3}" upper cap, where N is the latest released minor version, assuming no warnings using N
     "pandas": ">=2.0.0,<2.3.0",  # "<{N+3}" upper cap
     "scikit-learn": ">=1.4.0,<1.7.0",  # <{N+1} upper cap
     "scipy": ">=1.5.4,<1.16",  # "<{N+2}" upper cap


### PR DESCRIPTION
*Description of changes:*
update numpy cap, thus 2.3.0 is allowed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
