### PR TITLE
[tabular] Fix default loss_function for CatBoostModel with problem_type='regression'

### DIFF
--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -134,7 +134,7 @@ class CatBoostModel(AbstractModel):
             params.setdefault("loss_function",  SoftclassObjective.SoftLogLossObjective())
             params["eval_metric"] = SoftclassCustomMetric.SoftLogLossMetric()
         elif self.problem_type in [REGRESSION, QUANTILE]:
-            # Make sure that the regression loss function matches the evaluation metric if it can be used for optimization
+            # Choose appropriate loss_function that is as close as possible to the eval_metric
             params.setdefault(
                 "loss_function",
                 CATBOOST_EVAL_METRIC_TO_LOSS_FUNCTION.get(params["eval_metric"], params["eval_metric"])

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -13,7 +13,7 @@ from autogluon.common.features.types import R_BOOL, R_CATEGORY, R_FLOAT, R_INT
 from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
 from autogluon.common.utils.resource_utils import ResourceManager
 from autogluon.common.utils.try_import import try_import_catboost
-from autogluon.core.constants import MULTICLASS, PROBLEM_TYPES_CLASSIFICATION, QUANTILE, SOFTCLASS
+from autogluon.core.constants import MULTICLASS, PROBLEM_TYPES_CLASSIFICATION, REGRESSION, QUANTILE, SOFTCLASS
 from autogluon.core.models import AbstractModel
 from autogluon.core.models._utils import get_early_stopping_rounds
 from autogluon.core.utils.exceptions import TimeLimitExceeded
@@ -136,6 +136,9 @@ class CatBoostModel(AbstractModel):
         elif self.problem_type == QUANTILE:
             # FIXME: Unless specified, CatBoost defaults to loss_function='MultiQuantile' and raises an exception
             params["loss_function"] = params["eval_metric"]
+        elif self.problem_type == REGRESSION:
+            # CatBoostRegressor defaults to loss_function='RMSE', which leads to poor results for median-based losses like MAE
+            params.setdefault("loss_function", params["eval_metric"])
 
         model_type = CatBoostClassifier if self.problem_type in PROBLEM_TYPES_CLASSIFICATION else CatBoostRegressor
         num_rows_train = len(X)

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -19,7 +19,7 @@ from autogluon.core.models._utils import get_early_stopping_rounds
 from autogluon.core.utils.exceptions import TimeLimitExceeded
 
 from .callbacks import EarlyStoppingCallback, MemoryCheckCallback, TimeCheckCallback
-from .catboost_utils import get_catboost_metric_from_ag_metric, CATBOOST_EVALUATION_ONLY_METRICS
+from .catboost_utils import get_catboost_metric_from_ag_metric, CATBOOST_EVAL_METRIC_TO_LOSS_FUNCTION
 from .hyperparameters.parameters import get_param_baseline
 from .hyperparameters.searchspaces import get_default_searchspace
 
@@ -135,8 +135,10 @@ class CatBoostModel(AbstractModel):
             params["eval_metric"] = SoftclassCustomMetric.SoftLogLossMetric()
         elif self.problem_type in [REGRESSION, QUANTILE]:
             # Make sure that the regression loss function matches the evaluation metric if it can be used for optimization
-            if params["eval_metric"] not in CATBOOST_EVALUATION_ONLY_METRICS:
-                params.setdefault("loss_function", params["eval_metric"])
+            params.setdefault(
+                "loss_function",
+                CATBOOST_EVAL_METRIC_TO_LOSS_FUNCTION.get(params["eval_metric"], params["eval_metric"])
+            )
 
         model_type = CatBoostClassifier if self.problem_type in PROBLEM_TYPES_CLASSIFICATION else CatBoostRegressor
         num_rows_train = len(X)

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_utils.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_utils.py
@@ -6,8 +6,13 @@ logger = logging.getLogger(__name__)
 
 
 CATBOOST_QUANTILE_PREFIX = "Quantile:"
+# Mapping from non-optimizable eval_metric to optimizable loss_function.
 # See https://catboost.ai/docs/en/concepts/loss-functions-regression#usage-information
-CATBOOST_EVALUATION_ONLY_METRICS = ["MedianAbsoluteError", "SMAPE", "R2"]
+CATBOOST_EVAL_METRIC_TO_LOSS_FUNCTION = {
+    "MedianAbsoluteError": "MAE",
+    "SMAPE": "MAPE",
+    "R2": "RMSE",
+}
 
 
 # TODO: Add weight support?
@@ -68,6 +73,7 @@ def get_catboost_metric_from_ag_metric(metric, problem_type, quantile_levels=Non
             root_mean_squared_error="RMSE",
             mean_absolute_error="MAE",
             mean_absolute_percentage_error="MAPE",
+            # Non-optimizable metrics, see CATBOOST_EVAL_METRIC_TO_LOSS_FUNCTION
             median_absolute_error="MedianAbsoluteError",
             symmetric_mean_absolute_percentage_error="SMAPE",
             r2="R2",

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_utils.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_utils.py
@@ -6,6 +6,8 @@ logger = logging.getLogger(__name__)
 
 
 CATBOOST_QUANTILE_PREFIX = "Quantile:"
+# See https://catboost.ai/docs/en/concepts/loss-functions-regression#usage-information
+CATBOOST_EVALUATION_ONLY_METRICS = ["MedianAbsoluteError", "SMAPE", "R2"]
 
 
 # TODO: Add weight support?
@@ -65,7 +67,9 @@ def get_catboost_metric_from_ag_metric(metric, problem_type, quantile_levels=Non
             mean_squared_error="RMSE",
             root_mean_squared_error="RMSE",
             mean_absolute_error="MAE",
+            mean_absolute_percentage_error="MAPE",
             median_absolute_error="MedianAbsoluteError",
+            symmetric_mean_absolute_percentage_error="SMAPE",
             r2="R2",
         )
         metric_class = metric_map.get(metric.name, "RMSE")

--- a/tabular/src/autogluon/tabular/testing/fit_helper.py
+++ b/tabular/src/autogluon/tabular/testing/fit_helper.py
@@ -441,9 +441,9 @@ class FitHelper:
                 num_bag_sets=1,
             )
             if isinstance(bag, bool):
-                problem_types_bag = supported_problem_types
+                problem_types_bag = problem_types_to_check
             elif bag == "first":
-                problem_types_bag = supported_problem_types[:1]
+                problem_types_bag = problem_types_to_check[:1]
             else:
                 raise ValueError(f"Unknown 'bag' value: {bag}")
 

--- a/tabular/tests/unittests/models/test_catboost.py
+++ b/tabular/tests/unittests/models/test_catboost.py
@@ -14,3 +14,16 @@ def test_catboost():
     model_hyperparameters = toy_model_params
 
     FitHelper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters)
+
+
+@pytest.mark.parametrize("eval_metric", ["r2", "mean_absolute_error"])
+def test_catboost_can_train_with_nondefault_regression_eval_metrics(eval_metric):
+    model_cls = CatBoostModel
+    model_hyperparameters = toy_model_params
+
+    FitHelper.verify_model(
+        model_cls=model_cls,
+        model_hyperparameters=model_hyperparameters,
+        init_args={"eval_metric": eval_metric},
+        problem_types=["regression"],
+    )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Currently, the `CatBoostModel` in AutoGluon always uses the default `loss_function` [(RMSE)](https://catboost.ai/docs/en/concepts/python-reference_catboostregressor) when `problem_type="regression"` is used. This means, the model always tries to estimate the conditional mean, which can lead to poor results for datasets with skewed targets if the user actually cares about the conditional median (e.g., cares about the metric like MAE).

  This PR updates the default value of the `loss_function` used by CatBoostRegressor to match the user-defined `eval_metric`. 

On a small benchmark of 31 time series forecasting tasks, the `PerStepTabular` model (based on CatBoost) achieves 77% win rate and up to 30% error reduction (median: 4% reduction) compared to the default CatBoost version with the RMSE loss.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
