### PR TITLE
[post-release] Remove redundant TabPFNv2 CPU log

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_model.py
@@ -198,12 +198,6 @@ class TabPFNV2Model(AbstractModel):
             # logs "Built with PriorLabs-TabPFN"
             self._log_license(device=device)
 
-        if num_gpus == 0:
-            logger.log(
-                30,
-                f"\tWARNING: Running TabPFNv2 on CPU. This can be very slow. We recommend using a GPU instead."
-            )
-
         X = self.preprocess(X, is_train=True)
 
         hps = self._get_model_params()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Remove redundant TabPFNv2 CPU log
- This log is already logged in the `self._log_license` call above.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
