### PR TITLE
[tabular] Gracefully handle ray exceptions

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -987,7 +987,13 @@ class AbstractModel(ModelBase, Tunable):
         assert self.is_initialized(), "Model must be initialized before calling self._get_child_aux_val!"
         return self.params_aux.get(key, default)
 
-    def fit(self, *, log_resources: bool = False, **kwargs):
+    def fit(
+        self,
+        *,
+        log_resources: bool = False,
+        log_resources_prefix: str | None = None,
+        **kwargs,
+    ):
         """
         Fit model to predict values in y based on X.
 
@@ -1049,8 +1055,10 @@ class AbstractModel(ModelBase, Tunable):
             When using a bagged model, this value differs per fold model. The first fold model uses `model_random_seed`,
             the second uses `model_random_seed + 1`, and the last uses `model_random_seed+n_splits-1` where `n_splits`.
             The start value `model_random_seed` can be set via `ag_args_ensemble` in the model's hyperparameters.
-        log_resources: bool, default = False
+        log_resources : bool, default = False
             If True, will log information about the number of CPUs, GPUs, and memory usage during fit.
+        log_resources_prefix : str | None, default = None
+            If specified, will be prepended to the log generated when `log_resources=True`.
         **kwargs :
             Any additional fit arguments a model supports.
         """
@@ -1075,7 +1083,9 @@ class AbstractModel(ModelBase, Tunable):
             num_gpus = kwargs.get("num_gpus", None)
             approx_mem_size_req_gb = approx_mem_size_req / (1024 ** 3) if approx_mem_size_req is not None else None
             available_mem_gb = available_mem / (1024 ** 3) if available_mem is not None else None
-            msg = f"\tFitting with cpus={num_cpus}, gpus={num_gpus}"
+            if log_resources_prefix is None:
+                log_resources_prefix = ""
+            msg = f"\t{log_resources_prefix}Fitting with cpus={num_cpus}, gpus={num_gpus}"
             if approx_mem_size_req_gb is not None and available_mem_gb is not None:
                 msg_mem = f", mem={approx_mem_size_req_gb:.1f}/{available_mem_gb:.1f} GB"
                 msg += msg_mem

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -645,7 +645,20 @@ class BaggedEnsembleModel(AbstractModel):
         else:
             X_fit = X
             y_fit = y
-        model_base.fit(X=X_fit, y=y_fit, time_limit=time_limit, random_seed=self.random_seed, **kwargs)
+        log_resources_prefix = f"Fitting 1 model on all data"
+        if use_child_oof:
+            log_resources_prefix += f" (use_child_oof={use_child_oof})"
+        log_resources_prefix += " | "
+
+        model_base.fit(
+            X=X_fit,
+            y=y_fit,
+            time_limit=time_limit,
+            random_seed=self.random_seed,
+            log_resources=True,
+            log_resources_prefix=log_resources_prefix,
+            **kwargs,
+        )
         model_base.fit_time = time.time() - time_start_fit
         model_base.predict_time = None
         if not skip_oof:

--- a/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
+++ b/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
+
 import copy
+import json
 import logging
 import math
 import os
 import pickle
 import time
+import traceback
 from abc import abstractmethod
-from typing import Any, Dict, Optional, Tuple, Union, TYPE_CHECKING
+from typing import Any, Dict, Mapping, Optional, Tuple, Type, Union, TYPE_CHECKING
 
 import pandas as pd
 from numpy import ndarray
@@ -21,7 +25,7 @@ from autogluon.common.utils.log_utils import reset_logger_for_remote_call
 
 from ...pseudolabeling.pseudolabeling import assert_pseudo_column_match
 from ...ray.resources_calculator import ResourceCalculatorFactory
-from ...utils.exceptions import AutoGluonException, NotEnoughCudaMemoryError, NotEnoughMemoryError, TimeLimitExceeded
+from ...utils.exceptions import AutoGluonException, NoGPUError, NoValidFeatures, NoStackFeatures, NotValidStacker, InsufficientTime, NotEnoughCudaMemoryError, NotEnoughMemoryError, TimeLimitExceeded
 from ..abstract.abstract_model import AbstractModel
 
 if TYPE_CHECKING:
@@ -460,9 +464,10 @@ def _ray_fit(
         )
         save_path = fold_model.save()
     except (AutoGluonException, ImportError, MemoryError) as e:
+        e = encode_exception(e)
         return {
-            "message": str(e),
-            "exception": e,
+            "status": "expected_error",
+            "error": e,
         }
 
     if model_sync_path is not None and not is_head_node:
@@ -595,7 +600,11 @@ class ParallelFoldFittingStrategy(FoldFittingStrategy):
             if isinstance(out, dict):
                 # TODO: Improve the structure of this logic for better logging
                 # TODO: Also do this for HPO w/ Ray
-                raise out["exception"]
+                assert "status" in out
+                assert out["status"] == "expected_error"
+                err_dict = out["error"]
+                err = decode_exception(err_dict)
+                raise err
             else:
                 fold_model, pred_proba, time_start_fit, time_end_fit, predict_time, predict_1_time, predict_n_size, fit_num_cpus, fit_num_gpus = out
             assert fold_ctx is not None
@@ -740,8 +749,21 @@ class ParallelFoldFittingStrategy(FoldFittingStrategy):
             self._run_parallel(X, y, X_pseudo, y_pseudo, model_base_ref, time_limit_fold, head_node_id)
 
     def terminate_all_unfinished_tasks(self, unfinished_tasks):
+        # Cancel everyone else, forcefully, and drain to observe their cancellations
         for task in unfinished_tasks:
-            self.ray.cancel(task, force=True)
+            try:
+                self.ray.cancel(task, force=True)
+            except Exception:
+                pass
+
+        for task in unfinished_tasks:
+            try:
+                _ = self.ray.get(task)
+            except self.ray.exceptions.TaskCancelledError:
+                pass
+            except Exception:
+                # If something else failed while we were cancelling, ignore here
+                pass
 
     def _fit(
         self,
@@ -1001,3 +1023,83 @@ class ParallelDistributedFoldFittingStrategy(ParallelFoldFittingStrategy):
 
         bucket, path = s3_path_to_bucket_prefix(model_sync_path)
         download_s3_folder(bucket=bucket, prefix=path, local_path=local_path, error_if_exists=False, verbose=False)
+
+
+def _json_safe(x: Any) -> Any:
+    try:
+        json.dumps(x)  # fast path
+        return x
+    except Exception:
+        return repr(x)
+
+
+def encode_exception(e: BaseException) -> dict[str, Any]:
+    return {
+        "exc_type": e.__class__.__name__,
+        "message": str(e),
+        "args": [_json_safe(a) for a in getattr(e, "args", ())],
+        "attrs": {k: _json_safe(v) for k, v in getattr(e, "__dict__", {}).items()},
+        "remote_traceback": traceback.format_exc(),
+    }
+
+
+class UnknownRemoteException(RuntimeError):
+    def __init__(self, exc_type: str, message: str):
+        super().__init__(f"{exc_type}: {message}")
+        self.exc_type = exc_type
+
+
+EXPECTED_EXC_LST = [
+    AutoGluonException,
+    NoGPUError,
+    NoValidFeatures,
+    NoStackFeatures,
+    NotValidStacker,
+    InsufficientTime,
+    NotEnoughCudaMemoryError,
+    NotEnoughMemoryError,
+    TimeLimitExceeded,
+    MemoryError,
+    ImportError,
+]
+EXPECTED_EXC_REGISTRY: Mapping[str, Type[BaseException]] = {
+    err_cls.__name__: err_cls for err_cls in EXPECTED_EXC_LST
+}
+
+
+def decode_exception(payload: Dict[str, Any],
+                     registry: Mapping[str, Type[BaseException]] = EXPECTED_EXC_REGISTRY
+                     ) -> BaseException:
+    name = payload.get("exc_type", "Exception")
+    args = payload.get("args", [])
+    attrs = payload.get("attrs", {}) or {}
+    msg = payload.get("message", "")
+    tb_str = payload.get("remote_traceback")
+
+    cls = registry.get(name)
+    if cls is None:
+        # If it's not registered, wrap as UnknownRemoteException but keep context
+        ex = UnknownRemoteException(name, msg)
+        ex.remote_traceback = tb_str
+        ex.remote_attrs = attrs
+        return ex
+
+    # Try normal construction with original args; fall back to message-only
+    try:
+        ex = cls(*args)
+    except Exception:
+        ex = cls(msg)
+
+    # Restore extra attributes (best-effort)
+    for k, v in attrs.items():
+        try:
+            setattr(ex, k, v)
+        except Exception:
+            pass
+
+    # Attach remote traceback string for debugging
+    try:
+        setattr(ex, "remote_traceback", tb_str)
+    except Exception:
+        pass
+    return ex

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -314,6 +314,8 @@ class CatBoostModel(AbstractModel):
         max_memory_iters = math.floor(available_mem * max_memory_proportion / mem_usage_per_iter)
 
         final_iters = min(default_iters, min(max_memory_iters, estimated_iters_in_time))
+        if final_iters < 1:
+            raise TimeLimitExceeded
         return final_iters
 
     def _predict_proba(self, X, **kwargs):

--- a/tabular/src/autogluon/tabular/models/knn/knn_model.py
+++ b/tabular/src/autogluon/tabular/models/knn/knn_model.py
@@ -255,9 +255,13 @@ class KNNModel(AbstractModel):
             self._X_unused_index = [i for i in range(num_rows_max) if i not in idx]
         return self.model
 
-    def _get_maximum_resources(self) -> Dict[str, Union[int, float]]:
+    def _get_maximum_resources(self) -> dict[str, int | float]:
         # use at most 32 cpus to avoid OpenBLAS error: https://github.com/autogluon/autogluon/issues/1020
-        return {"num_cpus": 32}
+        # no GPU support
+        return {
+            "num_cpus": 32,
+            "num_gpus": 0,
+        }
 
     def _get_default_resources(self):
         # use at most 32 cpus to avoid OpenBLAS error: https://github.com/autogluon/autogluon/issues/1020

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -168,7 +168,7 @@ class LGBModel(AbstractModel):
                 #  Before enabling GPU, we should add code to detect that GPU-enabled version is installed and that a valid GPU exists.
                 #  GPU training heavily alters accuracy, often in a negative manner. We will have to be careful about when to use GPU.
                 params["device"] = "gpu"
-                logger.log(20, f"\tTraining {self.name} with GPU, note that this may negatively impact model quality compared to CPU training.")
+                logger.log(20, f"\tWarning: Training LightGBM with GPU. This may negatively impact model quality compared to CPU training.")
         logger.log(15, f"\tFitting {num_boost_round} rounds... Hyperparameters: {params}")
 
         if "num_threads" not in params:

--- a/tabular/src/autogluon/tabular/models/lr/lr_model.py
+++ b/tabular/src/autogluon/tabular/models/lr/lr_model.py
@@ -322,6 +322,10 @@ class LinearModel(AbstractModel):
     ) -> int:
         return 4 * get_approximate_df_mem_usage(X).sum()
 
+    def _get_maximum_resources(self) -> dict[str, int | float]:
+        # no GPU support
+        return {"num_gpus": 0}
+
     @classmethod
     def supported_problem_types(cls) -> list[str] | None:
         return ["binary", "multiclass", "regression"]

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -370,6 +370,10 @@ class RFModel(AbstractModel):
 
         return self._convert_proba_to_unified_form(y_oof_pred_proba)
 
