### PR TITLE
[after v1.4] [timeseries] Replace inf values with NaN inside _check_and_prepare_data_frame

### DIFF
--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -297,6 +297,16 @@ class TimeSeriesPredictor:
         if not pd.api.types.is_numeric_dtype(df[self.target]):
             raise ValueError(f"Target column {name}['{self.target}'] has a non-numeric dtype {df[self.target].dtype}")
         df = df.assign(**{self.target: df[self.target].astype("float64")})
+
+        # Only replace inf values if they are present in the data to avoid the expensive df.replace call
+        has_inf = False
+        for col in df.columns:
+            # Only float and complex dtypes can contain inf values
+            if pd.api.types.is_numeric_dtype(df[col]) and df[col].dtype.kind in "fc":
+                if np.isinf(df[col].values).any():
+                    has_inf = True
+        if has_inf:
+            df = df.replace(to_replace=[float("-inf"), float("inf")], value=float("nan"))
         # MultiIndex.is_monotonic_increasing checks if index is sorted by ["item_id", "timestamp"]
         if not df.index.is_monotonic_increasing:
             df = df.sort_index()

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -540,7 +540,7 @@ def test_when_fit_receives_only_future_data_as_tuning_data_then_exception_is_rai
     prediction_length = 3
     predictor = TimeSeriesPredictor(path=temp_model_path, prediction_length=prediction_length)
     future_data = DUMMY_TS_DATAFRAME.slice_by_timestep(-prediction_length, None)
-    with pytest.raises(ValueError, match="tuning\_data includes both historical and future data"):
+    with pytest.raises(ValueError, match=r"tuning_data includes both historical and future data"):
         predictor.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}}, tuning_data=future_data)
 
 
@@ -597,6 +597,15 @@ def test_given_data_is_not_sorted_then_preprocessed_data_is_sorted(temp_model_pa
     predictor = TimeSeriesPredictor(path=temp_model_path)
     ts_df_processed = predictor._check_and_prepare_data_frame(ts_df)
     assert ts_df_processed.index.is_monotonic_increasing
+
+
+def test_when_data_passed_to_predictor_contains_infs_then_they_are_replaced_with_nans(temp_model_path):
+    ts_df = DUMMY_TS_DATAFRAME.copy()
+    ts_df.iloc[5] = float("inf")
+    predictor = TimeSeriesPredictor(path=temp_model_path)
+    ts_df_processed = predictor._check_and_prepare_data_frame(ts_df)
+    assert not np.isinf(ts_df_processed).any(axis=None)
+    assert np.isnan(ts_df_processed).any(axis=None)
 
 
 def test_when_both_argument_aliases_are_passed_to_init_then_exception_is_raised(temp_model_path):

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -599,9 +599,10 @@ def test_given_data_is_not_sorted_then_preprocessed_data_is_sorted(temp_model_pa
     assert ts_df_processed.index.is_monotonic_increasing
 
 
-def test_when_data_passed_to_predictor_contains_infs_then_they_are_replaced_with_nans(temp_model_path):
+@pytest.mark.parametrize("value", [float("inf"), float("-inf")])
+def test_when_data_passed_to_predictor_contains_infs_then_they_are_replaced_with_nans(temp_model_path, value):
     ts_df = DUMMY_TS_DATAFRAME.copy()
-    ts_df.iloc[5] = float("inf")
+    ts_df.iloc[5] = value
     predictor = TimeSeriesPredictor(path=temp_model_path)
     ts_df_processed = predictor._check_and_prepare_data_frame(ts_df)
     assert not np.isinf(ts_df_processed).any(axis=None)


### PR DESCRIPTION
*Issue #, if available:* Fixes #5239

*Description of changes:*
- If numeric columns in the dataframe passed to the predictor contain `-inf` or `inf` values, replace them with `nan`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
