### PR TITLE
[tabular] Add support for max_rows, max_features, max_classes, problem_types

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -2702,7 +2702,6 @@ class AbstractModel(ModelBase, Tunable):
             "max_classes",
         }
 
-
     @property
     def _features(self) -> List[str]:
         return self._features_internal

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -11,7 +11,7 @@ import sys
 import time
 from abc import ABC, abstractmethod
 from types import MappingProxyType
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -107,7 +107,7 @@ class Tunable(ABC):
         """
         return None
 
-    def get_minimum_resources(self, is_gpu_available: bool = False) -> Dict[str, Union[int, float]]:
+    def get_minimum_resources(self, is_gpu_available: bool = False) -> dict[str, int | float]:
         return {
             "num_cpus": 1,
         }
@@ -281,14 +281,14 @@ class AbstractModel(ModelBase, Tunable):
 
     @classmethod
     def _init_user_params(
-        cls, params: Optional[Dict[str, Any]] = None, ag_args_fit: str = AG_ARGS_FIT, ag_arg_prefix: str = AG_ARG_PREFIX
-    ) -> (Dict[str, Any], Dict[str, Any]):
+        cls, params: dict[str, Any] | None = None, ag_args_fit: str = AG_ARGS_FIT, ag_arg_prefix: str = AG_ARG_PREFIX
+    ) -> (dict[str, Any], dict[str, Any]):
         """
         Given the user-specified hyperparameters, split into `params` and `params_aux`.
 
         Parameters
         ----------
-        params : Optional[Dict[str, Any]], default = None
+        params : dict[str, Any], default = None
             The model hyperparameters dictionary
         ag_args_fit : str, default = "ag_args_fit"
             The params key to look for that contains params_aux.
@@ -309,7 +309,7 @@ class AbstractModel(ModelBase, Tunable):
 
         Returns
         -------
-        params, params_aux : (Dict[str, Any], Dict[str, Any])
+        params, params_aux : (dict[str, Any], dict[str, Any])
             params will contain the native model hyperparameters
             params_aux will contain special auxiliary hyperparameters
         """
@@ -776,8 +776,8 @@ class AbstractModel(ModelBase, Tunable):
         return user_specified_lower_level_resource
 
     def _calculate_total_resources(
-        self, silent: bool = False, total_resources: Optional[Dict[str, Union[int, float]]] = None, parallel_hpo: bool = False, **kwargs
-    ) -> Dict[str, Any]:
+        self, silent: bool = False, total_resources: dict[str, int | float] | None = None, parallel_hpo: bool = False, **kwargs
+    ) -> dict[str, Any]:
         """
         Process user-specified total resources.
         Sanity checks will be done to user-specified total resources to make sure it's legit.
@@ -909,8 +909,8 @@ class AbstractModel(ModelBase, Tunable):
         return kwargs
 
     def _preprocess_fit_resources(
-        self, silent: bool = False, total_resources: Optional[Dict[str, Union[int, float]]] = None, parallel_hpo: bool = False, **kwargs
-    ) -> Dict[str, Any]:
+        self, silent: bool = False, total_resources: dict[str, int | float] | None = None, parallel_hpo: bool = False, **kwargs
+    ) -> dict[str, Any]:
         """
         This function should be called to process user-specified total resources.
         Sanity checks will be done to user-specified total resources to make sure it's legit.
@@ -1140,7 +1140,7 @@ class AbstractModel(ModelBase, Tunable):
             self.predict_1_time = time_func(f=self.predict, args=[X_1]) / len(X_1)
         return self
 
-    def get_features(self) -> List[str]:
+    def get_features(self) -> list[str]:
         assert self.is_fit(), "The model must be fit before calling the get_features method."
         if self.feature_metadata:
             return self.feature_metadata.get_features()
@@ -1429,7 +1429,7 @@ class AbstractModel(ModelBase, Tunable):
                 model.model = model._compiler.load(path=path)
         return model
 
-    def save_learning_curves(self, metrics: str | List[str], curves: dict[dict[str : List[float]]], path: str = None) -> str:
+    def save_learning_curves(self, metrics: str | list[str], curves: dict[dict[str, list[float]]], path: str = None) -> str:
         """
         Saves learning curves to disk.
 
@@ -1501,7 +1501,7 @@ class AbstractModel(ModelBase, Tunable):
         self.saved_learning_curves = True
         return file_path
 
