### PR TITLE
[Tabular] Optimize memory usage in RealTabPFNv2.5 preprocessing

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
@@ -60,7 +60,7 @@ class TabPFNModel(AbstractTorchModel):
 
         # This converts categorical features to numeric via stateful label encoding.
         if self._feature_generator.features_in:
-            X = X.copy()
+            X = X.copy(deep=False)
             X[self._feature_generator.features_in] = self._feature_generator.transform(X=X)
 
             if is_train:


### PR DESCRIPTION
*Description of changes:*
TabPFNModel._preprocess (used by RealTabPFNv2.5) was performing a deep copy of the entire input DataFrame X to safely transform categorical features. For datasets with many numerical features, this unnecessarily duplicated large amounts of data.

Solution: Switched to X = X.copy(deep=False). This allows feature_generator.transform to assign new transformed columns to the DataFrame without duplicating the potentially large numerical columns that remain unchanged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
