### PR TITLE
[tabular] Enhance GPU resource handling across foundational tab models with error logging

### DIFF
--- a/common/src/autogluon/common/utils/resource_utils.py
+++ b/common/src/autogluon/common/utils/resource_utils.py
@@ -11,6 +11,7 @@ from .distribute_utils import DistributedContext
 from .lite import disable_if_lite_mode
 from .utils import bytes_to_mega_bytes
 
+logger = logging.getLogger(__name__)
 
 class ResourceManager:
     """Manager that fetches system related info"""
@@ -50,19 +51,38 @@ class ResourceManager:
         return num_gpus
 
     @staticmethod
-    def get_gpu_count_torch() -> int:
+    def get_gpu_count_torch(cuda_only: bool = False) -> int:
+        """
+        Get the number of available GPUs
+        
+        Parameters
+        ----------
+        cuda_only : bool, default=False
+            If True, only check for CUDA GPUs and ignore other supported accelerators.
+            This is useful for models that only support CUDA and not other accelerators.
+        
+        Returns
+        -------
+        int
+            Number of available GPUs. When cuda_only=True, returns the actual CUDA device count.
+        """
         try:
             import torch
 
             if torch.cuda.is_available():
                 num_gpus = torch.cuda.device_count()
-            elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+            elif not cuda_only and hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
                 # Apple Silicon MPS (Metal Performance Shaders) support
                 # Apple Silicon Macs have only one integrated GPU
                 num_gpus = 1
             else:
                 num_gpus = 0
         except Exception:
+            logger.log(
+                40,
+                "\tFailed to import torch or check CUDA availability!"
+                "Please ensure you have the correct version of PyTorch installed by running `pip install -U torch`"
+            )
             num_gpus = 0
         return num_gpus
 

--- a/common/src/autogluon/common/utils/resource_utils.py
+++ b/common/src/autogluon/common/utils/resource_utils.py
@@ -13,6 +13,7 @@ from .utils import bytes_to_mega_bytes
 
 logger = logging.getLogger(__name__)
 
+
 class ResourceManager:
     """Manager that fetches system related info"""
 
