### PR TITLE
[tabular] Respect num_cpus/num_gpus in sequential_local fit

### DIFF
--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -845,6 +845,12 @@ class BaggedEnsembleModel(AbstractModel):
             extra_log = (
                 f" ({num_parallel_jobs} workers, " f"per: cpus={num_cpus_per}, gpus={num_gpus_per}, " f"memory={(100*mem_est_proportion_per_fold):.2f}%)"
             )
+        elif isinstance(fold_fitting_strategy, SequentialLocalFoldFittingStrategy):
+            num_cpus_per = fold_fitting_strategy.resources["num_cpus"]
+            num_gpus_per = fold_fitting_strategy.resources["num_gpus"]
+            extra_log = (
+                f" (sequential: cpus={num_cpus_per}, gpus={num_gpus_per})"
+            )
         else:
             extra_log = ""
 

--- a/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
+++ b/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
@@ -300,7 +300,7 @@ class SequentialLocalFoldFittingStrategy(FoldFittingStrategy):
         total_num_cpus = self.num_cpus
         total_num_gpus = self.num_gpus
 
-        default_num_cpus, default_num_gpus = self.model_base._get_default_resources()
+        default_num_cpus, default_num_gpus = self._initialized_model_base._get_default_resources()
         if self.user_resources_per_job is None:
             fit_num_cpus, fit_num_gpus = default_num_cpus, default_num_gpus
         else:
@@ -313,6 +313,32 @@ class SequentialLocalFoldFittingStrategy(FoldFittingStrategy):
 
         assert fit_num_cpus >= 1
         assert fit_num_gpus >= 0
+
+        # TODO: v1.5: Fix the below, need to consistently define what `get_minimum_resources` and `get_default_resources` mean.
+        #  Currently SequentialLocal will use default resources to define the resources to fit the model
+        #  But this differs from ParallelLocal which can use more than default resources if num_jobs=1 (pseudo sequential)
+        #  This means ParallelLocal can use all logical cores to fit 1 model even if the model's default specifies only physical cores.
+        #  Currently I think that the above code is the more correct code, as it respects `get_default_resources`
+        #  TL;DR: Align logic between parallel and sequential so when num_jobs=1, they both do the same thing in terms of num_cpus and num_gpus during fit.
+        # model_min_resources = self._initialized_model_base.get_minimum_resources(is_gpu_available=(self.num_gpus > 0))
+        # resources_calculator = ResourceCalculatorFactory.get_resource_calculator(calculator_type="cpu" if self.num_gpus == 0 else "gpu")
+        # # use minimum resource to control number of jobs running in parallel
+        # min_cpu_based_on_model = model_min_resources.get("num_cpus", 1)
+        # min_gpu_based_on_model = model_min_resources.get("num_gpus", 0)
+        #
+        # get_resources_per_job_args = dict(
+        #     total_num_cpus=self.num_cpus,
+        #     total_num_gpus=self.num_gpus,
+        #     num_jobs=1,
+        #     minimum_cpu_per_job=max(self.num_cpus, min_cpu_based_on_model),
+        #     minimum_gpu_per_job=max(self.num_gpus, min_gpu_based_on_model),
+        #     user_resources_per_job=self.user_resources_per_job,
+        # )
+        # if self.user_resources_per_job is not None:
+        #     get_resources_per_job_args["minimum_cpu_per_job"] = min_cpu_based_on_model
+        #     get_resources_per_job_args["minimum_gpu_per_job"] = min_gpu_based_on_model
+        #
+        # resources_info = resources_calculator.get_resources_per_job(**get_resources_per_job_args)
 
         self.resources = {"num_cpus": fit_num_cpus, "num_gpus": fit_num_gpus}
 

--- a/tabular/tests/unittests/resource_allocation/test_bagging_resource_allocation.py
+++ b/tabular/tests/unittests/resource_allocation/test_bagging_resource_allocation.py
@@ -178,10 +178,10 @@ def test_sequential_bagging_resources_per_fold():
         num_folds_parallel=8,
         bagged_resources={"num_cpus": 8, "num_gpus": 1},
         model_base_resources={"num_cpus": 4, "num_gpus": 1},
+        model_base_default_resources={"num_cpus": 1, "num_gpus": 0},
         model_base_minimum_resources={"num_cpus": 1, "num_gpus": 0.1},
     )
