### PR TITLE
[timeseries] add Toto model

### DIFF
--- a/docs/tutorials/timeseries/forecasting-model-zoo.md
+++ b/docs/tutorials/timeseries/forecasting-model-zoo.md
@@ -70,6 +70,7 @@ Note that some of the models' hyperparameters have names and default values that
    PerStepTabularModel
    RecursiveTabularModel
    ChronosModel
+   TotoModel
 
 ```
 
@@ -263,6 +264,13 @@ Deep learning models pretrained on large time series datasets, able to perform z
 
 ```{eval-rst}
 .. autoclass:: ChronosModel
+   :members: init
+
+```
+
+
+```{eval-rst}
+.. autoclass:: TotoModel
    :members: init
 
 ```

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -61,7 +61,7 @@ extras_require = {
 }
 
 # chronos-openvino and chronos-onnx are deprecated, and will be removed in a future version
-extras_require["all"] = []
+extras_require["all"] = list(set.union(*(set(extras_require[extra]) for extra in ["toto"])))
 install_requires = ag.get_dependency_version_ranges(install_requires)
 
 if __name__ == "__main__":

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -57,7 +57,7 @@ extras_require = {
     "toto": [
         "einops>=0.7,<1",
         "rotary-embedding-torch>=0.8,<1",
-    ]
+    ],
 }
 
 # chronos-openvino and chronos-onnx are deprecated, and will be removed in a future version

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -54,6 +54,10 @@ extras_require = {
         "flaky>=3.7,<4",
         "pytest-timeout>=2.1,<3",
     ],
+    "toto": [
+        "einops>=0.7,<1",
+        "rotary-embedding-torch>=0.8,<1",
+    ]
 }
 
 # chronos-openvino and chronos-onnx are deprecated, and will be removed in a future version

--- a/timeseries/src/autogluon/timeseries/models/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/__init__.py
@@ -28,6 +28,7 @@ from .local import (
     ZeroModel,
 )
 from .registry import ModelRegistry
+from .toto import TotoModel
 
 __all__ = [
     "ADIDAModel",
@@ -56,6 +57,7 @@ __all__ = [
     "TemporalFusionTransformerModel",
     "ThetaModel",
     "TiDEModel",
+    "TotoModel",
     "WaveNetModel",
     "ZeroModel",
 ]

--- a/timeseries/src/autogluon/timeseries/models/toto/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/__init__.py
@@ -1,0 +1,3 @@
+from .model import TotoModel
+
+__all__ = ["TotoModel"]

--- a/timeseries/src/autogluon/timeseries/models/toto/_internal/LICENSE
+++ b/timeseries/src/autogluon/timeseries/models/toto/_internal/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/timeseries/src/autogluon/timeseries/models/toto/_internal/README.txt
+++ b/timeseries/src/autogluon/timeseries/models/toto/_internal/README.txt
@@ -1,0 +1,7 @@
+The code in this directory adapted from the original repository: https://github.com/DataDog/toto,
+with minor edits for code conventions and removing xformers support. 
+
+Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+
+This product includes software developed at Datadog (https://www.datadoghq.com/)
+Copyright 2025 Datadog, Inc.

--- a/timeseries/src/autogluon/timeseries/models/toto/_internal/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/_internal/__init__.py
@@ -1,0 +1,12 @@
+from .backbone import TotoBackbone
+from .dataset import MaskedTimeseries
+from .forecaster import TotoForecaster
+from .model import TotoConfig, TotoPretrainedModel
+
+__all__ = [
+    "MaskedTimeseries",
+    "TotoBackbone",
+    "TotoConfig",
+    "TotoPretrainedModel",
+    "TotoForecaster",
+]

--- a/timeseries/src/autogluon/timeseries/models/toto/_internal/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/_internal/__init__.py
@@ -1,12 +1,9 @@
 from .backbone import TotoBackbone
 from .dataset import MaskedTimeseries
 from .forecaster import TotoForecaster
-from .model import TotoConfig, TotoPretrainedModel
 
 __all__ = [
     "MaskedTimeseries",
     "TotoBackbone",
-    "TotoConfig",
-    "TotoPretrainedModel",
     "TotoForecaster",
 ]

--- a/timeseries/src/autogluon/timeseries/models/toto/_internal/backbone/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/_internal/backbone/__init__.py
@@ -1,0 +1,3 @@
+from .backbone import TotoBackbone
+
+__all__ = ["TotoBackbone"]

--- a/timeseries/src/autogluon/timeseries/models/toto/_internal/backbone/attention.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/_internal/backbone/attention.py
@@ -1,0 +1,197 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/)
+# Copyright 2025 Datadog, Inc.
+
+import logging
+from enum import Enum
+from typing import Optional, Union
+
+import torch
+from einops import rearrange
+from torch.nn.functional import scaled_dot_product_attention
+
+from .rope import TimeAwareRotaryEmbedding
+
+log = logging.getLogger(__name__)
+
+
+class AttentionAxis(Enum):
+    TIME = 1
+    SPACE = 2
+
+
+class BaseMultiheadAttention(torch.nn.Module):
+    def __init__(
+        self,
+        embed_dim: int,
+        num_heads: int,
+        dropout: float,
+        rotary_emb: Optional[TimeAwareRotaryEmbedding],
+        use_memory_efficient_attention: bool,
+    ):
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        assert embed_dim % num_heads == 0, "Embedding dimension must be divisible by number of heads."
+        self.head_dim = embed_dim // num_heads
+        self.rotary_emb = rotary_emb
+
+        # We allocate a single tensor for the q, k, and v projection matrices,
+        # multiply them with the inputs, and then split the projected tensors into q, k, and v using unbind.
+        # This reduces overhead a bit vs. having multiple separate Linear layers,
+        # which need to be initialized, tracked by the optimizer, etc.
+        self.wQKV = torch.nn.Linear(embed_dim, embed_dim * 3)
+        self.dropout = dropout
+        self.use_memory_efficient_attention = use_memory_efficient_attention
+        self.wO = torch.nn.Linear(embed_dim, embed_dim)
+
+        assert not self.use_memory_efficient_attention, (
+            "xformers is not available, so use_memory_efficient_attention must be False"
+        )
+
+        if not hasattr(self, "attention_axis") or self.attention_axis not in (AttentionAxis.TIME, AttentionAxis.SPACE):
+            raise ValueError("Child class must define attention_axis as AttentionAxis.TIME or AttentionAxis.SPACE.")
+
+    def rearrange_inputs(self, inputs: torch.Tensor) -> torch.Tensor:
+        pattern = (
+            "batch variate seq_len embed_dim -> (batch variate) seq_len embed_dim"
+            if self.attention_axis == AttentionAxis.TIME
+            else "batch variate seq_len embed_dim -> (batch seq_len) variate embed_dim"
+        )
+
+        return rearrange(inputs, pattern)
+
+    def get_qkv(
+        self,
+        inputs: torch.Tensor,
+    ) -> tuple[torch.Tensor, ...]:
+        pattern: str = ""
+        if self.attention_axis == AttentionAxis.TIME and self.use_memory_efficient_attention:
+            pattern = "batch_X_variate seq_len (qkv head_dim n_heads) -> qkv batch_X_variate seq_len n_heads head_dim"
+        elif self.attention_axis == AttentionAxis.TIME and not self.use_memory_efficient_attention:
+            pattern = "batch_X_variate seq_len (qkv head_dim n_heads) -> qkv batch_X_variate n_heads seq_len head_dim"
+        elif self.attention_axis == AttentionAxis.SPACE and self.use_memory_efficient_attention:
+            pattern = "batch_X_seq_len variate (qkv head_dim n_heads) -> qkv batch_X_seq_len variate n_heads head_dim"
+        elif self.attention_axis == AttentionAxis.SPACE and not self.use_memory_efficient_attention:
+            pattern = "batch_X_seq_len variate (qkv head_dim n_heads) -> qkv batch_X_seq_len n_heads variate head_dim"
+
+        assert pattern
+        qkv = self.wQKV(inputs.contiguous())
+        return rearrange(qkv, pattern, qkv=3, head_dim=self.head_dim, n_heads=self.num_heads).unbind(dim=0)
+
+    def positional_embedding(self, q, k, v, kv_cache, layer_idx):
+        # Apply the rotary embeddings
+        seq_pos_offset = 0
+        if self.rotary_emb is not None and self.attention_axis == AttentionAxis.TIME:
+            if kv_cache is not None:
+                seq_pos_offset = kv_cache.seq_len(layer_idx)
+
+            # We need to permute because rotary embeddings expect the sequence dimension to be the second-to-last dimension
+            q, k = self.rotary_emb.rotate_queries_and_keys(q, k, seq_pos_offset=seq_pos_offset)
+
+        if kv_cache is not None and self.attention_axis == AttentionAxis.TIME:
+            # First, we append the current input key and value tensors to the cache.
+            # This concatenates the current key and value tensors to the existing key and value tensors
+            kv_cache.append(layer_idx, (k, v))
+            # Then, we retrieve the key and value tensors from the cache.
+            # This includes all the key and value tensors from previous time steps
+            # as well as the current time step.
+            k, v = kv_cache[layer_idx]
+
+        q = q.contiguous()
+        k = k.contiguous().to(q.dtype)  # Ensure k is the same dtype as q; this is necessary when using mixed precision
+        v = v.contiguous().to(q.dtype)  # Ensure v is the same dtype as q; this is necessary when using mixed precision
+
+        return q, k, v, seq_pos_offset
+
+    def rearrange_output(self, output: torch.Tensor, batch: int, variate: int, seq_len: int) -> torch.Tensor:
+        if self.attention_axis == AttentionAxis.TIME and self.use_memory_efficient_attention:
+            pattern = "(batch variate) seq_len n_heads head_dim -> batch variate seq_len (n_heads head_dim)"
+        elif self.attention_axis == AttentionAxis.TIME and not self.use_memory_efficient_attention:
+            pattern = "(batch variate) n_heads seq_len head_dim -> batch variate seq_len (n_heads head_dim)"
+        elif self.attention_axis == AttentionAxis.SPACE and self.use_memory_efficient_attention:
+            pattern = "(batch seq_len) variate n_heads head_dim -> batch variate seq_len (n_heads head_dim)"
+        elif self.attention_axis == AttentionAxis.SPACE and not self.use_memory_efficient_attention:
+            pattern = "(batch seq_len) n_heads variate head_dim -> batch variate seq_len (n_heads head_dim)"
+
+        return rearrange(output, pattern, batch=batch, variate=variate, seq_len=seq_len)  # type: ignore
+
+    def run_attention(self, attention_mask, q, k, v, seq_pos_offset, dropout, seq_len, variate):
+        # Determine dimension ranges for attention
+        # Ensure the last query vector index is used from the cache
+        q_dim_start, q_dim_end = seq_pos_offset, seq_pos_offset + seq_len
+        kv_dim_start, kv_dim_end = 0, v.shape[1] if self.use_memory_efficient_attention else v.shape[2]
+        if self.attention_axis == AttentionAxis.TIME:
+            attention_mask = (
+                attention_mask[..., q_dim_start:q_dim_end, kv_dim_start:kv_dim_end]
+                if torch.is_tensor(attention_mask)
+                else None
+            )
+            return scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=attention_mask,
+                dropout_p=dropout,
+                is_causal=(attention_mask is None and seq_pos_offset == 0),
+            )
+        elif self.attention_axis == AttentionAxis.SPACE:
+            # We don't use causal masking for space-wise attention
+            attention_mask = (
+                attention_mask[..., kv_dim_start:kv_dim_end, kv_dim_start:kv_dim_end]
+                if torch.is_tensor(attention_mask)
+                else None
+            )
+            return scaled_dot_product_attention(q, k, v, attn_mask=attention_mask, dropout_p=dropout, is_causal=False)
+        else:
+            raise ValueError("Invalid attention axis")
+
+    def forward(
+        self,
+        layer_idx: int,
+        inputs: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        kv_cache=None,
+    ) -> torch.Tensor:
+        batch_size, variate, seq_len, _ = inputs.shape
+        dropout = self.dropout if self.training else 0.0
+
+        rearranged_inputs = self.rearrange_inputs(inputs)
+        q, k, v = self.get_qkv(rearranged_inputs)
+
+        q, k, v, seq_pos_offset = self.positional_embedding(q, k, v, kv_cache, layer_idx)
+
+        output = self.run_attention(attention_mask, q, k, v, seq_pos_offset, dropout, seq_len, variate)
+
+        output = self.rearrange_output(output, batch_size, variate, seq_len)
+        return self.wO(output)
+
+
+class TimeWiseMultiheadAttention(BaseMultiheadAttention):
+    """
+    Computes standard multihead causal attention over the time axis.
+    It does this by flattening out the variates along the batch dimension.
+    It also applies rotary position embeddings to the query and key matrices
+    in order to incorporate relative positional information.
+    """
+
+    attention_axis = AttentionAxis.TIME
+
+
+class SpaceWiseMultiheadAttention(BaseMultiheadAttention):
+    """
+    Computes bidirectional multihead attention over the space axis (i.e. across variates within
+    a multi-variate time series). This is done by flattening out the time axis along the batch dimension.
+    This allows the model to attend to different variates at the same time point. By alternating
+    between time-wise and space-wise attention, the model can learn both temporal and cross-variate
+    dependencies in the data.
+
+    Unlike with time-wise attention, don't apply rotary embeddings here
+    because we want cross-variate attention to be invariant to the order of the variates.
+    """
+
+    attention_axis = AttentionAxis.SPACE
+
+
+MultiHeadAttention = Union[TimeWiseMultiheadAttention, SpaceWiseMultiheadAttention]

--- a/timeseries/src/autogluon/timeseries/models/toto/_internal/backbone/backbone.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/_internal/backbone/backbone.py
@@ -1,0 +1,262 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/)
+# Copyright 2025 Datadog, Inc.
+
+import math
+from typing import NamedTuple, Optional
+
+import torch
+
+from .distribution import MixtureOfStudentTsOutput
+from .kvcache import KVCache
+from .scaler import CausalPatchStdMeanScaler
+from .transformer import Transformer
+
+
+class TotoOutput(NamedTuple):
+    """
+    Output of the Toto model. Contains the output distribution, the location parameters,
+    and the scale parameters.
+    """
+
+    distribution: torch.distributions.Distribution
+    loc: torch.Tensor
+    scale: torch.Tensor
+
+
+def patchify_id_mask(id_mask: torch.Tensor, patch_size: int) -> torch.Tensor:
+    patched_id_mask = id_mask.unfold(dimension=-1, size=patch_size, step=patch_size)
+    patched_id_mask_min = patched_id_mask.min(-1).values
+    patched_id_mask_max = patched_id_mask.max(-1).values
+    assert torch.eq(patched_id_mask_min, patched_id_mask_max).all(), "Patches cannot span multiple datasets"
+    return patched_id_mask_min
+
+
+class PatchEmbedding(torch.nn.Module):
+    """
+    Multivariate time series patch embedding.
+    Patchifies each variate separately.
+    """
+
+    def __init__(self, patch_size: int, stride: int, embed_dim: int):
+        super().__init__()
+        self.patch_size = patch_size
+        self.embed_dim = embed_dim
+        self.stride = stride
+        self.projection = torch.nn.Linear(self.patch_size, self.embed_dim)
+
+    def _patchify(self, x: torch.Tensor) -> torch.Tensor:
+        return x.unfold(dimension=-1, size=self.patch_size, step=self.stride)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        id_mask: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        assert x.shape[-1] % self.patch_size == 0, (
+            f"Series length ({x.shape=}) must be divisible by ({self.patch_size=})"
+        )
+        x_patched: torch.Tensor = self._patchify(x)
+        id_mask_patched: torch.Tensor = self._patchify(id_mask)
+
+        assert torch.eq(id_mask_patched.min(-1).values, id_mask_patched.max(-1).values).all(), (
+            "Patches cannot span multiple datasets"
+        )
+
+        return (
+            self.projection(x_patched),
+            id_mask_patched.min(-1).values,
+        )
+
+
+class TotoBackbone(torch.nn.Module):
+    """
+    Toto (Timeseries-Optimized Transformer for Observability) is a transformer-based model for multivariate
+    time series forecasting. It applies a patch embedding to the input data, followed by a transformer
+    that alternates between time-wise and space-wise attention. The transformer is followed by a linear projection
+    that maps the transformer output to the output distribution.
+
+    The output distribution can be a single distribution (e.g. Gaussian) or a mixture of distributions.
+    If a mixture of distributions is used, the model will learn to predict the mixture weights
+    as well as the parameters of the individual distributions.
+
+    Parameters
+    ----------
+    patch_size
+        Size of the patch to use for the patch embedding.
+    stride
+        Stride to use for the patch embedding.
+    embed_dim
+        Dimension of the model's latent space.
+    num_layers
+        Number of transformer layers to use.
+    num_heads
+        Number of attention heads to use in each self-attention layer.
+    mlp_hidden_dim
+        Dimension of the hidden layer in the feedforward network.
+    dropout
+        Dropout rate to use in the model.
+    spacewise_every_n_layers
+        How many time-wise transformer layers to apply between each space-wise transformer layer.
+    spacewise_first
+        Whether to apply space-wise attention before time-wise attention.
+    scaler_cls
+        Class to use for scaling the input data.
+    output_distribution_classes
+        List of classes to use for the output distribution. If a single class is provided, the model
+        will output a single distribution. If multiple classes are provided, the model will output a
+        learned mixture of distributions.
+    output_distribution_kwargs
+        Keyword arguments to pass to the output distribution class. Note: this currently only works
+        with a single output distribution class.
+    use_memory_efficient_attention:
+        Whether to use memory-efficient attention. If True, the model will use the memory-efficient from xFormers.
+    stabilize_with_global:
+        Whether to use global statistics to stabilize causal statistics by clamping extreme values. Only applies to causal scalers.
+    scale_factor_exponent:
+        Exponent that controls the allowed range of deviation from global scale for causal scalers.
+    """
+
+    def __init__(
+        self,
+        patch_size: int,
+        stride: int,
+        embed_dim: int,
+        num_layers: int,
+        num_heads: int,
+        mlp_hidden_dim: int,
+        dropout: float,
+        spacewise_every_n_layers: int,
+        scaler_cls: str,
+        output_distribution_classes: list[str],
+        spacewise_first: bool = True,
+        output_distribution_kwargs: Optional[dict] = None,
+        use_memory_efficient_attention: bool = True,
+        stabilize_with_global: bool = True,
+        scale_factor_exponent: float = 10.0,
+    ):
+        super().__init__()
+        self.embed_dim = embed_dim
+        # strings are used when loading a safetensors checkpoint
+        # Initialize patch-based scalers with the correct patch_size
+
+        self.scaler = CausalPatchStdMeanScaler(
+            patch_size=patch_size,
+            stabilize_with_global=stabilize_with_global,
+            scale_factor_exponent=scale_factor_exponent,
+        )
+        self.patch_embed = PatchEmbedding(patch_size, stride, embed_dim)
+        self.dropout = dropout
+        self.num_layers = num_layers
+        self.use_memory_efficient_attention = use_memory_efficient_attention
+        self.transformer = Transformer(
+            embed_dim=embed_dim,
+            num_heads=num_heads,
+            num_layers=self.num_layers,
+            mlp_hidden_dim=mlp_hidden_dim,
+            dropout=dropout,
+            spacewise_every_n_layers=spacewise_every_n_layers,
+            spacewise_first=spacewise_first,
+            use_memory_efficient_attention=self.use_memory_efficient_attention,
+        )
+        self.unembed = torch.nn.Linear(embed_dim, embed_dim * patch_size)
+
+        # TODO[BEN] this doesn't need to be a list
+        output_distribution_classes_ = [MixtureOfStudentTsOutput]
+        self.output_distribution = output_distribution_classes_[0](embed_dim, **(output_distribution_kwargs or {}))
+
+    def allocate_kv_cache(
+        self,
+        batch_size: int,
+        num_variates: int,
+        max_time_steps: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> KVCache:
+        return KVCache(
+            batch_size=batch_size,
+            num_variates=num_variates,
+            transformer_layers=list(self.transformer.layers),
+            num_layers=self.num_layers,
+            embed_dim=self.embed_dim,
+            num_heads=self.transformer.layers[0].num_heads,  # type: ignore
+            max_seq_len=math.ceil(max_time_steps / self.patch_embed.stride),
+            device=device,
+            dtype=dtype,
+            use_memory_efficient_attention=self.use_memory_efficient_attention,
+        )
+
+    def backbone(
+        self,
+        inputs: torch.Tensor,
+        input_padding_mask: torch.Tensor,
+        id_mask: torch.Tensor,
+        kv_cache: Optional[KVCache] = None,
+        scaling_prefix_length: Optional[int] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        scaled_inputs: torch.Tensor
+        loc: torch.Tensor
+        scale: torch.Tensor
+
+        # Standard scaling operation, same API but without ID mask.
+        scaled_inputs, loc, scale = self.scaler(
+            inputs,
+            weights=torch.ones_like(inputs, device=inputs.device),
+            padding_mask=input_padding_mask,
+            prefix_length=scaling_prefix_length,
+        )
+
+        if kv_cache is not None:
+            prefix_len = self.patch_embed.stride * kv_cache.current_len(0)
+
+            # Truncate inputs so that the transformer only processes
+            # the last patch in the sequence. We'll use the KVCache
+            # for the earlier patches.
+            scaled_inputs = scaled_inputs[:, :, prefix_len:]
+
+            # As a simplification, when using kv cache we only allow decoding
+            # one step at a time after the initial forward pass.
+            assert (prefix_len == 0) or (scaled_inputs.shape[-1] == self.patch_embed.stride), (
+                "Must decode one step at a time."
+            )
+
+            input_padding_mask = input_padding_mask[:, :, prefix_len:]
+            id_mask = id_mask[:, :, prefix_len:]
+
+        embeddings: torch.Tensor
+        reduced_id_mask: torch.Tensor
+
+        embeddings, reduced_id_mask = self.patch_embed(scaled_inputs, id_mask)
+
+        # Apply the transformer on the embeddings
+        transformed: torch.Tensor = self.transformer(embeddings, reduced_id_mask, kv_cache)
+
+        # Unembed and flatten the sequence
+        unembedded = self.unembed(transformed)
+        batch_size, num_variates, seq_len = unembedded.shape[:3]
+        patch_size = unembedded.shape[-1] // self.embed_dim
+        flattened = unembedded.view(batch_size, num_variates, seq_len * patch_size, self.embed_dim)
+        return flattened, loc, scale
+
+    def forward(
+        self,
+        inputs: torch.Tensor,
+        input_padding_mask: torch.Tensor,
+        id_mask: torch.Tensor,
+        kv_cache: Optional[KVCache] = None,
+        scaling_prefix_length: Optional[int] = None,
+    ) -> TotoOutput:
+        flattened, loc, scale = self.backbone(
+            inputs,
+            input_padding_mask,
+            id_mask,
+            kv_cache,
+            scaling_prefix_length,
+        )
+
+        return TotoOutput(self.output_distribution(flattened), loc, scale)
+
+    @property
+    def device(self):
+        return next(self.parameters()).device

--- a/timeseries/src/autogluon/timeseries/models/toto/_internal/backbone/distribution.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/_internal/backbone/distribution.py
@@ -1,0 +1,70 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/)
+# Copyright 2025 Datadog, Inc.
+
+from abc import ABC
+
+import torch
+import torch.nn.functional as F
+from gluonts.torch.distributions import AffineTransformed
+from gluonts.torch.distributions.studentT import StudentT
+
+
+class DistributionOutput(ABC, torch.nn.Module):
+    pass
+
+
+class StudentTOutput(DistributionOutput):
+    def __init__(self, embed_dim):
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.df = torch.nn.Linear(embed_dim, 1)
+        self.loc_proj = torch.nn.Linear(embed_dim, 1)
+        self.scale_proj = torch.nn.Linear(embed_dim, 1)
+
+    def forward(self, inputs, loc=None, scale=None):
+        eps = torch.finfo(inputs.dtype).eps
+        df = 2.0 + F.softplus(self.df(inputs)).clamp_min(eps).squeeze(-1)
+        base_loc = self.loc_proj(inputs).squeeze(-1)
+        base_scale = F.softplus(self.scale_proj(inputs)).clamp_min(eps).squeeze(-1)
+
+        base_dist = torch.distributions.StudentT(df, base_loc, base_scale, validate_args=False)  # type: ignore
+
+        if loc is not None and scale is not None:
+            return AffineTransformed(
+                base_dist,
+                loc=loc,
+                scale=scale,
+            )
+        return base_dist
+
+
+class MixtureOfStudentTsOutput(DistributionOutput):
+    def __init__(
+        self,
+        embed_dim,
+        k_components,
+    ):
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.k_components = k_components
+
+        self.df = torch.nn.Linear(embed_dim, k_components)
+        self.loc_proj = torch.nn.Linear(embed_dim, k_components)
+        self.scale_proj = torch.nn.Linear(embed_dim, k_components)
+        self.mixture_weights = torch.nn.Linear(embed_dim, k_components)
+
+    def forward(self, inputs, loc=None, scale=None):
+        df = 2.0 + F.softplus(self.df(inputs)).clamp_min(torch.finfo(inputs.dtype).eps)
+        loc = self.loc_proj(inputs)
+        scale = F.softplus(self.scale_proj(inputs)).clamp_min(torch.finfo(inputs.dtype).eps)
+        logits = self.mixture_weights(inputs)
+        probs = F.softmax(logits, dim=-1)
+        components = StudentT(df, loc, scale)
+        mixture_distribution = torch.distributions.Categorical(probs=probs)
+
+        return torch.distributions.MixtureSameFamily(
+            mixture_distribution,
+            components,
+        )

--- a/timeseries/src/autogluon/timeseries/models/toto/_internal/backbone/kvcache.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/_internal/backbone/kvcache.py
@@ -1,0 +1,136 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/)
+# Copyright 2025 Datadog, Inc.
+
+from dataclasses import dataclass, field
+
+import torch
+
+from .attention import TimeWiseMultiheadAttention
+
+K = torch.Tensor
+V = torch.Tensor
+KV = tuple[torch.Tensor, torch.Tensor]
+
+
+@dataclass
+class KVCache:
+    """
+    Key/Value cache for storing intermediate attention values
+    during multistep inference. Only stores KV cache for timewise layers, skipping spacewise layers.
+    """
+
+    batch_size: int
+    num_variates: int
+    transformer_layers: list
+    num_layers: int
+    embed_dim: int
+    num_heads: int
+    max_seq_len: int
+    device: torch.device = torch.device("cpu")
+    dtype: torch.dtype = torch.float32
+    use_memory_efficient_attention: bool = True
+
+    _keys: torch.Tensor = field(init=False)
+    _values: torch.Tensor = field(init=False)
+    _current_idx: torch.Tensor = field(init=False)
+    _layer_cache_map: torch.Tensor = field(init=False)
+
+    def __post_init__(self):
+        """
+        - Determine timewise vs. spacewise layers and allocate KV only for timewise.
+        - Create a fast tensor-based mapping from global layer_idx -> timewise layer_idx.
+        """
+        assert self.embed_dim % self.num_heads == 0, "embed_dim must be divisible by num_heads"
+        head_dim = self.embed_dim // self.num_heads
+
+        # Compute which layers are timewise
+        time_layer_indices = [
+            i
+            for i in range(self.num_layers)
+            if isinstance(self.transformer_layers[i].attention, TimeWiseMultiheadAttention)
+        ]
+
+        time_layer_count = max(1, len(time_layer_indices))  # handle edge case for no timewise layers
+        # Allocate for only the timewise layers
+        if self.use_memory_efficient_attention:
+            shape = (
+                time_layer_count,
+                self.batch_size * self.num_variates,
+                self.max_seq_len,
+                self.num_heads,
+                head_dim,
+            )
+        else:
+            shape = (
+                time_layer_count,
+                self.batch_size * self.num_variates,
+                self.num_heads,
+                self.max_seq_len,
+                head_dim,
+            )
+        self._keys = torch.zeros(shape, device=self.device, dtype=self.dtype)
+        self._values = torch.zeros_like(self._keys)
+        self._current_idx = torch.zeros(time_layer_count, device=self.device, dtype=torch.int)
+        # Build a tensor lookup for global -> timewise layer index (default to 0)
+        self._layer_cache_map = torch.zeros((self.num_layers,), dtype=torch.int, device=self.device)
+        for cache_idx, layer_idx in enumerate(time_layer_indices):
+            self._layer_cache_map[layer_idx] = int(cache_idx)  # Assign correct indices
+
+    def __getitem__(self, layer_idx: int) -> KV:
+        cache_idx = int(self._layer_cache_map[layer_idx].item())
+        end_idx = int(self._current_idx[cache_idx].item())
+
+        if self.use_memory_efficient_attention:
+            return self._keys[cache_idx, :, :end_idx, :, :], self._values[cache_idx, :, :end_idx, :, :]
+        else:
+            return self._keys[cache_idx, :, :, :end_idx, :], self._values[cache_idx, :, :, :end_idx, :]
+
+    def current_len(self, cache_idx: int) -> int:
+        return int(self._current_idx[cache_idx].item()) if self._current_idx.numel() > 0 else 0
+
+    def seq_len(self, layer_idx: int) -> int:
+        cache_idx = int(self._layer_cache_map[layer_idx].item())
+        return self.current_len(cache_idx)
+
+    def append(self, layer_idx: int, kv: KV):
+        cache_idx = int(self._layer_cache_map[layer_idx].item())
+        keys, values = kv
+
+        # Validate dimensions
+        assert keys.shape == values.shape, "keys and values must have the same shape"
+        assert keys.shape[0] == self.batch_size * self.num_variates, (
+            "keys and values must have batch_size * num_variates as their first dimension"
+        )
+
+        if self.use_memory_efficient_attention:
+            assert keys.shape[2] == self.num_heads, "keys and values must have num_heads as their third dimension"
+        else:
+            assert keys.shape[1] == self.num_heads, "keys and values must have num_heads as their second dimension"
+        assert keys.shape[3] == self.embed_dim // self.num_heads, (
+            "keys and values must have head_dim as their fourth dimension"
+        )
+
+        start_idx = self._current_idx[cache_idx]
+        if self.use_memory_efficient_attention:
+            end_idx = start_idx + keys.shape[1]
+        else:
+            end_idx = start_idx + keys.shape[2]
+        assert end_idx <= self.max_seq_len, (
+            f"max_seq_len exceeded {end_idx} > {self.max_seq_len}, keys.shape: {keys.shape}"
+        )
+
+        if self.use_memory_efficient_attention:
+            self._keys[cache_idx, :, start_idx:end_idx, :, :] = keys
+            self._values[cache_idx, :, start_idx:end_idx, :, :] = values
+        else:
+            self._keys[cache_idx, :, :, start_idx:end_idx, :] = keys
+            self._values[cache_idx, :, :, start_idx:end_idx, :] = values
+
+        self._current_idx[cache_idx] = end_idx
+
+    def reset(self):
+        self._keys.zero_()
+        self._values.zero_()
+        self._current_idx.zero_()

--- a/timeseries/src/autogluon/timeseries/models/toto/_internal/backbone/rope.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/_internal/backbone/rope.py
@@ -1,0 +1,94 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/)
+# Copyright 2025 Datadog, Inc.
+
+from typing import Optional
+
+import torch
+from einops import rearrange
+from rotary_embedding_torch import RotaryEmbedding, apply_rotary_emb
+from rotary_embedding_torch.rotary_embedding_torch import default
+
+
+def exists(val):
+    return val is not None
+
+
+class TimeAwareRotaryEmbedding(RotaryEmbedding):
+    """
+    A variant of the rotary position embedding that (optionally) uses the time index
+    to compute the sinusoidal and cosine embeddings. This is useful for
+    time series data, where the time index is the most important positional
+    information.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # If the parent stored `freqs` as a Parameter, remove it and register as a buffer
+        # Register buffer is needed for sharding with FSDP
+        if hasattr(self, "freqs") and isinstance(self.freqs, torch.nn.Parameter):
+            # Extract the underlying Tensor
+            freqs_data = self.freqs.data
+
+            # Remove `freqs` from the module's parameters
+            self._parameters.pop("freqs")
+
+            # Register as non-persistent buffer
+            self.register_buffer("freqs", freqs_data, persistent=False)
+
+    def rotate_queries_and_keys(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        seq_dim: Optional[int] = None,
+        seq_pos: Optional[torch.Tensor] = None,
+        seq_pos_offset: int = 0,
+    ):
+        """
+        This method is the same as the one on the base class, except it allows you to override
+        the sequence position tensor with a custom one. It also removes the ability
+        to cache the position encodings, since we have to compute them dynamically
+        based on the timesteps in the input data.
+        """
+        if seq_dim is None:
+            seq_dim = self.default_seq_dim
+
+        assert self.use_xpos
+        device, dtype, seq_len = q.device, q.dtype, q.shape[seq_dim]
+
+        seq = default(seq_pos, self.get_seq_pos(seq_len, dtype=dtype, device=device))
+        seq = seq + seq_pos_offset  # type: ignore
+
+        freqs = self.forward(seq)
+
+        scale = self.get_scale(seq).to(dtype)
+
+        # used for xformers
+        if seq_dim == -3:
+            num_heads = q.shape[-2]
+            freqs = freqs.unsqueeze(1).expand(-1, num_heads, -1)
+            scale = scale.unsqueeze(1).expand(-1, num_heads, -1)
+
+        rotated_q = apply_rotary_emb(freqs, q, scale=scale, seq_dim=seq_dim)  # type: ignore
+        rotated_k = apply_rotary_emb(freqs, k, scale=scale**-1, seq_dim=seq_dim)  # type: ignore
+
+        rotated_q = rotated_q.type(q.dtype)
+        rotated_k = rotated_k.type(k.dtype)
+
+        return rotated_q, rotated_k
+
+    def get_scale(self, t: torch.Tensor, seq_len: Optional[int] = None, offset=0):
+        """
+        This method is adapted closely from the base class, but it knows how to handle
+        when `t` has more than 1 dim (as is the case when we're using time-aware RoPE, and have a different
+        sequence position vector for each time series).
+        """
+        assert self.use_xpos
+
+        power = (t - t.max(-1).values.unsqueeze(-1) // 2) / self.scale_base
+
+        scale = self.scale ** rearrange(power, "... n -> ... n 1")  # type: ignore
+        scale = torch.cat((scale, scale), dim=-1)
+
+        return scale

--- a/timeseries/src/autogluon/timeseries/models/toto/_internal/backbone/scaler.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/_internal/backbone/scaler.py
@@ -1,0 +1,306 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/)
+# Copyright 2025 Datadog, Inc.
+
+import warnings
+from typing import Optional
+
+import torch
+from einops import repeat
+from gluonts.core.component import validated
+from gluonts.torch.scaler import Scaler
+
+
+def compute_causal_statistics(
+    data: torch.Tensor,
+    weights: torch.Tensor,
+    padding_mask: torch.Tensor,
+    dim: int,
+    minimum_scale: float,
+    use_bessel_correction: bool = True,
+    stabilize_with_global: bool = False,
+    scale_factor_exponent: float = 10.0,
+    prefix_length: Optional[int] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Compute causal mean and scale statistics along a specified dimension using
+    a vectorized implementation of Welford's algorithm for numerical stability.
+
+    This implementation avoids explicit loops while maintaining the numerical stability
+    of Welford's algorithm, achieving better performance with the same robustness
+    against overflow issues.
+
+
+    Can optionally use global statistics to stabilize causal statistics by clamping
+    extreme values, preventing instability while preserving a relaxed version of the
+    causal property. This allows a controlled amount of future information leakage,
+    introducing an explicit tradeoff between causality and stability.
+    extreme values, preventing instability while preserving the causal property.
+
+    Parameters
+    ----------
+    data
+        The input data tensor
+    weights
+        The weight tensor (same shape as data)
+    padding_mask
+        The padding mask tensor (same shape as data)
+    dim
+        The dimension along which to compute statistics (must be -1, the time dimension)
+    minimum_scale
+        Minimum scale value to use
+    use_bessel_correction
+        Whether to use Bessel's correction to get an unbiased estimator
+    stabilize_with_global
+        Whether to use global statistics to stabilize the causal statistics by clamping
+        extreme values
+    scale_factor_exponent
+        Exponent that controls the allowed range of deviation from global scale.
+        For example, with exponent=1.0, causal scale must be between 0.1x and 10x the global scale.
+        With exponent=2.0, the range would be 0.01x to 100x.
+    prefix_length
+        If specified, the global statistics will be computed using only the prefix length
+        requested. This is used for multistep decoding, where we only want to use the
+        initial historical data to compute the global statistics. If stabilize_with_global
+        is False, this parameter is ignored.
+
+    Returns
+    -------
+    tuple[torch.Tensor, torch.Tensor]
+        Causal mean and scale tensors, potentially stabilized with global statistics
+    """
+    # Assert that dim is -1 (last dimension)
+    assert dim == -1, "compute_causal_statistics only supports dim=-1 (last dimension)"
+
+    with torch.no_grad():
+        # Apply padding mask to weights
+        weights = weights * padding_mask
+
+        # Try to use higher precision for numerical stability
+        try:
+            high_precision_data = data.to(torch.float64)
+            high_precision_weights = weights.to(torch.float64)
+        except TypeError:
+            # Fallback for devices that don't support float64
+            warnings.warn(
+                f"Float64 is not supported by device {data.device}. "
+                "Using float32 instead for causal scaler calculations. "
+                "This may lead to numerical issues if the data contains extreme values.",
+                RuntimeWarning,
+            )
+            high_precision_data = data.to(torch.float32)
+            high_precision_weights = weights.to(torch.float32)
+
+        # Check if deterministic algorithms are enabled and we're using CUDA.
+        # Cumsum operations do not support deterministic mode in CUDA,
+        # so we need to disable it for just this section.
+        prev_deterministic = torch.are_deterministic_algorithms_enabled()
+        if prev_deterministic and data.device.type == "cuda":
+            # Disable deterministic algorithms for operations
+            torch.use_deterministic_algorithms(False)
+
+        try:
+            # Create weighted data
+            weighted_data = high_precision_weights * high_precision_data
+
+            # Compute cumulative sum of weights and weighted data along time dimension
+            cum_weights = torch.cumsum(high_precision_weights, dim=dim)
+            cum_values = torch.cumsum(weighted_data, dim=dim)
+
+            # Avoid division by zero for the first time step or when no valid values
+            denominator = cum_weights.clamp_min(1.0)
+
+            # Compute causal means at each time step
+            causal_means = cum_values / denominator
+
+            # For Welford's algorithm, we need to compute the correction term
+            # using the difference between the current value and the current mean
+
+            # Create shifted version of causal means to compute delta efficiently
+            # First item in shifted_means will be zero
+            shifted_means = torch.zeros_like(causal_means)
+            shifted_means[..., 1:] = causal_means[..., :-1]
+
+            # Compute delta between current data point and previous mean
+            # For t=0, this is just the first data point
+            delta = high_precision_data - shifted_means
+
+            # Compute the increment term for Welford's algorithm.
+            # This is defined as the product of the delta and the difference between the current data point and the causal mean.
+            # This is where we avoid the traditional E[X²] - E[X]² computation
+            increment = delta * (high_precision_data - causal_means) * high_precision_weights
+
+            # The Welford algorithm uses the term m_2, which is the cumulative sum of the increment term.
+            # This is an accumulator that helps us compute the second moment (hence m_2) of the distribution.
+            # Compute cumulative sum of the increment term
+            m_2 = torch.cumsum(increment, dim=dim)
+
+            # Compute variance according to Welford's algorithm
+            if use_bessel_correction:
+                causal_variance = m_2 / torch.clamp(denominator - 1.0, min=1.0)
+            else:
+                causal_variance = m_2 / denominator
+
+            # Add minimum scale but keep in high precision for now
+            causal_scale = torch.sqrt(causal_variance + minimum_scale)
+
+            # Apply stabilization with global statistics if requested
+            if stabilize_with_global:
+                if prefix_length is not None:
+                    # Create a prefix mask for global statistics computation
+                    prefix_mask = torch.zeros_like(weights)
+                    prefix_mask[..., :prefix_length] = 1.0
+
+                    # Apply prefix mask to restrict computation to prefix
+                    weighted_data = weighted_data * prefix_mask
+                    weights = weights * prefix_mask
+                    padding_mask = padding_mask * prefix_mask
+
+                # Calculate scale factors from the exponent
+                scale_factor_min = 10.0 ** (-scale_factor_exponent)
+                scale_factor_max = 10.0**scale_factor_exponent
+
+                global_denominator = (weights * padding_mask).sum(dim, keepdim=True).clamp_min(1.0)
+                global_means = (weighted_data).sum(dim, keepdim=True) / global_denominator
+                global_means = torch.nan_to_num(global_means)
+
+                global_variance = (((high_precision_data - global_means) * weights * padding_mask) ** 2).sum(
+                    dim, keepdim=True
+                ) / global_denominator
+                global_scale = torch.sqrt(global_variance + minimum_scale)
+
+                # Expand global statistics to match the time dimension
+                expanded_global_scale = global_scale.expand_as(causal_scale)
+
+                # Define bounds using scale factors
+                min_allowed_scale = expanded_global_scale * scale_factor_min
+                max_allowed_scale = expanded_global_scale * scale_factor_max
+
+                # Clamp the causal scale between min_allowed_scale and max_allowed_scale
+                causal_scale = torch.clamp(
+                    causal_scale,
+                    min=torch.max(torch.tensor(minimum_scale, device=causal_scale.device), min_allowed_scale),
+                    max=max_allowed_scale,
+                )
+
+            # Now convert means and scale to original dtype after all numerical operations
+            causal_means = causal_means.to(data.dtype)
+            causal_scale = causal_scale.to(data.dtype)
+
+        finally:
+            # Restore original deterministic setting if it was changed
+            if prev_deterministic and data.device.type == "cuda":
+                torch.use_deterministic_algorithms(True)
+
+        return causal_means, causal_scale
+
+
+class CausalPatchStdMeanScaler(Scaler):
+    """
+    Causally scales data in patches, where each patch uses statistics computed
+    from all data up to and including that patch. Within each patch, all timesteps
+    use the same scaling values.
+
+    This approach provides more stability than per-timestep causal scaling while
+    still maintaining the causal property (not using future data).
+
+    Can optionally stabilize causal statistics using global statistics to prevent
+    extreme values, while preserving the causal property.
+
+    The statistics are computed using Welford's algorithm, which provides better
+    numerical stability compared to the direct computation of variance, especially
+    when dealing with large values or a large number of data points.
+
+    Note: This scaler only works with the following constraints:
+    - The input must have shape [batch, variates, time_steps]
+    - It only operates on the last dimension (-1)
+    - The time_steps must be divisible by patch_size
+
+    Parameters
+    ----------
+    dim
+        dimension along which to compute the causal scale. Must be -1 (the last dimension).
+    patch_size
+        number of timesteps in each patch
+    minimum_scale
+        default scale that is used for elements that are constantly zero
+        along dimension `dim` or for the first patch.
+    use_bessel_correction
+        whether to use Bessel's correction to get an unbiased estimator
+    stabilize_with_global
+        whether to use global statistics to stabilize extreme causal statistics
+    scale_factor_exponent
+        exponent that controls the allowed range of deviation from global scale.
+        For example, with exponent=1.0, causal scale must be between 0.1x and 10x the global scale.
+        With exponent=2.0, the range would be 0.01x to 100x.
+    """
+
+    @validated()
+    def __init__(
+        self,
+        dim: int = -1,
+        patch_size: int = 32,
+        minimum_scale: float = 0.1,
+        use_bessel_correction: bool = True,
+        stabilize_with_global: bool = False,
+        scale_factor_exponent: float = 10.0,
+    ) -> None:
+        super().__init__()
+        assert dim == -1, "CausalPatchStdMeanScaler only supports dim=-1 (last dimension)"
+        self.dim = dim
+        self.patch_size = patch_size
+        self.minimum_scale = minimum_scale
+        self.use_bessel_correction = use_bessel_correction
+        self.stabilize_with_global = stabilize_with_global
+        self.scale_factor_exponent = scale_factor_exponent
+
+    def __call__(  # type: ignore[override]
+        self,
+        data: torch.Tensor,
+        padding_mask: torch.Tensor,
+        weights: torch.Tensor,
+        prefix_length: Optional[int] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        assert data.shape == weights.shape, "data and weights must have same shape"
+        assert len(data.shape) == 3, "Input data must have shape [batch, variates, time_steps]"
+
+        with torch.no_grad():
+            # Get the number of time steps (last dimension)
+            time_steps = data.shape[-1]
+
+            # Assert that time_steps is divisible by patch_size
+            assert time_steps % self.patch_size == 0, (
+                f"Time steps ({time_steps}) must be divisible by patch size ({self.patch_size})"
+            )
+
+            # First compute causal statistics with optional stabilization
+            causal_means, causal_scale = compute_causal_statistics(
+                data,
+                weights,
+                padding_mask,
+                -1,
+                self.minimum_scale,
+                self.use_bessel_correction,
+                self.stabilize_with_global,
+                self.scale_factor_exponent,
+                prefix_length,
+            )
+
+            # Unfold the causal means and scales to get the patches
+            means_unfolded = causal_means.unfold(-1, self.patch_size, self.patch_size)
+            scales_unfolded = causal_scale.unfold(-1, self.patch_size, self.patch_size)
+
+            # Get the last element of each patch (the most recent statistic)
+            patch_stats_means = means_unfolded[..., -1]
+            patch_stats_scales = scales_unfolded[..., -1]
+
+            # Tile the patch statistics across time dimension using einops.repeat
+            # With our fixed [batch, variates, num_patches] shape this is much simpler
+            patch_means = repeat(patch_stats_means, "b v p -> b v (p s)", s=self.patch_size)
+            patch_scales = repeat(patch_stats_scales, "b v p -> b v (p s)", s=self.patch_size)
+
+            # Apply normalization
+            scaled_data = (data - patch_means) / patch_scales
+
+            return scaled_data, patch_means, patch_scales

--- a/timeseries/src/autogluon/timeseries/models/toto/_internal/backbone/transformer.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/_internal/backbone/transformer.py
@@ -1,0 +1,333 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/)
+# Copyright 2025 Datadog, Inc.
+
+from typing import Optional, Union, cast
+
+import torch
+import torch.nn.functional as F
+from einops import rearrange
+from rotary_embedding_torch import RotaryEmbedding
+
+from .attention import (
+    AttentionAxis,
+    MultiHeadAttention,
+    SpaceWiseMultiheadAttention,
+    TimeWiseMultiheadAttention,
+)
+from .kvcache import KVCache
+from .rope import TimeAwareRotaryEmbedding
+
+
+class SwiGLU(torch.nn.Module):
+    """
+    https://arxiv.org/abs/2002.05202
+    NOTE: x should be 2x the size you want
+    """
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Note this ordering is unusual, but is done so to match xFormers
+        gate, x = x.chunk(2, dim=-1)
+        return F.silu(gate) * x
+
+
+class RMSNorm(torch.nn.Module):
+    def __init__(self, dim: int, include_weight: bool = True, eps: float = 1e-8):
+        super(RMSNorm, self).__init__()
+        self.eps = eps
+        if include_weight:
+            self.scale: Optional[torch.nn.Parameter] = torch.nn.Parameter(torch.ones(dim))
+        else:
+            self.scale = None
+
+    def forward(self, x: torch.Tensor):
+        x_normed = x / torch.sqrt(torch.mean(x * x, dim=-1, keepdim=True) + self.eps)
+        return x_normed if self.scale is None else x_normed * self.scale
+
+    def increment_and_forward_(self, x: torch.Tensor, y: torch.Tensor):
+        """
+        If you need the fused addition with RMS norm, do the same check here.
+        """
+        return self.forward(x + y)
+
+
+def make_batched_block_mask(t: torch.Tensor) -> torch.Tensor:
+    unsqueezed = rearrange(t, "... d -> ... 1 d")
+    return unsqueezed == unsqueezed.transpose(-1, -2)
+
+
+class TransformerLayer(torch.nn.Module):
+    """
+    A transformer block that applies multihead attention followed by a feedforward network.
+
+    The transformer can be configured to apply time-wise attention (i.e. attention over the time axis)
+    or space-wise attention (i.e. attention over the variate axis).
+
+    The transformer block uses pre-norm, which is a variant of the transformer architecture where
+    LayerNorm is applied before each sublayer, rather than after. This is the approach taken in
+    LLaMA and other recent transformer-based models.
+
+    The transformer block also uses SwiGLU, which is a variant of the Gated Linear Unit (GLU) activation
+    function. SwiGLU is a variant of the GLU activation that uses the Swish activation function. This
+    activation function has been used extensively in recent transformer-based models and has been shown
+    to improve performance.
+    """
+
+    embed_dim: int
+    num_heads: int
+    mlp_hidden_dim: int
+    dropout: float
+    attention_axis: AttentionAxis
+
+    def __init__(
+        self,
+        embed_dim: int,
+        num_heads: int,
+        mlp_hidden_dim: int,
+        dropout: float,
+        rotary_emb: Optional[RotaryEmbedding] = None,
+        attention_axis: AttentionAxis = AttentionAxis.TIME,
+        RMS_norm: bool = True,
+        use_memory_efficient_attention: bool = True,
+    ):
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.mlp_hidden_dim = mlp_hidden_dim
+        self.dropout = dropout
+        self.attention_axis = attention_axis
+
+        if RMS_norm:
+            self.norm1: Union[RMSNorm, torch.nn.LayerNorm] = RMSNorm(embed_dim)
+            self.norm2: Union[RMSNorm, torch.nn.LayerNorm] = RMSNorm(embed_dim)
+
+        else:
+            self.norm1 = torch.nn.LayerNorm(embed_dim)
+            self.norm2 = torch.nn.LayerNorm(embed_dim)
+
+        self.attention: MultiHeadAttention
+
+        if attention_axis == AttentionAxis.TIME:
+            self.attention = TimeWiseMultiheadAttention(
+                embed_dim=embed_dim,
+                num_heads=num_heads,
+                dropout=dropout,
+                rotary_emb=rotary_emb,  # type: ignore
+                use_memory_efficient_attention=use_memory_efficient_attention,
+            )
+        elif attention_axis == AttentionAxis.SPACE:
+            self.attention = SpaceWiseMultiheadAttention(
+                embed_dim=embed_dim,
+                num_heads=num_heads,
+                dropout=dropout,
+                rotary_emb=None,
+                use_memory_efficient_attention=use_memory_efficient_attention,
+            )
+        else:
+            raise ValueError("Invalid attention axis")
+
+        self.mlp = torch.nn.Sequential(
+            torch.nn.Linear(embed_dim, 2 * mlp_hidden_dim),
+            SwiGLU(),
+            torch.nn.Linear(mlp_hidden_dim, embed_dim),
+            torch.nn.Dropout(dropout),
+        )
+
+    def forward(
+        self,
+        layer_idx: int,
+        inputs: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        kv_cache: Optional[KVCache] = None,
+    ) -> torch.Tensor:
+        pre_norm_1 = self.norm1(inputs)
+        hidden_state = inputs + self.attention(layer_idx, pre_norm_1, attention_mask, kv_cache).contiguous()
+
+        pre_norm_2 = self.norm2(hidden_state)
+        return hidden_state + self.mlp(pre_norm_2)
+
+
+class Transformer(torch.nn.Module):
+    """
+    A stack of transformer layers. The transformer alternates between time-wise and space-wise attention
+    to learn both temporal and cross-variate dependencies in the data.
+
+    Based on the intuition that time-wise attention is more important overall than space-wise attention
+    (because an individual variate is more likely to be correlated with itself across time than with other variates),
+    the transformer can be configured to apply space-wise attention less frequently than time-wise attention.
+    This is controlled by the `spacewise_every_n_layers` parameter, which specifies how many time-wise transformer
+    layers to apply between every space-wise transformer layer.
+
+    Parameters
+    ----------
+    num_layers
+        Number of transformer layers to use.
+    num_heads
+        Number of attention heads to use in each self-attention layer.
+    mlp_hidden_dim
+        Dimension of the hidden layer in the feedforward network.
+    dropout
+        Dropout rate to use in the model.
+    spacewise_every_n_layers
+        How many time-wise transformer layers to apply between each space-wise transformer layer.
+    spacewise_first
+        Whether to apply space-wise attention before time-wise attention.
+    use_memory_efficient_attention
+        Whether to use memory-efficient attention. If True, the model will use the memory-efficient from xFormers.
+    """
+
+    def __init__(
+        self,
+        num_layers: int,
+        embed_dim: int,
+        num_heads: int,
+        mlp_hidden_dim: int,
+        dropout: float,
+        spacewise_every_n_layers: int,
+        spacewise_first: bool,
+        use_memory_efficient_attention: bool = True,
+    ):
+        super().__init__()
+
+        assert embed_dim % num_heads == 0, "Embedding dimension must be divisible by number of heads."
+
+        self.rotary_emb = TimeAwareRotaryEmbedding(
+            embed_dim // num_heads,
+            use_xpos=True,
+            cache_if_possible=True,
+            seq_before_head_dim=use_memory_efficient_attention,
+        )
+        attention_axes = self._get_layer_types(num_layers, spacewise_every_n_layers, spacewise_first)
+
+        self.use_memory_efficient_attention = use_memory_efficient_attention
+
+        self.layers = torch.nn.ModuleList(
+            [
+                TransformerLayer(
+                    embed_dim=embed_dim,
+                    num_heads=num_heads,
+                    mlp_hidden_dim=mlp_hidden_dim,
+                    dropout=dropout,
+                    rotary_emb=self.rotary_emb,
+                    attention_axis=attention_axes[i],
+                    use_memory_efficient_attention=self.use_memory_efficient_attention,
+                )
+                for i in range(num_layers)
+            ]
+        )
+
+    def _get_mask(
+        self,
+        num_heads: int,
+        dtype: torch.dtype,
+        id_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """
+        Unified method to create and process space-wise masks.
+
+        Args:
+            mask_type: Type of mask to create ('spacewise').
+            seq_len: Total sequence length.
+            num_heads: Number of attention heads.
+            device: Device where the mask should be created.
+            dtype: Desired dtype for the bias tensor.
+            id_mask: Mask for variates (used for spacewise masks).
+
+        Returns:
+            Processed attention mask tensor with the correct shape for the given mask type.
+        """
+
+        if id_mask is None:
+            raise ValueError("id_mask must be provided for spacewise masks.")
+
+        # Create spacewise mask
+        mask = make_batched_block_mask(id_mask.transpose(-1, -2))
+
+        if self.use_memory_efficient_attention:
+            mask = self._pad_to_multiple(mask)
+            mask = mask.float().masked_fill(~mask, float("-inf")).masked_fill(mask, 0.0).to(dtype)
+
+        # Rearrange for space-wise attention
+        mask = rearrange(mask, "batch seq_len variate1 variate2 -> (batch seq_len) 1 variate1 variate2")
+        # Stack along num_heads dimension
+        return mask.expand(-1, num_heads, -1, -1).contiguous()
+
+    def _pad_to_multiple(
+        self,
+        tensor: torch.Tensor,
+        multiple: int = 8,
+        causal: bool = False,  # New flag to indicate causal mask extension
+    ) -> torch.Tensor:
+        """
+        Pads the last two dimensions of a tensor to be divisible by `multiple`.
+        For causal masks, the padded area is filled with the continued lower-triangular pattern,
+        rather than with zeros.
+        """
+        pad_amount = (multiple - tensor.shape[-1] % multiple) % multiple
+        if pad_amount > 0:
+            new_size = tensor.shape[-1] + pad_amount
+            if causal:
+                # Create a full causal mask for the new size.
+                full_mask = torch.tril(torch.ones((new_size, new_size), dtype=tensor.dtype, device=tensor.device))
+                # Preserve any modifications from the original mask (e.g., condition tokens in top-left)
+                full_mask[: tensor.shape[-1], : tensor.shape[-1]] = tensor
+                tensor = full_mask
+            else:
+                tensor = F.pad(tensor, (0, pad_amount, 0, pad_amount))
+        return tensor
+
+    def _get_layer_types(
+        self,
+        num_layers: int,
+        spacewise_every_n_layers: int,
+        spacewise_first: bool,
+    ) -> list[AttentionAxis]:
+        if spacewise_every_n_layers == -1:
+            return [AttentionAxis.TIME] * num_layers
+        assert num_layers % spacewise_every_n_layers == 0
+
+        block = [AttentionAxis.TIME] * (spacewise_every_n_layers - 1)
+
+        if spacewise_first:
+            block = [AttentionAxis.SPACE] + block
+        else:
+            block = block + [AttentionAxis.SPACE]
+
+        layer_types = block * (num_layers // spacewise_every_n_layers)
+
+        return layer_types
+
+    def forward(
+        self,
+        inputs: torch.Tensor,
+        id_mask: torch.Tensor,
+        kv_cache: Optional[KVCache] = None,
+    ) -> torch.Tensor:
+        batch, _, seq_len, _ = inputs.shape
+        # Get the sequence length by looking up a timewise layer in the kv cache.
+        # Regardless of whether spacewise is first in the stack, the layer
+        # at index 1 is always a timewise layer.
+        seq_len = (kv_cache.seq_len(1) if kv_cache else 0) + seq_len
+
+        num_heads: int = cast(int, self.layers[0].num_heads)
+
+        timewise_attention_mask = None
+
+        # We create a space-wise ID mask by creating a block triangular mask from the ID mask
+        # in the space-wise direction. This ensures that the model can only attend to
+        # variates in the same group.
+        spacewise_attention_mask = self._get_mask(
+            num_heads=num_heads,
+            dtype=inputs.dtype,
+            id_mask=id_mask,
+        )
+
+        for layer_idx, layer in enumerate(self.layers):
+            inputs = layer(
+                layer_idx,
+                inputs,
+                (timewise_attention_mask if layer.attention_axis == AttentionAxis.TIME else spacewise_attention_mask),
+                kv_cache,
+            )
+        return inputs

--- a/timeseries/src/autogluon/timeseries/models/toto/_internal/dataset.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/_internal/dataset.py
@@ -1,0 +1,165 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/)
+# Copyright 2025 Datadog, Inc.
+
+from functools import reduce
+from typing import NamedTuple, Union
+
+import numpy as np
+import pandas as pd
+import torch
+from einops import repeat
+
+
+def pad_array(
+    values: torch.Tensor,
+    patch_stride: int,
+) -> torch.Tensor:
+    """
+    Makes sure that the series length is divisible by the patch_stride
+    by adding left-padding.
+    """
+    if isinstance(values, np.ndarray):
+        values = torch.from_numpy(values)
+    series_len = values.shape[-1]
+    # left-pad the time series to make sure we can divide it into patches.
+    padded_length = int(np.ceil(series_len / patch_stride) * patch_stride)
+    if values.ndim == 2:  # variates series_len
+        padded_values = torch.zeros((values.shape[0], padded_length), dtype=values.dtype, device=values.device)
+    elif values.ndim == 3:  # batch variates series_len
+        padded_values = torch.zeros(
+            (values.shape[0], values.shape[1], padded_length),
+            dtype=values.dtype,
+            device=values.device,
+        )
+    else:
+        raise ValueError(f"Unsupported number of dimensions: {values.ndim}")
+    padded_values[..., -series_len:] = values
+
+    return padded_values
+
+
+def pad_id_mask(
+    id_mask: torch.Tensor,
+    patch_stride: int,
+) -> torch.Tensor:
+    """
+    Makes sure that the series length is divisible by the patch_stride
+    by adding left-padding to the id mask. It does this by repeating
+    the leftmost value of the id mask for each variate
+    """
+    series_len = id_mask.shape[-1]
+    # left-pad the time series to make sure we can divide it into patches.
+    padded_length = int(np.ceil(series_len / patch_stride) * patch_stride)
+    padding_amount = padded_length - series_len
+    left_edge: torch.Tensor = id_mask[..., 0]
+    if id_mask.ndim == 2:  # variates series_len
+        # repeat the left edge of the id mask for padding_amount
+        padding = repeat(
+            left_edge,
+            "variates -> variates padding_amount",
+            padding_amount=padding_amount,
+        )
+        id_mask = torch.cat([padding, id_mask], dim=1)
+    elif id_mask.ndim == 3:  # batch variates series_len
+        # repeat the left edge of the id mask for padding_amount
+        padding = repeat(
+            left_edge,
+            "batch variates -> batch variates padding_amount",
+            padding_amount=padding_amount,
+        )
+        id_mask = torch.cat([padding, id_mask], dim=2)
+    else:
+        raise ValueError(f"Unsupported number of dimensions: {id_mask.ndim}")
+
+    return id_mask
+
+
+class MaskedTimeseries(NamedTuple):
+    series: torch.Tensor
+    """
+    The time series data, of shape (batch_size, num_variates, sequence_length). The first
+    dimension is optional.
+    """
+
+    padding_mask: torch.Tensor
+    """
+    A mask that indicates which values are padding. If padding_mask[..., i] is True,
+    then series[..., i] is _NOT_ padding; i.e., it's a valid value in the time series.
+    Same shape as `series`.
+    """
+
+    id_mask: torch.Tensor
+    """
+    A mask that indicates the group ID of each variate. Any
+    variates with the same ID are considered to be part of the same multivariate
+    time series, and can attend to each other.
+
+    Note: the sequence_length dimension can be 1 if the IDs should
+    be broadcast across the time dimension.
+    """
+
+    timestamp_seconds: torch.Tensor
+    """
+    A POSIX timestamp in seconds for each time step in the series. Of same shape as 
+    `series`.
+    """
+
+    time_interval_seconds: torch.Tensor
+    """
+    The time frequency of each variate in seconds. Of shape (batch_size, num_variates) with
+    the first dimension optional.
+    """
+
+    def to(self, device: torch.device) -> "MaskedTimeseries":
+        return MaskedTimeseries(
+            series=self.series.to(device),
+            padding_mask=self.padding_mask.to(device),
+            id_mask=self.id_mask.to(device),
+            timestamp_seconds=self.timestamp_seconds.to(device),
+            time_interval_seconds=self.time_interval_seconds.to(device),
+        )
+
+
+def is_extreme_value(t: torch.Tensor) -> torch.Tensor:
+    if torch.is_floating_point(t):
+        max_value = torch.finfo(t.dtype).max
+    else:
+        max_value = torch.iinfo(t.dtype).max
+
+    return reduce(
+        torch.logical_or,
+        (
+            torch.isinf(t),
+            torch.isnan(t),
+            t.abs() >= max_value / 2,
+        ),
+    )
+
+
+def replace_extreme_values(t: torch.Tensor, replacement: float = 0.0) -> torch.Tensor:
+    return torch.where(is_extreme_value(t), torch.tensor(replacement, dtype=t.dtype, device=t.device), t)
+
+
+def freq_to_seconds(freq: Union[str, pd.offsets.BaseOffset]) -> float:
+    # Modified from: https://github.com/DataDog/toto/blob/846d599f4b8d377db3088d5cd1a736d050cef5ac/toto/inference/gluonts_predictor.py#L58
+    if isinstance(freq, str):
+        freq = pd.tseries.frequencies.to_offset(freq)
+    try:
+        # Use nanos for fixed frequencies
+        return freq.nanos / 1e9  # Convert nanoseconds to seconds
+    except ValueError:
+        # Handle non-fixed frequencies like Week
+        if isinstance(freq, pd.offsets.BusinessDay):
+            return freq.n * 24 * 60 * 60
+        elif isinstance(freq, pd.offsets.Week):
+            return freq.n * 7 * 24 * 60 * 60  # n weeks to seconds
+        elif isinstance(freq, pd.offsets.MonthBegin) or isinstance(freq, pd.offsets.MonthEnd):
+            return 30 * 24 * 60 * 60  # Approximate a month as 30 days
+        elif isinstance(freq, pd.offsets.QuarterEnd) or isinstance(freq, pd.offsets.QuarterBegin):
+            return 90 * 24 * 60 * 60  # Approximate a quarter as 90 days
+        elif isinstance(freq, pd.offsets.YearEnd) or isinstance(freq, pd.offsets.YearBegin):
+            return 365.25 * 24 * 60 * 60  # Approximate a year as 365.25 days
+        else:
+            raise ValueError(f"Cannot handle frequency of type {type(freq)}: {freq}")

--- a/timeseries/src/autogluon/timeseries/models/toto/_internal/forecaster.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/_internal/forecaster.py
@@ -1,0 +1,423 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/)
+# Copyright 2025 Datadog, Inc.
+
+from dataclasses import dataclass
+from typing import Optional, Union, cast
+
+import numpy as np
+import torch
+from einops import rearrange, repeat
+from gluonts.torch.distributions import AffineTransformed
+from torch.distributions import Distribution
+
+from .backbone import TotoBackbone
+from .dataset import (
+    MaskedTimeseries,
+    pad_array,
+    pad_id_mask,
+    replace_extreme_values,
+)
+
+
+@dataclass(frozen=True)
+class Forecast:
+    mean: torch.Tensor
+    samples: Optional[torch.Tensor]
+
+    def quantile(self, q: Union[float, torch.Tensor]) -> torch.Tensor:
+        """
+        Compute the quantile of the forecast samples.
+        """
+        assert self.samples is not None, "samples must be provided to compute quantiles"
+        assert isinstance(q, float) or isinstance(q, torch.Tensor), "q must be a float or a tensor"
+        if isinstance(q, float):
+            q = torch.tensor(q, device=self.samples.device, dtype=self.samples.dtype)
+        return self.samples.quantile(q, dim=-1)
+
+    @property
+    def median(self) -> torch.Tensor:
+        """
+        The median of the forecast samples.
+        """
+        return self.quantile(0.5)
+
+    @property
+    def std(self) -> torch.Tensor:
+        """
+        Compute the standard deviation of the forecast samples.
+        """
+        assert self.samples is not None, "samples must be provided to compute standard deviation"
+        return self.samples.std(dim=-1)
+
+
+class TotoForecaster:
+    """
+    A forecaster class for the Toto model that handles autoregressive decoding for time series forecasting.
+
+    This class wraps a TotoBackbone model and provides methods to generate forecasts for time series data.
+    The forecasting process uses an autoregressive decoding algorithm:
+
+    1. The model first processes the entire input context (historical data)
+    2. For each future time step:
+       - The model generates a distribution over possible values
+       - Either the mean or random samples are drawn from this distribution
+       - The generated value(s) are appended to the input sequence
+       - The process repeats with this extended sequence
+
+    When generating multiple samples (num_samples > 1), the model creates separate trajectories for each sample:
+    - Each trajectory starts with the same historical context
+    - As sampling progresses, each trajectory evolves independently
+    - This results in num_samples different possible future paths
+    - Samples can be processed in batches (samples_per_batch) to manage memory usage
+
+    The forecaster efficiently reuses computation from the context processing phase using a key-value cache,
+    which stores intermediate transformer attention states to avoid redundant computation.
+
+    The forecaster handles data preprocessing, including padding to match the model's patch size,
+    and postprocessing to format the outputs as a Forecast object containing means and optional samples.
+    """
+
+    model: TotoBackbone
+
+    def __init__(self, model: TotoBackbone):
+        self.model = model
+
+    def forecast(
+        self,
+        inputs: MaskedTimeseries,
+        prediction_length: int,
+        num_samples: Optional[int] = None,
+        samples_per_batch: int = 10,
+        use_kv_cache: bool = True,
+    ) -> Forecast:
+        """
+        Generate a forecast for a batch of time series. This method works autoregressively,
+        i.e. it feeds the model's predictions back into itself. The decoding process is as follows:
+
+        1. The model first processes the entire input context (historical data)
+        2. For each future time step:
+            - The model generates a distribution over possible values
+            - Either the mean or random samples are drawn from this distribution
+            - The generated value(s) are appended to the input sequence
+            - The process repeats with this extended sequence
+
+        There are two modes of operation:
+        1. num_samples is None: generate a single mean prediction
+        2. num_samples is not None: generate num_samples random samples
+
+        When num_samples is not None, the model creates num_samples separate trajectories for each sample:
+        - Each trajectory starts with the same historical context
+        - As sampling progresses, each trajectory evolves independently
+        - This results in num_samples different possible future paths
+        - Samples can be processed in batches (samples_per_batch) to manage memory usage
+
+        When using samples_per_batch, this batch size compounds with the optional batch dimension of the input.
+        For example, if you have a batch of 10 time series, and you set samples_per_batch to 10,
+        the effective batch size is 100. For the best performance, set samples_per_batch
+        as high as possible, subject to memory constraints.
+
+        Args:
+            inputs: A MaskedTimeseries object containing the input time series.
+            prediction_length: The number of future time steps to predict.
+            num_samples:
+                The number of samples to generate.
+                If None, a single mean prediction is generated. However,
+                the mean point forecast tends to be less accurate than the
+                median or mean of the samples (provided enough samples are generated).
+                It's recommended to use at least 128 samples for reliable forecasts.
+            samples_per_batch:
+                The number of samples to generate per batch.
+                In most cases, this should be as high as possible, subject to memory constraints.
+                When the inputs have a batch dimension, the effective batch size is samples_per_batch * batch_size.
+            use_kv_cache:
+                Whether to use a key-value cache for the model. In most cases, this should be True,
+                as it significantly speeds up inference.
+        """
+        if len(inputs.series.shape) == 2:
+            # unbatched input, variates x time_steps
+            batch = cast(MaskedTimeseries, torch.utils.data.default_collate([inputs]))
+        else:
+            # input is already batched
+            batch = inputs
+
+        # pad the input to the nearest multiple of the patch size
+        series = pad_array(batch.series, self.model.patch_embed.stride)
+        padding_mask = pad_array(batch.padding_mask, self.model.patch_embed.stride)
+        id_mask = batch.id_mask
+        if id_mask is not None:
+            id_mask = pad_id_mask(batch.id_mask, self.model.patch_embed.stride)
+        timestamp_seconds = pad_array(batch.timestamp_seconds, self.model.patch_embed.stride)
+        time_interval_seconds: torch.Tensor = torch.as_tensor(
+            batch.time_interval_seconds, device=series.device, dtype=torch.int
+        )
+
+        if num_samples is not None:
+            samples = self.generate_samples(
+                inputs=series,
+                prediction_length=prediction_length,
+                num_samples=num_samples,
+                timestamp_seconds=timestamp_seconds,
+                time_interval_seconds=time_interval_seconds,
+                input_padding_mask=padding_mask,
+                id_mask=id_mask,
+                sampling_batch_size=samples_per_batch,
+                use_kv_cache=use_kv_cache,
+            )
+            mean = samples.mean(dim=-1)
+        else:
+            mean = self.generate_mean(
+                inputs=series,
+                prediction_length=prediction_length,
+                timestamp_seconds=timestamp_seconds,
+                time_interval_seconds=time_interval_seconds,
+                input_padding_mask=padding_mask,
+                id_mask=id_mask,
+                use_kv_cache=use_kv_cache,
+            )
+            samples = None
+
+        return Forecast(mean=mean, samples=samples)
+
+    @torch.no_grad()
+    def generate_mean(
+        self,
+        inputs: torch.Tensor,
+        prediction_length: int,
+        timestamp_seconds: torch.Tensor,
+        time_interval_seconds: torch.Tensor,
+        input_padding_mask: Optional[torch.Tensor] = None,
+        id_mask: Optional[torch.Tensor] = None,
+        use_kv_cache: bool = False,
+    ) -> torch.Tensor:
+        """
+        Generate a point prediction by taking the mean of the output distribution at each step.
+        This method works autoregressively, i.e. it feeds the model's predictions back into itself
+        to generate the next prediction.
+        """
+        if input_padding_mask is None:
+            input_padding_mask = torch.ones_like(inputs, dtype=torch.bool, device=inputs.device)
+        if id_mask is None:
+            id_mask = torch.zeros_like(inputs, dtype=torch.int, device=inputs.device)
+
+        ## round up the prediction length to the nearest multiple of the patch size
+        patch_size = self.model.patch_embed.stride
+        rounded_steps = int(np.ceil(prediction_length / patch_size) * patch_size)
+        start_index = inputs.shape[-1]
+        end_index = start_index + prediction_length
+
+        # TODO: maybe pass in future masks, rather than making assumptions here?
+        dummy_padding = torch.ones(
+            (input_padding_mask.shape[0], input_padding_mask.shape[1], patch_size),
+            device=inputs.device,
+            dtype=torch.bool,
+        )
+        dummy_id_mask = repeat(
+            id_mask[:, :, -1:],
+            "batch variates 1 -> batch variates patch_size",
+            patch_size=patch_size,
+        )
+        if use_kv_cache:
+            kv_cache = self.model.allocate_kv_cache(
+                batch_size=inputs.shape[0],
+                num_variates=inputs.shape[1],
+                max_time_steps=inputs.shape[2] + rounded_steps,
+                device=inputs.device,
+                dtype=inputs.dtype,
+            )
+        else:
+            kv_cache = None
+
+        scaling_prefix_length = inputs.shape[-1]
+
+        for _ in range(rounded_steps // patch_size):
+            base_distr, loc, scale = self.model(
+                inputs=inputs,
+                input_padding_mask=input_padding_mask,
+                id_mask=id_mask,
+                kv_cache=kv_cache,
+                scaling_prefix_length=scaling_prefix_length,
+            )
+            distr = self.create_affine_transformed(base_distr, loc, scale)
+
+            # We remove extreme values that can occur early in training
+            # and cause validation metrics to be NaN
+            samples = replace_extreme_values(distr.mean[:, :, -patch_size:])
+
+            inputs = torch.cat([inputs, samples], dim=-1)
+            id_mask = torch.cat([id_mask, dummy_id_mask], dim=-1)
+            input_padding_mask = torch.cat([input_padding_mask, dummy_padding], dim=-1)
+            for _ in range(patch_size):
+                next_timestamp: torch.Tensor = timestamp_seconds[:, :, -1] + time_interval_seconds
+                timestamp_seconds = torch.cat([timestamp_seconds, next_timestamp.unsqueeze(-1)], dim=-1)
+
+        return inputs.detach()[:, :, start_index:end_index]
+
+    @torch.no_grad()
+    def generate_samples(
+        self,
+        inputs: torch.Tensor,
+        prediction_length: int,
+        num_samples: int,
+        timestamp_seconds: torch.Tensor,
+        time_interval_seconds: torch.Tensor,
+        input_padding_mask: Optional[torch.Tensor] = None,
+        id_mask: Optional[torch.Tensor] = None,
+        sampling_batch_size: int = 10,
+        use_kv_cache: bool = False,
+    ) -> torch.Tensor:
+        """
+        Generate samples from the output distribution.
+        This method works autorregressively, i.e. it feeds the model's predictions back into itself.
+        It works by creating num_samples chains. Each chain is a separate sequence of predictions.
+        At each time step, for each chain we take a single sample from the output distribution and append
+        it to the end of the sequence.
+        """
+        if input_padding_mask is None:
+            input_padding_mask = torch.ones_like(inputs, dtype=torch.bool, device=inputs.device)
+        if id_mask is None:
+            id_mask = torch.zeros_like(inputs, dtype=torch.int, device=inputs.device)
+
+        assert num_samples % sampling_batch_size == 0, "num_samples must be divisible by sampling_batch_size"
+        num_batches = num_samples // sampling_batch_size
+
+        # round up the prediction length to the nearest multiple of the patch size
+        patch_size = self.model.patch_embed.patch_size
+        rounded_steps = int(np.ceil(prediction_length / patch_size) * patch_size)
+        start_index = inputs.shape[-1]
+        end_index = start_index + prediction_length
+
+        dummy_padding = torch.ones(
+            (
+                input_padding_mask.shape[0] * sampling_batch_size,
+                input_padding_mask.shape[1],
+                patch_size,
+            ),
+            dtype=torch.bool,
+            device=inputs.device,
+        )
+        dummy_id_mask = repeat(
+            id_mask[:, :, -1:],
+            "batch variates 1 -> (sampling_batch_size batch) variates patch_size",
+            sampling_batch_size=sampling_batch_size,
+            patch_size=patch_size,
+        )
+        inputs = repeat(
+            inputs,
+            "batch variates seq_len -> (sampling_batch_size batch) variates seq_len",
+            sampling_batch_size=sampling_batch_size,
+        )
+        input_padding_mask = repeat(
+            input_padding_mask,
+            "batch variates seq_len -> (sampling_batch_size batch) variates seq_len",
+            sampling_batch_size=sampling_batch_size,
+        )
+        id_mask = repeat(
+            id_mask,
+            "batch variates seq_len -> (sampling_batch_size batch) variates seq_len",
+            sampling_batch_size=sampling_batch_size,
+        )
+        timestamp_seconds = repeat(
+            timestamp_seconds,
+            "batch variates seq_len -> (sampling_batch_size batch) variates seq_len",
+            sampling_batch_size=sampling_batch_size,
+        )
+        time_interval_seconds = repeat(
+            time_interval_seconds,
+            "batch variates -> (sampling_batch_size batch) variates",
+            sampling_batch_size=sampling_batch_size,
+        )
+
+        all_samples = []
+        if use_kv_cache:
+            kv_cache = self.model.allocate_kv_cache(
+                batch_size=inputs.shape[0],
+                num_variates=inputs.shape[1],
+                max_time_steps=inputs.shape[2] + rounded_steps,
+                device=inputs.device,
+                dtype=inputs.dtype,
+            )
+        else:
+            kv_cache = None
+
+        scaling_prefix_length = inputs.shape[-1]
+
+        for _ in range(num_batches):
+            batch_inputs = torch.clone(inputs)
+            batch_input_padding_mask = torch.clone(input_padding_mask)
+            batch_id_mask = torch.clone(id_mask)
+            batch_timestamp_seconds = torch.clone(timestamp_seconds)
+
+            for _ in range(rounded_steps // patch_size):
+                base_distr, loc, scale = self.model(
+                    inputs=batch_inputs,
+                    input_padding_mask=batch_input_padding_mask,
+                    id_mask=batch_id_mask,
+                    kv_cache=kv_cache,
+                    scaling_prefix_length=scaling_prefix_length,
+                )
+                distr = self.create_affine_transformed(base_distr, loc, scale)
+
+                sample = distr.sample()
+                assert sample is not None
+
+                # We remove extreme values that can occur early in training
+                # and cause validation metrics to be NaN
+                samples = replace_extreme_values(sample[:, :, -patch_size:])
+                batch_inputs = torch.cat([batch_inputs, samples], dim=-1)
+                batch_id_mask = torch.cat([batch_id_mask, dummy_id_mask], dim=-1)
+                batch_input_padding_mask = torch.cat([batch_input_padding_mask, dummy_padding], dim=-1)
+                for _ in range(patch_size):
+                    next_timestamp = batch_timestamp_seconds[:, :, -1] + time_interval_seconds
+                    batch_timestamp_seconds = torch.cat(
+                        [batch_timestamp_seconds, next_timestamp.unsqueeze(-1)], dim=-1
+                    )
+            all_samples.append(batch_inputs)
+            if kv_cache is not None:
+                kv_cache.reset()
+
+        outputs = torch.cat(all_samples, dim=0)
+        unfolded_outputs = rearrange(
+            outputs,
+            "(samples batch) variates seq_len -> batch variates seq_len samples",
+            samples=num_samples,
+        ).detach()
+
+        trimmed_predictions = unfolded_outputs[:, :, start_index:end_index, :]
+        return trimmed_predictions
+
+    @staticmethod
+    def create_affine_transformed(base_distr: Distribution, loc: torch.Tensor, scale: torch.Tensor) -> Distribution:
+        """
+        Creates an AffineTransformed distribution with correctly matched shapes.
+
+        Handles three cases:
+        1. When loc/scale are per-timestep (from CausalStdMeanScaler)
+        2. When base_distr only contains the distribution for the latest patch
+           while loc/scale contain values for the entire sequence
+        3. When loc/scale have a single time step (from StdMeanScaler/StdMinScaler)
+           and need to be broadcast to match a multi-step base distribution
+
+        Args:
+            base_distr: The base distribution to transform
+            loc: Location parameter
+            scale: Scale parameter
+
+        Returns:
+            An AffineTransformed distribution with properly handled shapes
+        """
+        # Get the shape of the base distribution
+        # We'll use this to match the time dimension of loc/scale
+        base_shape = base_distr.mean.shape
+
+        base_time_dim = base_shape[-1]  # Time dimension of base distribution
+        loc_time_dim = loc.shape[-1]  # Time dimension of loc
+
+        if loc_time_dim == 1:
+            # Case 1: If loc/scale have time dimension 1 (standard scalers), PyTorch broadcasting will handle it
+            return AffineTransformed(base_distr, loc=loc, scale=scale)
+
+        # Case 2: If loc/scale have time dimension > 1 (causal scaler with history)
+        # We need to extract only the suffix that matches the base distribution
+        return AffineTransformed(base_distr, loc=loc[:, :, -base_time_dim:], scale=scale[:, :, -base_time_dim:])

--- a/timeseries/src/autogluon/timeseries/models/toto/_internal/model.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/_internal/model.py
@@ -1,0 +1,94 @@
+from typing import Optional
+
+from transformers import PretrainedConfig, PreTrainedModel
+
+from .backbone import TotoBackbone
+
+
+class TotoConfig(PretrainedConfig):
+    model_type = "toto"
+
+    def __init__(
+        self,
+        dropout: float = 0.0,
+        embed_dim: int = 768,
+        num_heads: int = 12,
+        num_layers: int = 12,
+        output_distribution_classes: Optional[list[str]] = None,
+        output_distribution_kwargs: Optional[dict] = None,
+        patch_size: int = 64,
+        scale_factor_exponent: float = 10.0,
+        spacewise_every_n_layers: int = 12,
+        spacewise_first: bool = False,
+        stabilize_with_global: bool = True,
+        stride: int = 64,
+        transformers_version: str = "4.49.0",
+        use_memory_efficient_attention: bool = False,
+        **kwargs,
+    ):
+        self.dropout = dropout
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.num_layers = num_layers
+        self.output_distribution_classes = output_distribution_classes or ["MixtureOfStudentTsOutput"]
+        self.output_distribution_kwargs = output_distribution_kwargs or {"k_components": 24}
+        self.patch_size = patch_size
+        self.scale_factor_exponent = scale_factor_exponent
+        self.spacewise_every_n_layers = spacewise_every_n_layers
+        self.spacewise_first = spacewise_first
+        self.stabilize_with_global = stabilize_with_global
+        self.stride = stride
+        self.transformers_version = transformers_version
+        self.use_memory_efficient_attention = use_memory_efficient_attention
+
+        super().__init__(**kwargs)
+
+
+class TotoPretrainedModel(PreTrainedModel):
+    config_class = TotoConfig
+    base_model_prefix = "model"  # optional, used for weight naming conventions
+
+    def __init__(self, config: TotoConfig):
+        super().__init__(config)
+        self.model = TotoBackbone(
+            patch_size=config.patch_size,
+            stride=config.stride,
+            embed_dim=config.embed_dim,
+            num_layers=config.num_layers,
+            num_heads=config.num_heads,
+            mlp_hidden_dim=getattr(config, "mlp_hidden_dim", 3072),
+            dropout=config.dropout,
+            spacewise_every_n_layers=config.spacewise_every_n_layers,
+            scaler_cls=getattr(config, "scaler_cls", "model.scaler.CausalPatchStdMeanScaler"),
+            output_distribution_classes=config.output_distribution_classes,
+            spacewise_first=config.spacewise_first,
+            output_distribution_kwargs=config.output_distribution_kwargs,
+            use_memory_efficient_attention=False,
+            stabilize_with_global=config.stabilize_with_global,
+            scale_factor_exponent=config.scale_factor_exponent,
+            **getattr(config, "extra_kwargs", {}),
+        )
+        self.post_init()
+
+    def forward(self, *args, **kwargs):
+        return self.model(*args, **kwargs)
+
+    def load_state_dict(self, state_dict, strict: bool = True, assign: bool = False):
+        state_dict = self._map_state_dict_keys(state_dict)
+        return super().load_state_dict(state_dict, strict=strict)
+
+    @staticmethod
+    def _map_state_dict_keys(state_dict):
+        remap = {
+            "mlp.0.w12.weight": "mlp.0.weight",
+            "mlp.0.w12.bias": "mlp.0.bias",
+            "mlp.0.w3.weight": "mlp.2.weight",
+            "mlp.0.w3.bias": "mlp.2.bias",
+        }
+
+        def r(k):
+            for old, new in remap.items():
+                k = k.replace(old, new)
+            return k
+
+        return {r(k): v for k, v in state_dict.items()}

--- a/timeseries/src/autogluon/timeseries/models/toto/dataloader.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/dataloader.py
@@ -98,19 +98,19 @@ class TotoDataLoader:
                 1, 1, context_length
             )
 
-            mts = MaskedTimeseries(
+            time_interval_seconds = torch.full(
+                (current_batch_size, 1),
+                fill_value=freq_to_seconds(self.freq),
+                device=self.device,
+                dtype=torch.int,
+            )
+
+            yield MaskedTimeseries(
                 time_series,
                 padding_mask=~nan_mask,
                 id_mask=id_mask,
                 timestamp_seconds=torch.zeros_like(time_series, dtype=torch.int),
-                time_interval_seconds=torch.full(
-                    (current_batch_size, 1),
-                    fill_value=freq_to_seconds(self.freq),
-                    device=self.device,
-                    dtype=torch.int,
-                ),
+                time_interval_seconds=time_interval_seconds,
             )
-
-            yield mts
 
             self.on_batch()

--- a/timeseries/src/autogluon/timeseries/models/toto/dataloader.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/dataloader.py
@@ -1,0 +1,97 @@
+import time
+from typing import Any, Callable, Iterator, Optional, Union
+
+import numpy as np
+import torch.utils.data
+
+from autogluon.core.utils.exceptions import TimeLimitExceeded
+from autogluon.timeseries import TimeSeriesDataFrame
+
+from ._internal.dataset import MaskedTimeseries, freq_to_seconds
+
+
+class TotoInferenceDataset(torch.utils.data.Dataset):
+    def __init__(
+        self,
+        target_df: TimeSeriesDataFrame,
+        context_length: int,
+        target_column: str = "target",
+    ):
+        assert context_length > 0
+        self.context_length = context_length
+        self.target_array = target_df[target_column].to_numpy(dtype=np.float32)
+
+        target_df = target_df.sort_index()
+
+        # store pointer to start:end of each time series
+        self.indptr = target_df.get_indptr()
+
+        self.freq = target_df.freq
+
+    def __len__(self):
+        return len(self.indptr) - 1  # noqa
+
+    def _get_context(self, a: np.ndarray, pad_value=np.nan):
+        a = a[-self.context_length :]
+        pad_size = self.context_length - len(a)
+        if pad_size > 0:
+            pad = np.full(shape=(pad_size,), fill_value=pad_value)
+            a = np.concatenate((pad, a))
+        return a
+
+    def __getitem__(self, idx) -> np.ndarray:
+        start_idx = self.indptr[idx]
+        end_idx = self.indptr[idx + 1]
+
+        return self._get_context(self.target_array[start_idx:end_idx])
+
+
+class TotoDataLoader:
+    def __init__(
+        self,
+        dataset: TotoInferenceDataset,
+        freq: Optional[str] = None,
+        batch_size: int = 1,
+        time_limit: Optional[Union[int, float]] = None,
+        device: Any = None,
+    ):
+        self.batch_loader = torch.utils.data.DataLoader(
+            dataset=dataset,
+            batch_size=batch_size,
+        )
+        self.on_batch = self._get_timeout_callback(time_limit) if time_limit is not None else (lambda *a, **k: None)
+        self.device = torch.device(device)
+
+        self.freq: str = freq or dataset.freq or "h"
+
+    @staticmethod
+    def _get_timeout_callback(seconds: Optional[float]) -> Callable:
+        start_time = time.monotonic()
+
+        def callback() -> None:
+            if seconds is not None and time.monotonic() - start_time > seconds:
+                raise TimeLimitExceeded
+
+        return callback
+
+    def __iter__(self) -> Iterator[MaskedTimeseries]:
+        for batch in self.batch_loader:
+            time_series = batch.unsqueeze(1).to(self.device)
+            current_batch_size = batch.shape[0]
+
+            mts = MaskedTimeseries(
+                time_series,
+                padding_mask=~torch.isnan(time_series),
+                id_mask=torch.arange(current_batch_size, dtype=torch.int, device=self.device)[:, None, None],
+                timestamp_seconds=torch.zeros_like(time_series, dtype=torch.int),
+                time_interval_seconds=torch.full(
+                    (current_batch_size, 1),
+                    fill_value=freq_to_seconds(self.freq),
+                    device=self.device,
+                    dtype=torch.int,
+                ),
+            )
+
+            yield mts
+
+            self.on_batch()

--- a/timeseries/src/autogluon/timeseries/models/toto/dataloader.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/dataloader.py
@@ -71,18 +71,12 @@ class TotoDataLoader:
 
     @staticmethod
     def _collate(time_series: list[np.ndarray], device: Any) -> torch.Tensor:
-        max_len = max(len(c) for c in time_series)
-        padded = []
-        for c in time_series:
-            padding = torch.full(
-                size=(max_len - len(c),),
-                fill_value=torch.nan,
-                device=device,
-                dtype=torch.float32,
-            )
-            data = torch.tensor(c, device=device, dtype=torch.float32)
-            padded.append(torch.concat((padding, data)))
-        return torch.stack(padded)
+        return torch.nn.utils.rnn.pad_sequence(
+            sequences=[torch.tensor(c, device=device, dtype=torch.float32) for c in time_series],
+            batch_first=True,
+            padding_value=torch.nan,
+            padding_side="left",
+        )
 
     def __iter__(self) -> Iterator[MaskedTimeseries]:
         for batch in self.batch_loader:

--- a/timeseries/src/autogluon/timeseries/models/toto/model.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/model.py
@@ -50,6 +50,9 @@ class TotoModel(AbstractTimeSeriesModel):
     context_length : int or None, default = 4096
         The context length to use in the model. Shorter context lengths will decrease model accuracy, but result
         in faster inference.
+    compile_model : bool, default = True
+        Whether to compile the model using torch.compile() for faster inference. May increase initial loading time
+        but can provide speedups during inference.
     """
 
     default_model_path: str = "Datadog/Toto-Open-Base-1.0"
@@ -126,6 +129,9 @@ class TotoModel(AbstractTimeSeriesModel):
             device_map=hyperparameters["device"],
         )
 
+        if hyperparameters["compile_model"]:
+            pretrained_model.model.compile()
+
         self._forecaster = TotoForecaster(model=pretrained_model.model)
 
     def persist(self) -> Self:
@@ -139,6 +145,7 @@ class TotoModel(AbstractTimeSeriesModel):
             "num_samples": 256,
             "device": "cuda",
             "context_length": 4096,
+            "compile_model": True,
         }
 
     @property
@@ -149,6 +156,7 @@ class TotoModel(AbstractTimeSeriesModel):
             "num_samples",
             "device",
             "context_length",
+            "compile_model",
         ]
 
     def _more_tags(self) -> dict:

--- a/timeseries/src/autogluon/timeseries/models/toto/model.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/model.py
@@ -12,8 +12,6 @@ from autogluon.timeseries import TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 from autogluon.timeseries.utils.features import CovariateMetadata
 
-from .dataloader import TotoDataLoader, TotoInferenceDataset
-
 if TYPE_CHECKING:
     from ._internal import TotoForecaster
 
@@ -28,7 +26,7 @@ class TotoModel(AbstractTimeSeriesModel):
     architecture that autoregressively outputs parametric distribution forecasts. More details can be found on
     `Hugging Face <https://huggingface.co/Datadog/Toto-Open-Base-1.0>`_ and `GitHub <https://github.com/DataDog/toto>.
 
