### PR TITLE
[Tabular] Support different random seeds per fold

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -1034,6 +1034,11 @@ class AbstractModel(ModelBase, Tunable):
             verbosity 2: logs only important information.
             verbosity 1: logs only warnings and exceptions.
             verbosity 0: logs only exceptions.
+        random_seed : int, default = 0
+            The random seed used to control the randomness during fitting the model.
+            By default, we keep a static seed of 0 to ensure reproducibility.
+            When using a bagged model, a static seed of 0 to n_splits-1 is used to ensure that each fold has a
+            different seed that is consistent across different models.
         log_resources: bool, default = False
             If True, will log information about the number of CPUs, GPUs, and memory usage during fit.
         **kwargs :
@@ -1179,6 +1184,7 @@ class AbstractModel(ModelBase, Tunable):
         num_cpus: int = None,
         num_gpus: int = None,
         verbosity: int = 2,
+        random_seed: int = 0,
         **kwargs,
     ):
         """

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -1247,12 +1247,17 @@ class AbstractModel(ModelBase, Tunable):
 
         self.random_seed = random_seed
 
-    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict) -> int | None | str:
         """Extract the random seed from the hyperparameters if available.
 
         A model implementation may override this method to extract the random seed from the hyperparameters such that
         it is used to init the model's random seed. Otherwise, we default to not being able to extract a random seed
         and use the random seed provided by AutoGluon.
+
+        Parameters
+        ----------
+        hyperparameters:
+            The hyperparameters that may contain a random seed.
 
         Returns
         -------

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -115,7 +115,7 @@ class BaggedEnsembleModel(AbstractModel):
             self._set_default_param_value(param, val)
         super()._set_default_params()
 
-    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict) -> int | None | str:
         return hyperparameters.get("model_random_seed", "N/A")
 
     def _get_default_auxiliary_params(self) -> dict:

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -60,8 +60,6 @@ class BaggedEnsembleModel(AbstractModel):
     """
 
     _oof_filename = "oof.pkl"
-    _vary_seed_across_folds: bool = True
-    """If True, the seed used for each fold will be varied across folds."""
 
     def __init__(self, model_base: AbstractModel | Type[AbstractModel], model_base_kwargs: dict[str, any] = None, random_state: int = 0, **kwargs):
         if inspect.isclass(model_base):
@@ -110,6 +108,7 @@ class BaggedEnsembleModel(AbstractModel):
             "stratify": "auto",
             "bin": "auto",
             "n_bins": None,
+            "vary_seed_across_folds": True, # If True, the seed used for each fold will be varied across folds.
         }
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
@@ -802,7 +801,7 @@ class BaggedEnsembleModel(AbstractModel):
             k_fold_end=k_fold_end,
             n_repeat_start=n_repeat_start,
             n_repeat_end=n_repeats,
-            vary_seed_across_folds=self._vary_seed_across_folds,
+            vary_seed_across_folds=self.params.get("vary_seed_across_folds"),
         )
 
         fold_fit_args_list = [dict(fold_ctx=fold_ctx) for fold_ctx in fold_fit_args_list]

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -109,6 +109,7 @@ class BaggedEnsembleModel(AbstractModel):
             "bin": "auto",
             "n_bins": None,
             "vary_seed_across_folds": True, # If True, the seed used for each fold will be varied across folds.
+            "model_random_seed": 0,  # Start value for the random seed used for the seeds of the fold models.
         }
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
@@ -801,7 +802,8 @@ class BaggedEnsembleModel(AbstractModel):
             k_fold_end=k_fold_end,
             n_repeat_start=n_repeat_start,
             n_repeat_end=n_repeats,
-            vary_seed_across_folds=self.params.get("vary_seed_across_folds"),
+            vary_seed_across_folds=self.params["vary_seed_across_folds"],
+            random_seed_start_value=self.params["model_random_seed"],
         )
 
         fold_fit_args_list = [dict(fold_ctx=fold_ctx) for fold_ctx in fold_fit_args_list]
@@ -906,6 +908,7 @@ class BaggedEnsembleModel(AbstractModel):
         n_repeat_start: int,
         n_repeat_end: int,
         vary_seed_across_folds: bool,
+        random_seed_start_value: int,
     ) -> (list, int, int):
         """
         Generates fold configs given a cv_splitter, k_fold start-end and n_repeat start-end.
@@ -923,7 +926,7 @@ class BaggedEnsembleModel(AbstractModel):
         fold_fit_args_list = []
         n_repeats_started = 0
         n_repeats_finished = 0
-        random_seed_value = 0
+        random_seed_value = random_seed_start_value
         for repeat in range(n_repeat_start, n_repeat_end):  # For each repeat
             is_first_set = repeat == n_repeat_start
             is_last_set = repeat == (n_repeat_end - 1)

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -108,7 +108,7 @@ class BaggedEnsembleModel(AbstractModel):
             "stratify": "auto",
             "bin": "auto",
             "n_bins": None,
-            "vary_seed_across_folds": True, # If True, the seed used for each fold will be varied across folds.
+            "vary_seed_across_folds": False, # If True, the seed used for each fold will be varied across folds.
             "model_random_seed": 0,  # Start value for the random seed used for the seeds of the fold models.
         }
         for param, val in default_params.items():

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -645,7 +645,7 @@ class BaggedEnsembleModel(AbstractModel):
         else:
             X_fit = X
             y_fit = y
-        model_base.fit(X=X_fit, y=y_fit, time_limit=time_limit, **kwargs)
+        model_base.fit(X=X_fit, y=y_fit, time_limit=time_limit, random_seed=self.random_seed, **kwargs)
         model_base.fit_time = time.time() - time_start_fit
         model_base.predict_time = None
         if not skip_oof:

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -109,11 +109,14 @@ class BaggedEnsembleModel(AbstractModel):
             "bin": "auto",
             "n_bins": None,
             "vary_seed_across_folds": False, # If True, the seed used for each fold will be varied across folds.
-            "model_random_seed": 0,  # Start value for the random seed used for the seeds of the fold models.
+            "model_random_seed": 0,
         }
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
         super()._set_default_params()
+
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
+        return hyperparameters.get("model_random_seed", "N/A")
 
     def _get_default_auxiliary_params(self) -> dict:
         default_auxiliary_params = super()._get_default_auxiliary_params()

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -806,7 +806,7 @@ class BaggedEnsembleModel(AbstractModel):
             n_repeat_start=n_repeat_start,
             n_repeat_end=n_repeats,
             vary_seed_across_folds=self.params["vary_seed_across_folds"],
-            random_seed_start_value=self.params["model_random_seed"],
+            random_seed_offset=self.params["model_random_seed"],
         )
 
         fold_fit_args_list = [dict(fold_ctx=fold_ctx) for fold_ctx in fold_fit_args_list]
@@ -911,7 +911,7 @@ class BaggedEnsembleModel(AbstractModel):
         n_repeat_start: int,
         n_repeat_end: int,
         vary_seed_across_folds: bool,