-    assert fold_fitting_strategy.num_cpus == 4
-    assert fold_fitting_strategy.num_gpus == 1
+    assert fold_fitting_strategy.resources == {"num_cpus": 4, "num_gpus": 1}
     assert fold_fitting_strategy.user_resources_per_job == {"num_cpus": 4, "num_gpus": 1}
 
     fold_fitting_strategy = _construct_dummy_fold_strategy(
@@ -190,10 +190,10 @@ def test_sequential_bagging_resources_per_fold():
         num_folds_parallel=8,
         bagged_resources={"num_cpus": 8, "num_gpus": 1},
         model_base_resources={"num_cpus": 1, "num_gpus": 0.1},
+        model_base_default_resources={"num_cpus": 1, "num_gpus": 0},
         model_base_minimum_resources={"num_cpus": 1, "num_gpus": 0.1},
     )
-    assert fold_fitting_strategy.num_cpus == 1
-    assert fold_fitting_strategy.num_gpus == 0.1
+    assert fold_fitting_strategy.resources == {"num_cpus": 1, "num_gpus": 0.1}
     assert fold_fitting_strategy.user_resources_per_job == {"num_cpus": 1, "num_gpus": 0.1}
 
 
@@ -208,4 +208,5 @@ def test_sequential_bagging_no_resources_per_fold():
     )
     assert fold_fitting_strategy.num_cpus == 8
     assert fold_fitting_strategy.num_gpus == 1
+    assert fold_fitting_strategy.resources == {"num_cpus": 4, "num_gpus": 0.5}
     assert fold_fitting_strategy.user_resources_per_job == None

--- a/tabular/tests/unittests/resource_allocation/test_resource_allocation_combined.py
+++ b/tabular/tests/unittests/resource_allocation/test_resource_allocation_combined.py
@@ -310,7 +310,12 @@ tests_dict = {
             "num_bag_folds": 8,
             "fold_strategy_cls": SequentialLocalFoldFittingStrategy,
             "expected_answer": {
-                "resources_per_model": {"num_cpus": 2, "num_gpus": 1},
+                # "resources_per_model": {"num_cpus": 2, "num_gpus": 1},
+                # FIXME: Above is commented out in v1.4 to fix bug in sequential.
+                #  But this creates inconsistency with Parallel logic. Resolve in v1.5.
+                #  To me, the below seems correct,
+                #  as we don't want to use GPUs for a model that doesn't default to using them.
+                "resources_per_model": {"num_cpus": 1, "num_gpus": 0},
             },
         }
     ),
@@ -626,7 +631,10 @@ tests_dict = {
             "fold_strategy_cls": SequentialLocalFoldFittingStrategy,
             "expected_answer": {
                 "resources_per_trial": {"num_cpus": 4, "num_gpus": 1},
-                "resources_per_model": {"num_cpus": 4, "num_gpus": 1},
+                # "resources_per_model": {"num_cpus": 4, "num_gpus": 1},
+                # FIXME: Above is commented out in v1.4 to fix bug in sequential.
+                #  But this creates inconsistency with Parallel logic. Resolve in v1.5.
+                "resources_per_model": {"num_cpus": 1, "num_gpus": 0},
             },
         }
     ),
@@ -759,7 +767,10 @@ tests_dict = {
             "fold_strategy_cls": SequentialLocalFoldFittingStrategy,
             "expected_answer": {
                 "resources_per_trial": {"num_cpus": 4, "num_gpus": 1},
-                "resources_per_model": {"num_cpus": 4, "num_gpus": 1},
+                # "resources_per_model": {"num_cpus": 4, "num_gpus": 1},
+                # FIXME: Above is commented out in v1.4 to fix bug in sequential.
+                #  But this creates inconsistency with Parallel logic. Resolve in v1.5.
+                "resources_per_model": {"num_cpus": 1, "num_gpus": 0},
             },
         }
     ),


### PR DESCRIPTION
*Issue #, if available:*

Related: #5180 

*Description of changes:*

**Major bug fix**
- Previously if the model is fit in bagged mode with `fold_fitting_strategy="sequential_local"`, the system level CPU and GPU arguments from `predictor.fit(num_cpus=..., num_gpus=...)` were ignored.
- This led to major problems, such as GPUs being used when they shouldn't be, or far more CPUs being used than the user expected.
- Now the system level CPU and GPU arguments are respected.
- Additionally fixed an issue in `fold_fitting_strategy="sequential_local"` where if the user specified `ag_args_fit` with only one of `num_cpus` or `num_gpus`, the other unspecified value would be set to an incorrect value, ignoring the model's default resource suggestion.
- Added logging in the bagged model to clearly show the num_cpus and num_gpus being used to fit when in sequential local mode. (previously was hidden, which was why this bug was undetected for so long)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
