### PR TITLE
[timeseries] factor prediction cache out of trainer

### DIFF
--- a/timeseries/src/autogluon/timeseries/trainer/prediction_cache.py
+++ b/timeseries/src/autogluon/timeseries/trainer/prediction_cache.py
@@ -1,0 +1,147 @@
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional, Protocol
+
+from autogluon.common.utils.utils import hash_pandas_df
+from autogluon.core.utils.loaders import load_pkl
+from autogluon.core.utils.savers import save_pkl
+from autogluon.timeseries import TimeSeriesDataFrame
+
+logger = logging.getLogger(__name__)
+
+
+class PredictionCache(Protocol):
+    """A prediction cache is an abstract key-value store for time series predictions. The storage is keyed by
+    (data, known_covariates) pairs and stores (model_pred_dict, pred_time_dict) pair values. In this stored pair,
+    (model_pred_dict, pred_time_dict), both dictionaries are keyed by model names.
+    """
+
+    def __init__(self, root_path: str): ...
+
+    def get(
+        self, data: TimeSeriesDataFrame, known_covariates: Optional[TimeSeriesDataFrame]
+    ) -> tuple[dict[str, Optional[TimeSeriesDataFrame]], dict[str, float]]: ...
+
+    def put(
+        self,
+        data: TimeSeriesDataFrame,
+        known_covariates: Optional[TimeSeriesDataFrame],
+        model_pred_dict: dict[str, Optional[TimeSeriesDataFrame]],
+        pred_time_dict: dict[str, float],
+    ) -> None: ...
+
+    def clear(self) -> None: ...
+
+
+def get_prediction_cache(use_cache: bool, root_path: str) -> PredictionCache:
+    if use_cache:
+        return FileBasedPredictionCache(root_path=root_path)
+    else:
+        return DummyPredictionCache(root_path=root_path)
+
+
+def compute_dataset_hash(data: TimeSeriesDataFrame, known_covariates: Optional[TimeSeriesDataFrame] = None) -> str:
+    """Compute a unique string that identifies the time series dataset."""
+    combined_hash = hash_pandas_df(data) + hash_pandas_df(known_covariates) + hash_pandas_df(data.static_features)
+    return combined_hash
+
+
+class DummyPredictionCache(PredictionCache):
+    """A dummy (no-op) prediction cache."""
+
+    def __init__(self, root_path: str):
+        pass
+
+    def get(
+        self, data: TimeSeriesDataFrame, known_covariates: Optional[TimeSeriesDataFrame]
+    ) -> tuple[dict[str, Optional[TimeSeriesDataFrame]], dict[str, float]]:
+        return {}, {}
+
+    def put(
+        self,
+        data: TimeSeriesDataFrame,
+        known_covariates: Optional[TimeSeriesDataFrame],
+        model_pred_dict: dict[str, Optional[TimeSeriesDataFrame]],
+        pred_time_dict: dict[str, float],
+    ) -> None:
+        pass
+
+    def clear(self) -> None:
+        pass
+
+
+class FileBasedPredictionCache(PredictionCache):
+    """A file-backed cache of model predictions."""
+
+    _cached_predictions_filename = "cached_predictions.pkl"
+
+    def __init__(self, root_path: str):
+        self.root_path = Path(root_path)
+
+    @property
+    def path(self) -> Path:
+        return Path(self.root_path) / self._cached_predictions_filename
+
+    def get(
+        self, data: TimeSeriesDataFrame, known_covariates: Optional[TimeSeriesDataFrame]
+    ) -> tuple[dict[str, Optional[TimeSeriesDataFrame]], dict[str, float]]:
+        dataset_hash = compute_dataset_hash(data, known_covariates)
+        return self._get_cached_pred_dicts(dataset_hash)
+
+    def put(
+        self,
+        data: TimeSeriesDataFrame,
+        known_covariates: Optional[TimeSeriesDataFrame],
+        model_pred_dict: dict[str, Optional[TimeSeriesDataFrame]],
+        pred_time_dict: dict[str, float],
+    ) -> None:
+        dataset_hash = compute_dataset_hash(data, known_covariates)
+        self._save_cached_pred_dicts(dataset_hash, model_pred_dict, pred_time_dict)
+
+    def clear(self) -> None:
+        if self.path.exists():
+            logger.debug(f"Removing existing cached predictions file {self.path}")
+            self.path.unlink()
+
+    def _load_cached_predictions(self) -> dict[str, dict[str, dict[str, Any]]]:
+        if self.path.exists():
+            try:
+                cached_predictions = load_pkl.load(str(self.path))
+            except Exception:
+                cached_predictions = {}
+        else:
+            cached_predictions = {}
+        return cached_predictions
+
+    def _get_cached_pred_dicts(
+        self, dataset_hash: str
+    ) -> tuple[dict[str, Optional[TimeSeriesDataFrame]], dict[str, float]]:
+        """Load cached predictions for given dataset_hash from disk, if possible.
+
+        If loading fails for any reason, empty dicts are returned.
+        """
+        cached_predictions = self._load_cached_predictions()
+        if dataset_hash in cached_predictions:
+            try:
+                model_pred_dict = cached_predictions[dataset_hash]["model_pred_dict"]
+                pred_time_dict = cached_predictions[dataset_hash]["pred_time_dict"]
+                assert model_pred_dict.keys() == pred_time_dict.keys()
+                return model_pred_dict, pred_time_dict
+            except Exception:
+                logger.warning("Cached predictions are corrupted. Predictions will be made from scratch.")
+        return {}, {}
+
+    def _save_cached_pred_dicts(
+        self,
+        dataset_hash: str,
+        model_pred_dict: dict[str, Optional[TimeSeriesDataFrame]],
+        pred_time_dict: dict[str, float],
+    ) -> None:
+        cached_predictions = self._load_cached_predictions()
+        # Do not save results for models that failed
+        cached_predictions[dataset_hash] = {
+            "model_pred_dict": {k: v for k, v in model_pred_dict.items() if v is not None},
+            "pred_time_dict": {k: v for k, v in pred_time_dict.items() if v is not None},
+        }
+        save_pkl.save(str(self.path), object=cached_predictions)
+        logger.debug(f"Cached predictions saved to {self.path}")

