### PR TITLE
[timeseries] Fix exception logging in case of model failures + minor fixes

### DIFF
--- a/docs/tutorials/timeseries/forecasting-indepth.ipynb
+++ b/docs/tutorials/timeseries/forecasting-indepth.ipynb
@@ -255,7 +255,7 @@
     "- columns with other dtypes are ignored\n",
     "\n",
     "To override this logic, we need to manually change the columns dtype.\n",
-    "For example, suppose the static features data frame contained an integer-valued column `\"store_id\"`.\n",
+    "For example, suppose the static features dataframe contained an integer-valued column `\"store_id\"`.\n",
     "\n",
     "```python\n",
     "train_data.static_features[\"store_id\"] = list(range(len(train_data.item_ids)))\n",

--- a/docs/tutorials/timeseries/forecasting-metrics.md
+++ b/docs/tutorials/timeseries/forecasting-metrics.md
@@ -73,7 +73,7 @@ predictor = TimeSeriesPredictor(eval_metric="WQL", quantile_levels=[0.1, 0.5, 0.
 ```
 
 All remaining forecast metrics described on this page are **point** forecast metrics.
-Note that if you select the `eval_metric` to a point forecast metric when creating the `TimeSeriesPredictor`, then the forecast minimizing this metric will always be provided in the `"mean"` column of the predictions data frame.
+Note that if you select the `eval_metric` to a point forecast metric when creating the `TimeSeriesPredictor`, then the forecast minimizing this metric will always be provided in the `"mean"` column of the predictions dataframe.
 
 **2. Do you care more about accurately predicting time series with large values?**
 

--- a/docs/tutorials/timeseries/forecasting-quick-start.ipynb
+++ b/docs/tutorials/timeseries/forecasting-quick-start.ipynb
@@ -89,7 +89,7 @@
    "metadata": {},
    "source": [
     "AutoGluon expects time series data in [long format](https://doc.dataiku.com/dss/latest/time-series/data-formatting.html#long-format).\n",
-    "Each row of the data frame contains a single observation (timestep) of a single time series represented by\n",
+    "Each row of the dataframe contains a single observation (timestep) of a single time series represented by\n",
     "\n",
     "- unique ID of the time series (`\"item_id\"`) as int or str\n",
     "- timestamp of the observation (`\"timestamp\"`) as a `pandas.Timestamp` or compatible format\n",

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -598,6 +598,10 @@ class AbstractTimeSeriesModel(TimeSeriesModelBase, TimeSeriesTunable, ABC):
             if self.must_drop_median:
                 predictions = predictions.drop("0.5", axis=1)
 
+        column_order = pd.Index(["mean"] + [str(q) for q in self.quantile_levels])
+        if not predictions.columns.equals(column_order):
+            predictions = predictions.reindex(columns=column_order)
+
         if self.covariate_regressor is not None:
             if known_covariates is None:
                 known_covariates = TimeSeriesDataFrame.from_data_frame(

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -591,16 +591,16 @@ class AbstractTimeSeriesModel(TimeSeriesModelBase, TimeSeriesTunable, ABC):
         predictions = self._predict(data=data, known_covariates=known_covariates, **kwargs)
         self.covariate_regressor = covariate_regressor
 
+        column_order = pd.Index(["mean"] + [str(q) for q in self.quantile_levels])
+        if not predictions.columns.equals(column_order):
+            predictions = predictions.reindex(columns=column_order)
+
         # "0.5" might be missing from the quantiles if self is a wrapper (MultiWindowBacktestingModel or ensemble)
         if "0.5" in predictions.columns:
             if self.eval_metric.optimized_by_median:
                 predictions["mean"] = predictions["0.5"]
             if self.must_drop_median:
                 predictions = predictions.drop("0.5", axis=1)
-
-        column_order = pd.Index(["mean"] + [str(q) for q in self.quantile_levels])
-        if not predictions.columns.equals(column_order):
-            predictions = predictions.reindex(columns=column_order)
 
         if self.covariate_regressor is not None:
             if known_covariates is None:

--- a/timeseries/src/autogluon/timeseries/models/ensemble/greedy.py
+++ b/timeseries/src/autogluon/timeseries/models/ensemble/greedy.py
@@ -85,6 +85,7 @@ class TimeSeriesEnsembleSelection(EnsembleSelection):
             dummy_pred = copy.deepcopy(predictions[0][window_idx])
             # This should never happen; sanity check to make sure that all predictions have the same index
             assert all(dummy_pred.index.equals(pred[window_idx].index) for pred in predictions)
+            assert all(dummy_pred.columns.equals(pred[window_idx].columns) for pred in predictions)
 
             self.dummy_pred_per_window.append(dummy_pred)
 

--- a/timeseries/src/autogluon/timeseries/trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer.py
@@ -370,10 +370,9 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
             self.save_model(model=model)
         except TimeLimitExceeded:
             logger.error(f"\tTime limit exceeded... Skipping {model.name}.")
-        except (Exception, MemoryError) as err:
+        except (Exception, MemoryError):
             logger.error(f"\tWarning: Exception caused {model.name} to fail during training... Skipping this model.")
-            logger.error(f"\t{err}")
-            logger.debug(traceback.format_exc())
+            logger.error(traceback.format_exc())
         else:
             self._add_model(model=model)  # noqa: F821
             model_names_trained.append(model.name)  # noqa: F821

--- a/timeseries/tests/unittests/models/test_abstract.py
+++ b/timeseries/tests/unittests/models/test_abstract.py
@@ -49,9 +49,10 @@ class ConcreteTimeSeriesModel(AbstractTimeSeriesModel):
         assert self.dummy_learned_parameters is not None
 
         return TimeSeriesDataFrame(
-            pd.DataFrame(index=self.get_forecast_horizon_index(data), columns=["mean"] + self.quantile_levels).fillna(
-                42.0
-            )
+            pd.DataFrame(
+                index=self.get_forecast_horizon_index(data),
+                columns=[str(q) for q in self.quantile_levels] + ["mean"],
+            ).fillna(42.0)
         )
 
 
@@ -195,3 +196,11 @@ def test_when_convert_to_refit_full_via_copy_called_then_output_is_correct(temp_
 
     assert isinstance(copied_model, ConcreteTimeSeriesModel)
     assert copied_model.path == model.path + REFIT_FULL_SUFFIX
+
+
+def test_when_model_predicts_then_columns_have_correct_order(temp_model_path, train_data):
+    model = ConcreteTimeSeriesModel(path=temp_model_path)
+    model.fit(train_data=train_data)
+    predictions = model.predict(train_data)
+
+    assert predictions.columns.tolist() == ["mean"] + [str(q) for q in model.quantile_levels]

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -547,7 +547,7 @@ def test_given_cache_predictions_is_true_when_predicting_multiple_times_then_cac
 ):
     trainer = TimeSeriesTrainer(path=temp_model_path)
     trainer.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}})
