### PR TITLE
[timeseries] Add regression mode support to PerStepTabularModel

### DIFF
--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -13,7 +13,7 @@ from autogluon.common.features.types import R_BOOL, R_CATEGORY, R_FLOAT, R_INT
 from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
 from autogluon.common.utils.resource_utils import ResourceManager
 from autogluon.common.utils.try_import import try_import_catboost
-from autogluon.core.constants import MULTICLASS, PROBLEM_TYPES_CLASSIFICATION, REGRESSION, QUANTILE, SOFTCLASS
+from autogluon.core.constants import MULTICLASS, PROBLEM_TYPES_CLASSIFICATION, QUANTILE, SOFTCLASS
 from autogluon.core.models import AbstractModel
 from autogluon.core.models._utils import get_early_stopping_rounds
 from autogluon.core.utils.exceptions import TimeLimitExceeded
@@ -136,8 +136,6 @@ class CatBoostModel(AbstractModel):
         elif self.problem_type == QUANTILE:
             # FIXME: Unless specified, CatBoost defaults to loss_function='MultiQuantile' and raises an exception
             params["loss_function"] = params["eval_metric"]
-        elif self.problem_type == REGRESSION:
-            params.setdefault("loss_function", params["eval_metric"])
 
         model_type = CatBoostClassifier if self.problem_type in PROBLEM_TYPES_CLASSIFICATION else CatBoostRegressor
         num_rows_train = len(X)

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -13,7 +13,7 @@ from autogluon.common.features.types import R_BOOL, R_CATEGORY, R_FLOAT, R_INT
 from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
 from autogluon.common.utils.resource_utils import ResourceManager
 from autogluon.common.utils.try_import import try_import_catboost
-from autogluon.core.constants import MULTICLASS, PROBLEM_TYPES_CLASSIFICATION, QUANTILE, SOFTCLASS
+from autogluon.core.constants import MULTICLASS, PROBLEM_TYPES_CLASSIFICATION, REGRESSION, QUANTILE, SOFTCLASS
 from autogluon.core.models import AbstractModel
 from autogluon.core.models._utils import get_early_stopping_rounds
 from autogluon.core.utils.exceptions import TimeLimitExceeded
@@ -136,6 +136,8 @@ class CatBoostModel(AbstractModel):
         elif self.problem_type == QUANTILE:
             # FIXME: Unless specified, CatBoost defaults to loss_function='MultiQuantile' and raises an exception
             params["loss_function"] = params["eval_metric"]
+        elif self.problem_type == REGRESSION:
+            params.setdefault("loss_function", params["eval_metric"])
 
         model_type = CatBoostClassifier if self.problem_type in PROBLEM_TYPES_CLASSIFICATION else CatBoostRegressor
         num_rows_train = len(X)

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -473,7 +473,7 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
 
 
 class DirectTabularModel(AbstractMLForecastModel):
-    """Predict all future time series values simultaneously using tabular regression models.
+    """Predict all future time series values simultaneously using a regression model from AutoGluon-Tabular.
 
     A single tabular model is used to forecast all future time series values using the following features:
 
@@ -654,16 +654,16 @@ class DirectTabularModel(AbstractMLForecastModel):
 
 
 class RecursiveTabularModel(AbstractMLForecastModel):
-    """Predict future time series values one by one using TabularPredictor from AutoGluon-Tabular.
+    """Predict future time series values one by one using a regression model from AutoGluon-Tabular.
 
-    A single TabularPredictor is used to forecast the future time series values using the following features:
+    A single tabular regression model is used to forecast the future time series values using the following features:
 
     - lag features (observed time series values) based on ``freq`` of the data
     - time features (e.g., day of the week) based on the timestamp of the measurement
     - known covariates (if available)
     - static features of each item (if available)
 
-    TabularPredictor will always be trained with ``"regression"`` problem type, and dummy quantiles will be
+    The tabular model will always be trained with ``"regression"`` problem type, and dummy quantiles will be
     obtained by assuming that the residuals follow zero-mean normal distribution.
 
     Based on the `mlforecast <https://github.com/Nixtla/mlforecast>`_ library.

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/per_step.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/per_step.py
@@ -2,15 +2,18 @@ import logging
 import math
 import os
 import time
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import Any, Callable, Dict, List, Literal, Optional, Type
 
 import numpy as np
 import pandas as pd