--- a/timeseries/tests/unittests/trainer/test_prediction_cache.py
+++ b/timeseries/tests/unittests/trainer/test_prediction_cache.py
@@ -1,0 +1,112 @@
+import pandas as pd
+
+from autogluon.timeseries.dataset import TimeSeriesDataFrame
+from autogluon.timeseries.trainer.prediction_cache import FileBasedPredictionCache, compute_dataset_hash
+from autogluon.timeseries.utils.forecast import make_future_data_frame
+
+from ..common import (
+    DATAFRAME_WITH_COVARIATES,
+    DATAFRAME_WITH_STATIC_AND_COVARIATES,
+    get_prediction_for_df,
+)
+
+
+class TestDatasetHashFunction:
+    def _get_known_covariates_for_df(self, df: TimeSeriesDataFrame) -> TimeSeriesDataFrame:
+        known_covariates = make_future_data_frame(df, prediction_length=5)
+        known_covariates["cov1"] = 42
+        return TimeSeriesDataFrame(known_covariates)
+
+    def test_when_dfs_are_identical_then_identical_hash_is_computed(self):
+        df = DATAFRAME_WITH_COVARIATES
+        df_other = DATAFRAME_WITH_COVARIATES.copy(deep=True)
+        df_other = df_other.reindex(reversed(df_other.columns), axis=1)
+
+        assert df is not df_other
+        assert compute_dataset_hash(df) == compute_dataset_hash(df_other)
+
+    def test_when_dfs_and_known_covariates_are_identical_then_identical_hash_is_computed(self):
+        df = DATAFRAME_WITH_COVARIATES
+        df_other = DATAFRAME_WITH_COVARIATES.copy(deep=True)
+        df_other = df_other.reindex(reversed(df_other.columns), axis=1)
+
+        known_covariates = self._get_known_covariates_for_df(df)
+        known_covariates_other = self._get_known_covariates_for_df(df_other)
+
+        assert df is not df_other
+        assert known_covariates is not known_covariates_other
+        assert compute_dataset_hash(df, known_covariates) == compute_dataset_hash(df_other, known_covariates_other)
+
+    def test_when_different_dfs_then_different_hashes_are_computed(self):
+        df = DATAFRAME_WITH_COVARIATES
+        df_other = DATAFRAME_WITH_COVARIATES.copy(deep=True)
+        df_other.iloc[0, 0] = df_other.iloc[0, 0] + 1  # type: ignore
+        assert compute_dataset_hash(df) != compute_dataset_hash(df_other)
+
+    def test_when_identical_dfs_and_different_known_covariates_are_identical_then_different_hashes_are_computed(self):
+        df = DATAFRAME_WITH_COVARIATES
+        df_other = DATAFRAME_WITH_COVARIATES.copy(deep=True)
+        df_other = df_other.reindex(reversed(df_other.columns), axis=1)
+
+        known_covariates = self._get_known_covariates_for_df(df)
+        known_covariates_other = self._get_known_covariates_for_df(df_other)
+
+        known_covariates_other.iloc[0, 0] = known_covariates_other.iloc[0, 0] * 2  # type: ignore
+
+        assert df is not df_other
+        assert compute_dataset_hash(df, known_covariates) != compute_dataset_hash(df_other, known_covariates_other)
+
+    def test_when_different_static_features_then_different_hashes_are_computed(self):
+        df = DATAFRAME_WITH_STATIC_AND_COVARIATES
+        df_other = df.copy(deep=True)
+
+        assert df_other.static_features is not None
+        df_other.static_features.iloc[0, 0] = df_other.static_features.iloc[0, 0] + 1  # type: ignore
+
+        assert compute_dataset_hash(df) != compute_dataset_hash(df_other)
+
+
+class TestFileBasedPredictionCache:
+    def test_when_identical_dfs_are_given_then_cache_hit_returns_true(self, tmp_path):
+        df = DATAFRAME_WITH_COVARIATES
+        df_other = DATAFRAME_WITH_COVARIATES.copy(deep=True)
+
+        preds = get_prediction_for_df(df)
+
+        cache = FileBasedPredictionCache(str(tmp_path))
+        cache.put(df, None, {"MyModel": preds}, {"MyModel": 0.5})
+
+        cached_preds, cached_times = cache.get(df_other, None)
+
+        cached_model_preds = cached_preds.get("MyModel")
+        assert cached_model_preds is not None
+        assert cached_times.get("MyModel") is not None
+        assert cached_model_preds.equals(preds)
+
+    def test_when_different_dfs_are_given_then_cache_hit_returns_false(self, tmp_path):
+        df = DATAFRAME_WITH_COVARIATES
+        df_other = DATAFRAME_WITH_COVARIATES.copy(deep=True)
+        df_other.iloc[0, 0] = df_other.iloc[0, 0] + 1  # type: ignore
+
+        preds = get_prediction_for_df(df)
+
+        cache = FileBasedPredictionCache(str(tmp_path))
+        cache.put(df, None, {"MyModel": preds}, {"MyModel": 0.5})
+
+        cached_preds, cached_times = cache.get(df_other, None)
+
+        assert not cached_preds
+        assert not cached_times
+
+    def test_when_cache_cleared_then_file_is_removed(self, tmp_path):
+        df = DATAFRAME_WITH_COVARIATES
+        preds = get_prediction_for_df(df)
+
+        cache = FileBasedPredictionCache(str(tmp_path))
+        cache.put(df, None, {"MyModel": preds}, {"MyModel": 0.5})
+
+        cache.clear()
+
+        expected_path = tmp_path / cache._cached_predictions_filename
+        assert expected_path == cache.path
+        assert not expected_path.exists()