-    def _make_learning_curves(self, metrics: str | List[str], curves: dict[dict[str : List[float]]]) -> List[List[str], List[str], List[List[float]]]:
+    def _make_learning_curves(self, metrics: str | list[str], curves: dict[dict[str, list[float]]]) -> list[list[str], list[str], list[list[float]]]:
         """
         Parameters
         ----------
@@ -1514,7 +1514,7 @@ class AbstractModel(ModelBase, Tunable):
 
         Returns
         -------
-        List[List[str], List[str], List[List[float]]]: The generated learning curve artifact.
+        list[list[str], list[str], list[list[float]]]: The generated learning curve artifact.
             if eval set names includes: train, val, or test
             these sets will be placed first in the above order.
         """
@@ -1537,7 +1537,7 @@ class AbstractModel(ModelBase, Tunable):
         return [eval_sets, metrics, data]
 
     @classmethod
-    def load_learning_curves(cls, path: str) -> List:
+    def load_learning_curves(cls, path: str) -> list:
         """
         Loads the learning_curve data from disk to memory.
 
@@ -1550,7 +1550,7 @@ class AbstractModel(ModelBase, Tunable):
 
         Returns
         -------
-        learning_curves : List
+        learning_curves : list
             Loaded learning curve data.
         """
         if not cls._get_class_tags().get("supports_learning_curves", False):
@@ -1570,7 +1570,7 @@ class AbstractModel(ModelBase, Tunable):
         self,
         X: pd.DataFrame,
         y: pd.Series,
-        features: List[str] = None,
+        features: list[str] = None,
         silent: bool = False,
         importance_as_list: bool = False,
         **kwargs,
@@ -1636,7 +1636,7 @@ class AbstractModel(ModelBase, Tunable):
         self,
         X: pd.DataFrame,
         y: pd.Series,
-        features: List[str],
+        features: list[str],
         eval_metric: Scorer = None,
         silent: bool = False,
         **kwargs,
@@ -1738,8 +1738,8 @@ class AbstractModel(ModelBase, Tunable):
 
         Returns
         -------
-        List of (shape: Tuple[int], dtype: Any)
-        shape: Tuple[int]
+        List of (shape: tuple[int], dtype: Any)
+        shape: tuple[int]
             A tuple that describes input
         dtype: Any, default=np.float32
             The element type in numpy dtype.
@@ -1922,8 +1922,8 @@ class AbstractModel(ModelBase, Tunable):
 
         Returns
         -------
-        Tuple of (hpo_results: Dict[str, dict], hpo_info: Any)
-        hpo_results: Dict[str, dict]
+        Tuple of (hpo_results: dict[str, dict], hpo_info: Any)
+        hpo_results: dict[str, dict]
             A dictionary of trial model names to a dictionary containing:
                 path: str
                     Absolute path to the trained model artifact. Used to load the model.
@@ -2259,7 +2259,7 @@ class AbstractModel(ModelBase, Tunable):
             if resources[resource_name] > resource_value:
                 raise AssertionError(f"Specified {resources[resource_name]} {resource_name} to fit, but only {resource_value} are available in total.")
 
-    def get_minimum_resources(self, is_gpu_available: bool = False) -> Dict[str, Union[int, float]]:
+    def get_minimum_resources(self, is_gpu_available: bool = False) -> dict[str, int | float]:
         """
         Parameters
         ----------
@@ -2528,7 +2528,7 @@ class AbstractModel(ModelBase, Tunable):
         """
         self._predict_n_size = len(X)
 
-    def _get_maximum_resources(self) -> Dict[str, Union[int, float]]:
+    def _get_maximum_resources(self) -> dict[str, int | float]:
         """
         Get the maximum resources allowed to use for this model.
         This can be useful when model not scale well with resources, i.e. cpu cores.
@@ -2536,13 +2536,13 @@ class AbstractModel(ModelBase, Tunable):
 
         Return
         ------
-        Dict[str, Union[int, float]]
+        dict[str, int | float]
             key, name of the resource, i.e. `num_cpus`, `num_gpus`
             value, maximum amount of resources
         """
         return {}
 
