### PR TITLE
[Fix] Pass predictions to eval metric when weight_evaluation=True

### DIFF
--- a/core/src/autogluon/core/metrics/score_func.py
+++ b/core/src/autogluon/core/metrics/score_func.py
@@ -96,7 +96,7 @@ def compute_metric(
     if not weight_evaluation:
         return func(y, predictions, **kwargs)
     try:
-        weighted_metric = func(y, y_pred, sample_weight=weights, **kwargs)
+        weighted_metric = func(y, predictions, sample_weight=weights, **kwargs)
     except (ValueError, TypeError, KeyError):
         if hasattr(metric, "name"):
             metric_name = metric.name
@@ -104,5 +104,5 @@ def compute_metric(
             metric_name = metric
         if not silent:
             logger.log(30, f"WARNING: eval_metric='{metric_name}' does not support sample weights so they will be ignored in reported metric.")
-        weighted_metric = func(y, y_pred, **kwargs)
+        weighted_metric = func(y, predictions, **kwargs)
     return weighted_metric


### PR DESCRIPTION
Fixes #5185.

Pass `predictions` (i.e., `y_pred` or `y_pred_proba`) to eval metric. `y_pred` is `None` for metrics like `roc_auc`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.