-    The AutoGluon implementation of Toto is based on the original implementation of the authors. It is optimized for easy maintenance
+    The AutoGluon implementation of Toto is on a port of the original implementation. It is optimized for easy maintenance
     with the rest of the AutoGluon model zoo, and does not feature some important optimizations such as xformers and flash-attention
     available in the original model repository. The AutoGluon implementation of Toto requires a CUDA-compatible GPU.
 
@@ -122,7 +120,8 @@ class TotoModel(AbstractTimeSeriesModel):
         return {"num_cpus": 1, "num_gpus": 1}
 
     def load_forecaster(self):
-        from ._internal import TotoConfig, TotoForecaster, TotoPretrainedModel
+        from ._internal import TotoForecaster
+        from .hf_pretrained_model import TotoConfig, TotoPretrainedModel
 
         if not self._is_gpu_available():
             raise RuntimeError(
@@ -190,6 +189,8 @@ class TotoModel(AbstractTimeSeriesModel):
         self, data: TimeSeriesDataFrame, known_covariates: Optional[TimeSeriesDataFrame] = None, **kwargs
     ) -> TimeSeriesDataFrame:
         import torch
+
+        from .dataloader import TotoDataLoader, TotoInferenceDataset
 
         hyperparameters = self.get_hyperparameters()
 

