### PR TITLE
[timeseries] Improve model-zoo hyperparameter typing

### DIFF
--- a/timeseries/src/autogluon/timeseries/__init__.py
+++ b/timeseries/src/autogluon/timeseries/__init__.py
@@ -7,8 +7,9 @@ except ImportError:
 
 from .dataset import TimeSeriesDataFrame
 from .predictor import TimeSeriesPredictor
+from .types import TimeSeriesHyperparameters
 
 _add_stream_handler()
 
 
-__all__ = ["TimeSeriesDataFrame", "TimeSeriesPredictor"]
+__all__ = ["TimeSeriesDataFrame", "TimeSeriesHyperparameters", "TimeSeriesPredictor"]

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -26,7 +26,7 @@ from autogluon.timeseries.dataset import TimeSeriesDataFrame
 from autogluon.timeseries.learner import TimeSeriesLearner
 from autogluon.timeseries.metrics import TimeSeriesScorer, check_get_evaluation_metric
 from autogluon.timeseries.trainer import TimeSeriesTrainer
-from autogluon.timeseries.types.hyperparameters.hyperparameters import TimeSeriesHyperparameters
+from autogluon.timeseries.types import TimeSeriesHyperparameters
 from autogluon.timeseries.utils.forecast import make_future_data_frame
 
 logger = logging.getLogger("autogluon.timeseries")

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -26,6 +26,7 @@ from autogluon.timeseries.dataset import TimeSeriesDataFrame
 from autogluon.timeseries.learner import TimeSeriesLearner
 from autogluon.timeseries.metrics import TimeSeriesScorer, check_get_evaluation_metric
 from autogluon.timeseries.trainer import TimeSeriesTrainer
+from autogluon.timeseries.types.hyperparameters.hyperparameters import TimeSeriesHyperparameters
 from autogluon.timeseries.utils.forecast import make_future_data_frame
 
 logger = logging.getLogger("autogluon.timeseries")
@@ -410,8 +411,8 @@ class TimeSeriesPredictor:
         tuning_data: TimeSeriesDataFrame | pd.DataFrame | Path | str | None = None,
         time_limit: int | None = None,
         presets: str | None = None,
-        hyperparameters: str | dict[str | Type, Any] | None = None,
-        hyperparameter_tune_kwargs: str | dict | None = None,
+        hyperparameters: str | dict[str | Type, Any] | TimeSeriesHyperparameters | None = None,
+        hyperparameter_tune_kwargs: Literal["auto", "random"] | dict | None = None,
         excluded_model_types: list[str] | None = None,
         ensemble_hyperparameters: dict[str, Any] | list[dict[str, Any]] | None = None,
         num_val_windows: int | tuple[int, ...] | Literal["auto"] = 1,

--- a/timeseries/src/autogluon/timeseries/types/__init__.py
+++ b/timeseries/src/autogluon/timeseries/types/__init__.py
@@ -1,0 +1,5 @@
+from .hyperparameters.hyperparameters import TimeSeriesHyperparameters
+
+__all__ = [
+    "TimeSeriesHyperparameters",
+]

--- a/timeseries/src/autogluon/timeseries/types/hyperparameters/__init__.py
+++ b/timeseries/src/autogluon/timeseries/types/hyperparameters/__init__.py
@@ -1,0 +1,5 @@
+from .hyperparameters import TimeSeriesHyperparameters
+
+__all__ = [
+    "TimeSeriesHyperparameters",
+]

--- a/timeseries/src/autogluon/timeseries/types/hyperparameters/_base.py
+++ b/timeseries/src/autogluon/timeseries/types/hyperparameters/_base.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from typing import TypeAlias
+
+from autogluon.common import space
+
+SearchableInt: TypeAlias = int | space.Int
+SearchableBool: TypeAlias = bool | space.Bool
+SearchableFloat: TypeAlias = float | space.Real

--- a/timeseries/src/autogluon/timeseries/types/hyperparameters/_base.py
+++ b/timeseries/src/autogluon/timeseries/types/hyperparameters/_base.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import TypeAlias
+from typing import TYPE_CHECKING, TypeAlias
 
-from autogluon.common import space
+if TYPE_CHECKING:
+    from autogluon.common import space
 
