### PR TITLE
Add multilabel support to multimodal package. Initial framework setup…

### DIFF
--- a/multimodal/src/autogluon/multimodal/configs/data/default.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/data/default.yaml
@@ -17,6 +17,7 @@ data:
   label:
     numerical_preprocessing: "standardscaler"  # The mode of numerical label preprocessing for . Support "standardscaler" or "minmaxscaler" or None (means no transform).
   pos_label:  # The name of binary classification's positive class. It's used in computing some metrics, e.g., roc_auc. If not provided, then use label_encoder.classes_[1],
+  ignore_label:  # The name of multi-label classification ignore class, indicating when label value is unknown. Can be provided as single scalar value for all label columns or as a map from column name to its respective ignore label value
   column_features_pooling_mode: "concat"  # How to pool multi-column features into one feature vector. Currently only support "concat" or "mean" for few shot classification.
   mixup:
     turn_on: False  # The total control of mixup.

--- a/multimodal/src/autogluon/multimodal/constants.py
+++ b/multimodal/src/autogluon/multimodal/constants.py
@@ -25,6 +25,7 @@ ZERO_SHOT = "zero_shot"
 CLASSIFICATION = "classification"
 BINARY = "binary"
 MULTICLASS = "multiclass"
+MULTILABEL = "multilabel"
 REGRESSION = "regression"
 NER = "ner"
 NAMED_ENTITY_RECOGNITION = "named_entity_recognition"
