### PR TITLE
[common] Use joblib instead of loky for cpu detection

### DIFF
--- a/common/setup.py
+++ b/common/setup.py
@@ -28,7 +28,7 @@ install_requires = (
         "psutil",  # version range defined in `core/_setup_utils.py`
         "tqdm",  # version range defined in `core/_setup_utils.py`
         "requests",
-        "loky",  # version range defined in `core/_setup_utils.py`
+        "joblib",  # version range defined in `core/_setup_utils.py`
         # s3fs is removed due to doubling install time due to version range resolution
         # "s3fs",  # version range defined in `core/_setup_utils.py`
     ]

--- a/common/src/autogluon/common/utils/cpu_utils.py
+++ b/common/src/autogluon/common/utils/cpu_utils.py
@@ -7,7 +7,7 @@ in containerized environments, SLURM clusters, and other resource-constrained sy
 import logging
 import os
 
-import loky
+import joblib
 
 logger = logging.getLogger(__name__)
 
@@ -45,8 +45,8 @@ def get_available_cpu_count(only_physical_cores: bool = False) -> int:
             except ValueError:
                 pass
 
-    # 2. Use loky's robust CPU detection
-    result = loky.cpu_count(only_physical_cores=only_physical_cores)
+    # 2. Use joblib's robust CPU detection
+    result = joblib.cpu_count(only_physical_cores=only_physical_cores)
     logger.debug(f"loky.cpu_count(only_physical_cores={only_physical_cores}): {result}")
 
     # Ensure we never return less than 1

--- a/common/tests/unittests/utils/test_cpu_detection.py
+++ b/common/tests/unittests/utils/test_cpu_detection.py
@@ -39,10 +39,10 @@ def test_ag_cpu_count_takes_precedence():
     assert get_available_cpu_count() == 4
 
 
-@patch("loky.cpu_count")
+@patch("joblib.cpu_count")
 @patch.dict(os.environ, {}, clear=True)
 def test_loky_logical_cores_detection(mock_loky_cpu_count):
-    """Test that loky.cpu_count() is used for logical cores"""
+    """Test that joblib.cpu_count() is used for logical cores"""
     mock_loky_cpu_count.return_value = 8
 
     result = get_available_cpu_count(only_physical_cores=False)
@@ -51,10 +51,10 @@ def test_loky_logical_cores_detection(mock_loky_cpu_count):
     assert result == 8
 
 
-@patch("loky.cpu_count")
+@patch("joblib.cpu_count")
 @patch.dict(os.environ, {}, clear=True)
 def test_loky_physical_cores_detection(mock_loky_cpu_count):
-    """Test that loky.cpu_count() is used for physical cores"""
+    """Test that joblib.cpu_count() is used for physical cores"""
     mock_loky_cpu_count.return_value = 4
 
     result = get_available_cpu_count(only_physical_cores=True)
@@ -63,7 +63,7 @@ def test_loky_physical_cores_detection(mock_loky_cpu_count):
     assert result == 4
 
 