@@ -54,13 +55,13 @@ class ResourceManager:
     def get_gpu_count_torch(cuda_only: bool = False) -> int:
         """
         Get the number of available GPUs
-        
+
         Parameters
         ----------
         cuda_only : bool, default=False
             If True, only check for CUDA GPUs and ignore other supported accelerators.
             This is useful for models that only support CUDA and not other accelerators.
-        
+
         Returns
         -------
         int
@@ -81,7 +82,7 @@ class ResourceManager:
             logger.log(
                 40,
                 "\tFailed to import torch or check CUDA availability!"
-                "Please ensure you have the correct version of PyTorch installed by running `pip install -U torch`"
+                "Please ensure you have the correct version of PyTorch installed by running `pip install -U torch`",
             )
             num_gpus = 0
         return num_gpus

--- a/tabular/src/autogluon/tabular/models/mitra/mitra_model.py
+++ b/tabular/src/autogluon/tabular/models/mitra/mitra_model.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from typing import List, Optional
 
@@ -6,9 +5,7 @@ import pandas as pd
 
 from autogluon.common.utils.resource_utils import ResourceManager
 from autogluon.core.models import AbstractModel
-from autogluon.tabular import __version__
 
-logger = logging.getLogger(__name__)
 
 # TODO: Needs memory usage estimate method
 class MitraModel(AbstractModel):
@@ -145,21 +142,7 @@ class MitraModel(AbstractModel):
         # Use only physical cores for better performance based on benchmarks
         num_cpus = ResourceManager.get_cpu_count(only_physical_cores=True)
 
-        # Only request GPU if CUDA is available
-        try:
-            import torch
-            if torch.cuda.is_available():
-                num_gpus = 1
-            else:
-                num_gpus = 0
-        except (ImportError, RuntimeError, SystemError) as e:
-            logger.log(
-                40,
-                f"\tFailed to import torch or check CUDA availability for Mitra! To use the Mitra model, "
-                f"do: `pip install autogluon.tabular[mitra]=={__version__}`. "
-                f"Error: {str(e)}",
-            )
-            num_gpus = 0
+        num_gpus = min(1, ResourceManager.get_gpu_count_torch(cuda_only=True))
 
         return num_cpus, num_gpus
 

--- a/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
+++ b/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
@@ -274,9 +274,20 @@ class RealMLPModel(AbstractModel):
     def _get_default_resources(self) -> tuple[int, int]:
         # Use only physical cores for better performance based on benchmarks
         num_cpus = ResourceManager.get_cpu_count(only_physical_cores=True)
+        
         # Only request GPU if CUDA is available (RealMLP doesn't support MPS)
-        import torch
-        num_gpus = 1 if torch.cuda.is_available() else 0
+        try:
+            import torch
+            num_gpus = 1 if torch.cuda.is_available() else 0
+        except (ImportError, RuntimeError, SystemError) as e:
+            logger.log(
+                40,
+                f"\tFailed to import torch or check CUDA availability for RealMLP! To use the RealMLP model, "
+                f"do: `pip install autogluon.tabular[realmlp]=={__version__}`. "
+                f"Error: {str(e)}",
+            )
+            num_gpus = 0
+        
         return num_cpus, num_gpus
 
     def _estimate_memory_usage(self, X: pd.DataFrame, **kwargs) -> int:

--- a/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
+++ b/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
@@ -274,20 +274,9 @@ class RealMLPModel(AbstractModel):
     def _get_default_resources(self) -> tuple[int, int]:
         # Use only physical cores for better performance based on benchmarks
         num_cpus = ResourceManager.get_cpu_count(only_physical_cores=True)
-        
-        # Only request GPU if CUDA is available (RealMLP doesn't support MPS)
-        try:
-            import torch
-            num_gpus = 1 if torch.cuda.is_available() else 0
-        except (ImportError, RuntimeError, SystemError) as e:
-            logger.log(
-                40,
-                f"\tFailed to import torch or check CUDA availability for RealMLP! To use the RealMLP model, "
-                f"do: `pip install autogluon.tabular[realmlp]=={__version__}`. "
-                f"Error: {str(e)}",
-            )
-            num_gpus = 0
-        
+
+        num_gpus = min(1, ResourceManager.get_gpu_count_torch(cuda_only=True))
+
         return num_cpus, num_gpus
 
     def _estimate_memory_usage(self, X: pd.DataFrame, **kwargs) -> int:

--- a/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
+++ b/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
@@ -111,9 +111,20 @@ class TabICLModel(AbstractModel):
     def _get_default_resources(self) -> tuple[int, int]:
         # Use only physical cores for better performance based on benchmarks
         num_cpus = ResourceManager.get_cpu_count(only_physical_cores=True)
+        
         # Only request GPU if CUDA is available (TabICL doesn't support MPS)
-        import torch
-        num_gpus = 1 if torch.cuda.is_available() else 0
+        try:
+            import torch
+            num_gpus = 1 if torch.cuda.is_available() else 0
+        except (ImportError, RuntimeError, SystemError) as e:
+            logger.log(
+                40,
+                f"\tFailed to import torch or check CUDA availability for TabICL! To use the TabICL model, "
+                f"do: `pip install autogluon.tabular[tabicl]=={__version__}`. "
+                f"Error: {str(e)}",
+            )
+            num_gpus = 0
+        
         return num_cpus, num_gpus
 
     def _estimate_memory_usage(self, X: pd.DataFrame, **kwargs) -> int:

--- a/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
+++ b/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
@@ -111,20 +111,8 @@ class TabICLModel(AbstractModel):
     def _get_default_resources(self) -> tuple[int, int]:
         # Use only physical cores for better performance based on benchmarks
         num_cpus = ResourceManager.get_cpu_count(only_physical_cores=True)
-        
-        # Only request GPU if CUDA is available (TabICL doesn't support MPS)
-        try:
-            import torch
-            num_gpus = 1 if torch.cuda.is_available() else 0
-        except (ImportError, RuntimeError, SystemError) as e:
-            logger.log(
-                40,
-                f"\tFailed to import torch or check CUDA availability for TabICL! To use the TabICL model, "
-                f"do: `pip install autogluon.tabular[tabicl]=={__version__}`. "
-                f"Error: {str(e)}",
-            )
-            num_gpus = 0
-        
+
+        num_gpus = min(1, ResourceManager.get_gpu_count_torch(cuda_only=True))
         return num_cpus, num_gpus
 
     def _estimate_memory_usage(self, X: pd.DataFrame, **kwargs) -> int:

--- a/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
+++ b/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
@@ -150,20 +150,8 @@ class TabMModel(AbstractModel):
     def _get_default_resources(self) -> tuple[int, int]:
         # Use only physical cores for better performance based on benchmarks
         num_cpus = ResourceManager.get_cpu_count(only_physical_cores=True)
-        
-        # Only request GPU if CUDA is available (TabM doesn't support other accelerators such as MPS)
-        try:
-            import torch
-            num_gpus = 1 if torch.cuda.is_available() else 0
-        except (ImportError, RuntimeError, SystemError) as e:
-            logger.log(
-                40,
-                f"\tFailed to import torch or check CUDA availability for TabM! To use the TabM model, "
-                f"do: `pip install autogluon.tabular[tabm]=={__version__}`. "
-                f"Error: {str(e)}",
-            )
-            num_gpus = 0
-        
+
+        num_gpus = min(1, ResourceManager.get_gpu_count_torch(cuda_only=True))
         return num_cpus, num_gpus
 
     def _estimate_memory_usage(self, X: pd.DataFrame, **kwargs) -> int:

--- a/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
+++ b/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
@@ -150,9 +150,20 @@ class TabMModel(AbstractModel):
     def _get_default_resources(self) -> tuple[int, int]:
         # Use only physical cores for better performance based on benchmarks
         num_cpus = ResourceManager.get_cpu_count(only_physical_cores=True)
+        
         # Only request GPU if CUDA is available (TabM doesn't support other accelerators such as MPS)
-        import torch
-        num_gpus = 1 if torch.cuda.is_available() else 0
+        try:
+            import torch
+            num_gpus = 1 if torch.cuda.is_available() else 0
+        except (ImportError, RuntimeError, SystemError) as e:
+            logger.log(
+                40,
+                f"\tFailed to import torch or check CUDA availability for TabM! To use the TabM model, "
+                f"do: `pip install autogluon.tabular[tabm]=={__version__}`. "
+                f"Error: {str(e)}",
+            )
+            num_gpus = 0
+        
         return num_cpus, num_gpus
 
     def _estimate_memory_usage(self, X: pd.DataFrame, **kwargs) -> int:

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_model.py
@@ -283,18 +283,7 @@ class TabPFNV2Model(AbstractModel):
         # Use only physical cores for better performance based on benchmarks
         num_cpus = ResourceManager.get_cpu_count(only_physical_cores=True)
 
-        # Only request GPU if CUDA is available (TabPFNV2 doesn't support other accelerators such as MPS)
-        try:
-            import torch
-            num_gpus = 1 if torch.cuda.is_available() else 0
-        except (ImportError, RuntimeError, SystemError) as e:
-            logger.log(
-                40,
-                f"\tFailed to import torch or check CUDA availability for TabPFN! To use the TabPFN model, "
-                f"do: `pip install autogluon.tabular[tabpfn]=={__version__}`. "
-                f"Error: {str(e)}",
-            )
-            num_gpus = 0
+        num_gpus = min(1, ResourceManager.get_gpu_count_torch(cuda_only=True))
 
         return num_cpus, num_gpus
 

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_model.py
@@ -282,9 +282,20 @@ class TabPFNV2Model(AbstractModel):
     def _get_default_resources(self) -> tuple[int, int]:
         # Use only physical cores for better performance based on benchmarks
         num_cpus = ResourceManager.get_cpu_count(only_physical_cores=True)
+
         # Only request GPU if CUDA is available (TabPFNV2 doesn't support other accelerators such as MPS)
-        import torch
-        num_gpus = 1 if torch.cuda.is_available() else 0
+        try:
+            import torch
+            num_gpus = 1 if torch.cuda.is_available() else 0
+        except (ImportError, RuntimeError, SystemError) as e:
+            logger.log(
+                40,
+                f"\tFailed to import torch or check CUDA availability for TabPFN! To use the TabPFN model, "
+                f"do: `pip install autogluon.tabular[tabpfn]=={__version__}`. "
+                f"Error: {str(e)}",
+            )
+            num_gpus = 0
+
         return num_cpus, num_gpus
 
     def _set_default_params(self):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR addresses a issue identified in the previous PR (#5221) where `torch` was being imported directly in the `_get_default_resources()` method across several foundational tabular models (RealMLP, TabPFNv2, TabM, TabICL, and Mitra).

The `_get_default_resources()` method is called very early in the AutoGluon workflow - during model initialization and resource calculation phases, before proper error handling mechanisms are established. When torch import fails at this stage, it can:
* Bypass error handling logic - The failure occurs before AutoGluon's try/catch mechanisms are set up
* Crash the entire AutoGluon process - Instead of gracefully falling back to CPU-only mode
* Prevent proper user feedback - Users don't get helpful error messages about missing dependencies

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
