### PR TITLE
[tabular] Switch to loky for get_cpu_count in all places

### DIFF
--- a/common/src/autogluon/common/utils/cpu_utils.py
+++ b/common/src/autogluon/common/utils/cpu_utils.py
@@ -12,7 +12,7 @@ import loky
 logger = logging.getLogger(__name__)
 
 
-def get_available_cpu_count(only_physical_cores=False):
+def get_available_cpu_count(only_physical_cores: bool = False) -> int:
     """
     Get the number of available CPU cores, respecting container limits,
     CPU affinity, and environment variables.

--- a/common/src/autogluon/common/utils/resource_utils.py
+++ b/common/src/autogluon/common/utils/resource_utils.py
@@ -17,7 +17,7 @@ class ResourceManager:
     """Manager that fetches system related info"""
 
     @staticmethod
-    def get_cpu_count(only_physical_cores=False):
+    def get_cpu_count(only_physical_cores: bool = False) -> int:
         """
         Get the number of available CPU cores.
 

--- a/core/src/autogluon/core/hpo/ray_hpo.py
+++ b/core/src/autogluon/core/hpo/ray_hpo.py
@@ -106,7 +106,7 @@ class RayTuneAdapter(ABC):
         assert (
             isinstance(minimum_gpu_per_trial, (int, float)) and minimum_gpu_per_trial >= 0
         ), "minimum_gpu_per_trial must be an integer or float that is equal to or larger than 0"
-        num_cpus = total_resources.get("num_cpus", ResourceManager.get_cpu_count_psutil())
+        num_cpus = total_resources.get("num_cpus", ResourceManager.get_cpu_count())
         num_gpus = total_resources.get("num_gpus", 0)
         assert (
             num_gpus >= minimum_gpu_per_trial

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -350,8 +350,8 @@ class CatBoostModel(AbstractModel):
         return minimum_resources
 
     def _get_default_resources(self):
-        # logical=False is faster in training
-        num_cpus = ResourceManager.get_cpu_count_psutil(logical=False)
+        # only_physical_cores=True is faster in training
+        num_cpus = ResourceManager.get_cpu_count(only_physical_cores=True)
         num_gpus = 0
         return num_cpus, num_gpus
 

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -584,8 +584,8 @@ class NNFastAiTabularModel(AbstractModel):
         return default_auxiliary_params
 
     def _get_default_resources(self):
-        # logical=False is faster in training
-        num_cpus = ResourceManager.get_cpu_count_psutil(logical=False)
+        # only_physical_cores=True is faster in training
+        num_cpus = ResourceManager.get_cpu_count(only_physical_cores=True)
         num_gpus = 0
         return num_cpus, num_gpus
 
@@ -642,7 +642,7 @@ class NNFastAiTabularModel(AbstractModel):
 
     def _get_maximum_resources(self) -> dict[str, Union[int, float]]:
         # fastai model trains slower when utilizing virtual cores and this issue scale up when the number of cpu cores increases
-        return {"num_cpus": ResourceManager.get_cpu_count_psutil(logical=False)}
+        return {"num_cpus": ResourceManager.get_cpu_count(only_physical_cores=True)}
 
     def get_minimum_resources(self, is_gpu_available=False):
         minimum_resources = {

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -532,8 +532,8 @@ class LGBModel(AbstractModel):
         return minimum_resources
 
     def _get_default_resources(self):
-        # logical=False is faster in training
-        num_cpus = ResourceManager.get_cpu_count_psutil(logical=False)
+        # only_physical_cores=True is faster in training
+        num_cpus = ResourceManager.get_cpu_count(only_physical_cores=True)
         num_gpus = 0
         return num_cpus, num_gpus
 

--- a/tabular/src/autogluon/tabular/models/tabpfnmix/tabpfnmix_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnmix/tabpfnmix_model.py
@@ -311,11 +311,11 @@ class TabPFNMixModel(AbstractModel):
 
     def _get_maximum_resources(self) -> dict[str, int | float]:
         # torch model trains slower when utilizing virtual cores and this issue scale up when the number of cpu cores increases
-        return {"num_cpus": ResourceManager.get_cpu_count_psutil(logical=False)}
+        return {"num_cpus": ResourceManager.get_cpu_count(only_physical_cores=True)}
 
     def _get_default_resources(self) -> tuple[int, float]:
-        # logical=False is faster in training
-        num_cpus = ResourceManager.get_cpu_count_psutil(logical=False)
+        # only_physical_cores=True is faster in training
+        num_cpus = ResourceManager.get_cpu_count(only_physical_cores=True)
         num_gpus = 0
         return num_cpus, num_gpus
 

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -814,11 +814,11 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
 
     def _get_maximum_resources(self) -> Dict[str, Union[int, float]]:
         # torch model trains slower when utilizing virtual cores and this issue scale up when the number of cpu cores increases
-        return {"num_cpus": ResourceManager.get_cpu_count_psutil(logical=False)}
+        return {"num_cpus": ResourceManager.get_cpu_count(only_physical_cores=True)}
 
     def _get_default_resources(self):
-        # logical=False is faster in training
-        num_cpus = ResourceManager.get_cpu_count_psutil(logical=False)
+        # only_physical_cores=True is faster in training
+        num_cpus = ResourceManager.get_cpu_count(only_physical_cores=True)
         num_gpus = 0
         return num_cpus, num_gpus
 

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -310,8 +310,8 @@ class XGBoostModel(AbstractModel):
 
     @disable_if_lite_mode(ret=(1, 0))
     def _get_default_resources(self):
-        # logical=False is faster in training
-        num_cpus = ResourceManager.get_cpu_count_psutil(logical=False)
+        # only_physical_cores=True is faster in training
+        num_cpus = ResourceManager.get_cpu_count(only_physical_cores=True)
         num_gpus = 0
         return num_cpus, num_gpus
 

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -2950,7 +2950,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         if fit_strategy == "parallel":
             num_cpus = kwargs.get("total_resources", {}).get("num_cpus", "auto")
             if isinstance(num_cpus, str) and num_cpus == "auto":
-                num_cpus = get_resource_manager().get_cpu_count_psutil()
+                num_cpus = get_resource_manager().get_cpu_count()
             if num_cpus < 12:
                 force_parallel = os.environ.get("AG_FORCE_PARALLEL", "False") == "True"
                 if not force_parallel:


### PR DESCRIPTION
*Issue #, if available:*

Follow-up to #5197

*Description of changes:*

- Switch from psutil to loky for get_cpu_count in all places
- This should improve AutoGluon's compatibility with docker / slurm clusters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