-        random_seed_start_value: int,
+        random_seed_offset: int,
     ) -> (list, int, int):
         """
         Generates fold configs given a cv_splitter, k_fold start-end and n_repeat start-end.
@@ -929,7 +929,6 @@ class BaggedEnsembleModel(AbstractModel):
         fold_fit_args_list = []
         n_repeats_started = 0
         n_repeats_finished = 0
-        random_seed_value = random_seed_start_value
         for repeat in range(n_repeat_start, n_repeat_end):  # For each repeat
             is_first_set = repeat == n_repeat_start
             is_last_set = repeat == (n_repeat_end - 1)
@@ -948,12 +947,10 @@ class BaggedEnsembleModel(AbstractModel):
                     folds_to_fit=folds_to_fit,
                     folds_finished=fold - fold_start,
                     folds_left=fold_end - fold,
-                    random_seed=random_seed_value
+                    random_seed=random_seed_offset + fold if vary_seed_across_folds else random_seed_offset,
                 )
 
                 fold_fit_args_list.append(fold_ctx)
-                if vary_seed_across_folds:
-                    random_seed_value += 1
 
             if fold_in_set_end == k_fold:
                 n_repeats_finished += 1

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -61,7 +61,7 @@ class BaggedEnsembleModel(AbstractModel):
 
     _oof_filename = "oof.pkl"
     _vary_seed_across_folds: bool = True
-    """If True, the seed used for each fold will be varied across repeats."""
+    """If True, the seed used for each fold will be varied across folds."""
 
     def __init__(self, model_base: AbstractModel | Type[AbstractModel], model_base_kwargs: dict[str, any] = None, random_state: int = 0, **kwargs):
         if inspect.isclass(model_base):

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -802,6 +802,7 @@ class BaggedEnsembleModel(AbstractModel):
             k_fold_end=k_fold_end,
             n_repeat_start=n_repeat_start,
             n_repeat_end=n_repeats,
+            vary_seed_across_folds=self._vary_seed_across_folds,
         )
 
         fold_fit_args_list = [dict(fold_ctx=fold_ctx) for fold_ctx in fold_fit_args_list]

--- a/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
+++ b/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
@@ -228,7 +228,7 @@ class FoldFittingStrategy(AbstractFoldFittingStrategy):
         self.user_resources_per_job = user_resources_per_job
 
     def _get_fold_time_limit(self, fold_ctx):
-        _, folds_finished, folds_left, folds_to_fit, _, _ = self._get_fold_properties(fold_ctx)
+        _, folds_finished, folds_left, folds_to_fit, _, _, _ = self._get_fold_properties(fold_ctx)
         time_elapsed = time.time() - self.time_start
         if self.time_limit is not None:
             time_left = self.time_limit - time_elapsed
@@ -261,7 +261,7 @@ class FoldFittingStrategy(AbstractFoldFittingStrategy):
         self.bagged_ensemble_model._add_child_num_gpus(num_gpus=fold_model.fit_num_gpus)
 
     def _predict_oof(self, fold_model: AbstractModel, fold_ctx) -> Tuple[AbstractModel, ndarray]:
-        fold, folds_finished, folds_left, folds_to_fit, is_last_fold, model_name_suffix = self._get_fold_properties(fold_ctx)
+        fold, folds_finished, folds_left, folds_to_fit, is_last_fold, model_name_suffix, _ = self._get_fold_properties(fold_ctx)
         _, val_index = fold
         X_val_fold = self.X.iloc[val_index, :]
         y_val_fold = self.y.iloc[val_index]
@@ -284,10 +284,10 @@ class FoldFittingStrategy(AbstractFoldFittingStrategy):
 
     @staticmethod
     def _get_fold_properties(fold_ctx):
-        fold, folds_finished, folds_left, folds_to_fit, is_last_fold, model_name_suffix = [
-            fold_ctx[f] for f in ["fold", "folds_finished", "folds_left", "folds_to_fit", "is_last_fold", "model_name_suffix"]
+        fold, folds_finished, folds_left, folds_to_fit, is_last_fold, model_name_suffix, random_seed = [
+            fold_ctx[f] for f in ["fold", "folds_finished", "folds_left", "folds_to_fit", "is_last_fold", "model_name_suffix", "random_seed"]
         ]
-        return fold, folds_finished, folds_left, folds_to_fit, is_last_fold, model_name_suffix
+        return fold, folds_finished, folds_left, folds_to_fit, is_last_fold, model_name_suffix, random_seed
 
 
 class SequentialLocalFoldFittingStrategy(FoldFittingStrategy):
@@ -357,7 +357,7 @@ class SequentialLocalFoldFittingStrategy(FoldFittingStrategy):
         self._update_bagged_ensemble(fold_model, pred_proba, fold_ctx)
 
     def _fit(self, model_base, time_start_fold, time_limit_fold, fold_ctx, kwargs):
-        fold, folds_finished, folds_left, folds_to_fit, is_last_fold, model_name_suffix = self._get_fold_properties(fold_ctx)
+        fold, folds_finished, folds_left, folds_to_fit, is_last_fold, model_name_suffix, random_seed = self._get_fold_properties(fold_ctx)
         train_index, val_index = fold
         X_fold, X_val_fold = self.X.iloc[train_index, :], self.X.iloc[val_index, :]
         y_fold, y_val_fold = self.y.iloc[train_index], self.y.iloc[val_index]
@@ -376,6 +376,9 @@ class SequentialLocalFoldFittingStrategy(FoldFittingStrategy):
             else:
                 kwargs_fold["sample_weight"] = self.sample_weight[train_index]
                 kwargs_fold["sample_weight_val"] = self.sample_weight[val_index]
+
+        if random_seed is not None:
+            kwargs_fold["random_seed"] = random_seed
 
         if is_pseudo:
             logger.log(15, f"{len(self.X_pseudo)} extra rows of pseudolabeled data added to training set for {fold_model.name}")
@@ -419,7 +422,7 @@ def _ray_fit(
     logger.debug(f"executing fold on node {node_id}")
     logger.log(10, "ray worker training")
     time_start_fold = time.time()
-    fold, folds_finished, folds_left, folds_to_fit, is_last_fold, model_name_suffix = FoldFittingStrategy._get_fold_properties(fold_ctx)
+    fold, folds_finished, folds_left, folds_to_fit, is_last_fold, model_name_suffix, _ = FoldFittingStrategy._get_fold_properties(fold_ctx)
     train_index, val_index = fold
     fold_model = copy.deepcopy(model_base)
     fold_model.name = f"{fold_model.name}{model_name_suffix}"
@@ -743,7 +746,7 @@ class ParallelFoldFittingStrategy(FoldFittingStrategy):
     ):
         if resources_model is None:
             resources_model = resources
-        fold, folds_finished, folds_left, folds_to_fit, is_last_fold, model_name_suffix = self._get_fold_properties(fold_ctx)
+        fold, folds_finished, folds_left, folds_to_fit, is_last_fold, model_name_suffix, random_seed = self._get_fold_properties(fold_ctx)
         train_index, val_index = fold
         fold_ctx_ref = self.ray.put(fold_ctx)
         save_bag_folds = self.save_folds
@@ -756,6 +759,8 @@ class ParallelFoldFittingStrategy(FoldFittingStrategy):
             else:
                 kwargs_fold["sample_weight"] = self.sample_weight[train_index]
                 kwargs_fold["sample_weight_val"] = self.sample_weight[val_index]
+        if random_seed is not None:
+            kwargs_fold["random_seed"] = random_seed
         pg = self.ray.util.get_current_placement_group()
         return self._ray_fit.options(
             **resources, scheduling_strategy=self.ray.util.scheduling_strategies.PlacementGroupSchedulingStrategy(placement_group=pg)

--- a/core/tests/unittests/models/test_bagged_ensemble_model.py
+++ b/core/tests/unittests/models/test_bagged_ensemble_model.py
@@ -25,7 +25,7 @@ def test_generate_fold_configs():
         n_repeat_start=n_repeat_start,
         n_repeat_end=n_repeats,
         vary_seed_across_folds=True,
-        random_seed_start_value=0
+        random_seed_offset=0
     )
 
     assert fold_fit_args_list[0]["model_name_suffix"] == "S3F3"
@@ -55,7 +55,7 @@ def test_generate_fold_configs():
         n_repeat_start=n_repeat_start,
         n_repeat_end=n_repeats,
         vary_seed_across_folds=False,
-        random_seed_start_value=0
+        random_seed_offset=0
     )
 
     assert fold_fit_args_list[0]["random_seed"] == 0
@@ -73,7 +73,7 @@ def test_generate_fold_configs():
         n_repeat_start=n_repeat_start,
         n_repeat_end=n_repeats,
         vary_seed_across_folds=True,
-        random_seed_start_value=42
+        random_seed_offset=42
     )
 
     assert fold_fit_args_list[0]["random_seed"] == 42

--- a/core/tests/unittests/models/test_bagged_ensemble_model.py
+++ b/core/tests/unittests/models/test_bagged_ensemble_model.py
@@ -25,6 +25,7 @@ def test_generate_fold_configs():
         n_repeat_start=n_repeat_start,
         n_repeat_end=n_repeats,
         vary_seed_across_folds=True,
+        random_seed_start_value=0
     )
 
     assert fold_fit_args_list[0]["model_name_suffix"] == "S3F3"
@@ -54,6 +55,7 @@ def test_generate_fold_configs():
         n_repeat_start=n_repeat_start,
         n_repeat_end=n_repeats,
         vary_seed_across_folds=False,
+        random_seed_start_value=0
     )
 
     assert fold_fit_args_list[0]["random_seed"] == 0
@@ -61,3 +63,21 @@ def test_generate_fold_configs():
     assert fold_fit_args_list[2]["random_seed"] == 0
     assert fold_fit_args_list[3]["random_seed"] == 0
     assert fold_fit_args_list[4]["random_seed"] == 0
+
+    fold_fit_args_list, n_repeats_started, n_repeats_finished = BaggedEnsembleModel._generate_fold_configs(
+        X=X,
+        y=y,
+        cv_splitter=cv_splitter,
+        k_fold_start=k_fold_start,
+        k_fold_end=k_fold_end,
+        n_repeat_start=n_repeat_start,
+        n_repeat_end=n_repeats,
+        vary_seed_across_folds=True,
+        random_seed_start_value=42
+    )
+
+    assert fold_fit_args_list[0]["random_seed"] == 42
+    assert fold_fit_args_list[1]["random_seed"] == 43
+    assert fold_fit_args_list[2]["random_seed"] == 44
+    assert fold_fit_args_list[3]["random_seed"] == 45
+    assert fold_fit_args_list[4]["random_seed"] == 46

--- a/core/tests/unittests/models/test_bagged_ensemble_model.py
+++ b/core/tests/unittests/models/test_bagged_ensemble_model.py
@@ -24,6 +24,7 @@ def test_generate_fold_configs():
         k_fold_end=k_fold_end,
         n_repeat_start=n_repeat_start,
         n_repeat_end=n_repeats,
+        vary_seed_across_folds=True,
     )
 
     assert fold_fit_args_list[0]["model_name_suffix"] == "S3F3"
@@ -37,3 +38,26 @@ def test_generate_fold_configs():
     assert fold_fit_args_list[2]["is_last_fold"] is False
     assert fold_fit_args_list[3]["is_last_fold"] is False
     assert fold_fit_args_list[4]["is_last_fold"] is True
+
+    assert fold_fit_args_list[0]["random_seed"] == 0
+    assert fold_fit_args_list[1]["random_seed"] == 1
+    assert fold_fit_args_list[2]["random_seed"] == 2
+    assert fold_fit_args_list[3]["random_seed"] == 3
+    assert fold_fit_args_list[4]["random_seed"] == 4
+
+    fold_fit_args_list, n_repeats_started, n_repeats_finished = BaggedEnsembleModel._generate_fold_configs(
+        X=X,
+        y=y,
+        cv_splitter=cv_splitter,
+        k_fold_start=k_fold_start,
+        k_fold_end=k_fold_end,
+        n_repeat_start=n_repeat_start,
+        n_repeat_end=n_repeats,
+        vary_seed_across_folds=False,
+    )
+
+    assert fold_fit_args_list[0]["random_seed"] == 0
+    assert fold_fit_args_list[1]["random_seed"] == 0
+    assert fold_fit_args_list[2]["random_seed"] == 0
+    assert fold_fit_args_list[3]["random_seed"] == 0
+    assert fold_fit_args_list[4]["random_seed"] == 0

--- a/core/tests/unittests/models/test_bagged_ensemble_model.py
+++ b/core/tests/unittests/models/test_bagged_ensemble_model.py
@@ -40,11 +40,18 @@ def test_generate_fold_configs():
     assert fold_fit_args_list[3]["is_last_fold"] is False
     assert fold_fit_args_list[4]["is_last_fold"] is True
 
-    assert fold_fit_args_list[0]["random_seed"] == 0
-    assert fold_fit_args_list[1]["random_seed"] == 1
-    assert fold_fit_args_list[2]["random_seed"] == 2
-    assert fold_fit_args_list[3]["random_seed"] == 3
-    assert fold_fit_args_list[4]["random_seed"] == 4
+    assert fold_fit_args_list[0]["random_seed"] == 8
+    assert fold_fit_args_list[1]["random_seed"] == 9
+    assert fold_fit_args_list[2]["random_seed"] == 10
+    assert fold_fit_args_list[3]["random_seed"] == 11
+    assert fold_fit_args_list[4]["random_seed"] == 12
+
+    k_fold_start = 0
+    k_fold_end = 3
+    k_fold = 3
+    n_repeat_start = 0
+    n_repeats = 5
+    cv_splitter = CVSplitter(n_splits=k_fold, n_repeats=n_repeats, stratify=True, random_state=0)
 
     fold_fit_args_list, n_repeats_started, n_repeats_finished = BaggedEnsembleModel._generate_fold_configs(
         X=X,

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -116,7 +116,7 @@ class CatBoostModel(AbstractModel):
         approx_mem_size_req = data_mem_usage_bytes + histogram_mem_usage_bytes + baseline_memory_bytes
         return approx_mem_size_req
 
-    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict) -> int | None | str:
         return hyperparameters.get("random_seed", "N/A")
 
     # TODO: Use Pool in preprocess, optimize bagging to do Pool.split() to avoid re-computing pool for each fold! Requires stateful + y

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -116,22 +116,18 @@ class CatBoostModel(AbstractModel):
         approx_mem_size_req = data_mem_usage_bytes + histogram_mem_usage_bytes + baseline_memory_bytes
         return approx_mem_size_req
 
-    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> tuple[bool, int | None]:
-        if "random_seed" in hyperparameters:
-            return True, hyperparameters["random_seed"]
-        return False, None
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
+        return hyperparameters.get("random_seed", "N/A")
 
     # TODO: Use Pool in preprocess, optimize bagging to do Pool.split() to avoid re-computing pool for each fold! Requires stateful + y
     #  Pool is much more memory efficient, avoids copying data twice in memory
-    def _fit(self, X, y, X_val=None, y_val=None, time_limit=None, num_gpus=0, num_cpus=-1, sample_weight=None, sample_weight_val=None, random_seed: int = 0, **kwargs):
+    def _fit(self, X, y, X_val=None, y_val=None, time_limit=None, num_gpus=0, num_cpus=-1, sample_weight=None, sample_weight_val=None, **kwargs):
         time_start = time.time()
         try_import_catboost()
         from catboost import CatBoostClassifier, CatBoostRegressor, Pool
 
         ag_params = self._get_ag_params()
         params = self._get_model_params()
-
-        self.init_random_seed(random_seed=random_seed, hyperparameters=params)
         params["random_seed"] = self.random_seed
 
         params["thread_count"] = num_cpus

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -322,8 +322,8 @@ class NNFastAiTabularModel(AbstractModel):
         # Make deterministic
         from fastai.torch_core import set_seed
 
-        set_seed(0, True)
-        dls.rng.seed(0)
+        set_seed(self.random_seed, True)
+        dls.rng.seed(self.random_seed)
 
         if self.problem_type == QUANTILE:
             dls.c = len(self.quantile_levels)

--- a/tabular/src/autogluon/tabular/models/knn/knn_model.py
+++ b/tabular/src/autogluon/tabular/models/knn/knn_model.py
@@ -214,7 +214,7 @@ class KNNModel(AbstractModel):
         def sample_func(chunk, frac):
             # Guarantee at least 1 sample (otherwise log_loss would crash or model would return different column counts in pred_proba)
             n = max(math.ceil(len(chunk) * frac), 1)
-            return chunk.sample(n=n, replace=False, random_state=0)
+            return chunk.sample(n=n, replace=False, random_state=self.random_seed)
 
         if self.problem_type != REGRESSION:
             y_df = y.to_frame(name="label").reset_index(drop=True)

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -128,7 +128,7 @@ class LGBModel(AbstractModel):
         approx_mem_size_req = data_mem_usage_bytes + histogram_mem_usage_bytes + mem_size_estimators
         return approx_mem_size_req
 
-    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict) -> int | None | str:
         if "seed_value" in hyperparameters:
             return hyperparameters["seed_value"]
         if "seed" in hyperparameters:

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -128,7 +128,7 @@ class LGBModel(AbstractModel):
         approx_mem_size_req = data_mem_usage_bytes + histogram_mem_usage_bytes + mem_size_estimators
         return approx_mem_size_req
 
-    def _fit(self, X, y, X_val=None, y_val=None, time_limit=None, num_gpus=0, num_cpus=0, sample_weight=None, sample_weight_val=None, verbosity=2, **kwargs):
+    def _fit(self, X, y, X_val=None, y_val=None, time_limit=None, num_gpus=0, num_cpus=0, sample_weight=None, sample_weight_val=None, verbosity=2, random_seed: int = 0, **kwargs):
         try_import_lightgbm()  # raise helpful error message if LightGBM isn't installed
         start_time = time.time()
         ag_params = self._get_ag_params()
@@ -225,7 +225,6 @@ class LGBModel(AbstractModel):
         if log_period is not None:
             callbacks.append(log_evaluation(period=log_period))
 
-        seed_val = params.pop("seed_value", 0)
         train_params = {
             "params": params,
             "train_set": dataset_train,
@@ -285,8 +284,16 @@ class LGBModel(AbstractModel):
             train_params["params"]["num_classes"] = self.num_classes
         elif self.problem_type == QUANTILE:
             train_params["params"]["quantile_levels"] = self.quantile_levels
-        if seed_val is not None:
-            train_params["params"]["seed"] = seed_val
+
+        if "seed_value" in params:
+            logger.log(
+                40,
+                "\t'seed_value' found in hyperparamters is ignored!"
+                "AutoGluon controls the random seed for the model training.",
+            )
+
+        if random_seed is not None:
+            train_params["params"]["seed"] = random_seed
 
         # Train LightGBM model:
         # Note that self.model contains a <class 'lightgbm.basic.Booster'> not a LightBGMClassifier or LightGBMRegressor object

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -131,6 +131,8 @@ class LGBModel(AbstractModel):
     def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> tuple[bool, int | None]:
         if "seed_value" in hyperparameters:
             return True, hyperparameters["seed_value"]
+        if "seed" in hyperparameters:
+            return True, hyperparameters["seed"]
         return False, None
 
     def _fit(self, X, y, X_val=None, y_val=None, time_limit=None, num_gpus=0, num_cpus=0, sample_weight=None, sample_weight_val=None, verbosity=2, random_seed: int = 0, **kwargs):

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -128,14 +128,14 @@ class LGBModel(AbstractModel):
         approx_mem_size_req = data_mem_usage_bytes + histogram_mem_usage_bytes + mem_size_estimators
         return approx_mem_size_req
 
-    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> tuple[bool, int | None]:
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
         if "seed_value" in hyperparameters:
-            return True, hyperparameters["seed_value"]
+            return hyperparameters["seed_value"]
         if "seed" in hyperparameters:
-            return True, hyperparameters["seed"]
-        return False, None
+            return hyperparameters["seed"]
+        return "N/A"
 
-    def _fit(self, X, y, X_val=None, y_val=None, time_limit=None, num_gpus=0, num_cpus=0, sample_weight=None, sample_weight_val=None, verbosity=2, random_seed: int = 0, **kwargs):
+    def _fit(self, X, y, X_val=None, y_val=None, time_limit=None, num_gpus=0, num_cpus=0, sample_weight=None, sample_weight_val=None, verbosity=2, **kwargs):
         try_import_lightgbm()  # raise helpful error message if LightGBM isn't installed
         start_time = time.time()
         ag_params = self._get_ag_params()
@@ -292,7 +292,6 @@ class LGBModel(AbstractModel):
         elif self.problem_type == QUANTILE:
             train_params["params"]["quantile_levels"] = self.quantile_levels
 
-        self.init_random_seed(random_seed=random_seed, hyperparameters=params)
         if random_seed is not None:
             train_params["params"]["seed"] = self.random_seed
 

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -292,8 +292,7 @@ class LGBModel(AbstractModel):
         elif self.problem_type == QUANTILE:
             train_params["params"]["quantile_levels"] = self.quantile_levels
 
-        if random_seed is not None:
-            train_params["params"]["seed"] = self.random_seed
+        train_params["params"]["seed"] = self.random_seed
 
         # Train LightGBM model:
         # Note that self.model contains a <class 'lightgbm.basic.Booster'> not a LightBGMClassifier or LightGBMRegressor object

--- a/tabular/src/autogluon/tabular/models/lr/lr_model.py
+++ b/tabular/src/autogluon/tabular/models/lr/lr_model.py
@@ -155,12 +155,15 @@ class LinearModel(AbstractModel):
         return self._pipeline.fit_transform(X)
 
     def _set_default_params(self):
-        default_params = {"random_state": 0, "fit_intercept": True}
+        default_params = {"fit_intercept": True}
         if self.problem_type != REGRESSION:
             default_params.update({"solver": _get_solver(self.problem_type)})
         default_params.update(get_param_baseline())
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
+
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
+        return hyperparameters.get("random_seed", "N/A")
 
     def _get_default_searchspace(self):
         return get_default_searchspace(self.problem_type)
@@ -215,7 +218,7 @@ class LinearModel(AbstractModel):
         total_iter = 0
         total_iter_used = 0
         total_max_iter = sum(max_iter_list)
-        model = model_cls(max_iter=max_iter_list[0], **params)
+        model = model_cls(max_iter=max_iter_list[0], random_state=self.random_seed, **params)
         early_stop = False
         for i, cur_max_iter in enumerate(max_iter_list):
             if time_left is not None and (i > 0):

--- a/tabular/src/autogluon/tabular/models/lr/lr_model.py
+++ b/tabular/src/autogluon/tabular/models/lr/lr_model.py
@@ -162,7 +162,7 @@ class LinearModel(AbstractModel):
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
 
-    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict) -> int | None | str:
         return hyperparameters.get("random_seed", "N/A")
 
     def _get_default_searchspace(self):

--- a/tabular/src/autogluon/tabular/models/mitra/mitra_model.py
+++ b/tabular/src/autogluon/tabular/models/mitra/mitra_model.py
@@ -77,7 +77,7 @@ class MitraModel(AbstractModel):
 
         return X
 
-    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict) -> int | None | str:
         return hyperparameters.get("seed", "N/A")
 
     def _fit(

--- a/tabular/src/autogluon/tabular/models/mitra/mitra_model.py
+++ b/tabular/src/autogluon/tabular/models/mitra/mitra_model.py
@@ -77,6 +77,9 @@ class MitraModel(AbstractModel):
 
         return X
 
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
+        return hyperparameters.get("seed", "N/A")
+
     def _fit(
         self,
         X: pd.DataFrame,
@@ -139,6 +142,7 @@ class MitraModel(AbstractModel):
             hyp["verbose"] = verbosity >= 3
 
         self.model = model_cls(
+            seed=self.random_seed,
             **hyp,
         )
 

--- a/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
+++ b/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
@@ -82,7 +82,7 @@ class RealMLPModel(AbstractModel):
                 model_cls = RealMLP_TD_S_Regressor
         return model_cls
 
-    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict) -> int | None | str:
         return hyperparameters.get("random_state", "N/A")
 
     def _fit(

--- a/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
+++ b/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
@@ -82,6 +82,9 @@ class RealMLPModel(AbstractModel):
                 model_cls = RealMLP_TD_S_Regressor
         return model_cls
 
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
+        return hyperparameters.get("random_state", "N/A")
+
     def _fit(
         self,
         X: pd.DataFrame,
@@ -175,6 +178,7 @@ class RealMLPModel(AbstractModel):
         self.model = model_cls(
             n_threads=num_cpus,
             device=device,
+            random_state=self.random_seed,
             **init_kwargs,
             **hyp,
         )
@@ -243,8 +247,6 @@ class RealMLPModel(AbstractModel):
 
     def _set_default_params(self):
         default_params = dict(
-            random_state=0,
-
             # Don't use early stopping by default, seems to work well without
             use_early_stopping=False,
             early_stopping_additive_patience=40,

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -97,7 +97,6 @@ class RFModel(AbstractModel):
             #  This size scales linearly with number of rows.
             "max_leaf_nodes": 15000,
             "n_jobs": -1,
-            "random_state": 0,
             "bootstrap": True,  # Required for OOB estimates, setting to False will raise exception if bagging.
             # TODO: min_samples_leaf=5 is too large on most problems, however on some datasets it helps a lot (airlines likes >40 min_samples_leaf, adult likes 2 much better than 1)
             #  This value would need to be tuned per dataset, likely very worthwhile.
@@ -107,6 +106,9 @@ class RFModel(AbstractModel):
         }
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
+
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
+        return hyperparameters.get("random_state", "N/A")
 
     # TODO: Add in documentation that Categorical default is the first index
     # TODO: enable HPO for RF models
@@ -206,7 +208,7 @@ class RFModel(AbstractModel):
             # FIXME: This is inefficient but sklearnex doesn't support computing oob_score after training
             params["oob_score"] = True
 
-        model = model_cls(**params)
+        model = model_cls(random_state=self.random_seed, **params)
 
         time_train_start = time.time()
         for i, n_estimators in enumerate(n_estimator_increments):

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -107,7 +107,7 @@ class RFModel(AbstractModel):
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
 
-    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict) -> int | None | str:
         return hyperparameters.get("random_state", "N/A")
 
     # TODO: Add in documentation that Categorical default is the first index

--- a/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
+++ b/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
@@ -89,6 +89,7 @@ class TabICLModel(AbstractModel):
             **hyp,
             device=device,
             n_jobs=num_cpus,
+            random_state=self.random_seed,
         )
         X = self.preprocess(X)
         self.model = self.model.fit(
@@ -96,12 +97,8 @@ class TabICLModel(AbstractModel):
             y=y,
         )
 
-    def _set_default_params(self):
-        default_params = {
-            "random_state": 42,
-        }
-        for param, val in default_params.items():
-            self._set_default_param_value(param, val)
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
+        return hyperparameters.get("random_state", "N/A")
 
     def _get_default_auxiliary_params(self) -> dict:
         default_auxiliary_params = super()._get_default_auxiliary_params()

--- a/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
+++ b/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
@@ -97,7 +97,7 @@ class TabICLModel(AbstractModel):
             y=y,
         )
 
-    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict) -> int | None | str:
         return hyperparameters.get("random_state", "N/A")
 
     def _get_default_auxiliary_params(self) -> dict:

--- a/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
+++ b/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
@@ -142,7 +142,7 @@ class TabMModel(AbstractModel):
 
         return X
 
-    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict) -> int | None | str:
         return hyperparameters.get("random_state", "N/A")
 
     @classmethod

--- a/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
+++ b/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
@@ -106,6 +106,7 @@ class TabMModel(AbstractModel):
             device=device,
             problem_type=self.problem_type,
             early_stopping_metric=self.stopping_metric,
+            random_state=self.random_seed,
             **hyp,
         )
 
@@ -141,12 +142,8 @@ class TabMModel(AbstractModel):
 
         return X
 
-    def _set_default_params(self):
-        default_params = dict(
-            random_state=0,
-        )
-        for param, val in default_params.items():
-            self._set_default_param_value(param, val)
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
+        return hyperparameters.get("random_state", "N/A")
 
     @classmethod
     def supported_problem_types(cls) -> list[str] | None:

--- a/tabular/src/autogluon/tabular/models/tabpfnmix/tabpfnmix_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnmix/tabpfnmix_model.py
@@ -178,7 +178,7 @@ class TabPFNMixModel(AbstractModel):
         elif weights_path is not None:
             logger.log(15, f'\tLoading pre-trained weights from file... (weights_path="{weights_path}")')
 
-        cfg = ConfigRun(hyperparams=params, task=task, device=device)
+        cfg = ConfigRun(hyperparams=params, task=task, device=device, seed=self.random_seed)
 
         if cfg.hyperparams["max_epochs"] == 0 and cfg.hyperparams["n_ensembles"] != 1:
             logger.log(
@@ -242,14 +242,14 @@ class TabPFNMixModel(AbstractModel):
         return self
 
     # TODO: Make this generic by creating a generic `preprocess_train` and putting this logic prior to `_preprocess`.
-    def _subsample_data(self, X: pd.DataFrame, y: pd.Series, num_rows: int, random_state=0) -> (pd.DataFrame, pd.Series):
+    def _subsample_data(self, X: pd.DataFrame, y: pd.Series, num_rows: int) -> (pd.DataFrame, pd.Series):
         num_rows_to_drop = len(X) - num_rows
         X, _, y, _ = generate_train_test_split(
             X=X,
             y=y,
             problem_type=self.problem_type,
             test_size=num_rows_to_drop,
-            random_state=random_state,
+            random_state=self.random_seed,
             min_cls_count_train=1,
         )
         return X, y

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_model.py
@@ -201,6 +201,7 @@ class TabPFNV2Model(AbstractModel):
         X = self.preprocess(X, is_train=True)
 
         hps = self._get_model_params()
+        hps["random_state"] = self.random_seed
         hps["device"] = device
         hps["n_jobs"] = num_cpus
         hps["categorical_features_indices"] = self._cat_indices
@@ -300,11 +301,13 @@ class TabPFNV2Model(AbstractModel):
 
     def _set_default_params(self):
         default_params = {
-            "random_state": 42,
             "ignore_pretraining_limits": True,  # to ignore warnings and size limits
         }
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
+
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
+        return hyperparameters.get("random_state", "N/A")
 
     @classmethod
     def supported_problem_types(cls) -> list[str] | None:

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_model.py
@@ -306,7 +306,7 @@ class TabPFNV2Model(AbstractModel):
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
 
-    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict) -> int | None | str:
         return hyperparameters.get("random_state", "N/A")
 
     @classmethod

--- a/tabular/src/autogluon/tabular/models/tabular_nn/hyperparameters/parameters.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/hyperparameters/parameters.py
@@ -7,9 +7,7 @@ from autogluon.core.constants import BINARY, MULTICLASS, QUANTILE, REGRESSION
 
 def get_fixed_params(framework):
     """Parameters that currently cannot be searched during HPO"""
-    fixed_params = {
-        # 'seed_value': 0,  # random seed for reproducibility (set = None to ignore)
-    }
+    fixed_params = {}
     # TODO: v1.2 Change default epochs_wo_improve to "auto", so that None can mean no early stopping.
     pytorch_fixed_params = {
         "num_epochs": 1000,  # maximum number of epochs (passes over full dataset) for training NN

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -164,7 +164,7 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
 
         return processor_kwargs, optimizer_kwargs, fit_kwargs, loss_kwargs, params
 
-    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict) -> int | None | str:
         return hyperparameters.get("seed_value", "N/A")
 
 

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -167,7 +167,6 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
     def _get_random_seed_from_hyperparameters(self, hyperparameters: dict) -> int | None | str:
         return hyperparameters.get("seed_value", "N/A")
 
-
     def _fit(
         self,
         X: pd.DataFrame,

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -164,6 +164,10 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
 
         return processor_kwargs, optimizer_kwargs, fit_kwargs, loss_kwargs, params
 
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
+        return hyperparameters.get("seed_value", "N/A")
+
+
     def _fit(
         self,
         X: pd.DataFrame,
@@ -191,7 +195,7 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
 
         processor_kwargs, optimizer_kwargs, fit_kwargs, loss_kwargs, params = self._prepare_params(params=params)
 
-        seed_value = params.pop("seed_value", 0)
+        seed_value = self.random_seed
 
         self._num_cpus_infer = params.pop("_num_cpus_infer", 1)
         if seed_value is not None:  # Set seeds

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -75,11 +75,15 @@ class XGBoostModel(AbstractModel):
 
         return X
 
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
+        return hyperparameters.get("seed", "N/A")
+
     def _fit(self, X, y, X_val=None, y_val=None, time_limit=None, num_gpus=0, num_cpus=None, sample_weight=None, sample_weight_val=None, verbosity=2, **kwargs):
         # TODO: utilize sample_weight_val in early-stopping if provided
         start_time = time.time()
         ag_params = self._get_ag_params()
         params = self._get_model_params()
+        params["seed"] = self.random_seed
         generate_curves = ag_params.get("generate_curves", False)
 
         if generate_curves:

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -75,7 +75,7 @@ class XGBoostModel(AbstractModel):
 
         return X
 
-    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict | None = None) -> int | None | str:
+    def _get_random_seed_from_hyperparameters(self, hyperparameters: dict) -> int | None | str:
         return hyperparameters.get("seed", "N/A")
 
     def _fit(self, X, y, X_val=None, y_val=None, time_limit=None, num_gpus=0, num_cpus=None, sample_weight=None, sample_weight_val=None, verbosity=2, **kwargs):

--- a/tabular/tests/unittests/models/advanced/test_model_random_seed.py
+++ b/tabular/tests/unittests/models/advanced/test_model_random_seed.py
@@ -13,24 +13,6 @@ TEST_CASES = []
 
 for model_key, model_hps in [
     ("GBM", {"num_boost_round": 10}),
-    # The below is only for full extended tests only for sanity check, not the CI
-    ("CAT", {"iterations": 10}),
-    ("FASTAI", {"epochs": 10}),
-    ("KNN", {}),
-    ("LR", {"max_iter": 10}),
-    ("MITRA", {}),
-    ("REALMLP", {"n_epochs": 10}),
-    ("TABICL", {}),
-    ("TABM", {"n_epochs": 10}),
-    ("TABPFNMIX", {}),
-    ("TABPFNV2", {}),
-    ("NN_TORCH", {"num_epochs": 10}),
-    ("XGB", {"n_estimators": 10}),
-
-
-
-    ("RF", {"n_estimators": 10}),  # counts for RF and XT
-
 ]:
     # Vary default
     TEST_CASES.append(({model_key: model_hps}, {"vary_seed_across_folds": True}, list(range(3))))

--- a/tabular/tests/unittests/models/advanced/test_model_random_seed.py
+++ b/tabular/tests/unittests/models/advanced/test_model_random_seed.py
@@ -13,6 +13,8 @@ TEST_CASES = []
 
 for model_key, model_hps in [
     ("GBM", {"num_boost_round": 10}),
+    ("KNN", {"n_neighbors": 2, "ag_args_ensemble": {"use_child_oof": True}}),
+    ("GBM", {"num_boost_round": 10, "ag_args_ensemble": {"refit_folds": True}}),
     # # The below is only for full extended tests only for sanity check, not the CI
     # ("CAT", {"iterations": 10}),
     # ("FASTAI", {"epochs": 10}),

--- a/tabular/tests/unittests/models/advanced/test_model_random_seed.py
+++ b/tabular/tests/unittests/models/advanced/test_model_random_seed.py
@@ -13,24 +13,46 @@ TEST_CASES = []
 
 for model_key, model_hps in [
     ("GBM", {"num_boost_round": 10}),
+    # # The below is only for full extended tests only for sanity check, not the CI
+    # ("CAT", {"iterations": 10}),
+    # ("FASTAI", {"epochs": 10}),
+    # ("LR", {"max_iter": 10}),
+    # ("REALMLP", {"n_epochs": 5}),
+    # ("TABM", {"n_epochs": 10}),
+    # ("TABPFNMIX", {}),
+    # ("TABPFNV2", {}),
+    # ("NN_TORCH", {"num_epochs": 10}),
+    # ("XGB", {"n_estimators": 10}),
+    # # Refit
+    # ("TABICL", {"ag_args_ensemble": {"refit_folds": False}}),
+    # ("TABPFNV2", {"ag_args_ensemble": {"refit_folds": False}}),
+    # ("MITRA", {"ag_args_ensemble": {"refit_folds": False}}),
+    # # OOF fit
+    # ("KNN", {"n_neighbors": 2, "ag_args_ensemble": {"use_child_oof": False}}),  # not enough samples?
+    # ("RF", {"n_estimators": 10, "ag_args_ensemble": {"use_child_oof": False}}),  # counts for RF and XT
 ]:
+    # Different fixed seed
+    TEST_CASES.append(({model_key: model_hps}, {"vary_seed_across_folds": False, "model_random_seed": 42}, [42] * 3))
     # Vary default
     TEST_CASES.append(({model_key: model_hps}, {"vary_seed_across_folds": True}, list(range(3))))
     # No vary default
     TEST_CASES.append(
         ({model_key: model_hps}, {"vary_seed_across_folds": False}, [0] * 3),
     )
-    # Different fixed seed
-    TEST_CASES.append(({model_key: model_hps}, {"vary_seed_across_folds": False, "model_random_seed": 42}, [42] * 3))
     # Two models, two different sets of seeds
     model_hps_2nd_model = deepcopy(model_hps)
-    model_hps_2nd_model["ag_args_ensemble"] = {"model_random_seed": 42}
+    if "ag_args_ensemble" not in model_hps_2nd_model:
+        model_hps_2nd_model["ag_args_ensemble"] = {}
+    model_hps_2nd_model["ag_args_ensemble"]["model_random_seed"] = 42
     TEST_CASES.append(
         ({model_key: [model_hps, model_hps_2nd_model]}, {"vary_seed_across_folds": True}, ([0, 1, 2], [42, 43, 44]))
     )
     # Vary via model HPs instead of fit args
     model_hps = deepcopy(model_hps)
-    model_hps["ag_args_ensemble"] = {"vary_seed_across_folds": False, "model_random_seed": 42}
+    if "ag_args_ensemble" not in model_hps:
+        model_hps["ag_args_ensemble"] = {}
+    model_hps["ag_args_ensemble"]["vary_seed_across_folds"] = False
+    model_hps["ag_args_ensemble"]["model_random_seed"] = 42
     TEST_CASES.append(({model_key: model_hps}, {}, [42] * 3))
 
 

--- a/tabular/tests/unittests/models/advanced/test_model_random_seed.py
+++ b/tabular/tests/unittests/models/advanced/test_model_random_seed.py
@@ -5,18 +5,37 @@ Unit tests to ensure correctness random seed logic
 import os
 import uuid
 from copy import deepcopy
-from autogluon.core.utils import generate_train_test_split_combined
 from autogluon.tabular import TabularPredictor
 from autogluon.tabular.testing import FitHelper
 import pytest
 
-TEST_CASES = [
-    ({"GBM": {"num_boost_round": 10}}, {}, list(range(3))),
-    ({"GBM": {"num_boost_round": 10}}, {"vary_seed_across_folds": False}, [0] * 3),
-    ({"GBM": {"num_boost_round": 10}}, {"model_random_seed": 42}, [42, 43, 44]),
-    ({"GBM": {"num_boost_round": 10}}, {"vary_seed_across_folds": False, "model_random_seed": 42}, [42] * 3),
-    ({"GBM": {"num_boost_round": 10, "ag_args_ensemble": {"vary_seed_across_folds": False, "model_random_seed": 42}}}, {}, [42] * 3),
-]
+TEST_CASES = []
+
+for model_key, model_hps in [
+    ("GBM", {"num_boost_round": 10}),
+    # The below is only for full extended tests only for sanity check, not the CI
+    # ("CAT", {"iterations": 10}),
+    # ("FASTAI", {"epochs": 10}),
+]:
+    # Vary default
+    TEST_CASES.append(({model_key: model_hps}, {"vary_seed_across_folds": True}, list(range(3))))
+    # No vary default
+    TEST_CASES.append(
+        ({model_key: model_hps}, {"vary_seed_across_folds": False}, [0] * 3),
+    )
+    # Different fixed seed
+    TEST_CASES.append(({model_key: model_hps}, {"vary_seed_across_folds": False, "model_random_seed": 42}, [42] * 3))
+    # Two models, two different sets of seeds
+    model_hps_2nd_model = deepcopy(model_hps)
+    model_hps_2nd_model["ag_args_ensemble"] = {"model_random_seed": 42}
+    TEST_CASES.append(
+        ({model_key: [model_hps, model_hps_2nd_model]}, {"vary_seed_across_folds": True}, ([0, 1, 2], [42, 43, 44]))
+    )
+    # Vary via model HPs instead of fit args
+    model_hps = deepcopy(model_hps)
+    model_hps["ag_args_ensemble"] = {"vary_seed_across_folds": False, "model_random_seed": 42}
+    TEST_CASES.append(({model_key: model_hps}, {}, [42] * 3))
+
 
 @pytest.mark.parametrize(
     "hyperparameters, ag_args_ensemble, expected_random_seeds",
@@ -32,23 +51,12 @@ def test_bagged_random_seed(hyperparameters, ag_args_ensemble, expected_random_s
     parallel fit + parallel bag
     parallel fit + sequential bag
     """