--- a/timeseries/src/autogluon/timeseries/models/toto/model.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/model.py
@@ -21,6 +21,42 @@ logger = logging.getLogger(__name__)
 
 
 class TotoModel(AbstractTimeSeriesModel):
+    """Toto (Time-Series-Optimized Transformer for Observability) [CohenKhwajaetal2025]_ pretrained time series forecasting model.
+
+    Toto is a 151M parameter model trained on over 1T data points from DataDog's internal observability systems, as well as
+    the GIFT-eval pretrain, Chronos pretraining, and synthetically generated time series corpora. It is a decoder-only
+    architecture that autoregressively outputs parameteric distribution forecasts. More details can be found on
+    `Hugging Face <https://huggingface.co/Datadog/Toto-Open-Base-1.0>`_ and `GitHub <https://github.com/DataDog/toto>.
+
+    The AutoGluon implementation of Toto is based on the original implementation of the authors. It is optimized for easy maintenance
+    with the rest of the AutoGluon model zoo, and does not feature some important optimizations such as xformers and flash-attention
+    available in the original model repository. The AutoGluon implementation of Toto requires a CUDA-compatible GPU.
+
+    References
+    ----------
+    .. [CohenKhwajaetal2025] Cohen, Ben, Khwaja, Emaad et al.
+        "This Time is Different: An Observability Perspective on Time Series Foundation Models."
+        https://arxiv.org/abs/2505.14766
+
+
+    Other Parameters
+    ----------------
+    model_path : str, default = "Datadog/Toto-Open-Base-1.0"
+        Model path used for the model, i.e., a HuggingFace transformers ``name_or_path``. Can be a
+        compatible model name on HuggingFace Hub or a local path to a model directory.
+    batch_size : int, default = 16
+        Size of batches used during inference.
+    num_samples : int, default = 256
+        Number of samples used during inference.
+    device : str, default = "cuda"
+        Device to use for inference. Toto requires a CUDA-compatible GPU to run.
+    context_length : int or None, default = 4096
+        The context length to use in the model. Shorter context lengths will decrease model accuracy, but result
+        in faster inference.
+    torch_dtype : torch.dtype or {"auto", "bfloat16", "float32", "float64"}, default = "bfloat16"
+        PyTorch data type to use for loading model weights.
+    """
+
     default_model_path: str = "Datadog/Toto-Open-Base-1.0"
 
     def __init__(
@@ -116,7 +152,7 @@ class TotoModel(AbstractTimeSeriesModel):
             "num_samples": 256,
             "device": "cuda",
             "torch_dtype": "bfloat16",
-            "context_length": 2048,
+            "context_length": 4096,
         }
 
     @property