+import scipy.stats
 from joblib import Parallel, cpu_count, delayed
 
+from autogluon.common.loaders import load_pkl
+from autogluon.common.savers import save_pkl
 from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
 from autogluon.common.utils.resource_utils import ResourceManager
-from autogluon.core.constants import QUANTILE
+from autogluon.core.constants import QUANTILE, REGRESSION
 from autogluon.tabular.models import AbstractModel as AbstractTabularModel
 from autogluon.tabular.registry import ag_model_registry
 from autogluon.timeseries import TimeSeriesDataFrame
@@ -23,8 +26,6 @@ from .utils import MLF_ITEMID, MLF_TARGET, MLF_TIMESTAMP
 
 logger = logging.getLogger(__name__)
 
-DUMMY_FREQ = "D"
-
 
 class PerStepTabularModel(AbstractTimeSeriesModel):
     """Fit a separate tabular regression model for each time step in the forecast horizon.
@@ -36,7 +37,11 @@ class PerStepTabularModel(AbstractTimeSeriesModel):
     - known covariates (if available)
     - static features of each item (if available)
 
-    This model is typically much slower to fit compared to other tabular forecasting models.
+    This model is typically slower to fit compared to other tabular forecasting models.
+
+    If ``eval_metric.needs_quantile``, the tabular regression models will be trained with ``"quantile"`` problem type.
+    Otherwise, the models will be trained with ``"regression"`` problem type, and dummy quantiles will be
+    obtained by assuming that the residuals follow zero-mean normal distribution.
 
     This model uses `mlforecast <https://github.com/Nixtla/mlforecast>`_ under the hood for efficient preprocessing,
     but the implementation of the per-step forecasting strategy is different from the `max_horizon` in `mlforecast`.
@@ -72,6 +77,8 @@ class PerStepTabularModel(AbstractTimeSeriesModel):
         Number of parallel jobs for fitting models across forecast horizons.
         If None, automatically determined based on available memory to prevent OOM errors.
     """
+
+    _dummy_freq = "D"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -116,13 +123,16 @@ class PerStepTabularModel(AbstractTimeSeriesModel):
             "max_num_items": 20_000,
         }
 
