### PR TITLE
[CI] Pin wheel version <0.46 for autogluon-bench compatibility

### DIFF
--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -17,6 +17,8 @@ function setup_build_contrib_env {
 }
 
 function setup_benchmark_env {
+    # Temporary workaround for autogluon-bench compatibility issues with newer wheel versions.
+    # TODO: This should be fixed in autogluon-bench to support newer wheel versions. @innixma please review.
     python -m pip install "wheel<0.46"
     git clone https://github.com/autogluon/autogluon-bench.git
     cd autogluon-bench

--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -17,6 +17,7 @@ function setup_build_contrib_env {
 }
 
 function setup_benchmark_env {
+    python -m pip install "wheel<0.46"
     git clone https://github.com/autogluon/autogluon-bench.git
     cd autogluon-bench
     pip install -e ".[tests]"


### PR DESCRIPTION
## Description
This PR explicitly pins the `wheel` package version to `<0.46` in the benchmark environment setup script ([.github/workflow_scripts/env_setup.sh](cci:7://file:///c:/Users/celes/autogluon/.github/workflow_scripts/env_setup.sh:0:0-0:0)) as a temporary workaround.
### Problem
The `autogluon-bench` package has a strict dependency on `wheel<0.46,>0.38.0`. The current CI environment installs a newer version (e.g., `wheel==0.46.3`), causing a dependency conflict and breaking the installation of benchmark tools.
### Solution
We are pinning `wheel<0.46` in [setup_benchmark_env](cci:1://file:///c:/Users/celes/autogluon/.github/workflow_scripts/env_setup.sh:18:0-31:1) before installing `autogluon-bench`.
> **Note:** This is a temporary fix. The definitive solution requires updating `autogluon-bench` to support newer `wheel` versions.
>
> cc: @innixma - Please review this workaround and consider updating the dependency constraints in the `autogluon-bench` repository when possible.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
