### PR TITLE
[install] Use standalone uv in full_install.sh

### DIFF
--- a/docs/install-modules.md
+++ b/docs/install-modules.md
@@ -4,8 +4,11 @@ AutoGluon is modularized into [sub-modules](https://packaging.python.org/guides/
     - The default installation of `autogluon.tabular` standalone is a skeleton installation.
     - Install via `pip install autogluon.tabular[all]` to get the same installation of tabular as via `pip install autogluon`
     - Available optional dependencies: `lightgbm,catboost,xgboost,fastai,ray`. These are included in `all`.
-    - Optional dependencies not included in `all`: `interpret,imodels,skex,skl2onnx`.
+    - Optional dependencies not included in `all`: `tabicl,tabpfn,realmlp,interpret,imodels,skex,skl2onnx`.
     - To run `autogluon.tabular` with only the optional LightGBM and CatBoost models for example, you can do: `pip install autogluon.tabular[lightgbm,catboost]`
+    - Optional dependency: `tabicl`. This will enable the TabICL model, used in the `extreme` preset (key=`TABICL`).
+    - Optional dependency: `tabpfn`. This will enable the TabPFNv2 model, used in the `extreme` preset (key=`TABPFNV2`).
+    - Optional dependency: `realmlp`. This will enable the RealMLP model (key=`REALMLP`).
     - Optional dependency: `skex`. This will speedup KNN models by 25x in training and inference on CPU. Use `pip install autogluon.tabular[all,skex]` to enable. Note: Not compatible with ARM processors.
     - Optional dependency: `interpret`. This will install the interpret package and allow you to fit EBM models.
     - Experimental optional dependency: `imodels`. This will install the imodels package and allow you to fit interpretable models in TabularPredictor.
@@ -18,10 +21,10 @@ AutoGluon is modularized into [sub-modules](https://packaging.python.org/guides/
 - `autogluon.features` - only functionality for feature generation / feature preprocessing pipelines (primarily related to Tabular data).
 - `autogluon.eda` - (Deprecated) only functionality for exploratory data analysis.
 
-To install a submodule from source, follow the instructions for installing the entire package from source but replace the line `cd autogluon && ./full_install.sh` with `cd autogluon && pip install -e {SUBMODULE_NAME}/{OPTIONAL_DEPENDENCIES}`
+To install a submodule from source, follow the instructions for installing the entire package from source but replace the line `./autogluon/full_install.sh` with `cd autogluon && pip install -e {SUBMODULE_NAME}/{OPTIONAL_DEPENDENCIES}`
 
 - For example, to install `autogluon.tabular[lightgbm,catboost]` from source, the command would be: `cd autogluon && pip install -e tabular/[lightgbm,catboost]`
 
 To install all AutoGluon optional dependencies:
 
-`pip install autogluon && pip install autogluon.tabular[interpret,imodels,skex,skl2onnx]`
+`pip install autogluon && pip install autogluon.tabular[all,test]`

--- a/docs/install.md
+++ b/docs/install.md
@@ -250,7 +250,7 @@ BRANCH=accel_preprocess_bool
 
 pip install -U pip
 git clone --depth 1 --single-branch --branch ${BRANCH} --recurse-submodules https://github.com/${GITHUB_USER}/autogluon.git
-cd autogluon && ./full_install.sh
+./autogluon/full_install.sh
 ```
 
 Note that the above example is only valid while the branch still exists. A user could delete the branch after the PR is merged, so this advice is primarily focused on unmerged PRs.

--- a/full_install.sh
+++ b/full_install.sh
@@ -2,17 +2,20 @@
 set -euo pipefail
 
 # Get the directory of the script and always change to it
-script_dir=$(dirname "$0")
+script_dir="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$script_dir"
 
+PY="${PYTHON:-python}"
+
 # Check if we're in Colab
-IN_COLAB=$(python -c "
+IN_COLAB="$("$PY" - <<'PYCODE'
 try:
-    import google.colab
-    print('true')
+    import google.colab  # type: ignore
+    print("true")
 except ImportError:
-    print('false')
-")
+    print("false")
+PYCODE
+)"
 
 # Set installation type based on environment
 if [ "$IN_COLAB" == "true" ]; then
@@ -33,20 +36,68 @@ do
     shift
 done
 
-# Check if uv is installed
-if ! python -m pip show uv &> /dev/null; then
-    echo "uv could not be found. Installing uv..."
-    python -m pip install uv
+# --- UV discovery (standalone or pip-installed) ---
+# Priority: 1) $UV env var  2) uv on PATH  3) python -m uv
+UV_BIN="${UV:-}"
+
+# Helper: set UV_LAUNCH to how we should invoke uv.
+_detect_uv() {
+  # 1) Explicit path via $UV
+  if [[ -n "$UV_BIN" && -x "$UV_BIN" ]]; then
+    UV_LAUNCH=("$UV_BIN")
+    return 0
+  fi
+
+  # 2) Standalone uv on PATH
+  if command -v uv >/dev/null 2>&1; then
+    UV_LAUNCH=("$(command -v uv)")
+    return 0
+  fi
+
+  # 3) Pip/conda-installed module importable by Python
+  if "$PY" - <<'PYCODE' >/dev/null 2>&1
+import importlib.util, sys
+sys.exit(0 if importlib.util.find_spec("uv") else 1)
+PYCODE
+  then
+    UV_LAUNCH=("$PY" -m uv)
+    return 0
+  fi
+
+  return 1
+}
+
+# Try to detect uv first
+if ! _detect_uv; then
+  # 4) If pip exists, install uv automatically (like the original script), then retry detection
+  if command -v pip >/dev/null 2>&1 || "$PY" -m pip --version >/dev/null 2>&1; then
+    echo "[INFO] 'uv' not found. Installing via pip..."
+    "$PY" -m pip install "uv"
+    # Retry detection after install
+    if ! _detect_uv; then
+      echo "[ERROR] 'uv' still not found after pip install. Check your Python environment." >&2
+      exit 1
+    fi
+  else
+    echo "[ERROR] 'uv' not found and pip is unavailable." >&2
+    echo "Install standalone uv:  curl -LsSf https://astral.sh/uv/install.sh | sh" >&2
+    echo "OR install via pip once pip is available:  $PY -m pip install uv" >&2
+    echo "OR set UV=/full/path/to/uv and retry." >&2
+    exit 1
+  fi
 fi
+
+# Convenience wrapper
+uvpip() { "${UV_LAUNCH[@]}" pip "$@"; }
 
 # Use uv to install packages
 # TODO: We should simplify this by having a single setup.py at project root, and let user call `pip install -e .`
 if [ "$EDITABLE" == "true" ]; then
   # Editable install (used outside Colab)
-  python -m uv pip install --refresh -e common/[tests]
-  python -m uv pip install -e core/[all,tests] -e features/ -e tabular/[all,tests] -e multimodal/[tests] -e timeseries/[all,tests] -e eda/ -e autogluon/
+  uvpip install --refresh -e "common/[tests]"
+  uvpip install -e "core/[all,tests]" -e "features/" -e "tabular/[all,tests]" -e "multimodal/[tests]" -e "timeseries/[all,tests]" -e "eda/" -e "autogluon/"
 else
   # Non-editable install (forced in Colab)
-  python -m uv pip install --refresh common/[tests]
-  python -m uv pip install core/[all,tests] features/ tabular/[all,tests] multimodal/[tests] timeseries/[all,tests] eda/ autogluon/
+  uvpip install --refresh "common/[tests]"
+  uvpip install "core/[all,tests]" "features/" "tabular/[all,tests]" "multimodal/[tests]" "timeseries/[all,tests]" "eda/" "autogluon/"
 fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

If the user doesn't have `pip` installed, the current `full_install.sh` source install script will fail even if the user has `uv` installed standalone:

```
$ ./autogluon/full_install.sh
uv could not be found. Installing uv...
/usr/bin/python: No module named pip
```

This PR fixes this by checking if a standalone uv install exists, and if so it will use it without requiring `pip` to be installed.

[Colab example](https://colab.research.google.com/drive/124DXEjBffUCDA9L7L6oq_Tfx31GoiTkp?usp=sharing) of this PR's install script: 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
