### PR TITLE
Fix usage of report API due to tune upgrade

### DIFF
--- a/core/tests/unittests/hpo/test_ray_hpo.py
+++ b/core/tests/unittests/hpo/test_ray_hpo.py
@@ -36,7 +36,7 @@ def _dummy_trainable(config):
     for x in range(20):
         score = _dummy_objective(x, config["a"], config["b"])
 
-        tune.report(score=score)
+        tune.report({"score": score})
 
 
 def test_invalid_searcher():
@@ -136,3 +136,5 @@ def test_run(searcher, scheduler):
             ray_tune_adapter=DummyAdapter(),
         )
         assert analysis is not None
+        assert analysis.best_result is not None
+        assert analysis.best_result["score"] is not None


### PR DESCRIPTION
*Description of changes:*
For older versions of `tune` -` tune.report(score=score)` was acceptable but with newer versions params in report need to be wrapped in a dict like:`tune.report({"score": score})`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