-SearchableInt: TypeAlias = int | space.Int
-SearchableBool: TypeAlias = bool | space.Bool
-SearchableFloat: TypeAlias = float | space.Real
+SearchableInt: TypeAlias = "int | space.Int"
+SearchableBool: TypeAlias = "bool | space.Bool"
+SearchableFloat: TypeAlias = "float | space.Real"

--- a/timeseries/src/autogluon/timeseries/types/hyperparameters/baseline_models.py
+++ b/timeseries/src/autogluon/timeseries/types/hyperparameters/baseline_models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .mixins import MaxTsLengthMixIn, NJobsMixIn, SeasonalPeriodMixIn
 
 

--- a/timeseries/src/autogluon/timeseries/types/hyperparameters/baseline_models.py
+++ b/timeseries/src/autogluon/timeseries/types/hyperparameters/baseline_models.py
@@ -1,0 +1,16 @@
+from .mixins import MaxTsLengthMixIn, NJobsMixIn, SeasonalPeriodMixIn
+
+
+class NaiveModel(NJobsMixIn, total=False): ...
+
+
+class SeasonalNaiveModel(NJobsMixIn, SeasonalPeriodMixIn, total=False): ...
+
+
+class AverageModel(NJobsMixIn, MaxTsLengthMixIn, total=False): ...
+
+
+class SeasonalAverageModel(NJobsMixIn, SeasonalPeriodMixIn, MaxTsLengthMixIn, total=False): ...
+
+
+class ZeroModel(NJobsMixIn, MaxTsLengthMixIn, total=False): ...

