### PR TITLE
[tabular] pytabkit bump to 1.6

### DIFF
--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -47,7 +47,7 @@ extras_require = {
         "xgboost>=2.0,<3.1",  # <{N+1} upper cap, where N is the latest released minor version
     ],
     "realmlp": [
-        "pytabkit>=1.5,<1.6",
+        "pytabkit>=1.6,<1.7",
     ],
     "fastai": [
         "spacy<3.9",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- pytabkit bump to 1.6, to enable the use of the new `n_ens` parameter for RealMLP.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
