### PR TITLE
Chronos: allow default downloading of weights

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/chronos/model.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/model.py
@@ -12,14 +12,21 @@ from autogluon.common.loaders import load_pkl
 from autogluon.common.space import Space
 from autogluon.timeseries.dataset.ts_dataframe import TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
-from autogluon.timeseries.utils.warning_filters import disable_duplicate_logs, warning_filter
+from autogluon.timeseries.utils.warning_filters import (
+    disable_duplicate_logs,
+    warning_filter,
+)
 
 logger = logging.getLogger("autogluon.timeseries.models.chronos")
 
 # TODO: Replace `evaluation_strategy` with `eval_strategy` when upgrading to `transformers>=4.41` + remove warning filter
-warnings.filterwarnings("ignore", category=FutureWarning, message="`evaluation_strategy` is deprecated")
+warnings.filterwarnings(
+    "ignore", category=FutureWarning, message="`evaluation_strategy` is deprecated"
+)
 # TODO: Remove warning filter when upgrading to `transformers>=4.40`
-warnings.filterwarnings("ignore", category=FutureWarning, message="Passing the following arguments to ")
+warnings.filterwarnings(
+    "ignore", category=FutureWarning, message="Passing the following arguments to "
+)
 
 
 # allowed HuggingFace model paths with custom parameter definitions
@@ -191,7 +198,13 @@ class ChronosModel(AbstractTimeSeriesModel):
         name = name if name is not None else "Chronos"
         if not isinstance(model_path_input, Space):
             # we truncate the name to avoid long path errors on Windows
-            model_path_suffix = "[" + str(model_path_input).replace("/", "__").replace(os.path.sep, "__")[-50:] + "]"
+            model_path_suffix = (
+                "["
+                + str(model_path_input)
+                .replace("/", "__")
+                .replace(os.path.sep, "__")[-50:]
+                + "]"
+            )
             if model_path_suffix not in name:
                 name += model_path_suffix
 
@@ -216,14 +229,20 @@ class ChronosModel(AbstractTimeSeriesModel):
         return str(path)
 
     @classmethod
-    def load(cls, path: str, reset_paths: bool = True, verbose: bool = True) -> "ChronosModel":
-        model = load_pkl.load(path=os.path.join(path, cls.model_file_name), verbose=verbose)
+    def load(
+        cls, path: str, reset_paths: bool = True, verbose: bool = True
+    ) -> "ChronosModel":
+        model = load_pkl.load(
+            path=os.path.join(path, cls.model_file_name), verbose=verbose
+        )
         if reset_paths:
             model.set_contexts(path)
 
         fine_tune_ckpt_path = Path(model.path) / cls.fine_tuned_ckpt_name
         if fine_tune_ckpt_path.exists():
-            logger.debug(f"\tFine-tuned checkpoint exists, setting model_path to {fine_tune_ckpt_path}")
+            logger.debug(
+                f"\tFine-tuned checkpoint exists, setting model_path to {fine_tune_ckpt_path}"
+            )
             model.model_path = str(fine_tune_ckpt_path)
 
         return model