-    sample_size = 50
-    dataset_name = "adult"
     directory_prefix = "./datasets/"
+    dataset_name = "toy_binary"
     train_data, _, dataset_info = FitHelper.load_dataset(name=dataset_name, directory_prefix=directory_prefix)
     label = dataset_info["label"]
-    init_args = dict(
-        label=label,
-        eval_metric="log_loss",
-        problem_type=dataset_info["problem_type"]
-    )
+    init_args = dict(label=label, eval_metric="log_loss", problem_type=dataset_info["problem_type"])
     save_path = os.path.join(directory_prefix, dataset_name, f"AutogluonOutput_{uuid.uuid4()}")
-    train_data, _ = generate_train_test_split_combined(
-        data=train_data,
-        label=init_args["label"],
-        problem_type=init_args["problem_type"],
-        train_size=sample_size,
-    )
 
     fit_args = dict(
         train_data=train_data,
@@ -59,14 +67,13 @@ def test_bagged_random_seed(hyperparameters, ag_args_ensemble, expected_random_s
         fit_weighted_ensemble=False,
     )
 
-
     for fit_strategy, fold_fitting_strategy in [
         ("sequential", "sequential_local"),
         ("sequential", None),
         ("parallel", "sequential_local"),
         ("parallel", None),
     ]:
-        if fold_fitting_strategy is not  None:
+        if fold_fitting_strategy is not None:
             ag_args_ensemble = deepcopy(ag_args_ensemble)
             ag_args_ensemble["fold_fitting_strategy"] = fold_fitting_strategy
 
@@ -77,15 +84,14 @@ def test_bagged_random_seed(hyperparameters, ag_args_ensemble, expected_random_s
             **fit_args,
         )
 
-        for model_name in predictor.model_names():
+        for model_i, model_name in enumerate(predictor.model_names()):
             model = predictor._trainer.load_model(model_name)
+            _expected_random_seeds = (
+                expected_random_seeds[model_i] if isinstance(expected_random_seeds, tuple) else expected_random_seeds
+            )
             for child_i, child_name in enumerate(model.models):
                 child_model = model.load_child(child_name)
-                expected_random_seed = expected_random_seeds[child_i]
+                expected_random_seed = _expected_random_seeds[child_i]
                 assert child_model.random_seed == expected_random_seed, (
                     f"Random seed for bagged model should be {expected_random_seed}, but got {child_model.random_seed}"
                 )
-
-
-
-

--- a/tabular/tests/unittests/models/advanced/test_model_random_seed.py
+++ b/tabular/tests/unittests/models/advanced/test_model_random_seed.py
@@ -26,7 +26,7 @@ def test_bagged_random_seed(hyperparameters, ag_args_ensemble, expected_random_s
     """
     Tests that the random seeds for bagged models are correct.
 
-    Tests 2 fit types:
+    Tests 4 fit types:
     sequential fit + sequential bag
     sequential fit + parallel bag
     parallel fit + parallel bag

--- a/tabular/tests/unittests/models/advanced/test_model_random_seed.py
+++ b/tabular/tests/unittests/models/advanced/test_model_random_seed.py
@@ -14,8 +14,23 @@ TEST_CASES = []
 for model_key, model_hps in [
     ("GBM", {"num_boost_round": 10}),
     # The below is only for full extended tests only for sanity check, not the CI
-    # ("CAT", {"iterations": 10}),
-    # ("FASTAI", {"epochs": 10}),
+    ("CAT", {"iterations": 10}),
+    ("FASTAI", {"epochs": 10}),
+    ("KNN", {}),
+    ("LR", {"max_iter": 10}),
+    ("MITRA", {}),
+    ("REALMLP", {"n_epochs": 10}),
+    ("TABICL", {}),
+    ("TABM", {"n_epochs": 10}),
+    ("TABPFNMIX", {}),
+    ("TABPFNV2", {}),
+    ("NN_TORCH", {"num_epochs": 10}),
+    ("XGB", {"n_estimators": 10}),
+
+
+
+    ("RF", {"n_estimators": 10}),  # counts for RF and XT
+
 ]:
     # Vary default
     TEST_CASES.append(({model_key: model_hps}, {"vary_seed_across_folds": True}, list(range(3))))

--- a/tabular/tests/unittests/models/advanced/test_model_random_seed.py
+++ b/tabular/tests/unittests/models/advanced/test_model_random_seed.py
@@ -1,0 +1,91 @@
+"""
+Unit tests to ensure correctness random seed logic
+"""
+
+import os
+import uuid
+from copy import deepcopy
+from autogluon.core.utils import generate_train_test_split_combined
+from autogluon.tabular import TabularPredictor
+from autogluon.tabular.testing import FitHelper
+import pytest
+
+TEST_CASES = [
+    ({"GBM": {"num_boost_round": 10}}, {}, list(range(3))),
+    ({"GBM": {"num_boost_round": 10}}, {"vary_seed_across_folds": False}, [0] * 3),
+    ({"GBM": {"num_boost_round": 10}}, {"model_random_seed": 42}, [42, 43, 44]),
+    ({"GBM": {"num_boost_round": 10}}, {"vary_seed_across_folds": False, "model_random_seed": 42}, [42] * 3),
+    ({"GBM": {"num_boost_round": 10, "ag_args_ensemble": {"vary_seed_across_folds": False, "model_random_seed": 42}}}, {}, [42] * 3),
+]
+
+@pytest.mark.parametrize(
+    "hyperparameters, ag_args_ensemble, expected_random_seeds",
+    TEST_CASES,
+)
+def test_bagged_random_seed(hyperparameters, ag_args_ensemble, expected_random_seeds):
+    """
+    Tests that the random seeds for bagged models are correct.
+
+    Tests 2 fit types:
+    sequential fit + sequential bag
+    sequential fit + parallel bag
+    parallel fit + parallel bag
+    parallel fit + sequential bag
+    """
+    sample_size = 50
+    dataset_name = "adult"
+    directory_prefix = "./datasets/"
+    train_data, _, dataset_info = FitHelper.load_dataset(name=dataset_name, directory_prefix=directory_prefix)
+    label = dataset_info["label"]
+    init_args = dict(
+        label=label,
+        eval_metric="log_loss",
+        problem_type=dataset_info["problem_type"]
+    )
+    save_path = os.path.join(directory_prefix, dataset_name, f"AutogluonOutput_{uuid.uuid4()}")
+    train_data, _ = generate_train_test_split_combined(
+        data=train_data,
+        label=init_args["label"],
+        problem_type=init_args["problem_type"],
+        train_size=sample_size,
+    )
+
+    fit_args = dict(
+        train_data=train_data,
+        num_bag_folds=3,
+        num_stack_levels=0,
+        calibrate=False,  # ensure calibration is also deterministic
+        dynamic_stacking=False,
+        fit_weighted_ensemble=False,
+    )
+
+
+    for fit_strategy, fold_fitting_strategy in [
+        ("sequential", "sequential_local"),
+        ("sequential", None),
+        ("parallel", "sequential_local"),
+        ("parallel", None),
+    ]:
+        if fold_fitting_strategy is not  None:
+            ag_args_ensemble = deepcopy(ag_args_ensemble)
+            ag_args_ensemble["fold_fitting_strategy"] = fold_fitting_strategy
+
+        predictor = TabularPredictor(path=save_path, **init_args).fit(
+            hyperparameters=hyperparameters,
+            fit_strategy=fit_strategy,
+            ag_args_ensemble=ag_args_ensemble,
+            **fit_args,
+        )
+
+        for model_name in predictor.model_names():
+            model = predictor._trainer.load_model(model_name)
+            for child_i, child_name in enumerate(model.models):
+                child_model = model.load_child(child_name)
+                expected_random_seed = expected_random_seeds[child_i]
+                assert child_model.random_seed == expected_random_seed, (
+                    f"Random seed for bagged model should be {expected_random_seed}, but got {child_model.random_seed}"
+                )
+
+
+
+


### PR DESCRIPTION
This PR ensures that each fold gets a different random seed. I implemented it as part of the kwargs to avoid users setting random seeds as a hyperparameter. 

> By default, we keep a static seed of 0 to ensure reproducibility. When using a bagged model, a static seed of 0 to n_splits-1 is used to ensure that each fold has a different seed that is consistent across different models.

Note, one can disable this behavior and use a static seed across all folds (similar to the prior implementation via):


TODO:

- [x] Add code to support this for all other models. 

--- 
One can control the seed behavior via `ag_args_ensemble`:

```python
# Enable behavior of varying the seeds across folds
predictor = TabularPredictor(label="class", path=str("./ag_path")).fit(
    train_data=train_data,
    hyperparameters={'GBM':{"num_boost_round": 10}},
    ag_args_ensemble={"fold_fitting_strategy": 'sequential_local', "vary_seed_across_folds": True}
)

# Set your own random seed for all models
predictor = TabularPredictor(label="class", path=str("./ag_path")).fit(
    train_data=train_data,
    hyperparameters={'GBM':{"num_boost_round": 10}},
    ag_args_ensemble={"fold_fitting_strategy": 'sequential_local', "model_random_seed": 42}
)

# Set your own random seed per configuration
predictor = TabularPredictor(label="class", path=str("./ag_path")).fit(
    train_data=train_data,
    hyperparameters={'GBM':{"num_boost_round": 10, "ag_args_ensemble": {"model_random_seed": 42}}},
)

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