-    def _get_default_resources(self) -> Tuple[int, int]:
+    def _get_default_resources(self) -> tuple[int, int]:
         """
         Determines the default resource usage of the model during fit.
 
@@ -2715,7 +2715,7 @@ class AbstractModel(ModelBase, Tunable):
         }
 
     @property
-    def _features(self) -> List[str]:
+    def _features(self) -> list[str]:
         return self._features_internal
 
     def _get_model_base(self):

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -1061,6 +1061,16 @@ class AbstractModel(ModelBase, Tunable):
 
     # FIXME: Simply log a message that the model is being skipped instead of logging a traceback.
     def validate_fit_args(self, X: pd.DataFrame, **kwargs):
+        """
+        Verifies if the fit arguments satisfy the model's constraints.
+        Raises an exception if constraints are not satisfied.
+
+        Checks for:
+            ag.problem_types
+            ag.max_rows
+            ag.max_features
+            ag.max_classes
+        """
         if self.is_initialized():
             ag_params = self._get_ag_params()
         else:
@@ -1074,8 +1084,8 @@ class AbstractModel(ModelBase, Tunable):
         if problem_types is not None:
             if self.problem_type not in problem_types:
                 raise AssertionError(
-                    f"Valid problem types for model '{self.name}' are {problem_types} "
-                    f"(problem_type='{self.problem_type}')"
+                    f"ag.problem_types={problem_types} for model '{self.name}', "
+                    f"but found '{self.problem_type}' problem_type."
                 )
             assert self.problem_type in problem_types
         if max_classes is not None:
@@ -2688,18 +2698,20 @@ class AbstractModel(ModelBase, Tunable):
 
         max_rows: int
             If specified, raises an AssertionError at fit time if len(X) > max_rows
-
         max_features: int
             If specified, raises an AssertionError at fit time if len(X.columns) > max_rows
-
         max_classes: int
             If specified, raises an AssertionError at fit time if self.num_classes > max_classes
+        problem_types: list[str]
+            If specified, raises an AssertionError at fit time if self.problem_type not in problem_types
+
 
         """
         return {
             "max_rows",
             "max_features",
             "max_classes",
+            "problem_types",
         }
 
     @property

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -419,6 +419,10 @@ class BaggedEnsembleModel(AbstractModel):
             else:
                 return self
 
+    def validate_fit_args(self, X: pd.DataFrame, **kwargs):
+        super().validate_fit_args(X=X, **kwargs)
+        self.model_base.validate_fit_args(X=X, **kwargs)
+
     def _update_k_fold(self, k_fold: int, k_fold_end: int = None, verbose: bool = True) -> tuple[int, int]:
         """Update k_fold and k_fold_end in case num_folds was specified"""
         k_fold_override = self.params.get("num_folds", None)

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -3,13 +3,11 @@ from __future__ import annotations
 import copy
 import inspect
 import logging
-import math
 import os
-import platform
 import time
 from collections import Counter
 from statistics import mean
-from typing import Dict, List, Type, Union
+from typing import Type
 
 import numpy as np
 import pandas as pd
@@ -20,6 +18,7 @@ from autogluon.common.utils.try_import import try_import_ray
 
 from ...constants import BINARY, MULTICLASS, QUANTILE, REFIT_FULL_SUFFIX, REGRESSION, SOFTCLASS
 from ...hpo.exceptions import EmptySearchSpace
+from ...hpo.executors import HpoExecutor
 from ...pseudolabeling.pseudolabeling import assert_pseudo_column_match
 from ...utils.exceptions import TimeLimitExceeded
 from ...utils.loaders import load_pkl
@@ -49,10 +48,10 @@ class BaggedEnsembleModel(AbstractModel):
 
     Parameters
     ----------
-    model_base : Union[AbstractModel, Type[AbstractModel]]
+    model_base : AbstractModel | Type[AbstractModel]
         The base model to repeatedly fit during bagging.
         If a AbstractModel class, then also provide model_base_kwargs which will be used to initialize the model via model_base(**model_base_kwargs).
-    model_base_kwargs : Dict[str, any], default = None
+    model_base_kwargs : dict[str, any], default = None
         kwargs used to initialize model_base if model_base is a class.
     random_state : int, default = 0
         Random state used to split the data into cross-validation folds during fit.
@@ -62,7 +61,7 @@ class BaggedEnsembleModel(AbstractModel):
 
     _oof_filename = "oof.pkl"
 
-    def __init__(self, model_base: Union[AbstractModel, Type[AbstractModel]], model_base_kwargs: Dict[str, any] = None, random_state: int = 0, **kwargs):
+    def __init__(self, model_base: AbstractModel | Type[AbstractModel], model_base_kwargs: dict[str, any] = None, random_state: int = 0, **kwargs):
         if inspect.isclass(model_base):
             if model_base_kwargs is None:
                 model_base_kwargs = dict()
