### PR TITLE
[docs] Show tabular model aliases in the documentation

### DIFF
--- a/docs/api/autogluon.tabular.models.rst
+++ b/docs/api/autogluon.tabular.models.rst
@@ -1,6 +1,3 @@
-.. role:: hidden
-    :class: hidden-section
-
 autogluon.tabular.models
 ========================
 

--- a/docs/api/autogluon.tabular.models.rst
+++ b/docs/api/autogluon.tabular.models.rst
@@ -1,3 +1,6 @@
+.. role:: hidden
+    :class: hidden-section
+
 autogluon.tabular.models
 ========================
 
@@ -17,6 +20,7 @@ To fit a model with TabularPredictor, you must specify it in the `TabularPredict
 For example:
 
 .. code-block:: python
+
     hyperparameters = {
         'NN_TORCH': {},
         'GBM': [
@@ -41,40 +45,40 @@ For example:
 Here is the mapping of keys to models:
 
 .. code-block:: python
-    MODEL_TYPES = dict(
-        RF=RFModel,
-        XT=XTModel,
-        KNN=KNNModel,
-        GBM=LGBModel,
-        CAT=CatBoostModel,
-        XGB=XGBoostModel,
-        NN_TORCH=TabularNeuralNetTorchModel,
-        LR=LinearModel,
-        FASTAI=NNFastAiTabularModel,
-        AG_TEXT_NN=TextPredictorModel,
-        AG_IMAGE_NN=ImagePredictorModel,
-        AG_AUTOMM=MultiModalPredictorModel,
 
-        FT_TRANSFORMER=FTTransformerModel,
-        TABPFN=TabPFNModel,
-
-        FASTTEXT=FastTextModel,
-        ENS_WEIGHTED=GreedyWeightedEnsembleModel,
-        SIMPLE_ENS_WEIGHTED=SimpleWeightedEnsembleModel,
+    MODEL_TYPES = {
+        "RF": RFModel,
+        "XT": XTModel,
+        "KNN": KNNModel,
+        "GBM": LGBModel,
+        "CAT": CatBoostModel,
+        "XGB": XGBoostModel,
+        "NN_TORCH": TabularNeuralNetTorchModel,
+        "LR": LinearModel,
+        "FASTAI": NNFastAiTabularModel,
+        "AG_TEXT_NN": TextPredictorModel,
+        "AG_IMAGE_NN": ImagePredictorModel,
+        "AG_AUTOMM": MultiModalPredictorModel,
+        "FT_TRANSFORMER": FTTransformerModel,
+        "TABPFN": TabPFNModel,
+        "FASTTEXT": FastTextModel,
+        "ENS_WEIGHTED": GreedyWeightedEnsembleModel,
+        "SIMPLE_ENS_WEIGHTED": SimpleWeightedEnsembleModel,
 
         # interpretable models
-        IM_RULEFIT=RuleFitModel,
-        IM_GREEDYTREE=GreedyTreeModel,
-        IM_FIGS=FigsModel,
-        IM_HSTREE=HSTreeModel,
-        IM_BOOSTEDRULES=BoostedRulesModel,
+        "IM_RULEFIT": RuleFitModel,
+        "IM_GREEDYTREE": GreedyTreeModel,
+        "IM_FIGS": FigsModel,
+        "IM_HSTREE": HSTreeModel,
+        "IM_BOOSTEDRULES": BoostedRulesModel,
 
-        DUMMY=DummyModel,
-    )
+        "DUMMY": DummyModel,
+    }
 
 Here is the mapping of model types to their default names when trained:
 
 .. code-block:: python
+
     DEFAULT_MODEL_NAMES = {
         RFModel: 'RandomForest',
         XTModel: 'ExtraTrees',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Currently, the model aliases and names are not displayed in the [documentation](https://auto.gluon.ai/dev/api/autogluon.tabular.models.html#lgbmodel):
<img width="1317" alt="image" src="https://github.com/user-attachments/assets/995baa90-243f-4482-80de-7ea40e3c589c" />

With this PR:
<img width="844" alt="image" src="https://github.com/user-attachments/assets/7e75d22f-fa96-4006-a334-c17dda46bd24" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