+    def _get_maximum_resources(self) -> dict[str, int | float]:
+        # no GPU support
+        return {"num_gpus": 0}
+
     def _get_default_auxiliary_params(self) -> dict:
         default_auxiliary_params = super()._get_default_auxiliary_params()
         extra_auxiliary_params = dict(


### PR DESCRIPTION
*Description of changes:*

- Fix Ray exception handling so that AutoGluon exceptions are gracefully handled.
- Add logging for refit_full and use_child_oof=True fits for the resource allocation
- Disable GPU usage for RandomForest, ExtraTrees, KNN, and LinearModel (they never used the GPU anyways). Now these models will never take GPU resources away from other tasks.
- Hide XGBoost warning when GPU is used
- Fix CatBoost exception when fitting with GPU and time_limit is low due to trying to fit with non-positive "iterations".

Kudos to @ncclementi for notifying me of the logging issues!

## Mainline

```
Fitting model: XGBoost_BAG_L2 ... Training model for up to 31.71s of the 31.68s of remaining time.
        Fitting 8 child models (S1F1 - S1F8) | Fitting with ParallelLocalFoldFittingStrategy (1.0 workers, per: cpus=1, gpus=1, memory=0.01%)
2025-09-19 23:25:13,228 ERROR worker.py:420 -- Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): The worker died unexpectedly while executing this task. Check python-core-worker-*.log files for more information.
2025-09-19 23:25:13,228 ERROR worker.py:420 -- Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): The worker died unexpectedly while executing this task. Check python-core-worker-*.log files for more information.
2025-09-19 23:25:13,229 ERROR worker.py:420 -- Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): The worker died unexpectedly while executing this task. Check python-core-worker-*.log files for more information.
        0.8747   = Validation score   (roc_auc)
        4.19s    = Training   runtime
        0.06s    = Validation runtime
Fitting model: NeuralNetTorch_BAG_L2 ... Training model for up to 26.53s of the 26.50s of remaining time.
        Fitting 8 child models (S1F1 - S1F8) | Fitting with ParallelLocalFoldFittingStrategy (1.0 workers, per: cpus=1, gpus=1, memory=0.00%)
        Time limit exceeded... Skipping NeuralNetTorch_BAG_L2.
Fitting model: LightGBMLarge_BAG_L2 ... Training model for up to 21.88s of the 21.85s of remaining time.
        Fitting 8 child models (S1F1 - S1F8) | Fitting with ParallelLocalFoldFittingStrategy (1.0 workers, per: cpus=1, gpus=1, memory=0.01%)
2025-09-19 23:25:23,231 ERROR worker.py:420 -- Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): The worker died unexpectedly while executing this task. Check python-core-worker-*.log files for more information.
2025-09-19 23:25:23,231 ERROR worker.py:420 -- Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): The worker died unexpectedly while executing this task. Check python-core-worker-*.log files for more information.
2025-09-19 23:25:23,232 ERROR worker.py:420 -- Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): The worker died unexpectedly while executing this task. Check python-core-worker-*.log files for more information.
        0.8433   = Validation score   (roc_auc)
        6.5s     = Training   runtime
        0.03s    = Validation runtime
Fitting model: CatBoost_r177_BAG_L2 ... Training model for up to 14.39s of the 14.37s of remaining time.
        Fitting 8 child models (S1F1 - S1F8) | Fitting with ParallelLocalFoldFittingStrategy (1.0 workers, per: cpus=1, gpus=1, memory=0.11%)
2025-09-19 23:25:28,653 ERROR serialization.py:462 -- Failed to unpickle serialized exception
Traceback (most recent call last):
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/ray/exceptions.py", line 51, in from_ray_exception
    return pickle.loads(ray_exception.serialized_exception)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named '_catboost'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/ray/_private/serialization.py", line 460, in deserialize_objects
    obj = self._deserialize_object(data, metadata, object_ref)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/ray/_private/serialization.py", line 342, in _deserialize_object
    return RayError.from_bytes(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/ray/exceptions.py", line 45, in from_bytes
    return RayError.from_ray_exception(ray_exception)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/ray/exceptions.py", line 54, in from_ray_exception
    raise RuntimeError(msg) from e
RuntimeError: Failed to unpickle serialized exception
        Warning: Exception caused CatBoost_r177_BAG_L2 to fail during training... Skipping this model.
                System error: Failed to unpickle serialized exception
traceback: Traceback (most recent call last):
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/ray/exceptions.py", line 51, in from_ray_exception
    return pickle.loads(ray_exception.serialized_exception)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named '_catboost'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/ray/_private/serialization.py", line 460, in deserialize_objects
    obj = self._deserialize_object(data, metadata, object_ref)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/ray/_private/serialization.py", line 342, in _deserialize_object
    return RayError.from_bytes(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/ray/exceptions.py", line 45, in from_bytes
    return RayError.from_ray_exception(ray_exception)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/ray/exceptions.py", line 54, in from_ray_exception
    raise RuntimeError(msg) from e
RuntimeError: Failed to unpickle serialized exception

Detailed Traceback:
Traceback (most recent call last):
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/autogluon/tabular/trainer/abstract_trainer.py", line 2171, in _train_and_save
    model = self._train_single(**model_fit_kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/autogluon/tabular/trainer/abstract_trainer.py", line 2055, in _train_single
    model = model.fit(X=X, y=y, X_val=X_val, y_val=y_val, X_test=X_test, y_test=y_test, total_resources=total_resources, **model_fit_kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/autogluon/core/models/abstract/abstract_model.py", line 1068, in fit
    out = self._fit(**kwargs)
          ^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/autogluon/core/models/ensemble/stacker_ensemble_model.py", line 270, in _fit
    return super()._fit(X=X, y=y, time_limit=time_limit, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/autogluon/core/models/ensemble/bagged_ensemble_model.py", line 389, in _fit
    self._fit_folds(
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/autogluon/core/models/ensemble/bagged_ensemble_model.py", line 868, in _fit_folds
    fold_fitting_strategy.after_all_folds_scheduled()
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/autogluon/core/models/ensemble/fold_fitting_strategy.py", line 723, in after_all_folds_scheduled
    self._run_parallel(X, y, X_pseudo, y_pseudo, model_base_ref, time_limit_fold, head_node_id)
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/autogluon/core/models/ensemble/fold_fitting_strategy.py", line 664, in _run_parallel
    self._process_fold_results(finished, unfinished, fold_ctx)
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/autogluon/core/models/ensemble/fold_fitting_strategy.py", line 620, in _process_fold_results
    raise processed_exception
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/autogluon/core/models/ensemble/fold_fitting_strategy.py", line 583, in _process_fold_results
    fold_model, pred_proba, time_start_fit, time_end_fit, predict_time, predict_1_time, predict_n_size, fit_num_cpus, fit_num_gpus = self.ray.get(finished)
                                                                                                                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/ray/_private/auto_init_hook.py", line 21, in auto_init_wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/ray/_private/client_mode_hook.py", line 103, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/ray/_private/worker.py", line 2782, in get
    values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/ray/_private/worker.py", line 931, in get_objects
    raise value
ray.exceptions.RaySystemError: System error: Failed to unpickle serialized exception
traceback: Traceback (most recent call last):
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/ray/exceptions.py", line 51, in from_ray_exception
    return pickle.loads(ray_exception.serialized_exception)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named '_catboost'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/ray/_private/serialization.py", line 460, in deserialize_objects
    obj = self._deserialize_object(data, metadata, object_ref)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/ray/_private/serialization.py", line 342, in _deserialize_object
    return RayError.from_bytes(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/ray/exceptions.py", line 45, in from_bytes
    return RayError.from_ray_exception(ray_exception)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/workspace/env/nvidia_test_venv/lib/python3.12/site-packages/ray/exceptions.py", line 54, in from_ray_exception
    raise RuntimeError(msg) from e
RuntimeError: Failed to unpickle serialized exception

Fitting model: NeuralNetTorch_r79_BAG_L2 ... Training model for up to 11.03s of the 11.00s of remaining time.
        Fitting 8 child models (S1F1 - S1F8) | Fitting with ParallelLocalFoldFittingStrategy (1.0 workers, per: cpus=1, gpus=1, memory=0.00%)
        Time limit exceeded... Skipping NeuralNetTorch_r79_BAG_L2.
2025-09-19 23:25:33,111 ERROR worker.py:420 -- Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): The worker died unexpectedly while executing this task. Check python-core-worker-*.log files for more information.
2025-09-19 23:25:33,111 ERROR worker.py:420 -- Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): The worker died unexpectedly while executing this task. Check python-core-worker-*.log files for more information.
2025-09-19 23:25:33,111 ERROR worker.py:420 -- Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): The worker died unexpectedly while executing this task. Check python-core-worker-*.log files for more information.
Fitting model: LightGBM_r131_BAG_L2 ... Training model for up to 6.65s of the 6.63s of remaining time.
        Fitting 8 child models (S1F1 - S1F8) | Fitting with ParallelLocalFoldFittingStrategy (1.0 workers, per: cpus=1, gpus=1, memory=0.00%)
2025-09-19 23:25:38,235 ERROR worker.py:420 -- Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): The worker died unexpectedly while executing this task. Check python-core-worker-*.log files for more information.
2025-09-19 23:25:38,235 ERROR worker.py:420 -- Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): The worker died unexpectedly while executing this task. Check python-core-worker-*.log files for more information.
2025-09-19 23:25:38,236 ERROR worker.py:420 -- Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): The worker died unexpectedly while executing this task. Check python-core-worker-*.log files for more information.
        0.817    = Validation score   (roc_auc)
        4.22s    = Training   runtime
        0.02s    = Validation runtime
```

## This PR

```
Fitting model: XGBoost_BAG_L2 ... Training model for up to 28.22s of the 28.19s of remaining time.
	Fitting 8 child models (S1F1 - S1F8) | Fitting with ParallelLocalFoldFittingStrategy (1.0 workers, per: cpus=1, gpus=1, memory=0.00%)
	0.87	 = Validation score   (roc_auc)
	4.31s	 = Training   runtime
	0.11s	 = Validation runtime
Fitting model: NeuralNetTorch_BAG_L2 ... Training model for up to 22.62s of the 22.59s of remaining time.
	Fitting 8 child models (S1F1 - S1F8) | Fitting with ParallelLocalFoldFittingStrategy (1.0 workers, per: cpus=1, gpus=1, memory=0.00%)
	Time limit exceeded... Skipping NeuralNetTorch_BAG_L2.
Fitting model: LightGBMLarge_BAG_L2 ... Training model for up to 17.65s of the 17.63s of remaining time.
	Fitting 8 child models (S1F1 - S1F8) | Fitting with ParallelLocalFoldFittingStrategy (1.0 workers, per: cpus=1, gpus=1, memory=0.01%)
	0.8405	 = Validation score   (roc_auc)
	5.68s	 = Training   runtime
	0.03s	 = Validation runtime
Fitting model: CatBoost_r177_BAG_L2 ... Training model for up to 10.67s of the 10.65s of remaining time.
	Fitting 8 child models (S1F1 - S1F8) | Fitting with ParallelLocalFoldFittingStrategy (1.0 workers, per: cpus=1, gpus=1, memory=0.11%)
	Time limit exceeded... Skipping CatBoost_r177_BAG_L2.
Fitting model: NeuralNetTorch_r79_BAG_L2 ... Training model for up to 7.11s of the 7.08s of remaining time.
	Fitting 8 child models (S1F1 - S1F8) | Fitting with ParallelLocalFoldFittingStrategy (1.0 workers, per: cpus=1, gpus=1, memory=0.00%)
	Time limit exceeded... Skipping NeuralNetTorch_r79_BAG_L2.
Fitting model: LightGBM_r131_BAG_L2 ... Training model for up to 3.24s of the 3.22s of remaining time.
	Fitting 8 child models (S1F1 - S1F8) | Fitting with ParallelLocalFoldFittingStrategy (1.0 workers, per: cpus=1, gpus=1, memory=0.00%)
	0.8398	 = Validation score   (roc_auc)
	4.17s	 = Training   runtime
	0.02s	 = Validation runtime
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
