### PR TITLE
[timeseries] Fix refit_full failing during ensemble prediction if quantile_levels=[]

### DIFF
--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -16,7 +16,7 @@ from autogluon.common import space
 from autogluon.common.loaders import load_pkl
 from autogluon.timeseries.dataset import TimeSeriesDataFrame
 from autogluon.timeseries.models import DeepARModel, ETSModel
-from autogluon.timeseries.models.ensemble import GreedyEnsemble
+from autogluon.timeseries.models.ensemble import GreedyEnsemble, SimpleAverageEnsemble
 from autogluon.timeseries.trainer import TimeSeriesTrainer
 
 from .common import DATAFRAME_WITH_COVARIATES, DUMMY_TS_DATAFRAME, dict_equal_primitive, get_data_frame_with_item_index
@@ -454,6 +454,24 @@ def test_when_refit_full_called_with_model_name_then_single_model_is_updated(tem
     )
     model_refit_map = trainer.refit_full("DeepAR")
     assert list(model_refit_map.values()) == ["DeepAR_FULL"]
+
+
+def test_given_quantile_levels_is_empty_when_refit_full_is_used_then_all_models_can_predict(temp_model_path):
+    trainer = TimeSeriesTrainer(
+        path=temp_model_path, ensemble_model_type=SimpleAverageEnsemble, quantile_levels=[], eval_metric="MAE"
+    )
+    trainer.fit(
+        DUMMY_TS_DATAFRAME,
+        hyperparameters={
+            "Naive": {},
+            "RecursiveTabular": {},
+        },
+    )
+    trainer.refit_full(model="all")
+    for model in trainer.get_model_names():
+        preds = trainer.predict(DUMMY_TS_DATAFRAME, model=model)
+        assert isinstance(preds, TimeSeriesDataFrame)
+        assert len(preds) == DUMMY_TS_DATAFRAME.num_items * trainer.prediction_length
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
*Issue #, if available:* Fixes #5186

*Description of changes:*
- Ensure that `quantile_levels` is set correctly when a model is cloned with `convert_to_refit_full_template`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