--- a/timeseries/src/autogluon/timeseries/models/toto/model.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/model.py
@@ -23,7 +23,7 @@ class TotoModel(AbstractTimeSeriesModel):
     Toto is a 151M parameter model trained on over 1T data points from DataDog's internal observability systems, as well as
     the GIFT-eval pretrain, Chronos pretraining, and synthetically generated time series corpora. It is a decoder-only
     architecture that autoregressively outputs parametric distribution forecasts. More details can be found on
-    `Hugging Face <https://huggingface.co/Datadog/Toto-Open-Base-1.0>`_ and `GitHub <https://github.com/DataDog/toto>.
+    `Hugging Face <https://huggingface.co/Datadog/Toto-Open-Base-1.0>`_ and `GitHub <https://github.com/DataDog/toto>`_.
 
     The AutoGluon implementation of Toto is on a port of the original implementation. It is optimized for easy maintenance
     with the rest of the AutoGluon model zoo, and does not feature some important optimizations such as xformers and flash-attention
@@ -41,7 +41,7 @@ class TotoModel(AbstractTimeSeriesModel):
     model_path : str, default = "Datadog/Toto-Open-Base-1.0"
         Model path used for the model, i.e., a HuggingFace transformers ``name_or_path``. Can be a
         compatible model name on HuggingFace Hub or a local path to a model directory.