--- a/timeseries/src/autogluon/timeseries/types/hyperparameters/deep_models.py
+++ b/timeseries/src/autogluon/timeseries/types/hyperparameters/deep_models.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, List, Literal
+
+if TYPE_CHECKING:
+    from autogluon.common import space
+
+from ._base import SearchableBool, SearchableFloat, SearchableInt
+from .mixins import (
+    ContextLengthMixIn,
+    DeepLearningMixIn,
+    DistrOutputMixIn,
+    PredictBatchSizeMixIn,
+    TrainerMixIn,
+)
+
+
+class DeepARModel(
+    ContextLengthMixIn,
+    DistrOutputMixIn,
+    DeepLearningMixIn,
+    TrainerMixIn,
+    PredictBatchSizeMixIn,
+    total=False,
+):
+    disable_static_features: SearchableBool
+    disable_known_covariates: SearchableBool
+    num_layers: SearchableInt
+    hidden_size: SearchableInt
+    dropout_rate: SearchableFloat
+    embedding_dimension: SearchableInt
+    max_cat_cardinality: SearchableInt
+    scaling: SearchableBool
+
+
+class DLinearModel(
+    ContextLengthMixIn,
+    DistrOutputMixIn,
+    DeepLearningMixIn,
+    TrainerMixIn,
+    PredictBatchSizeMixIn,
+    total=False,
+):
+    hidden_dimension: SearchableInt
+    scaling: Literal["mean", "std", None] | space.Categorical
+    weight_decay: SearchableFloat
+
+
+class PatchTSTModel(ContextLengthMixIn, DistrOutputMixIn, DeepLearningMixIn, total=False):
+    patch_len: SearchableInt
+    stride: SearchableInt
+    d_model: SearchableInt
+    nhead: SearchableInt
+    num_encoder_layers: SearchableInt
+    scaling: Literal["mean", "std", None] | space.Categorical
+    weight_decay: SearchableFloat
+
+
+class SimpleFeedForwardModel(
+    ContextLengthMixIn,
+    DistrOutputMixIn,
+    DeepLearningMixIn,
+    TrainerMixIn,
+    PredictBatchSizeMixIn,
+    total=False,
+):
+    hidden_dimensions: List[SearchableInt]
+    batch_normalization: SearchableBool
+    mean_scaling: SearchableBool
+
+
+class TemporalFusionTransformerModel(
+    ContextLengthMixIn,
+    DistrOutputMixIn,
+    DeepLearningMixIn,
+    TrainerMixIn,
+    PredictBatchSizeMixIn,
+    total=False,
+):
+    disable_static_features: SearchableBool
+    disable_known_covariates: SearchableBool
+    disable_past_covariates: SearchableBool
+    hidden_dim: SearchableInt
+    variable_dim: SearchableInt
+    num_heads: SearchableInt
+    dropout_rate: SearchableFloat
+
+
+class TiDEModel(ContextLengthMixIn, DeepLearningMixIn, TrainerMixIn, PredictBatchSizeMixIn, total=False):
+    disable_static_features: SearchableBool
+    disable_known_covariates: SearchableBool
+    feat_proj_hidden_dim: SearchableInt
+    encoder_hidden_dim: SearchableInt
+    decoder_hidden_dim: SearchableInt
+    temporal_hidden_dim: SearchableInt
+    distr_hidden_dim: SearchableInt
+    num_layers_encoder: SearchableInt
+    num_layers_decoder: SearchableInt
+    decoder_output_dim: SearchableInt
+    dropout_rate: SearchableFloat
+    num_feat_dynamic_proj: SearchableInt
+    embedding_dimension: SearchableInt | List[SearchableInt]
+    layer_norm: SearchableBool
+    scaling: Literal["mean", "std", None] | space.Categorical
+
+
+class WaveNetModel(DeepLearningMixIn, TrainerMixIn, PredictBatchSizeMixIn, total=False):
+    num_bins: SearchableInt
+    num_residual_channels: SearchableInt
+    num_skip_channels: SearchableInt
+    dilation_depth: SearchableInt | None
+    num_stacks: SearchableInt
+    temperature: SearchableFloat
+    seasonality: SearchableInt
+    embedding_dimension: SearchableInt
+    use_log_scale_feature: SearchableBool
+    negative_data: SearchableBool
+    max_cat_cardinality: SearchableInt
+    weight_decay: SearchableFloat
+
+
+class Chronos2Model(ContextLengthMixIn, total=False):
+    model_path: str
+    batch_size: SearchableInt
+    device: str | None
+    cross_learning: SearchableBool
+    fine_tune: SearchableBool
+    fine_tune_mode: str
+    fine_tune_lr: SearchableFloat
+    fine_tune_steps: SearchableInt
+    fine_tune_batch_size: SearchableInt
+    fine_tune_context_length: SearchableInt
+    eval_during_fine_tune: SearchableBool
+    fine_tune_eval_max_items: SearchableInt
+    fine_tune_lora_config: dict[str, Any]
+    fine_tune_trainer_kwargs: dict[str, Any]
+    revision: str
+    disable_known_covariates: SearchableBool
+    disable_past_covariates: SearchableBool
+
+
+class ChronosModel(ContextLengthMixIn, total=False):
+    model_path: str
+    batch_size: SearchableInt
+    num_samples: SearchableInt
+    device: str
+    torch_dtype: Any
+    data_loader_num_workers: int
+    fine_tune: SearchableBool
+    fine_tune_lr: SearchableFloat
+    fine_tune_steps: SearchableInt
+    fine_tune_batch_size: SearchableInt
+    fine_tune_shuffle_buffer_size: int
+    eval_during_fine_tune: SearchableBool
+    fine_tune_eval_max_items: SearchableInt
+    fine_tune_trainer_kwargs: dict[str, Any]
+    keep_transformers_logs: SearchableBool
+    revision: str
+
+
+class TotoModel(ContextLengthMixIn, total=False):
+    model_path: str
+    batch_size: SearchableInt
+    num_samples: SearchableInt
+    device: str
+    compile_model: bool

--- a/timeseries/src/autogluon/timeseries/types/hyperparameters/deep_models.py
+++ b/timeseries/src/autogluon/timeseries/types/hyperparameters/deep_models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, List, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from autogluon.common import space
@@ -64,7 +64,7 @@ class SimpleFeedForwardModel(
     PredictBatchSizeMixIn,
     total=False,
 ):
-    hidden_dimensions: List[SearchableInt]
+    hidden_dimensions: list[SearchableInt]
     batch_normalization: SearchableBool
     mean_scaling: SearchableBool
 
