### PR TITLE
[multimodal] Cap fsspec version to avoid backtracking during pip version resolution

### DIFF
--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -32,6 +32,7 @@ install_requires = [
     "lightning",  # version range defined in `core/_setup_utils.py`
     "transformers[sentencepiece]",  # version range defined in `core/_setup_utils.py`
     "accelerate",  # version range defined in `core/_setup_utils.py`
+    "fsspec[http]<=2025.3",  # pin version to avoid conflicts with `datasets`
     "requests>=2.30,<3",
     "jsonschema>=4.18,<4.24",
     "seqeval>=1.2.2,<1.3.0",
@@ -47,7 +48,7 @@ install_requires = [
     f"autogluon.common=={version}",
     "pytorch-metric-learning>=1.3.0,<2.9",
     "nlpaug>=1.1.10,<1.2.0",
-    "nltk>=3.4.5,<3.10", # Updated upper bound to address CVE-2024-39705
+    "nltk>=3.4.5,<3.10",  # Updated upper bound to address CVE-2024-39705
     "openmim>=0.3.7,<0.4.0",
     "defusedxml>=0.7.1,<0.7.2",
     "jinja2>=3.0.3,<3.2",


### PR DESCRIPTION
*Issue #, if available:*

Currently when we run `pip install --pre autogluon` or `uv pip install --pre autogluon`, the dependency resolution process does a lot of backtracking and ends up installing an ancient version of `datasets`.

```
INFO: pip is looking at multiple versions of datasets to determine which version is compatible with other requirements. This could take a while.
Collecting datasets>=2.0.0 (from evaluate<0.5.0,>=0.4.0->autogluon.multimodal==1.4.0b20250724->autogluon)
  Downloading datasets-3.6.0-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-3.5.1-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-3.5.0-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-3.4.1-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-3.4.0-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-3.3.2-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-3.3.1-py3-none-any.whl.metadata (19 kB)
INFO: pip is still looking at multiple versions of datasets to determine which version is compatible with other requirements. This could take a while.
  Downloading datasets-3.3.0-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-3.2.0-py3-none-any.whl.metadata (20 kB)
  Downloading datasets-3.1.0-py3-none-any.whl.metadata (20 kB)
  Downloading datasets-3.0.2-py3-none-any.whl.metadata (20 kB)
  Downloading datasets-3.0.1-py3-none-any.whl.metadata (20 kB)
INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. See https://pip.pypa.io/warnings/backtracking for guidance. If you want to abort this run, press Ctrl + C.
  Downloading datasets-3.0.0-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-2.21.0-py3-none-any.whl.metadata (21 kB)
  Downloading datasets-2.20.0-py3-none-any.whl.metadata (19 kB)
Collecting pyarrow-hotfix (from datasets>=2.0.0->evaluate<0.5.0,>=0.4.0->autogluon.multimodal==1.4.0b20250724->autogluon)
  Downloading pyarrow_hotfix-0.7-py3-none-any.whl.metadata (3.6 kB)
Collecting datasets>=2.0.0 (from evaluate<0.5.0,>=0.4.0->autogluon.multimodal==1.4.0b20250724->autogluon)
  Downloading datasets-2.19.2-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-2.19.1-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-2.19.0-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-2.18.0-py3-none-any.whl.metadata (20 kB)
  Downloading datasets-2.17.1-py3-none-any.whl.metadata (20 kB)
  Downloading datasets-2.17.0-py3-none-any.whl.metadata (20 kB)
  Downloading datasets-2.16.1-py3-none-any.whl.metadata (20 kB)
Collecting dill (from evaluate<0.5.0,>=0.4.0->autogluon.multimodal==1.4.0b20250724->autogluon)
  Downloading dill-0.3.7-py3-none-any.whl.metadata (9.9 kB)
Collecting datasets>=2.0.0 (from evaluate<0.5.0,>=0.4.0->autogluon.multimodal==1.4.0b20250724->autogluon)
  Downloading datasets-2.16.0-py3-none-any.whl.metadata (20 kB)
  Downloading datasets-2.15.0-py3-none-any.whl.metadata (20 kB)
  Downloading datasets-2.14.7-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-2.14.6-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-2.14.5-py3-none-any.whl.metadata (19 kB)
  Downloading datasets-2.14.4-py3-none-any.whl.metadata (19 kB)
```

This ends up installing the 2 year old `datasets-2.14` that, for example, is incompatible with `pyarrow>=21.0`, completely breaking the Chronos models (#5230). Currently this is not critical since in v1.4.0 we introduced an upper bound for `pyarrow<21`, but could be problematic in the future.

This happens because `fsspec-2025.7.0` gets locked in early during the resolution process, and there does not exist a `datasets` version that is compatible with `fsspec-2025.7.0`.

*Description of changes:*
- By pinning the `fsspec` version we simplify the resolution process and `pip` is able to install `datasets-4.0.0`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
