### PR TITLE
[timeseries] Silence performance warnings in PerStepTabularModel

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/per_step.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/per_step.py
@@ -20,7 +20,7 @@ from autogluon.timeseries import TimeSeriesDataFrame
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 from autogluon.timeseries.utils.datetime import get_lags_for_frequency, get_time_features_for_frequency
-from autogluon.timeseries.utils.warning_filters import set_loggers_level
+from autogluon.timeseries.utils.warning_filters import set_loggers_level, warning_filter
 
 from .utils import MLF_ITEMID, MLF_TARGET, MLF_TIMESTAMP
 
@@ -150,7 +150,8 @@ class PerStepTabularModel(AbstractTimeSeriesModel):
 
         mlf = MLForecast(models=[], freq=cls._dummy_freq, lags=lags, date_features=date_features)
 
-        features_df = mlf.preprocess(train_df, static_features=[], dropna=False)
+        with warning_filter():
+            features_df = mlf.preprocess(train_df, static_features=[], dropna=False)
         del train_df
         del mlf
         # Sort chronologically for efficient train/test split
@@ -422,7 +423,8 @@ class PerStepTabularModel(AbstractTimeSeriesModel):
 
         mlf = MLForecast(models=[], freq=cls._dummy_freq, lags=lags, date_features=date_features)
 
-        features_df = mlf.preprocess(full_df, static_features=[], dropna=False)
+        with warning_filter():
+            features_df = mlf.preprocess(full_df, static_features=[], dropna=False)
         del mlf
 
         end_idx_per_item = np.cumsum(features_df[MLF_ITEMID].value_counts(sort=False).to_numpy(dtype="int32"))

--- a/timeseries/src/autogluon/timeseries/utils/warning_filters.py
+++ b/timeseries/src/autogluon/timeseries/utils/warning_filters.py
@@ -8,12 +8,14 @@ import sys
 import warnings
 from collections import Counter
 
+import pandas as pd
+
 __all__ = ["warning_filter", "disable_root_logger", "disable_tqdm"]
 
 
 @contextlib.contextmanager
 def warning_filter(all_warnings: bool = False):
-    categories = [RuntimeWarning, UserWarning, FutureWarning]
+    categories = [RuntimeWarning, UserWarning, FutureWarning, pd.errors.PerformanceWarning]
     if all_warnings:
         categories.append(Warning)
     with warnings.catch_warnings():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Currently `PerStepTabularModel` may produce lots of `PerformanceWarning` if the users provides a large list of lags, which results in a fragmented dataframe. This PR silences these warnings.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
