### PR TITLE
Fix bug if pred is inf and weight is 0 in weighted ensemble

### DIFF
--- a/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py
+++ b/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py
@@ -25,7 +25,7 @@ class AbstractWeightedEnsemble:
 
     @staticmethod
     def weight_pred_probas(pred_probas, weights):
-        preds_norm = [pred * weight for pred, weight in zip(pred_probas, weights)]
+        preds_norm = [pred * weight for pred, weight in zip(pred_probas, weights) if weight != 0]
         preds_ensemble = np.sum(preds_norm, axis=0)
         return preds_ensemble
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix rare edge-case in weighted ensembling where a model's pred contains `inf` and the model's weight is `0`. This eventually leads to `np.nan` when calculating metrics.

This PR fixes this by not computing `pred * weight` when `weight = 0`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
