### PR TITLE
[tabular] Fix CatBoost crashing for problem_type="quantile" if len(quantile_levels) == 1

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -1277,9 +1277,11 @@ class AbstractModel(ModelBase, Tunable):
     def _predict_proba(self, X, **kwargs) -> np.ndarray:
         X = self.preprocess(X, **kwargs)
 
-        if self.problem_type in [REGRESSION, QUANTILE]:
+        if self.problem_type == REGRESSION:
+            return self.model.predict(X)
+        elif self.problem_type == QUANTILE:
             y_pred = self.model.predict(X)
-            return y_pred
+            return y_pred.reshape([-1, len(self.quantile_levels)])
 
         y_pred_proba = self.model.predict_proba(X)
         return self._convert_proba_to_unified_form(y_pred_proba)

--- a/tabular/src/autogluon/tabular/models/catboost/callbacks.py
+++ b/tabular/src/autogluon/tabular/models/catboost/callbacks.py
@@ -170,14 +170,15 @@ class EarlyStoppingCallback:
 
         self.eval_metric_name = eval_metric_name
         self.is_max_optimal = is_max_optimal
-        self.is_quantile = self.eval_metric_name.startswith(CATBOOST_QUANTILE_PREFIX)
+        self.is_quantile = CATBOOST_QUANTILE_PREFIX in self.eval_metric_name
 
     def after_iteration(self, info):
         is_best_iter = False
         if self.is_quantile:
             # FIXME: CatBoost adds extra ',' in the metric name if quantile levels are not balanced
             # e.g., 'MultiQuantile:alpha=0.1,0.25,0.5,0.95' becomes 'MultiQuantile:alpha=0.1,,0.25,0.5,0.95'
-            eval_metric_name = [k for k in info.metrics[self.compare_key] if k.startswith(CATBOOST_QUANTILE_PREFIX)][0]
+            # `'Quantile:' in k` catches both multiquantile (MultiQuantile:) and single-quantile mode (Quantile:)
+            eval_metric_name = [k for k in info.metrics[self.compare_key] if CATBOOST_QUANTILE_PREFIX in k][0]
         else:
             eval_metric_name = self.eval_metric_name
         cur_score = info.metrics[self.compare_key][eval_metric_name][-1]

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_utils.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_utils.py
@@ -5,7 +5,7 @@ from autogluon.core.constants import BINARY, MULTICLASS, QUANTILE, REGRESSION, S
 logger = logging.getLogger(__name__)
 
 
-CATBOOST_QUANTILE_PREFIX = "MultiQuantile:"
+CATBOOST_QUANTILE_PREFIX = "Quantile:"
 
 
 # TODO: Add weight support?
