### PR TITLE
[timeseries] Update hyperparameter handling in MLForecast models

### DIFF
--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -33,7 +33,7 @@ install_requires = [
     "gluonts>=0.15.0,<0.17",
     "networkx",  # version range defined in `core/_setup_utils.py`
     "statsforecast>=1.7.0,<2.0.2",
-    "mlforecast==1.0.2",
+    "mlforecast>=1.0.0,<1.0.3",
     "utilsforecast>=0.2.3,<0.2.12",  # to prevent breaking changes that propagate through mlforecast's dependency
     "coreforecast>=0.0.12,<0.0.17",  # to prevent breaking changes that propagate through mlforecast's dependency
     "fugue>=0.9.0",  # prevent dependency clash with omegaconf

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -33,7 +33,7 @@ install_requires = [
     "gluonts>=0.15.0,<0.17",
     "networkx",  # version range defined in `core/_setup_utils.py`
     "statsforecast>=1.7.0,<2.0.2",
-    "mlforecast>=1.0.0,<1.0.3",
+    "mlforecast>=0.14.0,<0.15.0",  # cannot upgrade since v0.15.0 introduced a breaking change to DirectTabular
     "utilsforecast>=0.2.3,<0.2.12",  # to prevent breaking changes that propagate through mlforecast's dependency
     "coreforecast>=0.0.12,<0.0.17",  # to prevent breaking changes that propagate through mlforecast's dependency
     "fugue>=0.9.0",  # prevent dependency clash with omegaconf

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -33,9 +33,9 @@ install_requires = [
     "gluonts>=0.15.0,<0.17",
     "networkx",  # version range defined in `core/_setup_utils.py`
     "statsforecast>=1.7.0,<2.0.2",
-    "mlforecast>0.13,<0.14",
-    "utilsforecast>=0.2.3,<0.2.11",  # to prevent breaking changes that propagate through mlforecast's dependency
-    "coreforecast>=0.0.12,<0.0.16",  # to prevent breaking changes that propagate through mlforecast's dependency
+    "mlforecast==1.0.2",
+    "utilsforecast>=0.2.3,<0.2.12",  # to prevent breaking changes that propagate through mlforecast's dependency
+    "coreforecast>=0.0.12,<0.0.17",  # to prevent breaking changes that propagate through mlforecast's dependency
     "fugue>=0.9.0",  # prevent dependency clash with omegaconf
     "tqdm",  # version range defined in `core/_setup_utils.py`
     "orjson~=3.9",  # use faster JSON implementation in GluonTS

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -546,6 +546,19 @@ class AbstractTimeSeriesModel(TimeSeriesModelBase, TimeSeriesTunable, ABC):
                 "as hyperparameters when initializing or use `hyperparameter_tune` instead."
             )
 
+    def _log_unused_hyperparameters(self, extra_allowed_hyperparameters: list[str] | None = None) -> None:
+        """Log a warning if unused hyperparameters were provided to the model."""
+        allowed_hyperparameters = self.allowed_hyperparameters
+        if extra_allowed_hyperparameters is not None:
+            allowed_hyperparameters = allowed_hyperparameters + extra_allowed_hyperparameters
+
+        unused_hyperparameters = [key for key in self.get_hyperparameters() if key not in allowed_hyperparameters]
+        if len(unused_hyperparameters) > 0:
+            logger.warning(
+                f"{self.name} ignores following hyperparameters: {unused_hyperparameters}. "
+                f"See the documentation for {self.name} for the list of supported hyperparameters."
+            )
+
     def predict(
         self,
         data: TimeSeriesDataFrame,

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -357,6 +357,7 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
             time_limit=(None if time_limit is None else time_limit - (time.time() - fit_start_time)),
         )
 
+        # We directly insert the trained model into models_ since calling _mlf.fit_models does not support X_val, y_val
         self._mlf.models_ = {"mean": tabular_model}
 
         self._save_residuals_std(val_df)

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -53,36 +53,6 @@ class TabularEstimator(BaseEstimator):
             return params
 
 
-# class TabularEstimator(BaseEstimator):
-#     """Scikit-learn compatible interface for TabularPredictor."""
-
-#     def __init__(
-#         self,
-#         predictor_init_kwargs: Optional[Dict[str, Any]] = None,
-#         predictor_fit_kwargs: Optional[Dict[str, Any]] = None,
-#     ):
-#         self.predictor_init_kwargs = predictor_init_kwargs if predictor_init_kwargs is not None else {}
-#         self.predictor_fit_kwargs = predictor_fit_kwargs if predictor_fit_kwargs is not None else {}
-
-#     def get_params(self, deep: bool = True) -> Dict[str, Any]:
-#         return {
-#             "predictor_init_kwargs": self.predictor_init_kwargs,
-#             "predictor_fit_kwargs": self.predictor_fit_kwargs,
-#         }
-
-#     def fit(self, X: pd.DataFrame, y: pd.Series) -> Self:
-#         assert isinstance(X, pd.DataFrame) and isinstance(y, pd.Series)
-#         df = pd.concat([X, y.rename(MLF_TARGET).to_frame()], axis=1)
-#         self.predictor = TabularPredictor(**self.predictor_init_kwargs)
-#         with warning_filter():
-#             self.predictor.fit(df, **self.predictor_fit_kwargs)
-#         return self
-
-#     def predict(self, X: pd.DataFrame) -> np.ndarray:
-#         assert isinstance(X, pd.DataFrame)
-#         return self.predictor.predict(X).values  # type: ignore
-
-
 class AbstractMLForecastModel(AbstractTimeSeriesModel):
     _supports_known_covariates = True
     _supports_static_features = True

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -302,7 +302,7 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
         from mlforecast import MLForecast
 
         self._check_fit_params()
-        self._check_unused_hyperparameters()
+        self._log_unused_hyperparameters()
         fit_start_time = time.time()
         self._train_target_median = train_data[self.target].median()
         for col in self.covariate_metadata.known_covariates_real:

--- a/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
+++ b/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
@@ -109,23 +109,12 @@ class AbstractLocalModel(AbstractTimeSeriesModel):
         if time_limit is not None and time_limit < self.init_time_in_seconds:
             raise TimeLimitExceeded
 
-        unused_local_model_args = []
         local_model_args = {}
-        # TODO: Move filtering logic to AbstractTimeSeriesModel
         for key, value in self.get_hyperparameters().items():
             if key in self.allowed_local_model_args:
                 local_model_args[key] = value
-            elif key in self.allowed_hyperparameters:
-                # Quietly ignore params in self.allowed_hyperparameters - they are used by AbstractTimeSeriesModel
-                pass
-            else:
-                unused_local_model_args.append(key)
 
-        if len(unused_local_model_args):
-            logger.warning(
-                f"{self.name} ignores following hyperparameters: {unused_local_model_args}. "
-                f"See the docstring of {self.name} for the list of supported hyperparameters."
-            )
+        self._log_unused_hyperparameters(extra_allowed_hyperparameters=self.allowed_local_model_args)
 
         if "seasonal_period" not in local_model_args or local_model_args["seasonal_period"] is None:
             local_model_args["seasonal_period"] = get_seasonality(self.freq)

--- a/timeseries/src/autogluon/timeseries/regressor.py
+++ b/timeseries/src/autogluon/timeseries/regressor.py
@@ -41,8 +41,8 @@ class GlobalCovariateRegressor(CovariateRegressor):
     Parameters
     ----------
     model_name : str
-        Name of the tabular regression model. See `autogluon.tabular.trainer.model_presets.presets.MODEL_TYPES` for the
-        list of available models.
+        Name of the tabular regression model. See `autogluon.tabular.registry.ag_model_registry` for the list of
+        available tabular models.
     model_hyperparameters : dict or None
         Hyperparameters passed to the tabular regression model.
     eval_metric : str

--- a/timeseries/src/autogluon/timeseries/regressor.py
+++ b/timeseries/src/autogluon/timeseries/regressor.py
@@ -41,8 +41,9 @@ class GlobalCovariateRegressor(CovariateRegressor):
     Parameters
     ----------
     model_name : str
-        Name of the tabular regression model. See `autogluon.tabular.registry.ag_model_registry` for the list of
-        available tabular models.
+        Name of the tabular regression model. See `autogluon.tabular.registry.ag_model_registry` or
+        `the documentation <https://auto.gluon.ai/stable/api/autogluon.tabular.models.html>`_ for the list of available
+        tabular models.
     model_hyperparameters : dict or None
         Hyperparameters passed to the tabular regression model.
     eval_metric : str

--- a/timeseries/tests/unittests/models/common.py
+++ b/timeseries/tests/unittests/models/common.py
@@ -96,7 +96,7 @@ DEFAULT_HYPERPARAMETERS: Dict[Type[AbstractTimeSeriesModel], Dict] = {
     # in case of an overlap
     AbstractLocalModel: {"n_jobs": 1, "use_fallback_model": False},
     AbstractGluonTSModel: {"max_epochs": 1, "num_batches_per_epoch": 1},
-    AbstractMLForecastModel: {"tabular_hyperparameters": {"DUMMY": {}}},
+    AbstractMLForecastModel: {"model_name": "DUMMY"},
     AutoARIMAModel: {
         "max_p": 2,
         "max_P": 1,

--- a/timeseries/tests/unittests/models/test_mlforecast.py
+++ b/timeseries/tests/unittests/models/test_mlforecast.py
@@ -7,6 +7,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
+import autogluon.core.utils.exceptions
+from autogluon.tabular.models import LinearModel
 from autogluon.timeseries import TimeSeriesDataFrame
 from autogluon.timeseries.models.autogluon_tabular.mlforecast import DirectTabularModel, RecursiveTabularModel
 from autogluon.timeseries.transforms.target_scaler import LocalMinMaxScaler, LocalStandardScaler
@@ -165,8 +167,8 @@ def test_given_long_time_series_passed_to_model_then_preprocess_receives_shorten
     with mock.patch("mlforecast.MLForecast.preprocess") as mock_preprocess:
         try:
             model.fit(train_data=data)
-        # using mock leads to AssertionError
-        except AssertionError:
+        # using mock leads to NoValidFeatures exception
+        except autogluon.core.utils.exceptions.NoValidFeatures:
             pass
         received_mlforecast_df = mock_preprocess.call_args[0][0]
         assert len(received_mlforecast_df) == max_num_samples + prediction_length + sum(differences)
@@ -345,3 +347,48 @@ def test_when_deprecated_scaler_hyperparameter_is_provided_then_correct_scaler_i
         assert model._scaler is None
     else:
         assert isinstance(model._scaler.ag_scaler, expected_ag_scaler_type)
+
+
+# TODO: Remove in v1.5 after 'tabular_hyperparameters' is removed
+@pytest.mark.parametrize(
+    "hparams_with_deprecated, model_name, model_hyperparameters",
+    [
+        ({"tabular_hyperparameters": {"CAT": {"iterations": 2}}}, "CAT", {"iterations": 2}),
+        ({"tabular_hyperparameters": {"DUMMY": {}}}, "DUMMY", {}),
+    ],
+)
+def test_when_deprecated_tabular_hyperparameters_are_provided_then_model_can_predict(
+    mlforecast_model_class, hparams_with_deprecated, model_name, model_hyperparameters
+):
+    data = DUMMY_TS_DATAFRAME.copy()
+    model = mlforecast_model_class(
+        freq=data.freq,
+        prediction_length=2,
+        hyperparameters=hparams_with_deprecated,
+    )
+    model.fit(train_data=data, time_limit=3)
+    tabular_model = model.get_tabular_model()
+    assert tabular_model.ag_key == model_name
+    assert tabular_model._user_params == model_hyperparameters
+    predictions = model.predict(data)
+    assert isinstance(predictions, TimeSeriesDataFrame)
+
+
+@pytest.mark.parametrize(
+    "invalid_hparams_with_deprecated",
+    [
+        {"tabular_hyperparameters": {"CAT": {"iterations": 2}, "DUMMY": {}}},
+        {"tabular_hyperparameters": {}},
+    ],
+)
+def test_when_invalid_deprecated_tabular_hyperparameters_are_provided_then_exception_is_raised(
+    mlforecast_model_class, invalid_hparams_with_deprecated
+):
+    data = DUMMY_TS_DATAFRAME.copy()
+    model = mlforecast_model_class(
+        freq=data.freq,
+        prediction_length=2,
+        hyperparameters=invalid_hparams_with_deprecated,
+    )
+    with pytest.raises(ValueError, match="cannot be automatically converted"):
+        model.fit(train_data=data)

--- a/timeseries/tests/unittests/models/test_mlforecast.py
+++ b/timeseries/tests/unittests/models/test_mlforecast.py
@@ -337,7 +337,7 @@ def test_when_deprecated_scaler_hyperparameter_is_provided_then_correct_scaler_i
     data = DUMMY_TS_DATAFRAME.copy().sort_index()
     model = mlforecast_model_class(
         freq=data.freq,
-        hyperparameters={"scaler": scaler_hp, "tabular_hyperparameters": {"DUMMY": {}}},
+        hyperparameters={"scaler": scaler_hp, "model_name": "DUMMY"},
     )
     model.fit(train_data=data)
     assert model.target_scaler is None

--- a/timeseries/tests/unittests/models/test_mlforecast.py
+++ b/timeseries/tests/unittests/models/test_mlforecast.py
@@ -8,7 +8,6 @@ import pandas as pd
 import pytest
 
 import autogluon.core.utils.exceptions
-from autogluon.tabular.models import LinearModel
 from autogluon.timeseries import TimeSeriesDataFrame
 from autogluon.timeseries.models.autogluon_tabular.mlforecast import DirectTabularModel, RecursiveTabularModel
 from autogluon.timeseries.transforms.target_scaler import LocalMinMaxScaler, LocalStandardScaler

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -1131,7 +1131,7 @@ def test_given_time_limit_is_not_none_then_time_is_distributed_across_windows_fo
             predictor.fit(
                 data,
                 time_limit=time_limit,
-                hyperparameters={"RecursiveTabular": {"tabular_hyperparameters": {"DUMMY": {}}}},
+                hyperparameters={"RecursiveTabular": {"model_name": "DUMMY"}},
                 num_val_windows=num_val_windows,
                 refit_every_n_windows=refit_every_n_windows,
                 enable_ensemble=enable_ensemble,

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -344,7 +344,7 @@ def test_when_trainer_fit_and_deleted_then_oof_predictions_can_be_loaded(temp_mo
         hyperparameters={
             "Naive": {},
             "ETS": {},
-            "DirectTabular": {"tabular_hyperparameters": {"GBM": {}}},
+            "DirectTabular": {"model_name": "GBM"},
             "DeepAR": {"max_epochs": 1, "num_batches_per_epoch": 1},
         },
     )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update version range for `mlforecast`, `coreforecast`, `utilsforecast`
- Log a warning if unsupported hyperparameters are provided to `DirectTabular`, `RecursiveTabular`, or `Chronos` models.
- Instead of creating a `TabularPredictor` inside `DirectTabular` and `RecursiveTabular` models, create a single tabular model (instance of `autogluon.core.models.AbstractModel`). This simplifies our internal logic and makes the API of the model compatible with the upcoming PerStepTabular model.
- Allow passing `lag_transforms` to `RecursiveTabular` model.

*To do:*
- [ ] Run benchmark to check for regressions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