@@ -190,6 +191,7 @@ EVALUATION_METRICS = {
     # Use evaluation metrics from METRICS for these types
     BINARY: list(METRICS[BINARY].keys()) + [COVERAGE],
     MULTICLASS: METRICS[MULTICLASS].keys(),
+    MULTILABEL: ["accuracy", "acc"], # TO DO: Add additional metrics if relevant
     REGRESSION: METRICS[REGRESSION].keys(),
     OBJECT_DETECTION: DETECTION_METRICS,
     SEMANTIC_SEGMENTATION: [IOU, BER, SM],
@@ -202,6 +204,8 @@ VALIDATION_METRICS = {
     problem_type: [metric for metric in metrics if metric in METRIC_MODE_MAP] + [DIRECT_LOSS]
     for problem_type, metrics in EVALUATION_METRICS.items()
 }
+
+
 
 # Training status
 TRAIN = "train"

--- a/multimodal/src/autogluon/multimodal/data/infer_types.py
+++ b/multimodal/src/autogluon/multimodal/data/infer_types.py
@@ -23,6 +23,7 @@ from ..constants import (
     IMAGE_BYTEARRAY,
     IMAGE_PATH,
     MULTICLASS,
+    MULTILABEL,
     NER,
     NER_ANNOTATION,
     NULL,
@@ -680,7 +681,7 @@ def infer_label_column_type_by_problem_type(
             raise ValueError(
                 f"Label column '{col_name}' contains only one label class. Make sure it has at least two label classes."
             )
-        if problem_type in [MULTICLASS, BINARY, CLASSIFICATION]:
+        if problem_type in [MULTICLASS, MULTILABEL, BINARY, CLASSIFICATION]:
             column_types[col_name] = CATEGORICAL
         elif problem_type == REGRESSION:
             column_types[col_name] = NUMERICAL
@@ -738,7 +739,7 @@ def infer_problem_type(
 
 
 def infer_output_shape(
-    label_column: str,
+    label_column: Union[str, List[str]],
     problem_type: str,
     data: pd.DataFrame,
 ) -> int:
@@ -746,11 +747,13 @@ def infer_output_shape(
     Infer the output shape based on the label column type, training data, and problem type.
     Binary classification should have class number 2, while multi-class classification's class
     number should be larger than 2. For regression, the output is restricted to 1 scalar.
+    For multilabel classification, the output shape is the number of unique labels across all columns.
 
     Parameters
     ----------
     label_column
-        The label column in a multimodal pd.DataFrame.
+        The label column(s) in a multimodal pd.DataFrame. Can be a string for single label
+        or a list of strings for multilabel classification.
     data
         The multimodal pd.DataFrame for training.
     problem_type
@@ -766,7 +769,23 @@ def infer_output_shape(
     if label_column is None:
         return None
 
-    if problem_type in [BINARY, MULTICLASS, REGRESSION, CLASSIFICATION]:
+    if problem_type == MULTILABEL:
+        if not isinstance(label_column, list):
+            raise ValueError("For multilabel classification, label_column must be a list of column names")
+
+        # For multilabel, count unique labels across all label columns
+        all_unique_labels = set()
+        for col in label_column:
+            unique_vals = data[col].dropna().unique()
+            # Convert to string to handle different data types consistently
+            all_unique_labels.update([f"{col}_{val}" for val in unique_vals if val != 0])
+
+        return len(all_unique_labels)
+
+    elif problem_type in [BINARY, MULTICLASS, REGRESSION, CLASSIFICATION]:
+        if isinstance(label_column, list):
+            raise ValueError(f"Problem type '{problem_type}' expects a single label column, but got a list")
+
         class_num = len(data[label_column].unique())
         err_msg = (
             f"Problem type is '{problem_type}' while the number of "
@@ -792,7 +811,7 @@ def infer_output_shape(
         raise ValueError(
             f"Problem type '{problem_type}' doesn't have a valid output shape "
             f"for training. The supported problem types are"
-            f" '{BINARY}', '{MULTICLASS}', '{REGRESSION}',"
+            f" '{BINARY}', '{MULTICLASS}', '{MULTILABEL}', '{REGRESSION}',"
             f" '{CLASSIFICATION}', '{NER}',"
             f" '{OBJECT_DETECTION}', "
             f" '{SEMANTIC_SEGMENTATION}"

--- a/multimodal/src/autogluon/multimodal/data/utils.py
+++ b/multimodal/src/autogluon/multimodal/data/utils.py
@@ -22,6 +22,7 @@ from ..constants import (
     MMDET_IMAGE,
     MMLAB_MODELS,
     MULTICLASS,
+    MULTILABEL,
     NER_ANNOTATION,
     NER_TEXT,
     NUMERICAL,
@@ -246,7 +247,7 @@ def default_holdout_frac(num_train_rows, hyperparameter_tune=False):
 def init_df_preprocessor(
     config: DictConfig,
     column_types: Dict,
-    label_column: Optional[str] = None,
+    label_column: Optional[Union[str, List[str]]] = None,
     train_df_x: Optional[pd.DataFrame] = None,
     train_df_y: Optional[pd.Series] = None,
 ):
@@ -273,7 +274,7 @@ def init_df_preprocessor(
     -------
     Initialized dataframe preprocessor.
     """
-    if label_column in column_types and column_types[label_column] == NER_ANNOTATION:
+    if isinstance(label_column, str) and label_column in column_types and column_types[label_column] == NER_ANNOTATION:
         label_generator = NerLabelEncoder(config)
     else:
         label_generator = None

--- a/multimodal/src/autogluon/multimodal/learners/ensemble.py
+++ b/multimodal/src/autogluon/multimodal/learners/ensemble.py
@@ -16,7 +16,7 @@ from autogluon.core.metrics import Scorer
 from autogluon.core.models.greedy_ensemble.ensemble_selection import EnsembleSelection
 
 from .. import version as ag_version
-from ..constants import BINARY, LOGITS, MULTICLASS, REGRESSION, TEST, VAL, Y_PRED, Y_TRUE
+from ..constants import BINARY, LOGITS, MULTICLASS, MULTILABEL, REGRESSION, TEST, VAL, Y_PRED, Y_TRUE
 from ..optim import compute_score
 from ..utils import (
     extract_from_output,
@@ -181,8 +181,8 @@ class EnsembleLearner(BaseLearner):
 
                 if self._problem_type == REGRESSION:
                     y_pred = per_learner._df_preprocessor.transform_prediction(y_pred=y_pred)
-                if self._problem_type in [BINARY, MULTICLASS]:
-                    y_pred = logits_to_prob(y_pred)
+                if self._problem_type in [BINARY, MULTICLASS, MULTILABEL]:
+                    y_pred = logits_to_prob(y_pred, problem_type=self._problem_type)
                     if self._problem_type == BINARY:
                         y_pred = y_pred[:, 1]
 
@@ -553,7 +553,7 @@ class EnsembleLearner(BaseLearner):
         )
         pred = self._weighted_ensemble.predict_proba(predictions)
         # for regression, the transform_prediction() is already called in predict_all()
-        if self._problem_type in [BINARY, MULTICLASS]:
+        if self._problem_type in [BINARY, MULTICLASS, MULTILABEL]:
             pred = self._df_preprocessor.transform_prediction(
                 y_pred=pred,
                 inverse_categorical=True,

--- a/multimodal/src/autogluon/multimodal/learners/few_shot_svm.py
+++ b/multimodal/src/autogluon/multimodal/learners/few_shot_svm.py
@@ -460,7 +460,7 @@ class FewShotSVMLearner(BaseLearner):
         self.on_predict_start()
         features = self.extract_embedding(data, realtime=realtime)
         logits = self._svm.decision_function(features)
-        prob = logits_to_prob(logits)
+        prob = logits_to_prob(logits, problem_type=self._problem_type)
         if (as_pandas is None and isinstance(data, pd.DataFrame)) or as_pandas is True:
             prob = self._as_pandas(data=data, to_be_converted=prob)
         return prob

--- a/multimodal/src/autogluon/multimodal/optim/losses/utils.py
+++ b/multimodal/src/autogluon/multimodal/optim/losses/utils.py
@@ -14,6 +14,7 @@ from ...constants import (
     FEW_SHOT_CLASSIFICATION,
     MULTI_NEGATIVES_SOFTMAX_LOSS,
     MULTICLASS,
+    MULTILABEL,
     NER,
     OBJECT_DETECTION,
     PAIR_MARGIN_MINER,
@@ -68,6 +69,10 @@ def get_loss_func(
             else:
                 loss_func = nn.CrossEntropyLoss(label_smoothing=config.label_smoothing)
                 logger.debug(f"loss_func.label_smoothing: {loss_func.label_smoothing}")
+    elif problem_type == MULTILABEL:
+        # Use BCEWithLogitsLoss for multilabel classification
+        loss_func = nn.BCEWithLogitsLoss()
+        logger.debug("Using BCEWithLogitsLoss for multilabel classification")
     elif problem_type == REGRESSION:
         if loss_func_name is not None:
             if "bcewithlogitsloss" in loss_func_name.lower():

--- a/multimodal/src/autogluon/multimodal/optim/metrics/utils.py
+++ b/multimodal/src/autogluon/multimodal/optim/metrics/utils.py
@@ -36,6 +36,7 @@ from ...constants import (
     METRIC_MODE_MAP,
     MIN,
     MULTICLASS,
+    MULTILABEL,
     NER_TOKEN_F1,
     OVERALL_ACCURACY,
     OVERALL_F1,
@@ -271,6 +272,7 @@ def get_torchmetric(
     num_classes: Optional[int] = None,
     is_matching: Optional[bool] = False,
     problem_type: Optional[str] = None,
+    #num_labels: Optional[int] = None,
 ):
     """
     Obtain a torchmerics.Metric from its name.
@@ -285,7 +287,9 @@ def get_torchmetric(
     is_matching
         Whether is matching.
     problem_type
-        Type of problem, e.g., binary and multiclass.
+        Type of problem, e.g., binary, multilabel, multiclass, ....
+    #num_labels
+    #    Number of distinct labels. Only applicable when problem_type == MULTILABEL
 
     Returns
     -------
@@ -296,8 +300,13 @@ def get_torchmetric(
     """
     metric_name = metric_name.lower()
     if metric_name in [ACC, ACCURACY, OVERALL_ACCURACY]:
-        # use MULTICLASS since the head output dim is 2 for the binary problem type.
-        return torchmetrics.Accuracy(task=MULTICLASS, num_classes=num_classes), None
+        if problem_type != MULTILABEL:
+            # use MULTICLASS since the head output dim is 2 for the binary problem type.
+            return torchmetrics.Accuracy(task=MULTICLASS, num_classes=num_classes), None
+        else:
+            # we are overloading meaning of num_classes to also function as num_labels here...
+            return torchmetrics.Accuracy(task=MULTILABEL, num_labels=num_classes), None
+
     elif metric_name == NER_TOKEN_F1:
         return torchmetrics.F1Score(task=MULTICLASS, num_classes=num_classes, ignore_index=1), None
     elif metric_name in [RMSE, ROOT_MEAN_SQUARED_ERROR]:

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -49,7 +49,7 @@ class MultiModalPredictor:
 
     def __init__(
         self,
-        label: Optional[str] = None,
+        label: Optional[Union[str, List[str]]] = None,
         problem_type: Optional[str] = None,
         query: Optional[Union[str, List[str]]] = None,
         response: Optional[Union[str, List[str]]] = None,
@@ -75,11 +75,13 @@ class MultiModalPredictor:
         ----------
         label
             Name of one pd.DataFrame column that contains the target variable to predict.
+            For multilabel classification, this can be a list of column names containing the labels.
         problem_type
             Type of problem. We support standard problems like
 
             - 'binary': Binary classification
             - 'multiclass': Multi-class classification
+            - 'multilabel': Multi-label classification
             - 'regression': Regression
             - 'classification': Classification problems include 'binary' and 'multiclass' classification.
 
@@ -254,6 +256,7 @@ class MultiModalPredictor:
     def label(self):
         """
         Name of one pd.DataFrame column that contains the target variable to predict.
+        For multilabel classification, this returns a list of column names containing the labels.
         """
         return self._learner.label
 

--- a/multimodal/src/autogluon/multimodal/utils/misc.py
+++ b/multimodal/src/autogluon/multimodal/utils/misc.py
@@ -9,10 +9,12 @@ import pandas as pd
 import torch
 from scipy.special import expit, softmax
 
+from ..constants import MULTILABEL
+
 logger = logging.getLogger(__name__)
 
 
-def logits_to_prob(logits: np.ndarray):
+def logits_to_prob(logits: np.ndarray, problem_type: str = None):
     """
     Convert logits to probabilities.
 
@@ -20,6 +22,10 @@ def logits_to_prob(logits: np.ndarray):
     ----------
     logits
         The logits output of a classification head.
+    problem_type
+        The type of problem. For multilabel classification, sigmoid is applied
+        to each label independently. For multiclass, softmax is applied across classes.
+        If None, uses legacy behavior based on logits dimensions.
 
     Returns
     -------
@@ -28,7 +34,12 @@ def logits_to_prob(logits: np.ndarray):
     if logits.ndim == 1:
         return expit(logits)
     elif logits.ndim == 2:
-        return softmax(logits, axis=1)
+        # For multilabel classification, apply sigmoid to each label independently
+        if problem_type == MULTILABEL:
+            return expit(logits)
+        else:
+            # For multiclass classification, apply softmax across classes
+            return softmax(logits, axis=1)
     else:
         raise ValueError(f"Unsupported logit dim: {logits.ndim}.")
 

--- a/multimodal/src/autogluon/multimodal/utils/presets.py
+++ b/multimodal/src/autogluon/multimodal/utils/presets.py
@@ -12,6 +12,7 @@ from ..constants import (
     MEDIUM_QUALITY,
     MODEL,
     MULTICLASS,
+    MULTILABEL,
     OPTIM,
     REGRESSION,
 )
@@ -1004,6 +1005,7 @@ def get_presets(problem_type: str, presets: str):
     if problem_type in [
         BINARY,
         MULTICLASS,
+        MULTILABEL,
         REGRESSION,
         None,
     ]:

--- a/multimodal/src/autogluon/multimodal/utils/problem_types.py
+++ b/multimodal/src/autogluon/multimodal/utils/problem_types.py
@@ -20,6 +20,7 @@ from ..constants import (
     IOU,
     MAP,
     MULTICLASS,
+    MULTILABEL,
     NAMED_ENTITY_RECOGNITION,
     NER,
     NER_ANNOTATION,
@@ -148,6 +149,20 @@ PROBLEM_TYPES_REG.register(
     MULTICLASS,
     ProblemTypeProperty(
         name=MULTICLASS,
+        supported_modality_type={IMAGE, IMAGE_BYTEARRAY, IMAGE_BASE64_STR, TEXT, CATEGORICAL, NUMERICAL},
+        supported_label_type={CATEGORICAL},
+        is_classification=True,
+        _support_eval=True,
+        _fallback_evaluation_metric=ACCURACY,
+        _fallback_validation_metric=ACCURACY,
+    ),
+)
+
+# Multilabel classification: Arbitrary combination of image, text, tabular data --> multiple categorical values
+PROBLEM_TYPES_REG.register(
+    MULTILABEL,
+    ProblemTypeProperty(
+        name=MULTILABEL,
         supported_modality_type={IMAGE, IMAGE_BYTEARRAY, IMAGE_BASE64_STR, TEXT, CATEGORICAL, NUMERICAL},
         supported_label_type={CATEGORICAL},
         is_classification=True,


### PR DESCRIPTION
… for handling ignore label values with custom BCE loss function, but further updates required.

*Issue #, if available:*

*Description of changes:*
* Overloads `label` input to be either string column name (current behavior) or list of string column names (new multilabel behavior)
* Adds `MULTILABEL` problem type currently with just `accuracy` metrics. Modifies backend lightning module to use torchmetrics `Accuracy(task = 'multilabel', ...)` metric when problem type is multilabel
* Validation check to require only two distinct values in each column
* Add `ignore_label_value` to default config, to be fully supported in future update
* Add custom BCE loss to multimodal/src/autogluon/multimodal/optim/losses/bce_loss.py to handle ignore labels, to be fully supported in future update

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