-@patch("loky.cpu_count")
+@patch("joblib.cpu_count")
 @patch.dict(os.environ, {}, clear=True)
 def test_minimum_cpu_count_is_one(mock_loky_cpu_count):
     """Test that we never return less than 1 CPU"""

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -19,7 +19,7 @@ DEPENDENT_PACKAGES = {
     "boto3": ">=1.10,<2",  # <2 because unlikely to introduce breaking changes in minor releases. >=1.10 because 1.10 is 3 years old, no need to support older
     "numpy": ">=1.25.0,<2.4.0",  # "<{N+3}" upper cap, where N is the latest released minor version, assuming no warnings using N
     "pandas": ">=2.0.0,<2.4.0",  # "<{N+3}" upper cap
-    "pyarrow": ">=7.0.0,<21.0.0",  #"<{N=1}.0.0" upper cap
+    "pyarrow": ">=7.0.0,<21.0.0",  # "<{N=1}.0.0" upper cap
     "scikit-learn": ">=1.4.0,<1.8.0",  # <{N+1} upper cap
     "scipy": ">=1.5.4,<1.17",  # "<{N+2}" upper cap
     "matplotlib": ">=3.7.0,<3.11",  # "<{N+2}" upper cap
@@ -34,10 +34,14 @@ DEPENDENT_PACKAGES = {
     "transformers[sentencepiece]": ">=4.38.0,<4.50",  # there is a breaking change in 4.50 for model config saving
     "accelerate": ">=0.34.0,<2.0",
     "typing-extensions": ">=4.0,<5",
-    "loky": ">=3.5,<3.7",
+    "joblib": ">=1.2,<1.7",  # <{N+1} upper cap
 }
 if LITE_MODE:
-    DEPENDENT_PACKAGES = {package: version for package, version in DEPENDENT_PACKAGES.items() if package not in ["psutil", "Pillow", "timm"]}
+    DEPENDENT_PACKAGES = {
+        package: version
+        for package, version in DEPENDENT_PACKAGES.items()
+        if package not in ["psutil", "Pillow", "timm"]
+    }
 
 DEPENDENT_PACKAGES = {package: package + version for package, version in DEPENDENT_PACKAGES.items()}
 # TODO: Use DOCS_PACKAGES and TEST_PACKAGES

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -37,11 +37,7 @@ DEPENDENT_PACKAGES = {
     "joblib": ">=1.2,<1.7",  # <{N+1} upper cap
 }
 if LITE_MODE:
-    DEPENDENT_PACKAGES = {
-        package: version
-        for package, version in DEPENDENT_PACKAGES.items()
-        if package not in ["psutil", "Pillow", "timm"]
-    }
+    DEPENDENT_PACKAGES = {package: version for package, version in DEPENDENT_PACKAGES.items() if package not in ["psutil", "Pillow", "timm"]}
 
 DEPENDENT_PACKAGES = {package: package + version for package, version in DEPENDENT_PACKAGES.items()}
 # TODO: Use DOCS_PACKAGES and TEST_PACKAGES

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -21,7 +21,7 @@ version = ag.update_version(version)
 submodule = "timeseries"
 install_requires = [
     # version ranges added in ag.get_dependency_version_ranges()
-    "joblib>=1.1,<2",
+    "joblib",  # version range defined in `core/_setup_utils.py`
     "numpy",  # version range defined in `core/_setup_utils.py`
     "scipy",  # version range defined in `core/_setup_utils.py`
     "pandas",  # version range defined in `core/_setup_utils.py`


### PR DESCRIPTION
*Issue #, if available:*

For some unexplainable reason, the statement `import loky` that was added in #5197 results in weird and verbose error messages printed by the `PerStepTabularModel` in the TS module.

MWE:
```python
from autogluon.timeseries import TimeSeriesPredictor

if __name__ == "__main__":
    predictor = TimeSeriesPredictor(prediction_length=2).fit(
        "https://autogluon.s3.amazonaws.com/datasets/timeseries/m4_hourly_subset/train.csv",
        hyperparameters={"PerStepTabular": {}},
        time_limit=15,
    )
```
Predictor log after #5197:
```
...
Provided data contains following columns:
        target: 'target'

AutoGluon will gauge predictive performance using evaluation metric: 'WQL'
        This metric's sign has been flipped to adhere to being higher_is_better. The metric score can be multiplied by -1 to get the metric value.
===================================================

Starting training. Start time is 2025-07-12 09:10:24
Models that will be trained: ['PerStepTabular']
Training timeseries model PerStepTabular. Training for up to 11.6s of the 11.6s of remaining time.
Traceback (most recent call last):
  File "/home/shchuro/envs/ag/lib/python3.11/site-packages/joblib/externals/loky/backend/resource_tracker.py", line 266, in main
    registry[rtype][name] -= 1
    ~~~~~~~~~~~~~~~^^^^^^
KeyError: '/dev/shm/joblib_memmapping_folder_2080267_a591a980abd144ab919ef92834853562_2c96e0fed1df41fdb77e1d2ed10be239/2080267-140641064160912-2b77f28e535345088edbec4477aab44a.pkl'
Traceback (most recent call last):
  File "/home/shchuro/envs/ag/lib/python3.11/site-packages/joblib/externals/loky/backend/resource_tracker.py", line 266, in main
    registry[rtype][name] -= 1
    ~~~~~~~~~~~~~~~^^^^^^
KeyError: '/dev/shm/joblib_memmapping_folder_2080267_a591a980abd144ab919ef92834853562_2c96e0fed1df41fdb77e1d2ed10be239/2080267-140641064160912-2b77f28e535345088edbec4477aab44a.pkl'
Traceback (most recent call last):
  File "/home/shchuro/envs/ag/lib/python3.11/site-packages/joblib/externals/loky/backend/resource_tracker.py", line 266, in main
    registry[rtype][name] -= 1
    ~~~~~~~~~~~~~~~^^^^^^
KeyError: '/dev/shm/joblib_memmapping_folder_2080267_a591a980abd144ab919ef92834853562_9f1bd0e79d824b2886fea08755112e8d/2080267-140641064160912-b913dccae3914e148e8984c440e9f28a.pkl'
Traceback (most recent call last):
  File "/home/shchuro/envs/ag/lib/python3.11/site-packages/joblib/externals/loky/backend/resource_tracker.py", line 266, in main
    registry[rtype][name] -= 1
    ~~~~~~~~~~~~~~~^^^^^^
KeyError: '/dev/shm/joblib_memmapping_folder_2080267_a591a980abd144ab919ef92834853562_9f1bd0e79d824b2886fea08755112e8d/2080267-140641064160912-a01d02dc55bb49daaee15f282d24e6eb.pkl'
Traceback (most recent call last):
  File "/home/shchuro/envs/ag/lib/python3.11/site-packages/joblib/externals/loky/backend/resource_tracker.py", line 266, in main
    registry[rtype][name] -= 1
    ~~~~~~~~~~~~~~~^^^^^^
KeyError: '/dev/shm/joblib_memmapping_folder_2080267_a591a980abd144ab919ef92834853562_9f1bd0e79d824b2886fea08755112e8d/2080267-140641064160912-b913dccae3914e148e8984c440e9f28a.pkl'
Traceback (most recent call last):
  File "/home/shchuro/envs/ag/lib/python3.11/site-packages/joblib/externals/loky/backend/resource_tracker.py", line 266, in main
    registry[rtype][name] -= 1
    ~~~~~~~~~~~~~~~^^^^^^
KeyError: '/dev/shm/joblib_memmapping_folder_2080267_a591a980abd144ab919ef92834853562_9f1bd0e79d824b2886fea08755112e8d/2080267-140641064160912-a01d02dc55bb49daaee15f282d24e6eb.pkl'
        -0.0103       = Validation score (-WQL)
        13.41   s     = Training runtime
        1.25    s     = Validation (prediction) runtime
Not fitting ensemble due to lack of time remaining. Time left: -3.1 seconds
Training complete. Models trained: ['PerStepTabular']
Total runtime: 14.68 s
Best model: PerStepTabular
Best model score: -0.0103
```
The number of the `KeyError: '/dev/shm/joblib_memmapping_...` log entries is proportional to the # of parallel jobs used when fitting the model.

The log messages have no effect on the model performance, the model trains as predicts normally.

This problem disappears if we remove the `import loky` line from `common/src/autogluon/common/utils/cpu_utils.py`, or replace it with `import joblib`. This is really surprising given that `joblib.cpu_count` just calls `loky.cpu_count` under the hood: https://github.com/joblib/joblib/blob/0672e76ad10e9f463221a58fb7bffa127287a4ba/joblib/parallel.py#L631-L648

I was unable to trace down the root cause of the problem, but I suspect it's related to some initialization that is performed during `import loky` that leads to errors if `joblib` is already imported.

Note that autogluon already has a hard dependency on `joblib` via [`sklearn`](https://github.com/scikit-learn/scikit-learn/blob/f187311fb7dbdf37f27868f9f054494171003068/pyproject.toml#L12), so this PR does not introduce any new dependencies.

*Description of changes:*
- Replace `loky.cpu_count()` with `joblib.cpu_count()`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
