### PR TITLE
[Timeseries] Fix version incompatibility for benchmarking

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/per_step.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/per_step.py
@@ -442,7 +442,7 @@ class PerStepTabularModel(AbstractTimeSeriesModel):
     def _predict(
         self,
         data: TimeSeriesDataFrame,
-        known_covariates: TimeSeriesDataFrame | None = None,
+        known_covariates: Optional[TimeSeriesDataFrame] = None,
         **kwargs,
     ) -> TimeSeriesDataFrame:
         if known_covariates is not None:


### PR DESCRIPTION
*Description of changes:*
Fixes failing benchmarking issue caused due to version incompatibility in python version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