-    @staticmethod
+    @classmethod
     def _fit_single_model(
+        cls,
         train_df: pd.DataFrame,
         path_root: str,
         step: int,
         model_cls: Type[AbstractTabularModel],
         model_hyperparameters: dict,
+        problem_type: Literal["quantile", "regression"],
+        eval_metric: str,
         validation_fraction: Optional[float],
         quantile_levels: list[float],
         lags: list[int],
@@ -135,13 +145,14 @@ class PerStepTabularModel(AbstractTimeSeriesModel):
 
         start_time = time.monotonic()
 
-        mlf = MLForecast(models=[], freq=DUMMY_FREQ, lags=lags, date_features=date_features)
+        mlf = MLForecast(models=[], freq=cls._dummy_freq, lags=lags, date_features=date_features)
 
         features_df = mlf.preprocess(train_df, static_features=[], dropna=False)
         del train_df
         del mlf
         # Sort chronologically for efficient train/test split
         features_df = features_df.sort_values(by=MLF_TIMESTAMP)
+        item_ids = features_df[MLF_ITEMID]
         X = features_df.drop(columns=[MLF_ITEMID, MLF_TIMESTAMP, MLF_TARGET])
         y = features_df[MLF_TARGET]
         del features_df
@@ -162,14 +173,16 @@ class PerStepTabularModel(AbstractTimeSeriesModel):
 
         elapsed = time.monotonic() - start_time
         time_left = time_limit - elapsed if time_limit is not None else None
+        if problem_type == QUANTILE:
+            model_hyperparameters = model_hyperparameters | {"ag.quantile_levels": quantile_levels}
         try:
             with set_loggers_level(regex=r"^autogluon.tabular.*", level=logging.ERROR):
                 model = model_cls(
                     path=os.path.join(path_root, f"step_{step}"),
                     name=model_cls.__name__,  # explicitly provide name to avoid warnings
-                    problem_type=QUANTILE,
-                    eval_metric="pinball_loss",
-                    hyperparameters={**model_hyperparameters, "ag.quantile_levels": quantile_levels},
+                    problem_type=problem_type,
+                    eval_metric=eval_metric,
+                    hyperparameters=model_hyperparameters,
                 )
                 model.fit(
                     X=X,
@@ -184,6 +197,9 @@ class PerStepTabularModel(AbstractTimeSeriesModel):
         except Exception as e:
             raise RuntimeError(f"Failed when fitting model for {step=}") from e
         model.save()
+        if problem_type == REGRESSION:
+            residuals_std = pd.Series((model.predict(X) - y) ** 2).groupby(item_ids).mean() ** 0.5
+            save_pkl.save(cls._get_residuals_std_path(model.path), residuals_std)
         relative_path = os.path.relpath(path=model.path, start=path_root)
         return relative_path
 
@@ -313,13 +329,8 @@ class PerStepTabularModel(AbstractTimeSeriesModel):
             date_features = get_time_features_for_frequency(self.freq)
         self._date_features = date_features
 
-        self._model_cls = ag_model_registry.key_to_cls(model_params["model_name"])
-        supported_problem_types = self._model_cls.supported_problem_types()
-        if supported_problem_types is not None and QUANTILE not in supported_problem_types:
-            raise ValueError(
-                f"Chosen model_name='{model_params['model_name']}' cannot be used by {self.name} because it does not "
-                f"support problem_type='quantile' ({supported_problem_types=})"
-            )
+        model_name = model_params["model_name"]
+        self._model_cls = ag_model_registry.key_to_cls(model_name)
         model_hyperparameters = model_params["model_hyperparameters"]
         # User-provided n_jobs takes priority over the automatic estimate
         if model_params.get("n_jobs") is not None:
@@ -339,18 +350,35 @@ class PerStepTabularModel(AbstractTimeSeriesModel):
             time_limit_per_model = time_limit / math.ceil(self.prediction_length / n_jobs)
         else:
             time_limit_per_model = None
+
+        if self.eval_metric.needs_quantile:
+            problem_type = QUANTILE
+            eval_metric = "pinball_loss"
+        else:
+            problem_type = REGRESSION
+            eval_metric = self.eval_metric.equivalent_tabular_regression_metric or "mean_absolute_error"
+
+        supported_problem_types = self._model_cls.supported_problem_types()
+        if supported_problem_types is not None and problem_type not in supported_problem_types:
+            raise ValueError(
+                f"Chosen model_name='{model_name}' cannot be used by {self.name} with eval_metric={self.eval_metric}"
+                f"because {model_name} does not support problem_type={problem_type} ({supported_problem_types=})"
+            )
         model_fit_kwargs = dict(
             train_df=train_df,
             path_root=self.path,
             model_cls=self._model_cls,
             quantile_levels=self.quantile_levels,
             validation_fraction=model_params["validation_fraction"],
+            problem_type=problem_type,
+            eval_metric=eval_metric,
             date_features=self._date_features,
             time_limit=time_limit_per_model,
             num_cpus=num_cpus_per_model,
             model_hyperparameters=model_hyperparameters.copy(),
             verbosity=verbosity - 1,
         )
+
         logger.debug(f"Fitting models in parallel with {n_jobs=}, {num_cpus_per_model=}, {time_limit_per_model=}")
         self._relative_paths_to_models = Parallel(n_jobs=n_jobs)(  # type: ignore
             delayed(self._fit_single_model)(
@@ -363,12 +391,19 @@ class PerStepTabularModel(AbstractTimeSeriesModel):
             for step in range(self.prediction_length)
         )
 
-    @staticmethod
+    @classmethod
+    def _get_residuals_std_path(cls, model_path: str) -> str:
+        """Path to the pd.Series storing the standard deviation of residuals for each item_id."""
+        return os.path.join(model_path, "residuals_std.pkl")
+
+    @classmethod
     def _predict_with_single_model(
+        cls,
         full_df: pd.DataFrame,
         path_to_model: str,
         model_cls: Type[AbstractTabularModel],
         step: int,
+        quantile_levels: list[float],
         prediction_length: int,
         lags: list[int],
         date_features: list[Callable],
@@ -382,7 +417,7 @@ class PerStepTabularModel(AbstractTimeSeriesModel):
         """
         from mlforecast import MLForecast
 
-        mlf = MLForecast(models=[], freq=DUMMY_FREQ, lags=lags, date_features=date_features)
+        mlf = MLForecast(models=[], freq=cls._dummy_freq, lags=lags, date_features=date_features)
 
         features_df = mlf.preprocess(full_df, static_features=[], dropna=False)
         del mlf
@@ -395,6 +430,13 @@ class PerStepTabularModel(AbstractTimeSeriesModel):
             logger.error(f"Could not load model for {step=} from {path_to_model}")
             raise
         predictions = model.predict(features_for_step)
+        if model.problem_type == REGRESSION:
+            predictions = np.tile(predictions[:, None], (1, len(quantile_levels)))
+            residuals_std: pd.Series = load_pkl.load(cls._get_residuals_std_path(model.path))
+            item_ids = features_for_step[MLF_ITEMID]
+            residuals_repeated = residuals_std.reindex(item_ids).fillna(residuals_std.mean()).to_numpy()
+            for i, q in enumerate(quantile_levels):
+                predictions[:, i] += scipy.stats.norm.ppf(q) * residuals_repeated
         return predictions
 
     def _predict(
@@ -425,6 +467,7 @@ class PerStepTabularModel(AbstractTimeSeriesModel):
 
         model_predict_kwargs = dict(
             full_df=full_df,
+            quantile_levels=self.quantile_levels,
             prediction_length=self.prediction_length,
             model_cls=self._model_cls,
             date_features=self._date_features,

--- a/timeseries/tests/unittests/models/test_per_step_tabular.py
+++ b/timeseries/tests/unittests/models/test_per_step_tabular.py
@@ -1,4 +1,5 @@
 import shutil
+from pathlib import Path
 from pickle import PicklingError
 from unittest import mock
 
@@ -8,6 +9,7 @@ import pytest
 from ..common import DUMMY_TS_DATAFRAME, get_data_frame_with_variable_lengths
 
 DUMMY_HYPERPARAMETERS = {"model_name": "DUMMY", "n_jobs": 1}
+EVAL_METRICS = ["WAPE", "WQL"]
 
 
 @pytest.mark.parametrize(
@@ -19,8 +21,14 @@ DUMMY_HYPERPARAMETERS = {"model_name": "DUMMY", "n_jobs": 1}
         ([12, 24], [1, 2], [[1, 2, 12, 24], [2, 3, 12, 24], [3, 4, 12, 24]]),
     ],
 )
+@pytest.mark.parametrize("eval_metric", EVAL_METRICS)
 def test_when_seasonal_and_trailing_lags_are_provided_then_each_model_receives_correct_lags(
-    per_step_tabular_model_class, df_with_covariates_and_metadata, seasonal_lags, trailing_lags, expected_lags_per_step
+    per_step_tabular_model_class,
+    df_with_covariates_and_metadata,
+    seasonal_lags,
+    trailing_lags,
+    expected_lags_per_step,
+    eval_metric,
 ):
     df, covariate_metadata = df_with_covariates_and_metadata
     prediction_length = 3
@@ -29,6 +37,7 @@ def test_when_seasonal_and_trailing_lags_are_provided_then_each_model_receives_c
         freq=df.freq,
         covariate_metadata=covariate_metadata,
         hyperparameters={"trailing_lags": trailing_lags, "seasonal_lags": seasonal_lags, **DUMMY_HYPERPARAMETERS},
+        eval_metric=eval_metric,
     )
 
     with mock.patch.object(model, "_fit_single_model") as mock_fit_single_model:
@@ -39,8 +48,9 @@ def test_when_seasonal_and_trailing_lags_are_provided_then_each_model_receives_c
             assert sorted(call_kwargs["lags"]) == expected_lags_per_step[step]
 
 
+@pytest.mark.parametrize("eval_metric", EVAL_METRICS)
 def test_when_model_predicts_then_tabular_models_receive_correct_data_for_inference(
-    per_step_tabular_model_class, df_with_covariates_and_metadata
+    per_step_tabular_model_class, df_with_covariates_and_metadata, eval_metric
 ):
     df, covariate_metadata = df_with_covariates_and_metadata
     df = df.sort_index()
@@ -49,6 +59,7 @@ def test_when_model_predicts_then_tabular_models_receive_correct_data_for_infere
         prediction_length=prediction_length,
         freq=df.freq,
         covariate_metadata=covariate_metadata,
+        eval_metric=eval_metric,
         hyperparameters={"trailing_lags": [1, 2, 3], "seasonal_lags": [5, 10], **DUMMY_HYPERPARAMETERS},
     )
     model.fit(train_data=df)
@@ -56,7 +67,10 @@ def test_when_model_predicts_then_tabular_models_receive_correct_data_for_infere
         model.prediction_length, known_covariates_names=covariate_metadata.known_covariates
     )
     with mock.patch("autogluon.core.models.dummy.dummy_model.DummyModel.predict") as mock_tabular_predict:
-        mock_tabular_predict.return_value = np.zeros([df.num_items, len(model.quantile_levels)])
+        if model.eval_metric.needs_quantile:
+            mock_tabular_predict.return_value = np.zeros([df.num_items, len(model.quantile_levels)])
+        else:
+            mock_tabular_predict.return_value = np.zeros([df.num_items])
         model.predict(past_data, known_covariates)
         for step, call_args in enumerate(mock_tabular_predict.call_args_list):
             X = call_args[0][0]
@@ -111,14 +125,21 @@ def test_when_models_are_fitted_then_time_limit_is_distributed_evenly(
         ([1, 2, 3], [30, 40], ["day_of_week", "hour"]),
     ],
 )
+@pytest.mark.parametrize("eval_metric", EVAL_METRICS)
 def test_when_per_step_models_are_fit_then_each_model_receives_correct_features(
-    per_step_tabular_model_class, df_with_covariates_and_metadata, trailing_lags, seasonal_lags, date_features
+    per_step_tabular_model_class,
+    df_with_covariates_and_metadata,
+    trailing_lags,
+    seasonal_lags,
+    date_features,
+    eval_metric,
 ):
     df, covariate_metadata = df_with_covariates_and_metadata
     model = per_step_tabular_model_class(
         freq=df.freq,
         prediction_length=3,
         covariate_metadata=covariate_metadata,
+        eval_metric=eval_metric,
         hyperparameters={
             **DUMMY_HYPERPARAMETERS,
             "trailing_lags": trailing_lags,
@@ -127,7 +148,11 @@ def test_when_per_step_models_are_fit_then_each_model_receives_correct_features(
         },
     )
     with mock.patch("autogluon.core.models.dummy.dummy_model.DummyModel.fit") as mock_dummy_fit:
-        model.fit(train_data=df)
+        try:
+            model.fit(train_data=df)
+        # Mock leads to AttributeError during fit
+        except AttributeError:
+            pass
         expected_num_features = (
             len(trailing_lags)
             + len(seasonal_lags)
@@ -163,12 +188,17 @@ def test_when_invalid_lags_are_passed_then_exception_is_raised_during_fit(
         model.fit(train_data=data)
 
 
+@pytest.mark.parametrize("eval_metric", EVAL_METRICS)
 def test_when_model_is_copied_to_new_folder_then_loaded_model_can_still_predict(
-    per_step_tabular_model_class, tmp_path
+    per_step_tabular_model_class, tmp_path, eval_metric
 ):
     data = DUMMY_TS_DATAFRAME.copy()
     model = per_step_tabular_model_class(
-        freq=data.freq, prediction_length=3, hyperparameters=DUMMY_HYPERPARAMETERS, path=str(tmp_path)
+        freq=data.freq,
+        prediction_length=3,
+        hyperparameters=DUMMY_HYPERPARAMETERS,
+        path=str(tmp_path),
+        eval_metric=eval_metric,
     )
     model.fit(train_data=data)
     model.save()
@@ -243,14 +273,19 @@ def test_when_validation_fraction_is_zero_then_no_validation_set_created(
         assert call_kwargs["y_val"] is None
 
 
-def test_when_model_is_fit_then_internal_model_receives_correct_hyperparameters(per_step_tabular_model_class):
+@pytest.mark.parametrize("eval_metric", EVAL_METRICS)
+def test_when_model_is_fit_then_internal_model_receives_correct_hyperparameters(
+    per_step_tabular_model_class, eval_metric
+):
     data = DUMMY_TS_DATAFRAME.copy()
     hyperparameters = {
         "n_jobs": 1,
         "model_name": "GBM",
         "model_hyperparameters": {"max_depth": 7, "n_estimators": 97},
     }
-    model = per_step_tabular_model_class(freq=data.freq, prediction_length=2, hyperparameters=hyperparameters)
+    model = per_step_tabular_model_class(
+        freq=data.freq, prediction_length=2, hyperparameters=hyperparameters, eval_metric=eval_metric
+    )
 
     with mock.patch("autogluon.tabular.models.lgb.lgb_model.train_lgb_model") as mock_train_lgb:
         # Using mock breaks the fitting process with a PicklingError
@@ -263,9 +298,71 @@ def test_when_model_is_fit_then_internal_model_receives_correct_hyperparameters(
         assert call_kwargs["params"]["n_estimators"] == 97
 
 
-def test_when_model_does_not_support_quantile_then_exception_raised(per_step_tabular_model_class):
+@pytest.mark.parametrize("model_name, eval_metric", [("LR", "WQL"), ("FASTTEXT", "WAPE")])
+def test_when_model_does_not_support_required_problem_type_then_exception_raised(
+    per_step_tabular_model_class, model_name, eval_metric
+):
     data = DUMMY_TS_DATAFRAME.copy()
-    model = per_step_tabular_model_class(freq=data.freq, hyperparameters={"model_name": "LR"})
+    model = per_step_tabular_model_class(
+        freq=data.freq, eval_metric=eval_metric, hyperparameters={"model_name": model_name}
+    )
 
-    with pytest.raises(ValueError, match="does not support.*quantile"):
+    with pytest.raises(ValueError, match=r"does not support problem_type"):
         model.fit(train_data=data)
+
+
+@pytest.mark.parametrize(
+    "forecasting_eval_metric, problem_type, tabular_eval_metric",
+    [
+        ("WQL", "quantile", "pinball_loss"),
+        ("SQL", "quantile", "pinball_loss"),
+        ("WAPE", "regression", "mean_absolute_error"),
+        ("RMSSE", "regression", "root_mean_squared_error"),
+    ],
+)
+def test_when_eval_metric_is_chosen_then_tabular_model_receives_correct_problem_type_and_eval_metric(
+    per_step_tabular_model_class, forecasting_eval_metric, problem_type, tabular_eval_metric
+):
+    data = DUMMY_TS_DATAFRAME.copy()
+    model = per_step_tabular_model_class(
+        freq=data.freq, eval_metric=forecasting_eval_metric, hyperparameters=DUMMY_HYPERPARAMETERS
+    )
+    with mock.patch(
+        "autogluon.core.models.dummy.dummy_model.DummyModel.__init__", side_effect=RuntimeError
+    ) as mock_dummy_init:
+        try:
+            model.fit(train_data=data)
+        # Intercept the error raised by mock
+        except RuntimeError:
+            pass
+        call_kwargs = mock_dummy_init.call_args[1]
+        assert call_kwargs["problem_type"] == problem_type
+        assert call_kwargs["eval_metric"] == tabular_eval_metric
+
+
+def test_when_regression_mode_is_used_then_residuals_are_saved(per_step_tabular_model_class, tmp_path):
+    data = DUMMY_TS_DATAFRAME.copy()
+    model = per_step_tabular_model_class(
+        freq=data.freq,
+        eval_metric="WAPE",
+        hyperparameters=DUMMY_HYPERPARAMETERS,
+        path=str(tmp_path),
+        prediction_length=4,
+    )
+    model.fit(train_data=data)
+    for step in range(model.prediction_length):
+        residuals_path = Path(model.path) / f"step_{step}" / model._model_cls.__name__ / "residuals_std.pkl"
+        assert residuals_path.exists()
+
+
+def test_when_regression_mode_predicts_then_quantile_columns_are_strictly_increasing(per_step_tabular_model_class):
+    data = DUMMY_TS_DATAFRAME.copy()
+    model = per_step_tabular_model_class(
+        freq=data.freq, eval_metric="WAPE", hyperparameters=DUMMY_HYPERPARAMETERS, prediction_length=4
+    )
+    model.fit(train_data=data)
+    predictions = model.predict(data)
+
+    quantile_cols = [col for col in predictions.columns if col != "mean"]
+    quantile_values = predictions[quantile_cols].to_numpy()
+    assert np.all(quantile_values[:, :-1] <= quantile_values[:, 1:])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix docstrings for `DirectTabular` and `RecursiveTabular` models
- Change the `PerStepTabular` model to adjust the tabular `problem_type` / `eval_metric` based on the forecasting metric. This behavior matches the current behavior of `DirectTabular` model:
  - For quantile metrics like WQL/SQL, the model will be fit in quantile regression mode.
  - For point metrics like MASE/RMSE, the model will be fit in regression mode, and prediction intervals will be obtained from the zero-mean normal distribution fitted to the residuals on the training set.

Since the model is not included in the default presets for v1.4.0, this is a very low-risk change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