--- a/timeseries/tests/unittests/trainer/test_trainer.py
+++ b/timeseries/tests/unittests/trainer/test_trainer.py
@@ -4,6 +4,7 @@ import copy
 import shutil
 import sys
 import tempfile
+from pathlib import Path
 from unittest import mock
 
 import numpy as np
@@ -17,6 +18,7 @@ from autogluon.timeseries.dataset import TimeSeriesDataFrame
 from autogluon.timeseries.models import DeepARModel, ETSModel
 from autogluon.timeseries.models.ensemble import GreedyEnsemble, SimpleAverageEnsemble
 from autogluon.timeseries.trainer import TimeSeriesTrainer
+from autogluon.timeseries.trainer.prediction_cache import DummyPredictionCache, FileBasedPredictionCache
 
 from ..common import (
     DATAFRAME_WITH_COVARIATES,
@@ -522,23 +524,15 @@ def test_when_get_model_pred_dict_called_then_pred_time_dict_contains_all_requir
     assert sorted(pred_time_dict.keys()) == sorted(model_names)
 
 
-def test_given_dfs_are_identical_then_identical_hash_is_computed(temp_model_path):
-    trainer = TimeSeriesTrainer(path=temp_model_path)
-    df = DATAFRAME_WITH_COVARIATES
-    df_other = DATAFRAME_WITH_COVARIATES.copy()
-    df_other = df_other.reindex(reversed(df_other.columns), axis=1)
-    assert df is not df_other
-    assert trainer._compute_dataset_hash(df) == trainer._compute_dataset_hash(df_other)
-
-
 def test_given_cache_predictions_is_true_when_calling_get_model_pred_dict_then_predictions_are_cached(temp_model_path):
     trainer = TimeSeriesTrainer(path=temp_model_path)
     trainer.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}, "SeasonalNaive": {}})
-    assert not trainer._cached_predictions_path.exists()
+
+    assert isinstance(trainer.cache, FileBasedPredictionCache)
+    assert not trainer.cache.path.exists()
     trainer.get_model_pred_dict(trainer.get_model_names(), data=DUMMY_TS_DATAFRAME)
 