@@ -271,16 +290,51 @@ class ChronosModel(AbstractTimeSeriesModel):
         """
         return self.ag_default_config.get("default_torch_dtype", "auto")
 
-    def get_minimum_resources(self, is_gpu_available: bool = False) -> Dict[str, Union[int, float]]:
+    def get_minimum_resources(
+        self, is_gpu_available: bool = False
+    ) -> Dict[str, Union[int, float]]:
         minimum_resources: Dict[str, Union[int, float]] = {"num_cpus": 1}
         # if GPU is available, we train with 1 GPU per trial
         if is_gpu_available:
             minimum_resources["num_gpus"] = self.min_num_gpus
         return minimum_resources
 
+    # def load_model_pipeline(self, is_training: bool = False):
+    #     from .pipeline import BaseChronosPipeline
+
+    #     gpu_available = self._is_gpu_available()
+
+    #     if not gpu_available and self.min_num_gpus > 0:
+    #         raise RuntimeError(
+    #             f"{self.name} requires a GPU to run, but no GPU was detected. "
+    #             "Please make sure that you are using a computer with a CUDA-compatible GPU and "
+    #             "`import torch; torch.cuda.is_available()` returns `True`."
+    #         )
+
+    #     device = self.device or ("cuda" if gpu_available else "cpu")
+
+    #     pipeline = BaseChronosPipeline.from_pretrained(
+    #         self.model_path,
+    #         device_map=device,
+    #         torch_dtype=self.torch_dtype,
+    #     )
+
+    #     self._model_pipeline = pipeline
+
     def load_model_pipeline(self, is_training: bool = False):
         from .pipeline import BaseChronosPipeline
+        from transformers import AutoConfig, AutoModelForCausalLM, AutoModelForSeq2SeqLM
+        from .pipeline.chronos import (
+            ChronosPipeline,
+            ChronosConfig,
+            ChronosPretrainedModel,
+        )
+        from .pipeline.chronos_bolt import (
+            ChronosBoltModelForForecasting,
+            ChronosBoltPipeline,
+        )
 
+        init_random = self._hyperparameters.get("init_random", False)
         gpu_available = self._is_gpu_available()
 
         if not gpu_available and self.min_num_gpus > 0:
@@ -291,13 +345,41 @@ class ChronosModel(AbstractTimeSeriesModel):
             )
 
         device = self.device or ("cuda" if gpu_available else "cpu")
+        print(f"Initialization by Default is {init_random}")
+        if not is_training and init_random:
+            init_random = False  # otherwise during inference the model is initialized from random...
+        if init_random:
+            config = AutoConfig.from_pretrained(self.model_path)
+            pipeline_class_name = getattr(
+                config, "chronos_pipeline_class", "ChronosPipeline"
+            )
+            if pipeline_class_name == "ChronosBoltPipeline":
+                model = ChronosBoltModelForForecasting(config)
+                model.to(device)
+                pipeline = ChronosBoltPipeline(model=model)
+            elif pipeline_class_name == "ChronosPipeline":
+                chronos_config = ChronosConfig(**config.chronos_config)
+                if chronos_config.model_type == "seq2seq":
+                    hf_model = AutoModelForSeq2SeqLM.from_config(config)
+                elif chronos_config.model_type == "causal":
+                    hf_model = AutoModelForCausalLM.from_config(config)
+                else:
+                    raise ValueError(f"Unknown model_type: {chronos_config.model_type}")
 
-        pipeline = BaseChronosPipeline.from_pretrained(
-            self.model_path,
-            device_map=device,
-            torch_dtype=self.torch_dtype,
-        )
-
+                tokenizer = chronos_config.create_tokenizer()
+                chronos_model = ChronosPretrainedModel(
+                    config=chronos_config, model=hf_model
+                )
+                chronos_model.to(device)
+                pipeline = ChronosPipeline(tokenizer=tokenizer, model=chronos_model)
+            else:
+                raise ValueError(f"Unsupported pipeline class: {pipeline_class_name}")
+        else:
+            pipeline = BaseChronosPipeline.from_pretrained(
+                self.model_path,
+                device_map=device,
+                torch_dtype=self.torch_dtype,
+            )
         self._model_pipeline = pipeline
 
     def persist(self) -> "ChronosModel":
@@ -315,7 +397,9 @@ class ChronosModel(AbstractTimeSeriesModel):
         init_args = super().get_hyperparameters()
 
         eval_during_fine_tune = init_args["eval_during_fine_tune"]
-        fine_tune_trainer_kwargs = self._get_fine_tune_trainer_kwargs(init_args, eval_during_fine_tune)
+        fine_tune_trainer_kwargs = self._get_fine_tune_trainer_kwargs(
+            init_args, eval_during_fine_tune
+        )
         user_fine_tune_trainer_kwargs = init_args.get("fine_tune_trainer_kwargs", {})
         fine_tune_trainer_kwargs.update(user_fine_tune_trainer_kwargs)
         init_args["fine_tune_trainer_kwargs"] = fine_tune_trainer_kwargs
@@ -359,6 +443,7 @@ class ChronosModel(AbstractTimeSeriesModel):
             "fine_tune_eval_max_items",
             "fine_tune_trainer_kwargs",
             "keep_transformers_logs",
+            "init_random",
         ]
 
     def _get_fine_tune_trainer_kwargs(self, init_args, eval_during_fine_tune: bool):
@@ -405,7 +490,10 @@ class ChronosModel(AbstractTimeSeriesModel):
         self.data_loader_num_workers = model_params["data_loader_num_workers"]
         self.context_length = model_params["context_length"]
 
-        if self.context_length is not None and self.context_length > self.maximum_context_length:
+        if (
+            self.context_length is not None
+            and self.context_length > self.maximum_context_length
+        ):
             logger.info(
                 f"\tContext length {self.context_length} exceeds maximum context length {self.maximum_context_length}."
                 f"Context length will be set to {self.maximum_context_length}."
@@ -440,7 +528,9 @@ class ChronosModel(AbstractTimeSeriesModel):
         for logger_name in logging.root.manager.loggerDict:
             if "transformers" in logger_name:
                 transformers_logger = logging.getLogger(logger_name)
-                transformers_logger.setLevel(logging.ERROR if verbosity <= 3 else logging.INFO)
+                transformers_logger.setLevel(
+                    logging.ERROR if verbosity <= 3 else logging.INFO
+                )
 
         self._check_fit_params()
         self._log_unused_hyperparameters()
@@ -449,9 +539,13 @@ class ChronosModel(AbstractTimeSeriesModel):
         do_fine_tune = model_params["fine_tune"]
 
         if do_fine_tune:
-            assert train_data is not None, "train_data cannot be None when fine_tune=True"
+            assert (
+                train_data is not None
+            ), "train_data cannot be None when fine_tune=True"
 
-        eval_during_fine_tune = val_data is not None and model_params["eval_during_fine_tune"]
+        eval_during_fine_tune = (
+            val_data is not None and model_params["eval_during_fine_tune"]
+        )
 
         if do_fine_tune:
             context_length = self._get_context_length(train_data)
@@ -459,7 +553,11 @@ class ChronosModel(AbstractTimeSeriesModel):
             self.load_model_pipeline(is_training=True)
 
             fine_tune_prediction_length = self.prediction_length
-            model_prediction_length = self.model_pipeline.inner_model.config.chronos_config["prediction_length"]
+            model_prediction_length = (
+                self.model_pipeline.inner_model.config.chronos_config[
+                    "prediction_length"
+                ]
+            )
 
             if isinstance(self.model_pipeline, ChronosPipeline):
                 pipeline_specific_trainer_kwargs = {}
@@ -467,17 +565,21 @@ class ChronosModel(AbstractTimeSeriesModel):
                 # Update prediction_length of the model
                 # NOTE: We only do this for ChronosPipeline because the prediction length of ChronosBolt models
                 # is fixed due to direct multistep forecasting setup
-                self.model_pipeline.model.config.prediction_length = fine_tune_prediction_length
-                self.model_pipeline.inner_model.config.chronos_config["prediction_length"] = (
+                self.model_pipeline.model.config.prediction_length = (
                     fine_tune_prediction_length
                 )
+                self.model_pipeline.inner_model.config.chronos_config[
+                    "prediction_length"
+                ] = fine_tune_prediction_length
 
             elif isinstance(self.model_pipeline, ChronosBoltPipeline):
                 # custom label_names is needed for validation to work with ChronosBolt models
                 pipeline_specific_trainer_kwargs = dict(label_names=["target"])
 
                 # truncate prediction_length if it goes beyond ChronosBolt's prediction_length
-                fine_tune_prediction_length = min(model_prediction_length, self.prediction_length)
+                fine_tune_prediction_length = min(
+                    model_prediction_length, self.prediction_length
+                )
 
                 if self.prediction_length != fine_tune_prediction_length:
                     logger.debug(
@@ -485,10 +587,14 @@ class ChronosModel(AbstractTimeSeriesModel):
                         f"Fine-tuning prediction_length has been changed to {fine_tune_prediction_length}."
                     )
             else:
-                raise ValueError(f"Unsupported model pipeline: {type(self.model_pipeline)}")
+                raise ValueError(
+                    f"Unsupported model pipeline: {type(self.model_pipeline)}"
+                )
 
             fine_tune_trainer_kwargs = model_params["fine_tune_trainer_kwargs"]
-            fine_tune_trainer_kwargs["use_cpu"] = str(self.model_pipeline.inner_model.device) == "cpu"
+            fine_tune_trainer_kwargs["use_cpu"] = (
+                str(self.model_pipeline.inner_model.device) == "cpu"
+            )
 
             if fine_tune_trainer_kwargs["use_cpu"]:
                 logger.info(
@@ -511,9 +617,13 @@ class ChronosModel(AbstractTimeSeriesModel):
 
             if version.parse(transformers.__version__) >= version.parse("4.46"):
                 # transformers changed the argument name from `evaluation_strategy` to `eval_strategy`
-                fine_tune_trainer_kwargs["eval_strategy"] = fine_tune_trainer_kwargs.pop("evaluation_strategy")
+                fine_tune_trainer_kwargs["eval_strategy"] = (
+                    fine_tune_trainer_kwargs.pop("evaluation_strategy")
+                )
 
-            training_args = TrainingArguments(**fine_tune_trainer_kwargs, **pipeline_specific_trainer_kwargs)
+            training_args = TrainingArguments(
+                **fine_tune_trainer_kwargs, **pipeline_specific_trainer_kwargs
+            )
             tokenizer_train_dataset = ChronosFineTuningDataset(
                 target_df=train_data,
                 target_column=self.target,
@@ -540,7 +650,9 @@ class ChronosModel(AbstractTimeSeriesModel):
 
                 if fine_tune_eval_max_items < val_data.num_items:
                     eval_items = np.random.choice(
-                        val_data.item_ids.values, size=fine_tune_eval_max_items, replace=False
+                        val_data.item_ids.values,
+                        size=fine_tune_eval_max_items,
+                        replace=False,
                     )
                     val_data = val_data.loc[eval_items]
 
@@ -576,7 +688,9 @@ class ChronosModel(AbstractTimeSeriesModel):
 
             fine_tuned_ckpt_path = Path(self.path) / self.fine_tuned_ckpt_name
             logger.info(f"\tSaving fine-tuned model to {fine_tuned_ckpt_path}")
-            self.model_pipeline.inner_model.save_pretrained(Path(self.path) / self.fine_tuned_ckpt_name)
+            self.model_pipeline.inner_model.save_pretrained(
+                Path(self.path) / self.fine_tuned_ckpt_name
+            )
 
             if not model_params["keep_transformers_logs"]:
                 logger.debug(f"Removing transformers_logs directory {output_dir}")
@@ -590,7 +704,11 @@ class ChronosModel(AbstractTimeSeriesModel):
         num_workers: int = 0,
         time_limit: Optional[float] = None,
     ):
-        from .pipeline.utils import ChronosInferenceDataLoader, ChronosInferenceDataset, timeout_callback
+        from .pipeline.utils import (
+            ChronosInferenceDataLoader,
+            ChronosInferenceDataset,
+            timeout_callback,
+        )
 
         chronos_dataset = ChronosInferenceDataset(
             target_df=data,
@@ -677,7 +795,9 @@ class ChronosModel(AbstractTimeSeriesModel):
             np.concatenate(
                 [
                     np.concatenate(batch_means, axis=0).reshape(-1, 1),
-                    np.concatenate(batch_quantiles, axis=0).reshape(-1, len(self.quantile_levels)),
+                    np.concatenate(batch_quantiles, axis=0).reshape(
+                        -1, len(self.quantile_levels)
+                    ),
                 ],
                 axis=1,
             ),


### PR DESCRIPTION
*Issue #, if available:*
Hello, for time series foundation models, sometimes PyTorch random initialization can be a strong baseline.
In the chronos-forecasting repository you already allowed random initialization, but here in AutoGluon it’s not the case.
*Description of changes:*
  I just updated this feature in the AutoGluon library for Chronos models by adding an init_random parameter.
I modified the load_model_pipeline method to include a condition on the init_random flag:

    1) If init_random is True, the model is loaded directly from its configuration, and it checks whether we are in training or evaluation mode (disabled during evaluation to ensure the correct model is loaded).

    2) If init_random is False, the original loading behavior is used.

I have conducted many tests to ensure I can reproduce results and verify that everything is correctly loaded during both training and inference.

Any feedback is welcome, do you think this addition would be useful for your libraries :) ?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
