### PR TITLE
[Tabular] Fix Source Install with New Models

### DIFF
--- a/tabular/src/autogluon/tabular/models/mitra/mitra_model.py
+++ b/tabular/src/autogluon/tabular/models/mitra/mitra_model.py
@@ -9,7 +9,6 @@ import pandas as pd
 from autogluon.common.utils.resource_utils import ResourceManager
 from autogluon.core.models import AbstractModel
 from autogluon.features.generators import LabelEncoderFeatureGenerator
-from autogluon.tabular import __version__
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +96,8 @@ class MitraModel(AbstractModel):
             model_cls = self.get_model_cls()
             import torch
         except ImportError as err:
+            from autogluon.tabular import __version__
+            
             logger.log(
                 40,
                 f"\tFailed to import Mitra! To use the Mitra model, "


### PR DESCRIPTION
All new models import the version of AutoGluon tabular, but the version does not exist when installing from source. 
Thus, one fix as shown here is to only import the version when needed. 

Otherwise, one could add a dummy version to https://github.com/autogluon/autogluon/blob/master/tabular/src/autogluon/tabular/__init__.py#L10


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