@@ -74,8 +74,12 @@ def get_catboost_metric_from_ag_metric(metric, problem_type, quantile_levels=Non
             raise AssertionError(f"quantile_levels must be provided for problem_type = {problem_type}")
         if not all(0 < q < 1 for q in quantile_levels):
             raise AssertionError(f"quantile_levels must fulfill 0 < q < 1, provided quantile_levels: {quantile_levels}")
-        quantile_string = ",".join(str(q) for q in quantile_levels)
-        metric_class = f"{CATBOOST_QUANTILE_PREFIX}alpha={quantile_string}"
+        # Loss function MultiQuantile: can only be used if len(quantile_levels) >= 2, otherwise we must use Quantile:
+        if len(quantile_levels) == 1:
+            metric_class = f"{CATBOOST_QUANTILE_PREFIX}alpha={quantile_levels[0]}"
+        else:
+            quantile_string = ",".join(str(q) for q in quantile_levels)
+            metric_class = f"Multi{CATBOOST_QUANTILE_PREFIX}alpha={quantile_string}"
     else:
         raise AssertionError(f"CatBoost does not support {problem_type} problem type.")
 

--- a/tabular/src/autogluon/tabular/testing/fit_helper.py
+++ b/tabular/src/autogluon/tabular/testing/fit_helper.py
@@ -21,6 +21,7 @@ from autogluon.tabular.testing.generate_datasets import (
     generate_toy_multiclass_dataset,
     generate_toy_regression_dataset,
     generate_toy_quantile_dataset,
+    generate_toy_quantile_single_level_dataset,
     generate_toy_multiclass_10_dataset,
     generate_toy_regression_10_dataset,
     generate_toy_quantile_10_dataset,
@@ -72,6 +73,7 @@ class DatasetLoaderHelper:
         toy_multiclass=generate_toy_multiclass_dataset,
         toy_regression=generate_toy_regression_dataset,
         toy_quantile=generate_toy_quantile_dataset,
+        toy_quantile_single_level=generate_toy_quantile_single_level_dataset,
         toy_binary_10=generate_toy_binary_10_dataset,
         toy_multiclass_10=generate_toy_multiclass_10_dataset,
         toy_regression_10=generate_toy_regression_10_dataset,
@@ -393,10 +395,10 @@ class FitHelper:
                     )
 
         problem_type_dataset_map = {
-            "binary": "toy_binary",
-            "multiclass": "toy_multiclass",
-            "regression": "toy_regression",
-            "quantile": "toy_quantile",
+            "binary": ["toy_binary"],
+            "multiclass": ["toy_multiclass"],
+            "regression": ["toy_regression"],
+            "quantile": ["toy_quantile", "toy_quantile_single_level"],
         }
 
         problem_types_refit_full = []
@@ -419,16 +421,16 @@ class FitHelper:
             if extra_metrics:
                 _extra_metrics = METRICS.get(problem_type, None)
             refit_full = problem_type in problem_types_refit_full
-            dataset_name = problem_type_dataset_map[problem_type]
-            FitHelper.fit_and_validate_dataset(
-                dataset_name=dataset_name,
-                fit_args=fit_args,
-                fit_weighted_ensemble=False,
-                refit_full=refit_full,
-                extra_metrics=_extra_metrics,
-                raise_on_model_failure=raise_on_model_failure,
-                **kwargs,
-            )
+            for dataset_name in problem_type_dataset_map[problem_type]:
+                FitHelper.fit_and_validate_dataset(
+                    dataset_name=dataset_name,
+                    fit_args=fit_args,
+                    fit_weighted_ensemble=False,
+                    refit_full=refit_full,
+                    extra_metrics=_extra_metrics,
+                    raise_on_model_failure=raise_on_model_failure,
+                    **kwargs,
+                )
 
         if bag:
             model_params_bag = copy.deepcopy(model_hyperparameters)
@@ -450,16 +452,16 @@ class FitHelper:
                 if extra_metrics:
                     _extra_metrics = METRICS.get(problem_type, None)
                 refit_full = problem_type in problem_types_refit_full
-                dataset_name = problem_type_dataset_map[problem_type]
-                FitHelper.fit_and_validate_dataset(
-                    dataset_name=dataset_name,
-                    fit_args=fit_args_bag,
-                    fit_weighted_ensemble=False,
-                    refit_full=refit_full,
-                    extra_metrics=_extra_metrics,
-                    raise_on_model_failure=raise_on_model_failure,
-                    **kwargs,
-                )
+                for dataset_name in problem_type_dataset_map[problem_type]:
+                    FitHelper.fit_and_validate_dataset(
+                        dataset_name=dataset_name,
+                        fit_args=fit_args_bag,
+                        fit_weighted_ensemble=False,
+                        refit_full=refit_full,
+                        extra_metrics=_extra_metrics,
+                        raise_on_model_failure=raise_on_model_failure,
+                        **kwargs,
+                    )
 
 
 def stacked_overfitting_assert(

--- a/tabular/src/autogluon/tabular/testing/generate_datasets.py
+++ b/tabular/src/autogluon/tabular/testing/generate_datasets.py
@@ -64,6 +64,13 @@ def generate_toy_quantile_dataset():
     return train_data, test_data, dataset_info
 
 
+def generate_toy_quantile_single_level_dataset():
+    train_data, test_data, dataset_info = generate_toy_regression_dataset()
+    dataset_info["problem_type"] = QUANTILE
+    dataset_info["init_kwargs"] = {"quantile_levels": [0.71]}
+    return train_data, test_data, dataset_info
+
+
 def generate_toy_binary_10_dataset():
     label = "label"
     dummy_dataset = {


### PR DESCRIPTION
*Issue #, if available:*

Currently CatBoost fails for problem_type="quantile" if len(quantile_levels) == 1. This PR fixes this problem.

MWE
```python
from autogluon.tabular import TabularPredictor

train_data = 'https://autogluon.s3.amazonaws.com/datasets/Inc/train.csv'
predictor = TabularPredictor(label='age', problem_type='quantile', quantile_levels=[0.5]).fit(train_data=train_data, time_limit=30)
```

Leads to
```
Fitting model: CatBoost ... Training model for up to 19.61s of the 19.61s of remaining time.
	Warning: Exception caused CatBoost to fail during training... Skipping this model.
		catboost/private/libs/algo/tensor_search_helpers.cpp:200: Parameter alpha should contain at least two quantiles separated by comma
Detailed Traceback:
Traceback (most recent call last):
  File "/home/shchuro/workspace/autogluon/tabular/src/autogluon/tabular/trainer/abstract_trainer.py", line 2169, in _train_and_save
    model = self._train_single(**model_fit_kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shchuro/workspace/autogluon/tabular/src/autogluon/tabular/trainer/abstract_trainer.py", line 2055, in _train_single
    model = model.fit(X=X, y=y, X_val=X_val, y_val=y_val, X_test=X_test, y_test=y_test, total_resources=total_resources, **model_fit_kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shchuro/workspace/autogluon/core/src/autogluon/core/models/abstract/abstract_model.py", line 1056, in fit
    out = self._fit(**kwargs)
          ^^^^^^^^^^^^^^^^^^^
  File "/home/shchuro/workspace/autogluon/tabular/src/autogluon/tabular/models/catboost/catboost_model.py", line 261, in _fit
    self.model.fit(X, **fit_final_kwargs)
  File "/home/shchuro/envs/ag/lib/python3.11/site-packages/catboost/core.py", line 5873, in fit
    return self._fit(X, y, cat_features, text_features, embedding_features, None, graph, sample_weight, None, None, None, None, baseline,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shchuro/envs/ag/lib/python3.11/site-packages/catboost/core.py", line 2410, in _fit
    self._train(
  File "/home/shchuro/envs/ag/lib/python3.11/site-packages/catboost/core.py", line 1790, in _train
    self._object._train(train_pool, test_pool, params, allow_clear_pool, init_model._object if init_model else None)
  File "_catboost.pyx", line 5023, in _catboost._CatBoost._train
  File "_catboost.pyx", line 5072, in _catboost._CatBoost._train
_catboost.CatBoostError: catboost/private/libs/algo/tensor_search_helpers.cpp:200: Parameter alpha should contain at least two quantiles separated by comma
```

*Description of changes:*
- Switch to evaluation metric `"Quantile:alpha={quantile_levels[0]}"` if `len(quantile_levels) == 1` for CatBoost.
- Add an extra test case for quantile regression models that ensures that these models work in case `len(quantile_levels) == 1`.
- Ensure that predictions of quantile regression models have shape `[len(X), len(self.quantile_levels)]`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