@@ -122,10 +121,10 @@ class BaggedEnsembleModel(AbstractModel):
         default_auxiliary_params.update(extra_auxiliary_params)
         return default_auxiliary_params
 
-    def is_valid(self):
+    def is_valid(self) -> bool:
         return self.is_fit() and (self._n_repeats == self._n_repeats_finished)
 
-    def can_infer(self):
+    def can_infer(self) -> bool:
         return self.is_fit() and self.params.get("save_bag_folds", True)
 
     def is_stratified(self) -> bool:
@@ -178,7 +177,7 @@ class BaggedEnsembleModel(AbstractModel):
         """Returns the count of fitted children"""
         return len(self.models)
 
-    def is_valid_oof(self):
+    def is_valid_oof(self) -> bool:
         return self.is_fit() and (self._child_oof or self._bagged_mode)
 
     def predict_proba_oof(self, **kwargs) -> np.array:
@@ -201,7 +200,7 @@ class BaggedEnsembleModel(AbstractModel):
         self.normalize_pred_probas = child.normalize_pred_probas
         self._params_aux_child = child.params_aux
 
-    def preprocess(self, X, preprocess_nonadaptive=True, model=None, **kwargs):
+    def preprocess(self, X: pd.DataFrame, preprocess_nonadaptive: bool = True, model: AbstractModel = None, **kwargs):
         if preprocess_nonadaptive:
             if model is None:
                 if not self.models:
@@ -421,7 +420,8 @@ class BaggedEnsembleModel(AbstractModel):
 
     def validate_fit_args(self, X: pd.DataFrame, **kwargs):
         super().validate_fit_args(X=X, **kwargs)
-        self.model_base.validate_fit_args(X=X, **kwargs)
+        model_base = self._get_model_base()
+        model_base.validate_fit_args(X=X, **kwargs)
 
     def _update_k_fold(self, k_fold: int, k_fold_end: int = None, verbose: bool = True) -> tuple[int, int]:
         """Update k_fold and k_fold_end in case num_folds was specified"""
@@ -497,15 +497,14 @@ class BaggedEnsembleModel(AbstractModel):
                 f"Instead, specify `use_child_oof=True` if the model supports this option."
             )
 
-
     def predict_proba_children(
         self,
         X: pd.DataFrame,
-        children_idx: List[int] = None,
+        children_idx: list[int] = None,
         normalize=None,
         preprocess_nonadaptive: bool = True,
         **kwargs,
-    ) -> List[np.ndarray]:
+    ) -> list[np.ndarray]:
         """
         Returns the prediction probabilities for each child model
 
@@ -513,7 +512,7 @@ class BaggedEnsembleModel(AbstractModel):
         ----------
         X : pd.DataFrame
             The input data to predict on
-        children_idx : List[int], default = None
+        children_idx : list[int], default = None
             The list of child indices to get results from, based on position in `self.models`.
             The returned list will be in the order specified in `children_idx`.
             If None, will predict with all children in `self.models` order.
@@ -545,11 +544,11 @@ class BaggedEnsembleModel(AbstractModel):
     def predict_children(
         self,
         X: pd.DataFrame,
-        children_idx: List[int] = None,
+        children_idx: list[int] = None,
         normalize=None,
         preprocess_nonadaptive: bool = True,
         **kwargs,
-    ) -> List[np.ndarray]:
+    ) -> list[np.ndarray]:
         """
         Returns the predictions for each child model
 
@@ -557,7 +556,7 @@ class BaggedEnsembleModel(AbstractModel):
         ----------
         X : pd.DataFrame
             The input data to predict on
-        children_idx : List[int], default = None
+        children_idx : list[int], default = None
             The list of child indices to get results from, based on position in `self.models`.
             The returned list will be in the order specified in `children_idx`.
             If None, will predict with all children in `self.models` order.
@@ -608,7 +607,18 @@ class BaggedEnsembleModel(AbstractModel):
             sample_weight = sample_weight[valid_indices]
         return self.score_with_y_pred_proba(y=y, y_pred_proba=y_pred_proba, sample_weight=sample_weight)
 