-    batch_size : int, default = 16
+    batch_size : int, default = 24
         Size of batches used during inference.
     num_samples : int, default = 256
         Number of samples used during inference.

--- a/timeseries/src/autogluon/timeseries/models/toto/model.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/model.py
@@ -7,7 +7,6 @@ import pandas as pd
 from typing_extensions import Self
 
 from autogluon.common.loaders import load_pkl
-from autogluon.common.space import Space
 from autogluon.timeseries import TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 from autogluon.timeseries.utils.features import CovariateMetadata
@@ -70,14 +69,6 @@ class TotoModel(AbstractTimeSeriesModel):
         hyperparameters = hyperparameters if hyperparameters is not None else {}
 
         self.model_path = hyperparameters.get("model_path", self.default_model_path)
-
-        name = name or "Toto"
-
-        if not isinstance(self.model_path, Space):
-            # we truncate the name to avoid long path errors on Windows
-            model_path_suffix = "[" + str(self.model_path).replace("/", "__").replace(os.path.sep, "__")[-50:] + "]"
-            if model_path_suffix not in name:
-                name += model_path_suffix
 
         super().__init__(
             path=path,
@@ -194,7 +185,9 @@ class TotoModel(AbstractTimeSeriesModel):
         assert self._forecaster, "Toto model failed to load"
         device = self._forecaster.model.device
 
-        dataset = TotoInferenceDataset(data, context_length=hyperparameters["context_length"])
+        dataset = TotoInferenceDataset(
+            target_df=data.fill_missing_values("auto"), context_length=hyperparameters["context_length"]
+        )
         loader = TotoDataLoader(
             dataset,
             freq=self.freq,

--- a/timeseries/src/autogluon/timeseries/models/toto/model.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/model.py
@@ -51,8 +51,6 @@ class TotoModel(AbstractTimeSeriesModel):
     context_length : int or None, default = 4096
         The context length to use in the model. Shorter context lengths will decrease model accuracy, but result
         in faster inference.
-    torch_dtype : torch.dtype or {"auto", "bfloat16", "float32", "float64"}, default = "bfloat16"
-        PyTorch data type to use for loading model weights.
     """
 
     default_model_path: str = "Datadog/Toto-Open-Base-1.0"
@@ -134,7 +132,6 @@ class TotoModel(AbstractTimeSeriesModel):
         pretrained_model = TotoPretrainedModel.from_pretrained(
             self.model_path,
             config=TotoConfig.from_pretrained(self.model_path),
-            torch_dtype=hyperparameters["torch_dtype"],
             device_map=hyperparameters["device"],
         )
 
@@ -150,7 +147,6 @@ class TotoModel(AbstractTimeSeriesModel):
             "batch_size": 16,
             "num_samples": 256,
             "device": "cuda",
-            "torch_dtype": "bfloat16",
             "context_length": 4096,
         }
 
@@ -162,7 +158,6 @@ class TotoModel(AbstractTimeSeriesModel):
             "num_samples",
             "device",
             "context_length",
-            "torch_dtype",
         ]
 
     def _more_tags(self) -> dict:

--- a/timeseries/src/autogluon/timeseries/models/toto/model.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/model.py
@@ -141,7 +141,7 @@ class TotoModel(AbstractTimeSeriesModel):
 
     def _get_default_hyperparameters(self) -> dict:
         return {
-            "batch_size": 16,
+            "batch_size": 24,
             "num_samples": 256,
             "device": "cuda",
             "context_length": 4096,
@@ -194,7 +194,8 @@ class TotoModel(AbstractTimeSeriesModel):
         device = self._forecaster.model.device
 
         dataset = TotoInferenceDataset(
-            target_df=data.fill_missing_values("auto"), context_length=hyperparameters["context_length"]
+            target_df=data.fill_missing_values("auto"),
+            max_context_length=hyperparameters["context_length"],
         )
         loader = TotoDataLoader(
             dataset,

--- a/timeseries/src/autogluon/timeseries/models/toto/model.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/model.py
@@ -25,7 +25,7 @@ class TotoModel(AbstractTimeSeriesModel):
 
     Toto is a 151M parameter model trained on over 1T data points from DataDog's internal observability systems, as well as
     the GIFT-eval pretrain, Chronos pretraining, and synthetically generated time series corpora. It is a decoder-only
-    architecture that autoregressively outputs parameteric distribution forecasts. More details can be found on
+    architecture that autoregressively outputs parametric distribution forecasts. More details can be found on
     `Hugging Face <https://huggingface.co/Datadog/Toto-Open-Base-1.0>`_ and `GitHub <https://github.com/DataDog/toto>.
 
     The AutoGluon implementation of Toto is based on the original implementation of the authors. It is optimized for easy maintenance

--- a/timeseries/src/autogluon/timeseries/models/toto/model.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/model.py
@@ -1,0 +1,200 @@
+import logging
+import os
+from typing import TYPE_CHECKING, Any, Optional, Sequence, Union
+
+import numpy as np
+import pandas as pd
+from typing_extensions import Self
+
+from autogluon.common.loaders import load_pkl
+from autogluon.common.space import Space
+from autogluon.timeseries import TimeSeriesDataFrame
+from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
+from autogluon.timeseries.utils.features import CovariateMetadata
+
+from .dataloader import TotoDataLoader, TotoInferenceDataset
+
+if TYPE_CHECKING:
+    from ._internal import TotoForecaster
+
+logger = logging.getLogger(__name__)
+
+
+class TotoModel(AbstractTimeSeriesModel):
+    default_model_path: str = "Datadog/Toto-Open-Base-1.0"
+
+    def __init__(
+        self,
+        path: Optional[str] = None,
+        name: Optional[str] = None,
+        hyperparameters: Optional[dict[str, Any]] = None,
+        freq: Optional[str] = None,
+        prediction_length: int = 1,
+        covariate_metadata: Optional[CovariateMetadata] = None,
+        target: str = "target",
+        quantile_levels: Sequence[float] = (0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9),
+        eval_metric: Any = None,
+    ):
+        hyperparameters = hyperparameters if hyperparameters is not None else {}
+
+        self.model_path = hyperparameters.get("model_path", self.default_model_path)
+
+        name = name or "Toto"
+
+        if not isinstance(self.model_path, Space):
+            # we truncate the name to avoid long path errors on Windows
+            model_path_suffix = "[" + str(self.model_path).replace("/", "__").replace(os.path.sep, "__")[-50:] + "]"
+            if model_path_suffix not in name:
+                name += model_path_suffix
+
+        super().__init__(
+            path=path,
+            name=name,
+            hyperparameters=hyperparameters,
+            freq=freq,
+            prediction_length=prediction_length,
+            covariate_metadata=covariate_metadata,
+            target=target,
+            quantile_levels=quantile_levels,
+            eval_metric=eval_metric,
+        )
+
+        self._forecaster: Optional[TotoForecaster] = None
+
+    def save(self, path: Optional[str] = None, verbose: bool = True) -> str:
+        forecaster = self._forecaster
+        self._forecaster = None
+        path = super().save(path=path, verbose=verbose)
+        self._forecaster = forecaster
+
+        return str(path)
+
+    @classmethod
+    def load(cls, path: str, reset_paths: bool = True, load_oof: bool = False, verbose: bool = True) -> Self:
+        model = load_pkl.load(path=os.path.join(path, cls.model_file_name), verbose=verbose)
+        if reset_paths:
+            model.set_contexts(path)
+
+        return model
+
+    def _is_gpu_available(self) -> bool:
+        import torch.cuda
+
+        return torch.cuda.is_available()
+
+    def get_minimum_resources(self, is_gpu_available: bool = False) -> dict[str, Union[int, float]]:
+        return {"num_cpus": 1, "num_gpus": 1}
+
+    def load_forecaster(self):
+        from ._internal import TotoConfig, TotoForecaster, TotoPretrainedModel
+
+        if not self._is_gpu_available():
+            raise RuntimeError(
+                f"{self.name} requires a GPU to run, but no GPU was detected. "
+                "Please make sure that you are using a computer with a CUDA-compatible GPU and "
+                "`import torch; torch.cuda.is_available()` returns `True`."
+            )
+
+        hyperparameters = self.get_hyperparameters()
+        pretrained_model = TotoPretrainedModel.from_pretrained(
+            self.model_path,
+            config=TotoConfig.from_pretrained(self.model_path),
+            torch_dtype=hyperparameters["torch_dtype"],
+            device_map=hyperparameters["device"],
+        )
+
+        self._forecaster = TotoForecaster(model=pretrained_model.model)
+
+    def persist(self) -> Self:
+        if self._forecaster is None:
+            self.load_forecaster()
+        return self
+
+    def _get_default_hyperparameters(self) -> dict:
+        return {
+            "batch_size": 16,
+            "num_samples": 256,
+            "device": "cuda",
+            "torch_dtype": "bfloat16",
+            "context_length": 2048,
+        }
+
+    @property
+    def allowed_hyperparameters(self) -> list[str]:
+        return super().allowed_hyperparameters + [
+            "model_path",
+            "batch_size",
+            "num_samples",
+            "device",
+            "context_length",
+            "torch_dtype",
+        ]
+
+    def _more_tags(self) -> dict:
+        return {
+            "allow_nan": True,
+            "can_use_train_data": False,
+            "can_use_val_data": False,
+        }
+
+    def _fit(
+        self,
+        train_data: TimeSeriesDataFrame,
+        val_data: Optional[TimeSeriesDataFrame] = None,
+        time_limit: Optional[float] = None,
+        num_cpus: Optional[int] = None,
+        num_gpus: Optional[int] = None,
+        verbosity: int = 2,
+        **kwargs,
+    ) -> None:
+        self._check_fit_params()
+        self.load_forecaster()
+
+    def _predict(
+        self, data: TimeSeriesDataFrame, known_covariates: Optional[TimeSeriesDataFrame] = None, **kwargs
+    ) -> TimeSeriesDataFrame:
+        import torch
+
+        hyperparameters = self.get_hyperparameters()
+
+        if self._forecaster is None:
+            self.load_forecaster()
+        assert self._forecaster, "Toto model failed to load"
+        device = self._forecaster.model.device
+
+        dataset = TotoInferenceDataset(data, context_length=hyperparameters["context_length"])
+        loader = TotoDataLoader(
+            dataset,
+            freq=self.freq,
+            batch_size=hyperparameters["batch_size"],
+            time_limit=kwargs.get("time_limit"),
+            device=device,
+        )
+
+        batch_means, batch_quantiles = [], []
+        with torch.inference_mode():
+            for masked_timeseries in loader:
+                forecast = self._forecaster.forecast(
+                    masked_timeseries,
+                    prediction_length=self.prediction_length,
+                    num_samples=hyperparameters["num_samples"],
+                    samples_per_batch=32,
+                )
+
+                batch_means.append(forecast.mean.cpu().numpy())
+                qs = np.array([forecast.quantile(q).cpu().numpy() for q in self.quantile_levels])
+                batch_quantiles.append(qs.squeeze(2).transpose(1, 2, 0))
+
+        df = pd.DataFrame(
+            np.concatenate(
+                [
+                    np.concatenate(batch_means, axis=0).reshape(-1, 1),
+                    np.concatenate(batch_quantiles, axis=0).reshape(-1, len(self.quantile_levels)),
+                ],
+                axis=1,
+            ),
+            columns=["mean"] + [str(q) for q in self.quantile_levels],
+            index=self.get_forecast_horizon_index(data),
+        )
+
+        return TimeSeriesDataFrame(df)

--- a/timeseries/tests/smoketests/test_all_models.py
+++ b/timeseries/tests/smoketests/test_all_models.py
@@ -86,7 +86,6 @@ ALL_MODELS = {
     "SimpleFeedForward": DUMMY_MODEL_HPARAMS,
     "TemporalFusionTransformer": DUMMY_MODEL_HPARAMS,
     "TiDE": DUMMY_MODEL_HPARAMS,
-    "Toto": DUMMY_MODEL_HPARAMS,
     "WaveNet": DUMMY_MODEL_HPARAMS,
     "Zero": DUMMY_MODEL_HPARAMS,
     # Override default hyperparameters for faster training
@@ -198,7 +197,6 @@ def test_all_models_can_handle_all_covariates(
         {"SimpleFeedForward": DUMMY_MODEL_HPARAMS},
         {"TemporalFusionTransformer": DUMMY_MODEL_HPARAMS},
         {"TiDE": DUMMY_MODEL_HPARAMS},
-        {"Toto": DUMMY_MODEL_HPARAMS},
         {"WaveNet": DUMMY_MODEL_HPARAMS},
         {"Zero": DUMMY_MODEL_HPARAMS},
     ],

--- a/timeseries/tests/smoketests/test_all_models.py
+++ b/timeseries/tests/smoketests/test_all_models.py
@@ -86,6 +86,7 @@ ALL_MODELS = {
     "SimpleFeedForward": DUMMY_MODEL_HPARAMS,
     "TemporalFusionTransformer": DUMMY_MODEL_HPARAMS,
     "TiDE": DUMMY_MODEL_HPARAMS,
+    "Toto": DUMMY_MODEL_HPARAMS,
     "WaveNet": DUMMY_MODEL_HPARAMS,
     "Zero": DUMMY_MODEL_HPARAMS,
     # Override default hyperparameters for faster training
@@ -197,6 +198,7 @@ def test_all_models_can_handle_all_covariates(
         {"SimpleFeedForward": DUMMY_MODEL_HPARAMS},
         {"TemporalFusionTransformer": DUMMY_MODEL_HPARAMS},
         {"TiDE": DUMMY_MODEL_HPARAMS},
+        {"Toto": DUMMY_MODEL_HPARAMS},
         {"WaveNet": DUMMY_MODEL_HPARAMS},
         {"Zero": DUMMY_MODEL_HPARAMS},
     ],

--- a/timeseries/tests/unittests/models/test_toto.py
+++ b/timeseries/tests/unittests/models/test_toto.py
@@ -25,6 +25,7 @@ class MockTotoForecaster:
         self.model.device = torch.device("cpu")
 
     def forecast(self, inputs, prediction_length, num_samples=None, samples_per_batch=32):
+        inputs.series[~inputs.padding_mask] = torch.nan
         input_mean = torch.nanmean(inputs.series, dim=-1, keepdim=True)
         mean = torch.nan_to_num(input_mean.repeat(1, 1, prediction_length), nan=0.0)
 
@@ -129,7 +130,7 @@ class TestTotoDataloader:
                 1,
                 context_length,
             )
-            assert masked_timeseries.id_mask.shape == (expected_size, 1, 1)
+            assert masked_timeseries.id_mask.shape == (expected_size, 1, context_length)
             assert masked_timeseries.timestamp_seconds.shape == (
                 expected_size,
                 1,

--- a/timeseries/tests/unittests/models/test_toto.py
+++ b/timeseries/tests/unittests/models/test_toto.py
@@ -1,0 +1,170 @@
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+import torch
+
+from autogluon.timeseries.models.toto._internal.forecaster import Forecast
+from autogluon.timeseries.models.toto.dataloader import (
+    TotoDataLoader,
+    TotoInferenceDataset,
+    freq_to_seconds,
+)
+
+from ..common import get_data_frame_with_item_index
+
+
+def noop():
+    # pickleable no-op function
+    pass
+
+
+class MockTotoForecaster:
+    def __init__(self):
+        self.model = Mock()
+        self.model.device = torch.device("cpu")
+
+    def forecast(self, inputs, prediction_length, num_samples=None, samples_per_batch=32):
+        input_mean = torch.nanmean(inputs.series, dim=-1, keepdim=True)
+        mean = torch.nan_to_num(input_mean.repeat(1, 1, prediction_length), nan=0.0)
+
+        if num_samples is not None:
+            samples = mean.unsqueeze(-1).repeat(1, 1, 1, num_samples)
+        else:
+            samples = None
+
+        return Forecast(mean=mean, samples=samples)
+
+
+class TestTotoDataset:
+    @pytest.mark.parametrize(
+        "input_freq, expected_freq, expected_num_seconds",
+        [
+            ("15min", "15min", 15 * 60),
+            ("h", "h", 60 * 60),
+            ("D", "D", 24 * 60 * 60),
+        ],
+    )
+    def test_when_dataset_created_then_frequency_set_correctly(self, input_freq, expected_freq, expected_num_seconds):
+        df = get_data_frame_with_item_index(["A", "B", "C", "D"], freq=input_freq, data_length=100)
+
+        dset = TotoInferenceDataset(df, context_length=10)
+        assert dset.freq == expected_freq
+        assert freq_to_seconds(dset.freq) == expected_num_seconds  # type: ignore
+
+    @pytest.mark.parametrize(
+        "input_data_length, context_length",
+        [
+            (100, 10),
+            (5, 10),
+            (100, 100),
+            (5, 100),
+        ],
+    )
+    def test_when_dataset_iterated_then_context_has_correct_length(self, input_data_length, context_length):
+        df = get_data_frame_with_item_index(["A", "B", "C", "D"], data_length=input_data_length)
+
+        dset = TotoInferenceDataset(df, context_length=context_length)
+
+        for i in range(len(dset)):
+            assert len(dset[i]) == context_length
+
+    @pytest.mark.parametrize(
+        "input_data_length, context_length",
+        [
+            (2, 10),
+            (5, 10),
+            (20, 100),
+            (5, 100),
+        ],
+    )
+    def test_when_dataset_iterated_then_context_is_left_padded(self, input_data_length, context_length):
+        df = get_data_frame_with_item_index(["A", "B", "C", "D"], data_length=input_data_length)
+
+        dset = TotoInferenceDataset(df, context_length=context_length)
+
+        for i in range(len(dset)):
+            assert np.all(np.isnan(dset[i][: (context_length - input_data_length)]))
+
+
+class TestTotoDataloader:
+    @pytest.fixture(scope="class")
+    def dataset(self):
+        df = get_data_frame_with_item_index([f"item{x:03d}" for x in range(100)], data_length=100)
+        return TotoInferenceDataset(df, context_length=32)
+
+    @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+    def test_when_dataloader_iterated_then_batches_are_on_correct_device(self, device, dataset):
+        if device == "cuda:0" and not torch.cuda.is_available():
+            pytest.skip()
+
+        loader = TotoDataLoader(dataset, batch_size=32, device=device)
+
+        for masked_timeseries in loader:
+            for tensor in [
+                masked_timeseries.series,
+                masked_timeseries.padding_mask,
+                masked_timeseries.id_mask,
+                masked_timeseries.timestamp_seconds,
+                masked_timeseries.time_interval_seconds,
+            ]:
+                assert tensor.device == torch.device(device)
+
+    @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+    @pytest.mark.parametrize("batch_size", [4, 8, 16, 32])
+    def test_when_dataloader_iterated_then_batches_have_correct_shape(self, device, batch_size, dataset):
+        if device == "cuda:0" and not torch.cuda.is_available():
+            pytest.skip()
+
+        loader = TotoDataLoader(dataset, batch_size=batch_size, device=device)
+
+        context_length = 32
+        nr_full_batches, remainder_batch_size = divmod(len(dataset), batch_size)
+        expected_sizes = [batch_size] * nr_full_batches + ([remainder_batch_size] if remainder_batch_size > 0 else [])
+
+        for masked_timeseries, expected_size in zip(loader, expected_sizes):
+            assert masked_timeseries.series.shape == (expected_size, 1, context_length)
+            assert masked_timeseries.padding_mask.shape == (
+                expected_size,
+                1,
+                context_length,
+            )
+            assert masked_timeseries.id_mask.shape == (expected_size, 1, 1)
+            assert masked_timeseries.timestamp_seconds.shape == (
+                expected_size,
+                1,
+                context_length,
+            )
+            assert masked_timeseries.time_interval_seconds.shape == (expected_size, 1)
+
+
+class TestTotoModel:
+    @pytest.mark.parametrize("num_items", [5, 100])
+    @pytest.mark.parametrize("batch_size", [4, 32])
+    def test_predict_returns_correct_format(self, num_items, batch_size):
+        from unittest.mock import patch
+
+        from autogluon.timeseries.models.toto import TotoModel
+
+        item_index = [f"item{x:03d}" for x in range(num_items)]
+        df = get_data_frame_with_item_index(item_index, data_length=50)  # type: ignore
+        for i, item_id in enumerate(item_index):
+            df.loc[item_id, "target"] = i + 1
+
+        model = TotoModel(
+            prediction_length=10,
+            quantile_levels=[0.1, 0.5, 0.9],
+            hyperparameters={"batch_size": batch_size},
+        )
+
+        with patch.object(model, "load_forecaster"), patch.object(model, "_forecaster", MockTotoForecaster()):
+            predictions = model._predict(df)
+
+            assert len(predictions) == num_items * 10
+            assert list(predictions.columns) == ["mean", "0.1", "0.5", "0.9"]
+            assert predictions.index.names == ["item_id", "timestamp"]
+
+            assert np.allclose(
+                np.repeat(np.arange(1, num_items + 1), 10),
+                predictions["mean"],
+            )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add Toto to the model zoo. Apart from very minor changes the code in `_internal/` is from the original [repository](https://github.com/DataDog/toto).

TODOS:
- [x] benchmark on fev
- [x] add docstrings
- [x] add documentation to model zoo
- [x] add missing value handling via forward filling
- [x] ~~add to smoketests?~~ did not add to smoketests as timeseries tests in HF_HUB_OFFLINE mode. this means the model has to be downloaded and cached beforehand, which works differently for Toto (it isn't compatible with AutoModel).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