-    mock_predictions = pd.DataFrame(columns=["mock_prediction"])
+    mock_predictions = pd.DataFrame(columns=["mean"] + [str(q) for q in trainer.quantile_levels])
     with mock.patch("autogluon.timeseries.models.local.naive.NaiveModel.predict") as naive_predict:
         naive_predict.return_value = mock_predictions
         trainer.predict(DUMMY_TS_DATAFRAME, model="Naive")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Currently, exceptions occurring during model fitting are reported as
https://github.com/autogluon/autogluon/blob/0ee849fc6dc2c44aa0f3e086317e4d11d16955fa/timeseries/src/autogluon/timeseries/trainer.py#L373-L376
So the log message at default `verbosity=2` may look like
    ```
    ...
    Training timeseries model DirectTabular. 
    	Warning: Exception caused DirectTabular to fail during training... Skipping this model.
    	'int' object is not iterable
    ...
    ```
    The only way to see the entire stack trace is to re-run the entire fit process with `verbosity=4`, in which case the logs look like
    ```
    Training timeseries model DirectTabular. 
		Window 0
		Warning: Exception caused DirectTabular to fail during training... Skipping this model.
		'int' object is not iterable
	Traceback (most recent call last):
	  File "/home/shchuro/workspace/autogluon/timeseries/src/autogluon/timeseries/trainer.py", line 357, in _train_and_save
	    model = self._train_single(train_data, model, val_data=val_data, time_limit=time_limit)
	            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/home/shchuro/workspace/autogluon/timeseries/src/autogluon/timeseries/trainer.py", line 273, in _train_single
	    model.fit(
	  File "/home/shchuro/workspace/autogluon/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py", line 511, in fit
	    self._fit(
	  File "/home/shchuro/workspace/autogluon/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py", line 137, in _fit
	    model.fit(
	  File "/home/shchuro/workspace/autogluon/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py", line 511, in fit
	    self._fit(
	  File "/home/shchuro/workspace/autogluon/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py", line 329, in _fit
	    mlforecast_init_args = self._get_mlforecast_init_args(train_data, model_params)
	                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/home/shchuro/workspace/autogluon/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py", line 168, in _get_mlforecast_init_args
	    self._target_lags = np.array(sorted(set(lags)), dtype=np.int64)
	                                        ^^^^^^^^^
	TypeError: 'int' object is not iterable
    ```
    This is very annoying and requires a lot of effort from the user just to be able to report the bug to us.
    
    We had this logic before because some models (e.g., AutoARIMA from pmdarima / ETS from statsmodels) were often randomly failing and polluting the logs. Now we got to a point where model failures are rare and only happen in case of bugs. Therefore it makes sense to update the logging logic and always report the full stack trace.
- Make `dataframe` spelling consistent in `docs/`.
- Ensure that all models return columns ordered as `["mean"] + [str(q) for q in self.quantile_levels]`. Previously this wasn't guaranteed, which could potentially lead to breaking the ensembling logic. This happened because of this line https://github.com/autogluon/autogluon/blob/0ee849fc6dc2c44aa0f3e086317e4d11d16955fa/timeseries/src/autogluon/timeseries/models/ensemble/greedy.py#L74 where we convert predictions dataframes into np.arrays without checking the order of the columns first.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
