### PR TITLE
[timeseries] Add AutoMLPipelineFeatureGenerator to MLForecast-based models

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -351,7 +351,7 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
             max_num_samples=model_params["max_num_samples"],
         )
 
-        with set_loggers_level(regex=r"^autogluon.tabular.*", level=logging.ERROR):
+        with set_loggers_level(regex=r"^autogluon\.(tabular|features).*", level=logging.ERROR):
             tabular_model = self._create_tabular_model(
                 model_name=model_params["model_name"], model_hyperparameters=model_params["model_hyperparameters"]
             )

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -370,7 +370,7 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
         self._save_residuals_std(val_df)
 
     def get_tabular_model(self) -> TabularModel:
-        """Get the unerlyin tabular regression model."""
+        """Get the underlying tabular regression model."""
         assert "mean" in self._mlf.models_, "Call `fit` before calling `get_tabular_model`"
         mean_estimator = self._mlf.models_["mean"]
         assert isinstance(mean_estimator, TabularModel)

--- a/timeseries/tests/unittests/models/test_mlforecast.py
+++ b/timeseries/tests/unittests/models/test_mlforecast.py
@@ -367,7 +367,7 @@ def test_when_deprecated_tabular_hyperparameters_are_provided_then_model_can_pre
         hyperparameters=hparams_with_deprecated,
     )
     model.fit(train_data=data, time_limit=3)
-    tabular_model = model.get_tabular_model()
+    tabular_model = model.get_tabular_model().model
     assert tabular_model.ag_key == model_name
     assert tabular_model._user_params == model_hyperparameters
     predictions = model.predict(data)

--- a/timeseries/tests/unittests/models/test_mlforecast.py
+++ b/timeseries/tests/unittests/models/test_mlforecast.py
@@ -8,7 +8,6 @@ import pandas as pd
 import pytest
 from mlforecast.lag_transforms import RollingMean
 
-import autogluon.core.utils.exceptions
 from autogluon.timeseries import TimeSeriesDataFrame
 from autogluon.timeseries.models.autogluon_tabular import DirectTabularModel, RecursiveTabularModel
 from autogluon.timeseries.transforms.target_scaler import LocalMinMaxScaler, LocalStandardScaler

--- a/timeseries/tests/unittests/models/test_mlforecast.py
+++ b/timeseries/tests/unittests/models/test_mlforecast.py
@@ -167,8 +167,8 @@ def test_given_long_time_series_passed_to_model_then_preprocess_receives_shorten
     with mock.patch("mlforecast.MLForecast.preprocess") as mock_preprocess:
         try:
             model.fit(train_data=data)
-        # using mock leads to NoValidFeatures exception
-        except autogluon.core.utils.exceptions.NoValidFeatures:
+        # using mock leads to ZeroDivisionError
+        except ZeroDivisionError:
             pass
         received_mlforecast_df = mock_preprocess.call_args[0][0]
         assert len(received_mlforecast_df) == max_num_samples + prediction_length + sum(differences)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- This PR adds an `AutoMLPipelineFeatureGenerator` to DirectTabular and RecursiveTabular models. This fixes a regression on some datasets with categorical features that was introduced in #5184. 

This object ensures that the features received by model during fit and predict have the same dtypes and category ordering. For some reason, removing this check led to worse performance of LightGBM on two datasets.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
