### PR TITLE
[tabular] Add tabular foundational model cache from s3 to benchmark avoid rate limit issue from HF

### DIFF
--- a/CI/bench/tabular/amlb_user_dir/frameworks_template.yaml
+++ b/CI/bench/tabular/amlb_user_dir/frameworks_template.yaml
@@ -7,6 +7,7 @@
 ######### Do Not Remove #########
 AutoGluon:
   version: "latest"
+  setup_cmd: python3 {user}/setup_hf_cache.py
 ######### Do Not Remove #########
 
 

--- a/CI/bench/tabular/amlb_user_dir/setup_hf_cache.py
+++ b/CI/bench/tabular/amlb_user_dir/setup_hf_cache.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+Script to cache HuggingFace models from S3 before AutoGluon training starts.
+This prevents rate limiting issues when multiple parallel benchmark runs try to download TabPFNv2 models.
+"""
+
+import subprocess
+from pathlib import Path
+
+
+def setup_hf_cache():
+    """Download tabular foundational models from S3 to HuggingFace cache directory."""
+
+    # HuggingFace cache directory
+    cache_dir = Path.home() / ".cache" / "huggingface" / "hub"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    # S3 bucket with model mirror
+    bucket = "s3://autogluon-hf-model-mirror"
+
+    # tabular foundational models to cache
+    models = [
+        "Prior-Labs/TabPFN-v2-clf",
+        "Prior-Labs/TabPFN-v2-reg"
+    ]
+
+    print("Setting up HuggingFace model cache for tabular foundational models...")
+
+    for model in models:
+        # Convert model name to S3 path format
+        model_name = "--".join(model.split('/'))
+        s3_model_name = f"models--{model_name}"
+        model_path = cache_dir / s3_model_name
+        s3_path = f"{bucket}/{s3_model_name}"
+
+        print(f"Caching {model} from {s3_path}...")
+
+        try:
+            # Create local directory
+            model_path.mkdir(parents=True, exist_ok=True)
+
+            # Download from S3 to local cache
+            cmd = ["aws", "s3", "cp", s3_path, str(model_path), "--recursive", "--quiet"]
+            result = subprocess.run(cmd, capture_output=True, text=True)
+
+            if result.returncode == 0:
+                print(f"Successfully cached {model}")
+            else:
+                print(f"Warning: Failed to cache {model} from S3: {result.stderr}")
+                print("Tabular foundational models will be downloaded from HuggingFace Hub during training")
+
+        except Exception as e:
+            print(f"Warning: Exception while caching {model}: {e}")
+            print("Tabular foundational models will be downloaded from HuggingFace Hub during training")
+
+    print("HuggingFace model cache setup completed.")
+
+
+if __name__ == "__main__":
+    setup_hf_cache()


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
[tabular] Add tabular foundational model cache from s3 to benchmark avoid rate limit issue from HF

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