-    def _fit_single(self, X, y, model_base, use_child_oof, time_limit=None, skip_oof=False, X_pseudo=None, y_pseudo=None, **kwargs):
+    def _fit_single(
+        self,
+        X: pd.DataFrame,
+        y: pd.Series,
+        model_base: AbstractModel,
+        use_child_oof: bool,
+        time_limit: float = None,
+        skip_oof: bool = False,
+        X_pseudo: pd.DataFrame = None,
+        y_pseudo: pd.Series = None,
+        **kwargs,
+    ):
         if self.is_fit():
             raise AssertionError("Model is already fit.")
         if self._n_repeats != 0:
@@ -748,22 +758,22 @@ class BaggedEnsembleModel(AbstractModel):
 
     def _fit_folds(
         self,
-        X,
-        y,
-        model_base,
-        X_pseudo=None,
-        y_pseudo=None,
-        k_fold=None,
-        k_fold_start=0,
-        k_fold_end=None,
-        n_repeats=1,
-        n_repeat_start=0,
-        time_limit=None,
+        X: pd.DataFrame,
+        y: pd.Series,
+        model_base: AbstractModel,
+        X_pseudo: pd.DataFrame = None,
+        y_pseudo: pd.Series = None,
+        k_fold: int = None,
+        k_fold_start: int = 0,
+        k_fold_end: int = None,
+        n_repeats: int = 1,
+        n_repeat_start: int = 0,
+        time_limit: float = None,
         sample_weight=None,
-        save_folds=True,
+        save_folds: bool = True,
         groups=None,
-        num_cpus=None,
-        num_gpus=None,
+        num_cpus: int = None,
+        num_gpus: float = None,
         **kwargs,
     ):
         fold_fitting_strategy_cls = self._get_fold_fitting_strategy(model_base=model_base, num_gpus=num_gpus)
@@ -878,7 +888,16 @@ class BaggedEnsembleModel(AbstractModel):
             self._n_repeats_finished = self._n_repeats - 1
 
     @staticmethod
-    def _generate_fold_configs(*, X, y, cv_splitter, k_fold_start, k_fold_end, n_repeat_start, n_repeat_end) -> (list, int, int):
+    def _generate_fold_configs(
+        *,
+        X: pd.DataFrame,
+        y: pd.Series,
+        cv_splitter: CVSplitter,
+        k_fold_start: int,
+        k_fold_end: int,
+        n_repeat_start: int,
+        n_repeat_end: int,
+    ) -> (list, int, int):
         """
         Generates fold configs given a cv_splitter, k_fold start-end and n_repeat start-end.
         Fold configs are used by inheritors of FoldFittingStrategy when fitting fold models.
@@ -949,7 +968,7 @@ class BaggedEnsembleModel(AbstractModel):
         self,
         X: pd.DataFrame,
         y: pd.Series,
-        features: List[str] = None,
+        features: list[str] = None,
         silent: bool = False,
         time_limit: float = None,
         is_oof: bool = False,
@@ -964,7 +983,7 @@ class BaggedEnsembleModel(AbstractModel):
             The data to use for calculating feature importance.
         y: pd.Series
             The ground truth to use for calculating feature importance.
-        features: List[str], default = None,
+        features: list[str], default = None,
             The list of features to compute feature importances for.
             If None, all features are computed.
         silent: bool, default = False
@@ -1060,24 +1079,24 @@ class BaggedEnsembleModel(AbstractModel):
 
         return fi_df
 
-    def get_features(self):
+    def get_features(self) -> list[str]:
         assert self.is_fit(), "The model must be fit before calling the get_features method."
         return self.load_child(self.models[0]).get_features()
 
-    def load_child(self, model: Union[AbstractModel, str], verbose=False) -> AbstractModel:
+    def load_child(self, model: AbstractModel | str, verbose: bool = False) -> AbstractModel:
         if isinstance(model, str):
             child_path = self.create_contexts(os.path.join(self.path, model))
             return self._child_type.load(path=child_path, verbose=verbose)
         else:
             return model
 
-    def add_child(self, model: Union[AbstractModel, str], add_child_times=False, add_child_resources=False):
+    def add_child(self, model: AbstractModel | str, add_child_times: bool = False, add_child_resources: bool = False):
         """
         Add a new fit child model to `self.models`
 
         Parameters
         ----------
-        model : Union[AbstractModel, str]
+        model : AbstractModel | str
             The child model to add. If str, it is the name of the model.
         add_child_times : bool, default = False
             Whether to add child metadata on times to the bag times.
