### PR TITLE
[tabular] add support for scikit-learn 1.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.5
+    rev: v0.15.4
     hooks:
       # Run the formatter.
       - id: ruff-format

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -20,7 +20,7 @@ DEPENDENT_PACKAGES = {
     "numpy": ">=1.25.0,<2.4.0",  # "<{N+3}" upper cap, where N is the latest released minor version, assuming no warnings using N
     "pandas": ">=2.0.0,<2.4.0",  # "<{N+3}" upper cap
     "pyarrow": ">=7.0.0,<21.0.0",  # "<{N=1}.0.0" upper cap
-    "scikit-learn": ">=1.4.0,<1.8.0",  # <{N+1} upper cap
+    "scikit-learn": ">=1.4.0,<1.9.0",  # <{N+1} upper cap
     "scipy": ">=1.5.4,<1.17",  # "<{N+2}" upper cap
     "matplotlib": ">=3.7.0,<3.11",  # "<{N+2}" upper cap
     "psutil": ">=5.7.3,<7.2.0",  # Major version cap

--- a/core/src/autogluon/core/metrics/classification_metrics.py
+++ b/core/src/autogluon/core/metrics/classification_metrics.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 def balanced_accuracy(solution, prediction):
-    y_type, solution, prediction = _check_targets(solution, prediction)
+    y_type, solution, prediction = _check_targets(solution, prediction)[:3]
 
     if y_type not in ["binary", "multiclass", "multilabel-indicator"]:
         raise ValueError(f"{y_type} is not supported")
@@ -283,7 +283,7 @@ def confusion_matrix(solution, prediction, labels=None, weights=None, normalize=
         output_format - output format of the matrix. Can take values {'python_list', 'numpy_array', 'pandas_dataframe'}
     TODO : Add dedicated confusion_matrix function to AbstractLearner
     """
-    y_type, solution, prediction = _check_targets(solution, prediction)
+    y_type, solution, prediction = _check_targets(solution, prediction)[:3]
     # Only binary and multiclass data is supported
     if y_type not in ("binary", "multiclass"):
         raise ValueError(f"{y_type} dataset is not currently supported")

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -87,7 +87,7 @@ extras_require = {
         f"{ag.PACKAGE_NAME}.core[all]=={version}",
     ],
     "skex": [
-        "scikit-learn-intelex>=2025.0,<2025.10",  # <{N+1} upper cap, where N is the latest released minor version
+        "scikit-learn-intelex>=2025.0,<2026.0",  # <{N+1} upper cap, where N is the latest released minor version
     ],
     "imodels": [
         "imodels>=1.3.10,<2.1.0",  # 1.3.8/1.3.9 either remove/renamed attribute `complexity_` causing failures. https://github.com/csinva/imodels/issues/147
@@ -95,7 +95,7 @@ extras_require = {
 }
 
 extras_require["skl2onnx"] = [
-    "skl2onnx>=1.15.0,<1.20.0",
+    "skl2onnx>=1.15.0,<1.21.0",
     # Sync ONNX requirements with multimodal/setup.py
     "onnx>=1.13.0,!=1.16.2,<1.21.0;platform_system=='Windows'",  # exclude 1.16.2 for issue https://github.com/onnx/onnx/issues/6267
     "onnx>=1.13.0,<1.21.0;platform_system!='Windows'",

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -51,6 +51,7 @@ from autogluon.core.constants import (
     PSEUDO_MODEL_SUFFIX,
     QUANTILE,
     REGRESSION,
+    SOFTCLASS,
 )
 from autogluon.core.data.label_cleaner import LabelCleanerMulticlassToBinary
 from autogluon.core.metrics import Scorer, get_metric
@@ -1113,9 +1114,9 @@ class TabularPredictor:
 
         if verbosity >= 2:
             if verbosity == 2:
-                logger.log(20, "Verbosity: 2 (Standard Logging)")
+                logger.log(20, f"Verbosity: 2 (Standard Logging)")
             elif verbosity == 3:
-                logger.log(20, "Verbosity: 3 (Detailed Logging)")
+                logger.log(20, f"Verbosity: 3 (Detailed Logging)")
             elif verbosity >= 4:
                 logger.log(20, f"Verbosity: {verbosity} (Maximum Logging)")
 
@@ -1197,9 +1198,9 @@ class TabularPredictor:
         # TODO: Temporary for v1.4. Make this more extensible for v1.5 by letting users make their own dynamic hyperparameters.
         dynamic_hyperparameters = kwargs["_experimental_dynamic_hyperparameters"]
         if dynamic_hyperparameters:
-            logger.log(20, "`extreme_v140` preset uses a dynamic portfolio based on dataset size...")
+            logger.log(20, f"`extreme_v140` preset uses a dynamic portfolio based on dataset size...")
             assert hyperparameters is None, (
-                "hyperparameters must be unspecified when `_experimental_dynamic_hyperparameters=True`."
+                f"hyperparameters must be unspecified when `_experimental_dynamic_hyperparameters=True`."
             )
             n_samples = len(train_data)
             if n_samples > 30000:
@@ -1210,7 +1211,7 @@ class TabularPredictor:
             if data_size == "large":
                 logger.log(
                     20,
-                    "\tDetected data size: large (>30000 samples), using `zeroshot` portfolio (identical to 'best_quality' preset).",
+                    f"\tDetected data size: large (>30000 samples), using `zeroshot` portfolio (identical to 'best_quality' preset).",
                 )
                 hyperparameters = "zeroshot"
             else:
@@ -1220,15 +1221,15 @@ class TabularPredictor:
                     kwargs["num_stack_levels"] = 0
                 logger.log(
                     20,
-                    "\tDetected data size: small (<=30000 samples), using `zeroshot_2025_tabfm` portfolio."
-                    "\n\t\tNote: `zeroshot_2025_tabfm` portfolio requires a CUDA compatible GPU for best performance."
-                    "\n\t\tMake sure you have all the relevant dependencies installed: "
-                    "`pip install autogluon.tabular[tabarena]`."
-                    "\n\t\tIt is strongly recommended to use a machine with 64+ GB memory "
-                    "and a CUDA compatible GPU with 32+ GB vRAM when using this preset. "
-                    "\n\t\tThis portfolio will download foundation model weights from HuggingFace during training. "
-                    "Ensure you have an internet connection or have pre-downloaded the weights to use these models."
-                    "\n\t\tThis portfolio was meta-learned with TabArena: https://tabarena.ai",
+                    f"\tDetected data size: small (<=30000 samples), using `zeroshot_2025_tabfm` portfolio."
+                    f"\n\t\tNote: `zeroshot_2025_tabfm` portfolio requires a CUDA compatible GPU for best performance."
+                    f"\n\t\tMake sure you have all the relevant dependencies installed: "
+                    f"`pip install autogluon.tabular[tabarena]`."
+                    f"\n\t\tIt is strongly recommended to use a machine with 64+ GB memory "
+                    f"and a CUDA compatible GPU with 32+ GB vRAM when using this preset. "
+                    f"\n\t\tThis portfolio will download foundation model weights from HuggingFace during training. "
+                    f"Ensure you have an internet connection or have pre-downloaded the weights to use these models."
+                    f"\n\t\tThis portfolio was meta-learned with TabArena: https://tabarena.ai",
                 )
                 hyperparameters = "zeroshot_2025_tabfm"
 
@@ -1335,7 +1336,7 @@ class TabularPredictor:
             if use_bag_holdout and not kwargs["save_bag_folds"]:
                 logger.log(
                     30,
-                    "WARNING: Attempted to disable saving of bagged fold models when `use_bag_holdout=True`. Forcing `save_bag_folds=True` to avoid errors.",
+                    f"WARNING: Attempted to disable saving of bagged fold models when `use_bag_holdout=True`. Forcing `save_bag_folds=True` to avoid errors.",
                 )
             else:
                 if num_bag_folds > 0 and not kwargs["save_bag_folds"]:
@@ -1359,7 +1360,7 @@ class TabularPredictor:
                 )
                 logger.log(
                     20,
-                    "\tConsider setting `time_limit` to ensure training finishes within an expected duration or experiment with a small portion of `train_data` to identify an ideal `presets` and `hyperparameters` configuration.",
+                    f"\tConsider setting `time_limit` to ensure training finishes within an expected duration or experiment with a small portion of `train_data` to identify an ideal `presets` and `hyperparameters` configuration.",
                 )
 
         core_kwargs = {
@@ -1492,7 +1493,7 @@ class TabularPredictor:
                 f"\tRunning DyStack for up to {time_limit}s of the {time_limit_og}s of remaining time ({detection_time_frac * 100:.0f}%)."
             )
         else:
-            logger.info("\tWarning: No time limit provided for DyStack. This could take awhile.")
+            logger.info(f"\tWarning: No time limit provided for DyStack. This could take awhile.")
             time_limit = None
 
         # -- Avoid copying data
@@ -1577,7 +1578,7 @@ class TabularPredictor:
                     )  # if we are faster, give more time to rest of the folds.
                     if sub_fit_time <= 0:
                         logger.info(
-                            "\tStop cross-validation during dynamic stacking early as no more time left. Consider specifying a larger time_limit."
+                            f"\tStop cross-validation during dynamic stacking early as no more time left. Consider specifying a larger time_limit."
                         )
                         break
                 ds_fit_kwargs.update(
@@ -1607,7 +1608,7 @@ class TabularPredictor:
         if clean_up_fits:
             try:
                 shutil.rmtree(path=ds_fit_context)
-            except FileNotFoundError:
+            except FileNotFoundError as e:
                 pass
 
         # -- Determine rest time and new num_stack_levels
@@ -1666,9 +1667,9 @@ class TabularPredictor:
                 if num_gpus > 0:
                     logger.log(
                         30,
-                        "DyStack: Disabling memory safe fit mode in DyStack "
-                        "because GPUs were detected and num_gpus='auto' (GPUs cannot be used in memory safe fit mode). "
-                        "If you want to use memory safe fit mode, manually set `num_gpus=0`.",
+                        f"DyStack: Disabling memory safe fit mode in DyStack "
+                        f"because GPUs were detected and num_gpus='auto' (GPUs cannot be used in memory safe fit mode). "
+                        f"If you want to use memory safe fit mode, manually set `num_gpus=0`.",
                     )
             if num_gpus > 0:
                 memory_safe_fits = False
@@ -1681,13 +1682,13 @@ class TabularPredictor:
                 if not _ds_ray.is_initialized():
                     if enable_ray_logging:
                         logger.info(
-                            "\tRunning DyStack sub-fit in a ray process to avoid memory leakage. "
+                            f"\tRunning DyStack sub-fit in a ray process to avoid memory leakage. "
                             "Enabling ray logging (enable_ray_logging=True). Specify `ds_args={'enable_ray_logging': False}` if you experience logging issues."
                         )
                         _ds_ray.init()
                     else:
                         logger.info(
-                            "\tRunning DyStack sub-fit in a ray process to avoid memory leakage. "
+                            f"\tRunning DyStack sub-fit in a ray process to avoid memory leakage. "
                             "Logs will not be shown until this process is complete (enable_ray_logging=False). "
                             "You can experimentally enable logging by specifying `ds_args={'enable_ray_logging': True}`."
                         )
@@ -1706,7 +1707,7 @@ class TabularPredictor:
                 # Subtract time taken to initialize ray
                 time_limit -= time.time() - time_start
                 if time_limit <= 0:
-                    logger.log(30, "Warning: Not enough time to fit DyStack! Skipping...")
+                    logger.log(30, f"Warning: Not enough time to fit DyStack! Skipping...")
                     return False
 
             if holdout_data is None:
@@ -1922,8 +1923,8 @@ class TabularPredictor:
                 calibrate_decision_threshold = False
                 logger.log(
                     30,
-                    "Disabling decision threshold calibration for metric `precision` to avoid undefined results. "
-                    "Force calibration via specifying `calibrate_decision_threshold=True`.",
+                    f"Disabling decision threshold calibration for metric `precision` to avoid undefined results. "
+                    f"Force calibration via specifying `calibrate_decision_threshold=True`.",
                 )
             elif calibrate_decision_threshold and self.eval_metric.name == "accuracy":
                 num_rows_val_for_calibration = self._trainer.num_rows_val_for_calibration
@@ -1953,7 +1954,7 @@ class TabularPredictor:
             if calibrate_decision_threshold:
                 logger.log(
                     20,
-                    "Enabling decision threshold calibration (calibrate_decision_threshold='auto', metric is valid, problem_type is 'binary')",
+                    f"Enabling decision threshold calibration (calibrate_decision_threshold='auto', metric is valid, problem_type is 'binary')",
                 )
         if calibrate_decision_threshold:
             if self.problem_type != BINARY:
@@ -2307,7 +2308,7 @@ class TabularPredictor:
 
         for i in range(max_iter):
             if len(X_test) == 0:
-                logger.log(20, "No more unlabeled data to pseudolabel. Done with pseudolabeling...")
+                logger.log(20, f"No more unlabeled data to pseudolabel. Done with pseudolabeling...")
                 break
 
             iter_print = str(i + 1)
@@ -2488,7 +2489,7 @@ class TabularPredictor:
                     " Autogluon is not fit and 'train_data' was not given"
                 )
 
-            logger.log(20, "Predictor not fit prior to pseudolabeling. Fitting now...")
+            logger.log(20, f"Predictor not fit prior to pseudolabeling. Fitting now...")
             self.fit(**kwargs)
 
         if self.problem_type is MULTICLASS and self.eval_metric.name != "accuracy":
@@ -3944,8 +3945,8 @@ class TabularPredictor:
         self._validate_fit_strategy(fit_strategy=fit_strategy)
 
         if train_data_extra is not None:
-            assert kwargs.get("X_pseudo", None) is None, "Cannot pass both train_data_extra and X_pseudo arguments"
-            assert kwargs.get("y_pseudo", None) is None, "Cannot pass both train_data_extra and y_pseudo arguments"
+            assert kwargs.get("X_pseudo", None) is None, f"Cannot pass both train_data_extra and X_pseudo arguments"
+            assert kwargs.get("y_pseudo", None) is None, f"Cannot pass both train_data_extra and y_pseudo arguments"
             X_pseudo, y_pseudo, _ = self._sanitize_pseudo_data(pseudo_data=train_data_extra, name="train_data_extra")
             kwargs["X_pseudo"] = X_pseudo
             kwargs["y_pseudo"] = y_pseudo
@@ -4931,8 +4932,8 @@ class TabularPredictor:
         """
         self._assert_is_fit("plot_ensemble_model")
         try:
-            import pygraphviz  # noqa: F401
-        except ImportError:
+            import pygraphviz
+        except:
             raise ImportError(
                 "Visualizing ensemble network architecture requires the `pygraphviz` library. "
                 "Try `sudo apt-get install graphviz graphviz-dev` followed by `pip install pygraphviz` to install on Linux, "
@@ -5949,8 +5950,8 @@ class TabularPredictor:
             predictor_clone.set_model_best(model=model, save_trainer=True)
         logger.log(
             30,
-            "Clone: Removing artifacts unnecessary for prediction. "
-            "NOTE: Clone can no longer fit new models, and most functionality except for predict and predict_proba will no longer work",
+            f"Clone: Removing artifacts unnecessary for prediction. "
+            f"NOTE: Clone can no longer fit new models, and most functionality except for predict and predict_proba will no longer work",
         )
         predictor_clone.save_space()
         return predictor_clone if return_clone else predictor_clone.path
@@ -6119,26 +6120,6 @@ class TabularPredictor:
             raise AssertionError(error_message)
 
 
-def _safe_rmtree(path: str, retries: int = 5, delay: float = 0.5):
-    """
-    shutil.rmtree with retry for Windows.
-    On Windows, files opened by subprocesses (e.g. Ray) might be
-    temporarily locked, causing PermissionError [WinError 32].
-    """
-    import sys
-    import time
-
-    for attempt in range(retries):
-        try:
-            shutil.rmtree(path)
-            return
-        except PermissionError:
-            if sys.platform == "win32" and attempt < retries - 1:
-                time.sleep(delay)
-            else:
-                raise
-
-
 def _dystack(
     predictor: TabularPredictor,
     train_data: Union[str, pd.DataFrame],
@@ -6180,7 +6161,7 @@ def _dystack(
     clean_up_fits = ds_fit_kwargs.get("clean_up_fits")
 
     predictor._learner.set_contexts(path_context=ds_fit_context)
-    logger.log(20, "Running DyStack sub-fit ...")
+    logger.log(20, f"Running DyStack sub-fit ...")
     try:
         predictor._fit(ag_fit_kwargs=ag_fit_kwargs, ag_post_fit_kwargs=ag_post_fit_kwargs)
     except Exception as e:
@@ -6188,7 +6169,7 @@ def _dystack(
 
     if not predictor.model_names():
         logger.log(
-            20, "Unable to determine stacked overfitting. AutoGluon's sub-fit did not successfully train any models!"
+            20, f"Unable to determine stacked overfitting. AutoGluon's sub-fit did not successfully train any models!"
         )
         stacked_overfitting = False
         ho_leaderboard = None
@@ -6205,7 +6186,7 @@ def _dystack(
 
     if clean_up_fits:
         logger.log(20, f"Deleting DyStack predictor artifacts (clean_up_fits={clean_up_fits}) ...")
-        _safe_rmtree(path=ds_fit_context)
+        shutil.rmtree(path=ds_fit_context)
     else:
         predictor._sub_fits.append(ds_fit_context)
 


### PR DESCRIPTION
Upgrade scikit-learn dependency to allow version 1.8.x (<1.9.0). Also update skl2onnx and scikit-learn-intelex versions in tabular setup to maintain compatibility.

Closes #5478


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