@@ -99,7 +99,7 @@ class TiDEModel(ContextLengthMixIn, DeepLearningMixIn, TrainerMixIn, PredictBatc
     decoder_output_dim: SearchableInt
     dropout_rate: SearchableFloat
     num_feat_dynamic_proj: SearchableInt
-    embedding_dimension: SearchableInt | List[SearchableInt]
+    embedding_dimension: SearchableInt | list[SearchableInt]
     layer_norm: SearchableBool
     scaling: Literal["mean", "std", None] | space.Categorical
 
@@ -131,10 +131,10 @@ class Chronos2Model(ContextLengthMixIn, total=False):
     fine_tune_batch_size: SearchableInt
     fine_tune_context_length: SearchableInt
     eval_during_fine_tune: SearchableBool
-    fine_tune_eval_max_items: SearchableInt
-    fine_tune_lora_config: dict[str, Any]
+    fine_tune_eval_max_items: SearchableInt | None
+    fine_tune_lora_config: dict[str, Any] | None
     fine_tune_trainer_kwargs: dict[str, Any]
-    revision: str
+    revision: str | None
     disable_known_covariates: SearchableBool
     disable_past_covariates: SearchableBool
 
@@ -143,19 +143,19 @@ class ChronosModel(ContextLengthMixIn, total=False):
     model_path: str
     batch_size: SearchableInt
     num_samples: SearchableInt
-    device: str
+    device: str | None
     torch_dtype: Any
     data_loader_num_workers: int
     fine_tune: SearchableBool
     fine_tune_lr: SearchableFloat
     fine_tune_steps: SearchableInt
     fine_tune_batch_size: SearchableInt
-    fine_tune_shuffle_buffer_size: int
+    fine_tune_shuffle_buffer_size: int | None
     eval_during_fine_tune: SearchableBool
-    fine_tune_eval_max_items: SearchableInt
+    fine_tune_eval_max_items: SearchableInt | None
     fine_tune_trainer_kwargs: dict[str, Any]
     keep_transformers_logs: SearchableBool
-    revision: str
+    revision: str | None
 
 
 class TotoModel(ContextLengthMixIn, total=False):

--- a/timeseries/src/autogluon/timeseries/types/hyperparameters/hyperparameters.py
+++ b/timeseries/src/autogluon/timeseries/types/hyperparameters/hyperparameters.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TypedDict
 
 from .baseline_models import (
@@ -38,42 +40,63 @@ from .tabular_models import (
 
 
 class BaselineHyperparameters(TypedDict, total=False):
-    Average: AverageModel
-    Naive: NaiveModel
-    SeasonalAverage: SeasonalAverageModel
-    SeasonalNaive: SeasonalNaiveModel
-    Zero: ZeroModel
+    """Hyperparameters for baseline models.
+
+    See https://auto.gluon.ai/stable/tutorials/timeseries/forecasting-model-zoo.html#baseline-models
+    """
+
+    Average: AverageModel | list[AverageModel]
+    Naive: NaiveModel | list[NaiveModel]
+    SeasonalAverage: SeasonalAverageModel | list[SeasonalAverageModel]
+    SeasonalNaive: SeasonalNaiveModel | list[SeasonalNaiveModel]
+    Zero: ZeroModel | list[ZeroModel]
 
 
 class StatisticalHyperparameters(TypedDict, total=False):
-    ADIDA: ADIDAModel
-    AutoARIMA: AutoARIMAModel
-    AutoCES: AutoCESModel
-    AutoETS: AutoETSModel
-    Croston: CrostonModel
-    ETS: ETSModel
-    IMAPA: IMAPAModel
-    NPTS: NPTSModel
-    Theta: ThetaModel
+    """Hyperparameters for statistical models.
+
+    See https://auto.gluon.ai/stable/tutorials/timeseries/forecasting-model-zoo.html#statistical-models
+    """
+
+    ADIDA: ADIDAModel | list[ADIDAModel]
+    AutoARIMA: AutoARIMAModel | list[AutoARIMAModel]
+    AutoCES: AutoCESModel | list[AutoCESModel]
+    AutoETS: AutoETSModel | list[AutoETSModel]
+    Croston: CrostonModel | list[CrostonModel]
+    ETS: ETSModel | list[ETSModel]
+    IMAPA: IMAPAModel | list[IMAPAModel]
+    NPTS: NPTSModel | list[NPTSModel]
+    Theta: ThetaModel | list[ThetaModel]
 
 
 class TabularHyperparameters(TypedDict, total=False):
-    DirectTabular: DirectTabularModel
-    PerStepTabular: PerStepTabularModel
-    RecursiveTabular: RecursiveTabularModel
+    """Hyperparameters for tabular models.
+
+    See https://auto.gluon.ai/stable/tutorials/timeseries/forecasting-model-zoo.html#tabular-models
+    """
+
+    DirectTabular: DirectTabularModel | list[DirectTabularModel]
+    PerStepTabular: PerStepTabularModel | list[PerStepTabularModel]
+    RecursiveTabular: RecursiveTabularModel | list[RecursiveTabularModel]
 
 
 class DeepLearningHyperparameters(TypedDict, total=False):
-    Chronos: ChronosModel
-    Chronos2: Chronos2Model
-    DeepAR: DeepARModel
-    DLinear: DLinearModel
-    PatchTST: PatchTSTModel
-    SimpleFeedForward: SimpleFeedForwardModel
-    TemporalFusionTransformer: TemporalFusionTransformerModel
-    TiDE: TiDEModel
-    Toto: TotoModel
-    WaveNet: WaveNetModel
+    """Hyperparameters for deep learning and pretrained models.
+
+    See https://auto.gluon.ai/stable/tutorials/timeseries/forecasting-model-zoo.html#deep-learning-models
+    See https://auto.gluon.ai/stable/tutorials/timeseries/forecasting-model-zoo.html#pretrained-models
+    """
+
+    Chronos: ChronosModel | list[ChronosModel]
+    Chronos2: Chronos2Model | list[Chronos2Model]
+    DeepAR: DeepARModel | list[DeepARModel]
+    DLinear: DLinearModel | list[DLinearModel]
+    PatchTST: PatchTSTModel | list[PatchTSTModel]
+    SimpleFeedForward: SimpleFeedForwardModel | list[SimpleFeedForwardModel]
+    TemporalFusionTransformer: TemporalFusionTransformerModel | list[TemporalFusionTransformerModel]
+    TiDE: TiDEModel | list[TiDEModel]
+    Toto: TotoModel | list[TotoModel]
+    WaveNet: WaveNetModel | list[WaveNetModel]
 
 
 class TimeSeriesHyperparameters(
@@ -82,4 +105,9 @@ class TimeSeriesHyperparameters(
     TabularHyperparameters,
     DeepLearningHyperparameters,
     total=False,
-): ...
+):
+    """
+    Hyperparameters for time series forecasting models.
+
+    https://auto.gluon.ai/stable/tutorials/timeseries/forecasting-model-zoo.html
+    """

--- a/timeseries/src/autogluon/timeseries/types/hyperparameters/hyperparameters.py
+++ b/timeseries/src/autogluon/timeseries/types/hyperparameters/hyperparameters.py
@@ -1,0 +1,85 @@
+from typing import TypedDict
+
+from .baseline_models import (
+    AverageModel,
+    NaiveModel,
+    SeasonalAverageModel,
+    SeasonalNaiveModel,
+    ZeroModel,
+)
+from .deep_models import (
+    Chronos2Model,
+    ChronosModel,
+    DeepARModel,
+    DLinearModel,
+    PatchTSTModel,
+    SimpleFeedForwardModel,
+    TemporalFusionTransformerModel,
+    TiDEModel,
+    TotoModel,
+    WaveNetModel,
+)
+from .statistical_models import (
+    ADIDAModel,
+    AutoARIMAModel,
+    AutoCESModel,
+    AutoETSModel,
+    CrostonModel,
+    ETSModel,
+    IMAPAModel,
+    NPTSModel,
+    ThetaModel,
+)
+from .tabular_models import (
+    DirectTabularModel,
+    PerStepTabularModel,
+    RecursiveTabularModel,
+)
+
+
+class BaselineHyperparameters(TypedDict, total=False):
+    Average: AverageModel
+    Naive: NaiveModel
+    SeasonalAverage: SeasonalAverageModel
+    SeasonalNaive: SeasonalNaiveModel
+    Zero: ZeroModel
+
+
+class StatisticalHyperparameters(TypedDict, total=False):
+    ADIDA: ADIDAModel
+    AutoARIMA: AutoARIMAModel
+    AutoCES: AutoCESModel
+    AutoETS: AutoETSModel
+    Croston: CrostonModel
+    ETS: ETSModel
+    IMAPA: IMAPAModel
+    NPTS: NPTSModel
+    Theta: ThetaModel
+
+
+class TabularHyperparameters(TypedDict, total=False):
+    DirectTabular: DirectTabularModel
+    PerStepTabular: PerStepTabularModel
+    RecursiveTabular: RecursiveTabularModel
+
+
+class DeepLearningHyperparameters(TypedDict, total=False):
+    Chronos: ChronosModel
+    Chronos2: Chronos2Model
+    DeepAR: DeepARModel
+    DLinear: DLinearModel
+    PatchTST: PatchTSTModel
+    SimpleFeedForward: SimpleFeedForwardModel
+    TemporalFusionTransformer: TemporalFusionTransformerModel
+    TiDE: TiDEModel
+    Toto: TotoModel
+    WaveNet: WaveNetModel
+
+
+class TimeSeriesHyperparameters(
+    BaselineHyperparameters,
+    StatisticalHyperparameters,
+    TabularHyperparameters,
+    DeepLearningHyperparameters,
+    total=False,
+): ...

--- a/timeseries/src/autogluon/timeseries/types/hyperparameters/mixins.py
+++ b/timeseries/src/autogluon/timeseries/types/hyperparameters/mixins.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable, Literal, TypedDict
+
+from gluonts.torch.distributions import Output as GluonTSOutput
+
+from autogluon.timeseries.types.hyperparameters._base import (
+    SearchableBool,
+    SearchableFloat,
+    SearchableInt,
+)
+
+if TYPE_CHECKING:
+    from autogluon.common import space
+
+
+class NJobsMixIn(TypedDict, total=False):
+    n_jobs: int | float
+
+
+class SeasonalPeriodMixIn(TypedDict, total=False):
+    seasonal_period: None | SearchableInt
+
+
+class MaxTsLengthMixIn(TypedDict, total=False):
+    max_ts_length: None | SearchableInt
+
+
+class ModelMixIn(TypedDict, total=False):
+    model: str | space.Categorical
+
+
+class DampedMixIn(TypedDict, total=False):
+    damped: SearchableBool
+
+
+class ContextLengthMixIn(TypedDict, total=False):
+    context_length: SearchableInt | None
+
+
+class DistrOutputMixIn(TypedDict, total=False):
+    distr_output: GluonTSOutput | space.Categorical
+
+
+class DeepLearningMixIn(TypedDict, total=False):
+    max_epochs: SearchableInt
+    batch_size: SearchableInt
+    num_batches_per_epoch: SearchableInt
+    lr: SearchableFloat
+    keep_lightning_logs: bool
+
+
+class TrainerMixIn(TypedDict, total=False):
+    trainer_kwargs: dict[str, Any]
+    early_stopping_patience: SearchableInt | None
+
+
+class PredictBatchSizeMixIn(TypedDict, total=False):
+    predict_batch_size: SearchableInt
+
+
+class TabularModelMixIn(TypedDict, total=False):
+    date_features: list[str | Callable] | None
+    target_scaler: Literal["standard", "mean_abs", "min_max", "robust"] | None
+    model_name: Literal["CAT", "RF", "GBM", "XT", "LR"] | space.Categorical
+    # TODO: Fill in with model-specific hyperparameters
+    model_hyperparameters: dict[str, Any]
+    max_num_items: int | None
+    max_num_samples: int | None

--- a/timeseries/src/autogluon/timeseries/types/hyperparameters/mixins.py
+++ b/timeseries/src/autogluon/timeseries/types/hyperparameters/mixins.py
@@ -2,15 +2,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Callable, Literal, TypedDict
 
-from gluonts.torch.distributions import Output as GluonTSOutput
-
-from autogluon.timeseries.types.hyperparameters._base import (
+from ._base import (
     SearchableBool,
     SearchableFloat,
     SearchableInt,
 )
 
 if TYPE_CHECKING:
+    from gluonts.torch.distributions import Output as GluonTSOutput
+
     from autogluon.common import space
 
 
@@ -62,7 +62,7 @@ class PredictBatchSizeMixIn(TypedDict, total=False):
 class TabularModelMixIn(TypedDict, total=False):
     date_features: list[str | Callable] | None
     target_scaler: Literal["standard", "mean_abs", "min_max", "robust"] | None
-    model_name: Literal["CAT", "RF", "GBM", "XT", "LR"] | space.Categorical
+    model_name: str | space.Categorical
     # TODO: Fill in with model-specific hyperparameters
     model_hyperparameters: dict[str, Any]
     max_num_items: int | None

--- a/timeseries/src/autogluon/timeseries/types/hyperparameters/statistical_models.py
+++ b/timeseries/src/autogluon/timeseries/types/hyperparameters/statistical_models.py
@@ -1,9 +1,12 @@
-from typing import Literal
+from __future__ import annotations
 
-from autogluon.common import space
+from typing import TYPE_CHECKING, Literal
 
 from ._base import SearchableBool, SearchableFloat, SearchableInt
 from .mixins import DampedMixIn, MaxTsLengthMixIn, ModelMixIn, NJobsMixIn, SeasonalPeriodMixIn
+
+if TYPE_CHECKING:
+    from autogluon.common import space
 
 
 class ETSModel(NJobsMixIn, SeasonalPeriodMixIn, MaxTsLengthMixIn, ModelMixIn, DampedMixIn, total=False): ...
@@ -41,10 +44,10 @@ class ThetaModel(NJobsMixIn, SeasonalPeriodMixIn, MaxTsLengthMixIn, total=False)
 
 class NPTSModel(NJobsMixIn, MaxTsLengthMixIn, total=False):
     kernel_type: Literal["exponential", "uniform"] | space.Categorical
-    exp_kernel_weights: float | SearchableFloat
-    use_seasonal_model: bool | SearchableBool
-    num_samples: int | SearchableInt
-    num_default_time_features: int | SearchableInt
+    exp_kernel_weights: SearchableFloat
+    use_seasonal_model: SearchableBool
+    num_samples: SearchableInt
+    num_default_time_features: SearchableInt
 
 
 class ADIDAModel(NJobsMixIn, MaxTsLengthMixIn, total=False): ...

--- a/timeseries/src/autogluon/timeseries/types/hyperparameters/statistical_models.py
+++ b/timeseries/src/autogluon/timeseries/types/hyperparameters/statistical_models.py
@@ -1,0 +1,57 @@
+from typing import Literal
+
+from autogluon.common import space
+
+from ._base import SearchableBool, SearchableFloat, SearchableInt
+from .mixins import DampedMixIn, MaxTsLengthMixIn, ModelMixIn, NJobsMixIn, SeasonalPeriodMixIn
+
+
+class ETSModel(NJobsMixIn, SeasonalPeriodMixIn, MaxTsLengthMixIn, ModelMixIn, DampedMixIn, total=False): ...
+
+
+class AutoETSModel(NJobsMixIn, SeasonalPeriodMixIn, MaxTsLengthMixIn, ModelMixIn, DampedMixIn, total=False): ...
+
+
+class AutoCESModel(NJobsMixIn, SeasonalPeriodMixIn, MaxTsLengthMixIn, ModelMixIn, total=False): ...
+
+
+class AutoARIMAModel(NJobsMixIn, SeasonalPeriodMixIn, MaxTsLengthMixIn, total=False):
+    d: SearchableInt | None
+    D: SearchableInt | None
+    max_p: SearchableInt
+    max_q: SearchableInt
+    max_P: SearchableInt
+    max_Q: SearchableInt
+    max_d: SearchableInt
+    max_D: SearchableInt
+    start_p: SearchableInt
+    start_q: SearchableInt
+    start_P: SearchableInt
+    start_Q: SearchableInt
+    stationary: SearchableBool
+    seasonal: SearchableBool
+    approximation: SearchableBool
+    allowdrift: SearchableBool
+    allowmean: SearchableBool
+
+
+class ThetaModel(NJobsMixIn, SeasonalPeriodMixIn, MaxTsLengthMixIn, total=False):
+    decomposition_type: Literal["multiplicative", "additive"] | space.Categorical
+
+
+class NPTSModel(NJobsMixIn, MaxTsLengthMixIn, total=False):
+    kernel_type: Literal["exponential", "uniform"] | space.Categorical
+    exp_kernel_weights: float | SearchableFloat
+    use_seasonal_model: bool | SearchableBool
+    num_samples: int | SearchableInt
+    num_default_time_features: int | SearchableInt
+
+
+class ADIDAModel(NJobsMixIn, MaxTsLengthMixIn, total=False): ...
+
+
+class CrostonModel(NJobsMixIn, MaxTsLengthMixIn, total=False):
+    variant: Literal["SBA", "classic", "optimized"] | space.Categorical
+
+
+class IMAPAModel(NJobsMixIn, MaxTsLengthMixIn, total=False): ...

--- a/timeseries/src/autogluon/timeseries/types/hyperparameters/tabular_models.py
+++ b/timeseries/src/autogluon/timeseries/types/hyperparameters/tabular_models.py
@@ -1,0 +1,23 @@
+from typing import Callable
+
+from autogluon.common import space
+from autogluon.timeseries.types.hyperparameters._base import SearchableFloat
+
+from .mixins import NJobsMixIn, TabularModelMixIn
+
+
+class DirectTabularModel(TabularModelMixIn, total=False):
+    lags: list[int] | space.Categorical | None
+    differences: list[int] | space.Categorical | None
+
+
+class PerStepTabularModel(TabularModelMixIn, NJobsMixIn, total=False):
+    trailing_lags: list[int] | space.Categorical | None
+    seasonal_lags: list[int] | space.Categorical | None
+    validation_fraction: SearchableFloat | None
+
+
+class RecursiveTabularModel(TabularModelMixIn, total=False):
+    lags: list[int] | space.Categorical | None
+    differences: list[int] | space.Categorical | None
+    lag_transforms: dict[int, list[Callable]] | None

--- a/timeseries/src/autogluon/timeseries/types/hyperparameters/tabular_models.py
+++ b/timeseries/src/autogluon/timeseries/types/hyperparameters/tabular_models.py
@@ -1,9 +1,12 @@
-from typing import Callable
+from __future__ import annotations
 
-from autogluon.common import space
-from autogluon.timeseries.types.hyperparameters._base import SearchableFloat
+from typing import TYPE_CHECKING, Callable
 
-from .mixins import NJobsMixIn, TabularModelMixIn
+from ._base import SearchableFloat
+from .mixins import TabularModelMixIn
+
+if TYPE_CHECKING:
+    from autogluon.common import space
 
 
 class DirectTabularModel(TabularModelMixIn, total=False):
@@ -11,7 +14,11 @@ class DirectTabularModel(TabularModelMixIn, total=False):
     differences: list[int] | space.Categorical | None
 
 
-class PerStepTabularModel(TabularModelMixIn, NJobsMixIn, total=False):
+class PerStepTabularModel(TabularModelMixIn, total=False):
+    # NJobsMixIn is not used here because its n_jobs type (int | float) is too
+    # wide — PerStepTabularModel only accepts int | None. TypedDict fields are
+    # invariant, so narrowing via inheritance would be a type error.
+    n_jobs: int | None
     trailing_lags: list[int] | space.Categorical | None
     seasonal_lags: list[int] | space.Categorical | None
     validation_fraction: SearchableFloat | None


### PR DESCRIPTION
## Summary
This PR improves the typing surface for `TimeSeriesPredictor.fit(..., hyperparameters=...)` by adding and refining model-specific type definitions for the Time Series model zoo.

## Motivation
This came out of a great AutoGluon experience in an academic forecasting competition a friend and I worked on.

We finished **8th overall (and not 1st 😄)**, so if anything was missing, it was definitely our “personal skills” and not AutoGluon.

While working, we found ourselves constantly going back and forth between docs and source to confirm accepted hyperparameters. This PR is meant to make that loop easier for future users through stronger, clearer type hints.

## What Changed
- Improved the overall typing experience for Time Series hyperparameters in `TimeSeriesPredictor.fit`.
- Brought type hints closer to the model-zoo/documentation expectations so users can rely more on editor/type-checker guidance.
- Refined internal type aliasing to keep typing robust without affecting runtime behavior.
- Kept changes scoped to typing and developer ergonomics (no intended functional training/inference changes).

## Validation
- Local syntax/import sanity checks on updated typing modules (`py_compile` + import checks).
- No functional model-training behavior changes expected from this PR.

## Notes
- Goal is developer ergonomics: better autocomplete, type-checking, and docs-to-code consistency.

## Demo
![Demo](https://github.com/user-attachments/assets/d6b96107-7913-4d02-a23d-da35596f1bf5)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