@@ -1106,7 +1125,7 @@ class BaggedEnsembleModel(AbstractModel):
             self._add_child_num_cpus(num_cpus=model.fit_num_cpus)
             self._add_child_num_gpus(num_gpus=model.fit_num_gpus)
 
-    def save_child(self, model: Union[AbstractModel, str], path=None, verbose=False):
+    def save_child(self, model: AbstractModel | str, path: str | None = None, verbose: bool = False):
         """Save child model to disk."""
         if path is None:
             path = self.path
@@ -1133,7 +1152,7 @@ class BaggedEnsembleModel(AbstractModel):
         return self.load_child(self.models[0]).get_compiler_name()
 
     # TODO: Multiply epochs/n_iterations by some value (such as 1.1) to account for having more training data than bagged models
-    def convert_to_refit_full_template(self, name_suffix=REFIT_FULL_SUFFIX) -> AbstractModel:
+    def convert_to_refit_full_template(self, name_suffix: str = REFIT_FULL_SUFFIX) -> AbstractModel:
         """
         After calling this function, returned model should be able to be fit without X_val, y_val using the iterations trained by the original model.
 
@@ -1187,7 +1206,7 @@ class BaggedEnsembleModel(AbstractModel):
         model_full._set_n_repeat_single()
         return model_full
 
-    def get_params(self):
+    def get_params(self) -> dict:
         init_args = dict(
             model_base=self._get_model_base(),
             random_state=self._random_state,
@@ -1251,13 +1270,13 @@ class BaggedEnsembleModel(AbstractModel):
         model_params_list = [self.load_child(child).params_trained for child in self.models]
         return self._get_compressed_params(model_params_list=model_params_list)
 
-    def _get_model_base(self):
+    def _get_model_base(self) -> AbstractModel:
         if self.model_base is None:
             return self.load_model_base()
         else:
             return self.model_base
 
-    def _add_child_times_to_bag(self, model):
+    def _add_child_times_to_bag(self, model: AbstractModel):
         self._add_parallel_child_times(fit_time=model.fit_time, predict_time=model.predict_time, predict_1_time=model.predict_1_time)
         assert model.predict_n_size is not None
         self._add_predict_n_size(predict_n_size_lst=[model.predict_n_size])
@@ -1278,7 +1297,7 @@ class BaggedEnsembleModel(AbstractModel):
         else:
             self.predict_1_time += predict_1_time
 
-    def _add_predict_n_size(self, predict_n_size_lst: List[float]):
+    def _add_predict_n_size(self, predict_n_size_lst: list[float]):
         if self._predict_n_size_lst is None:
             self._predict_n_size_lst = []
         self._predict_n_size_lst += predict_n_size_lst
@@ -1318,7 +1337,7 @@ class BaggedEnsembleModel(AbstractModel):
         return np.ceil(np.mean(self._predict_n_size_lst))
 
     @classmethod
-    def load(cls, path: str, reset_paths=True, low_memory=True, load_oof=False, verbose=True):
+    def load(cls, path: str, reset_paths: bool = True, low_memory: bool = True, load_oof: bool = False, verbose: bool = True):
         model = super().load(path=path, reset_paths=reset_paths, verbose=verbose)
         if not low_memory:
             model.persist_child_models(reset_paths=reset_paths)
@@ -1327,7 +1346,7 @@ class BaggedEnsembleModel(AbstractModel):
         return model
 
     @classmethod
-    def load_oof(cls, path, verbose=True):
+    def load_oof(cls, path: str, verbose: bool = True) -> np.array:
         try:
             oof = load_pkl.load(path=os.path.join(path, "utils", cls._oof_filename), verbose=verbose)
             oof_pred_proba = oof["_oof_pred_proba"]
@@ -1347,7 +1366,7 @@ class BaggedEnsembleModel(AbstractModel):
             self._oof_pred_proba = oof["_oof_pred_proba"]
             self._oof_pred_model_repeats = oof["_oof_pred_model_repeats"]
 
-    def persist_child_models(self, reset_paths=True):
+    def persist_child_models(self, reset_paths: bool = True):
         for i, model_name in enumerate(self.models):
             if isinstance(model_name, str):
                 child_path = self.create_contexts(os.path.join(self.path, model_name))
@@ -1357,22 +1376,22 @@ class BaggedEnsembleModel(AbstractModel):
     def unpersist_child_models(self):
         self.models = self._get_child_model_names(models=self.models)
 
-    def _get_child_model_names(self, models: list) -> list:
+    def _get_child_model_names(self, models: list[str | AbstractModel]) -> list[str]:
         model_names = []
-        for i, model in enumerate(models):
+        for model in models:
             if isinstance(model, str):
                 model_names.append(model)
             else:
                 model_names.append(model.name)
         return model_names
 
-    def load_model_base(self):
+    def load_model_base(self) -> AbstractModel:
         return load_pkl.load(path=os.path.join(self.path, "utils", "model_template.pkl"))
 
-    def save_model_base(self, model_base):
+    def save_model_base(self, model_base: AbstractModel):
         save_pkl.save(path=os.path.join(self.path, "utils", "model_template.pkl"), object=model_base)
 
-    def save(self, path=None, verbose=True, save_oof=True, save_children=False) -> str:
+    def save(self, path: str = None, verbose: bool = True, save_oof: bool = True, save_children: bool = False) -> str:
         if path is None:
             path = self.path
 
@@ -1427,14 +1446,8 @@ class BaggedEnsembleModel(AbstractModel):
                 if requires_save and self.low_memory:
                     self.save_child(model=model)
 
-    def _model_names(self):
-        model_names = []
-        for model in self.models:
-            if isinstance(model, str):
-                model_names.append(model)
-            else:
-                model_names.append(model.name)
-        return model_names
+    def _model_names(self) -> list[str]:
+        return self._get_child_model_names(models=self.models)
 
     def get_info(self, include_feature_metadata: bool = True):
         info = super().get_info(include_feature_metadata=include_feature_metadata)
@@ -1499,7 +1512,7 @@ class BaggedEnsembleModel(AbstractModel):
     def validate_fit_resources(self, **kwargs):
         self._get_model_base().validate_fit_resources(**kwargs)
 
-    def get_minimum_resources(self, **kwargs) -> Dict[str, int]:
+    def get_minimum_resources(self, **kwargs) -> dict[str, int]:
         return self._get_model_base().get_minimum_resources(**kwargs)
 
     def _get_default_resources(self):
@@ -1509,7 +1522,7 @@ class BaggedEnsembleModel(AbstractModel):
         # memory is checked downstream on the child model
         pass
 
-    def _get_child_info(self, include_feature_metadata: bool = True):
+    def _get_child_info(self, include_feature_metadata: bool = True) -> dict:
         child_info_dict = dict()
         for model in self.models:
             if isinstance(model, str):
@@ -1521,7 +1534,7 @@ class BaggedEnsembleModel(AbstractModel):
                 child_info_dict[model.name] = model.get_info(include_feature_metadata=include_feature_metadata)
         return child_info_dict
 
-    def _construct_empty_oof(self, X, y):
+    def _construct_empty_oof(self, X: pd.DataFrame, y: pd.Series) -> tuple[np.array, np.array]:
         if self.problem_type == MULTICLASS:
             oof_pred_proba = np.zeros(shape=(len(X), len(y.unique())), dtype=np.float64)
         elif self.problem_type == SOFTCLASS:
@@ -1533,7 +1546,17 @@ class BaggedEnsembleModel(AbstractModel):
         oof_pred_model_repeats = np.zeros(shape=len(X), dtype=np.uint8)
         return oof_pred_proba, oof_pred_model_repeats
 
-    def _hyperparameter_tune(self, X, y, X_val, y_val, hpo_executor, k_fold=None, k_fold_end=None, **kwargs):
+    def _hyperparameter_tune(
+        self,
+        X: pd.DataFrame,
+        y: pd.Series,
+        X_val: pd.DataFrame,
+        y_val: pd.Series,
+        hpo_executor: HpoExecutor,
+        k_fold: int = None,
+        k_fold_end: int = None,
+        **kwargs,
+    ):
         time_start = time.time()
         logger.log(15, "Starting generic AbstractModel hyperparameter tuning for %s model..." % self.name)
         k_fold, k_fold_end = self._update_k_fold(k_fold=k_fold, k_fold_end=k_fold_end)
@@ -1623,12 +1646,12 @@ class BaggedEnsembleModel(AbstractModel):
 
         return hpo_results
 
-    def _more_tags(self):
+    def _more_tags(self) -> dict:
         return {
             "valid_oof": True,
             "can_refit_full": True,
         }
 
-    def _get_tags_child(self):
+    def _get_tags_child(self) -> dict:
         """Gets the tags of the child model."""
         return self._get_model_base()._get_tags()

--- a/tabular/tests/unittests/models/test_dummy.py
+++ b/tabular/tests/unittests/models/test_dummy.py
@@ -91,7 +91,7 @@ def test_raise_on_model_failure():
 
 
 def test_raise_on_fit_args():
-    """Tests that ag.max_rows, ag.max_features, ag.max_classes work"""
+    """Tests that ag.max_rows, ag.max_features, ag.max_classes, ag.problem_types work"""
 
     dataset_name = "toy_binary"
     train_data, test_data, dataset_info = FitHelper.load_dataset(name=dataset_name)
@@ -154,6 +154,22 @@ def test_raise_on_fit_args():
     )
 
     # This works because self.num_classes = 2
+    FitHelper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
+
+    fit_args = dict(
+        hyperparameters={DummyModel: [{"ag.problem_types": ["abc", "multiclass", "regression"]}]},
+        raise_on_model_failure=True,
+    )
+
+    with pytest.raises(AssertionError, match=r"ag.problem_types=\['abc', 'multiclass', 'regression'\]"):
+        FitHelper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
+
+    fit_args = dict(
+        hyperparameters={DummyModel: [{"ag.problem_types": ["binary", "def"]}]},
+        raise_on_model_failure=True,
+    )
+
+    # This works because self.problem_type = "binary"
     FitHelper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
 
 

--- a/tabular/tests/unittests/models/test_dummy.py
+++ b/tabular/tests/unittests/models/test_dummy.py
@@ -90,6 +90,73 @@ def test_raise_on_model_failure():
     assert str(excinfo.value) == "Test Error Message"
 
 
+def test_raise_on_fit_args():
+    """Tests that ag.max_rows, ag.max_features, ag.max_classes work"""
+
+    dataset_name = "toy_binary"
+    train_data, test_data, dataset_info = FitHelper.load_dataset(name=dataset_name)
+
+    fit_args = dict(
+        hyperparameters={DummyModel: [{"ag.max_rows": 1}]},
+        raise_on_model_failure=True,
+    )
+
+    with pytest.raises(AssertionError, match=r'ag.max_rows=1'):
+        FitHelper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
+
+    assert len(train_data) == 4
+
+    fit_args = dict(
+        hyperparameters={DummyModel: [{"ag.max_rows": 3}]},
+        raise_on_model_failure=True,
+    )
+
+    # This works because len(X) = 3 and len(X_val) = 1
+    FitHelper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
+
+    # Check that bagging uses the full data for checking max rows
+    fit_args = dict(
+        hyperparameters={DummyModel: [{"ag.max_rows": 3}]},
+        raise_on_model_failure=True,
+        num_bag_folds=4,
+    )
+
+    with pytest.raises(AssertionError, match=r'ag.max_rows=3'):
+        FitHelper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
+
+    fit_args = dict(
+        hyperparameters={DummyModel: [{"ag.max_features": 0}]},
+        raise_on_model_failure=True,
+    )
+
+    with pytest.raises(AssertionError, match=r'ag.max_features=0'):
+        FitHelper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
+
+    fit_args = dict(
+        hyperparameters={DummyModel: [{"ag.max_features": 1}]},
+        raise_on_model_failure=True,
+    )
+
+    # This works because len(X.columns) == 1
+    FitHelper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
+
+    fit_args = dict(
+        hyperparameters={DummyModel: [{"ag.max_classes": 1}]},
+        raise_on_model_failure=True,
+    )
+
+    with pytest.raises(AssertionError, match=r'ag.max_classes=1'):
+        FitHelper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
+
+    fit_args = dict(
+        hyperparameters={DummyModel: [{"ag.max_classes": 2}]},
+        raise_on_model_failure=True,
+    )
+
+    # This works because self.num_classes = 2
+    FitHelper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
+
+
 def test_dummy():
     model_cls = DummyModel
     model_hyperparameters = {}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

-  Add support for max_rows, max_features, max_classes, problem_types
- This is useful for foundation models which focus on small data and don't work effectively on large data, so that we can dynamically disable these methods based on the data properties.

For example:

```python
from autogluon.tabular import TabularPredictor

hyperparameters = {
    "CAT": [{"ag.max_rows": 1000}],  # will raise an AssertionError if train data > 1000 samples
}

predictor = TabularPredictor(...).fit(..., hyperparameters=hyperparameters)
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
