### PR TITLE
Spunge Augmentation Speed-Up

### DIFF
--- a/core/src/autogluon/core/augmentation/distill_utils.py
+++ b/core/src/autogluon/core/augmentation/distill_utils.py
@@ -63,7 +63,6 @@ def postprocess_augmented(X_aug, X):
     return X_aug.reset_index(drop=True, inplace=False)
 
 
-# TODO: This can easily be optimized heavily
 def spunge_augment(X, feature_metadata: FeatureMetadata, num_augmented_samples=10000, frac_perturb=0.1, continuous_feature_noise=0.1, **kwargs):
     """Generates synthetic datapoints for learning to mimic teacher model in distillation
     via simplified version of MUNGE strategy (that does not require near-neighbor search).
@@ -90,21 +89,34 @@ def spunge_augment(X, feature_metadata: FeatureMetadata, num_augmented_samples=1
         else:
             X[feature] = X[feature].cat.add_categories(nan_category).fillna(nan_category)
 
-    num_feature_perturb = max(1, int(frac_perturb * len(X.columns)))
-    X_aug = pd.concat([X.iloc[[0]].copy()] * num_augmented_samples)
-    X_aug.reset_index(drop=True, inplace=True)
     continuous_types = [R_FLOAT, R_INT]
     continuous_featnames = feature_metadata.get_features(valid_raw_types=continuous_types)  # these features will have shuffled values with added noise
 
-    for i in range(num_augmented_samples):  # hot-deck sample some features per datapoint
-        og_ind = i % len(X)
-        augdata_i = X.iloc[og_ind].copy()
-        num_feature_perturb_i = np.random.choice(range(1, num_feature_perturb + 1))  # randomly sample number of features to perturb
-        cols_toperturb = np.random.choice(list(X.columns), size=num_feature_perturb_i, replace=False)
-        for feature in cols_toperturb:
-            feature_data = X[feature]
-            augdata_i[feature] = feature_data.sample(n=1).values[0]
-        X_aug.iloc[i] = augdata_i
+    # Rather than loop row-wise, we build a large mask that indicates all cells to be
+    # resampled and then loop column-wise, resampling and replacing
+    _, y_i = X.shape
+    feature_count = int(frac_perturb * y_i)
+    # Builds our new frame with much less copying than before
+    X_aug = pd.concat([X] * (int(num_augmented_samples / len(X)) + 1)).copy()[
+        :num_augmented_samples
+    ]
+    x_aug_i, _ = X_aug.shape
+    X_aug.reset_index(drop=True, inplace=True)
+    arr = np.array(
+        [np.random.choice(y_i, replace=False, size=feature_count) for _ in range(x_aug_i)]
+    )
+    max_col = y_i
+
+    # Create an empty boolean array of appropriate shape
+    n_rows = arr.shape[0]
+    mask = np.zeros((n_rows, max_col), dtype=bool)
+
+    # Use advanced indexing to set the specified positions to True
+    row_indices = np.arange(n_rows)[:, None]
+    mask[row_indices, arr] = True
+    mask = mask.T
+    for i, col in enumerate(mask):
+        X_aug.loc[col, X.columns[i]] = X.iloc[:, i].sample(col.sum(), replace=True).values
 
     for feature in X.columns:
         if feature in continuous_featnames:


### PR DESCRIPTION
When using .distill on my wimpy home laptop, I noticed that `spunge_augment` was extremely slow and had a TODO comment noting that it could be heavily optimized. Mostly I've removed lots of unnecessary copying and iterating. Now it builds the new dataframe, a frame at a time instead of a row at a time. It also produces a large mask of which values should be swapped then goes column by column resampling and replacing.

Speed Testing:
```python
timeit.timeit(
    """predictor.distill(
        train_data, hyperparameters={}, augment_args={"num_augmented_samples": 1000}
    )""",
    setup="""from autogluon.tabular import TabularDataset, TabularPredictor
from autogluon.features.generators import AutoMLPipelineFeatureGenerator
import timeit

subsample_size = 500
time_limit = 3

label = "class"  # specifies which column do we want to predict
train_file_path = "https://autogluon.s3.amazonaws.com/datasets/Inc/train.csv"
test_file_path = "https://autogluon.s3.amazonaws.com/datasets/Inc/test.csv"

train_data = TabularDataset(train_file_path)
test_data = TabularDataset(test_file_path)

# Fit model ensemble:
predictor = TabularPredictor(label).fit(
    train_data, auto_stack=True, time_limit=time_limit
)
""",
    number=10,
)

```

Previously was 21.75, now 1.35 on my machine.

This is my first attempt at open-source contribution, please let me know if there's anything I should fix to get this accepted. Thanks!