### PR TITLE
[Tabular][Maint] Allow fit helper to use large test datasets 

### DIFF
--- a/tabular/src/autogluon/tabular/testing/fit_helper.py
+++ b/tabular/src/autogluon/tabular/testing/fit_helper.py
@@ -389,6 +389,7 @@ class FitHelper:
         raise_on_model_failure: bool = True,
         problem_types: list[str] | None = None,
         verify_model_seed: bool = True,
+        use_larger_toy_datasets: bool = False,
         **kwargs,
     ):
         """
@@ -450,12 +451,20 @@ class FitHelper:
                         f"\nEither remove the unknown problem_type from `model_cls.supported_problem_types` or set `require_known_problem_types=False`"
                     )
 
-        problem_type_dataset_map = {
-            "binary": ["toy_binary"],
-            "multiclass": ["toy_multiclass"],
-            "regression": ["toy_regression"],
-            "quantile": ["toy_quantile", "toy_quantile_single_level"],
-        }
+        if use_larger_toy_datasets:
+            problem_type_dataset_map = {
+                "binary": ["toy_binary_10"],
+                "multiclass": ["toy_multiclass_10"],
+                "regression": ["toy_regression_10"],
+                "quantile": ["toy_quantile_10"],
+            }
+        else:
+            problem_type_dataset_map = {
+                "binary": ["toy_binary"],
+                "multiclass": ["toy_multiclass"],
+                "regression": ["toy_regression"],
+                "quantile": ["toy_quantile", "toy_quantile_single_level"],
+            }
 
         problem_types_refit_full = []
         if refit_full:


### PR DESCRIPTION
For some models, we have to create several internal splits, which does not work with using just 4 samples from the default toy tasks. This add a toggle to the fit helper to run on the large toy datasets. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