-    dataset_hash = trainer._compute_dataset_hash(DUMMY_TS_DATAFRAME)
-    model_pred_dict, pred_time_dict = trainer._get_cached_pred_dicts(dataset_hash)
+    model_pred_dict, pred_time_dict = trainer.cache.get(DUMMY_TS_DATAFRAME, known_covariates=None)
     assert pred_time_dict.keys() == model_pred_dict.keys() == set(trainer.get_model_names())
     assert all(isinstance(v, TimeSeriesDataFrame) for v in model_pred_dict.values())
     assert all(isinstance(v, float) for v in pred_time_dict.values())
@@ -550,14 +544,12 @@ def test_given_cache_predictions_is_true_when_predicting_multiple_times_then_cac
     trainer = TimeSeriesTrainer(path=temp_model_path)
     trainer.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}, "SeasonalNaive": {}})
 
-    dataset_hash = trainer._compute_dataset_hash(DUMMY_TS_DATAFRAME)
-
     trainer.predict(DUMMY_TS_DATAFRAME, model="Naive")
-    model_pred_dict, pred_time_dict = trainer._get_cached_pred_dicts(dataset_hash)
+    model_pred_dict, pred_time_dict = trainer.cache.get(DUMMY_TS_DATAFRAME, None)
     assert sorted(model_pred_dict.keys()) == sorted(pred_time_dict.keys()) == ["Naive"]
 
     trainer.predict(DUMMY_TS_DATAFRAME, model="SeasonalNaive")
-    model_pred_dict, pred_time_dict = trainer._get_cached_pred_dicts(dataset_hash)
+    model_pred_dict, pred_time_dict = trainer.cache.get(DUMMY_TS_DATAFRAME, None)
     assert sorted(model_pred_dict.keys()) == sorted(pred_time_dict.keys()) == ["Naive", "SeasonalNaive"]
 
 
@@ -581,10 +573,12 @@ def test_given_cache_predictions_is_false_when_calling_get_model_pred_dict_then_
     temp_model_path,
 ):
     trainer = TimeSeriesTrainer(path=temp_model_path, cache_predictions=False)
+    assert isinstance(trainer.cache, DummyPredictionCache)
+
     trainer.fit(DUMMY_TS_DATAFRAME, hyperparameters=DUMMY_TRAINER_HYPERPARAMETERS)
-    assert not trainer._cached_predictions_path.exists()
     trainer.get_model_pred_dict(trainer.get_model_names(), data=DUMMY_TS_DATAFRAME)
-    assert not trainer._cached_predictions_path.exists()
+
+    assert not Path.exists(Path(temp_model_path) / FileBasedPredictionCache._cached_predictions_filename)
 
 
 def test_given_cached_predictions_cannot_be_loaded_when_predict_call_then_new_predictions_are_generated(
@@ -594,8 +588,10 @@ def test_given_cached_predictions_cannot_be_loaded_when_predict_call_then_new_pr
     trainer.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}})
     trainer.predict(DUMMY_TS_DATAFRAME, model="Naive")
 
+    assert isinstance(trainer.cache, FileBasedPredictionCache)
+
     # Corrupt the cached predictions file by writing a string into it
-    trainer._cached_predictions_path.write_text("foo")
+    trainer.cache.path.write_text("foo")
 
     with mock.patch("autogluon.timeseries.models.local.naive.NaiveModel.predict") as naive_predict:
         naive_predict.return_value = pd.DataFrame()
@@ -603,7 +599,7 @@ def test_given_cached_predictions_cannot_be_loaded_when_predict_call_then_new_pr
         naive_predict.assert_called()
 
     # Assert that predictions have been successfully stored
-    assert isinstance(load_pkl.load(str(trainer._cached_predictions_path)), dict)
+    assert isinstance(load_pkl.load(str(trainer.cache.path)), dict)
 
 
 @pytest.mark.parametrize("use_test_data", [True, False])
@@ -659,7 +655,7 @@ def test_when_add_ci_to_feature_importance_called_then_confidence_bands_correct(
     alpha = 1 - confidence_level
 
     for i, r in feature_importance.iterrows():
-        if np.isnan(r["stdev"]) or np.isnan(r["n"]) or np.isnan(r["importance"]) or r["n"] == 1:
+        if np.isnan(r["stdev"]) or np.isnan(r["n"]) or np.isnan(r["importance"]) or r["n"] == 1:  # type: ignore
             assert np.isnan(r[lower_ci_name])
             assert np.isnan(r[upper_ci_name])
         else:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Moves caching logic out of Trainer and abstracts it behind a Protocol.
- Add unit tests of data hashing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
