### PR TITLE
feat: add cv_splitter param to TabularPredictor for custom CV strategies

### DIFF
--- a/common/src/autogluon/common/utils/cv_splitter.py
+++ b/common/src/autogluon/common/utils/cv_splitter.py
@@ -24,6 +24,7 @@ class CVSplitter:
     def __init__(
         self,
         splitter_cls=None,
+        splitter: BaseCrossValidator | None = None,
         n_splits: int = 5,
         n_repeats: int = 1,
         random_state: int | None = 0,
@@ -42,6 +43,11 @@ class CVSplitter:
         splitter_cls, default None
             The class to use for splitting.
             If None, will automatically be determined based off of `stratify`, `groups`, and `n_repeats`.
+            Ignored if `splitter` is provided.
+        splitter : BaseCrossValidator, default None
+            A pre-configured sklearn-compatible cross-validator instance (e.g. ``TimeSeriesSplit(n_splits=5)``).
+            When provided, all other parameters are ignored and the splitter is used directly.
+            ``n_splits`` is inferred via ``splitter.get_n_splits()``.
         n_splits : int, default 5
             The number of splits to perform.
             Ignored if `groups` is specified.
@@ -62,6 +68,19 @@ class CVSplitter:
             If specified, splitter_cls will default to LeaveOneGroupOut.
 
         """
+        if splitter is not None:
+            self._splitter = splitter
+            self.n_splits = splitter.get_n_splits()
+            self.n_repeats = 1
+            self.random_state = None
+            self.stratify = False
+            self.shuffle = False
+            self.bin = False
+            self.n_bins = None
+            self.groups = None
+            self._is_custom = True
+            return
+        self._is_custom = False
         self.n_splits = n_splits
         self.n_repeats = n_repeats
         self.random_state = random_state
@@ -106,6 +125,8 @@ class CVSplitter:
             y = pd.Series(y)
         if X is None:
             X = pd.DataFrame(index=y.index)
+        if self._is_custom:
+            return [[ti, vi] for ti, vi in self._splitter.split(X, y)]
         splitter = self._splitter
         if isinstance(splitter, (RepeatedStratifiedKFold, StratifiedKFold)):
             if self.bin:

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -228,7 +228,9 @@ class BaggedEnsembleModel(AbstractModel):
         else:
             return X
 
-    def _get_cv_splitter(self, n_splits: int, n_repeats: int, groups=None) -> CVSplitter:
+    def _get_cv_splitter(self, n_splits: int, n_repeats: int, groups=None, cv_splitter=None) -> CVSplitter:
+        if cv_splitter is not None:
+            return CVSplitter(splitter=cv_splitter)
         return CVSplitter(
             n_splits=n_splits,
             n_repeats=n_repeats,
@@ -253,6 +255,7 @@ class BaggedEnsembleModel(AbstractModel):
         n_repeats: int = 1,
         n_repeat_start: int = 0,
         groups: pd.Series = None,
+        cv_splitter=None,
         _skip_oof: bool = False,
         **kwargs,
     ):
@@ -302,6 +305,11 @@ class BaggedEnsembleModel(AbstractModel):
         groups : pd.Series, default None
             If specified, will split X and y based on `groups`, with each sample going to a specific group.
             Overrides `k_fold` and disables `n_repeats>1` if specified.
+            Mutually exclusive with `cv_splitter`.
+        cv_splitter : BaseCrossValidator, default None
+            A pre-configured sklearn-compatible cross-validator instance (e.g. ``TimeSeriesSplit(n_splits=5)``).
+            When provided, overrides the default KFold splitting strategy.
+            Mutually exclusive with `groups`.
         _skip_oof : bool, default False
             If True, will not calculate the out-of-fold predictions from the fold models.
             This should be set to True when performing a bagged refit.
@@ -317,8 +325,8 @@ class BaggedEnsembleModel(AbstractModel):
 
         """
         use_child_oof = self.params.get("use_child_oof", False)
-        if use_child_oof and groups is not None:
-            logger.log(20, f"\tForcing `use_child_oof=False` because `groups` is specified")
+        if use_child_oof and (groups is not None or cv_splitter is not None):
+            logger.log(20, f"\tForcing `use_child_oof=False` because `groups` or `cv_splitter` is specified")
             use_child_oof = False
         if use_child_oof:
             if self.is_fit():
@@ -327,11 +335,14 @@ class BaggedEnsembleModel(AbstractModel):
             k_fold = 1
             k_fold_end = None
             groups = None
+            cv_splitter = None
         else:
             k_fold, k_fold_end = self._update_k_fold(k_fold=k_fold, k_fold_end=k_fold_end)
-        if k_fold is None and groups is None:
+        if cv_splitter is not None:
+            k_fold = self._get_cv_splitter(n_splits=k_fold, n_repeats=n_repeats, cv_splitter=cv_splitter).n_splits
+        elif k_fold is None and groups is None:
             k_fold = 5
-        if k_fold is None or k_fold > 1:
+        if cv_splitter is None and (k_fold is None or k_fold > 1):
             k_fold = self._get_cv_splitter(n_splits=k_fold, n_repeats=n_repeats, groups=groups).n_splits
         max_sets = self._get_model_params().get("max_sets", None)
         if max_sets is not None:
@@ -420,6 +431,7 @@ class BaggedEnsembleModel(AbstractModel):
                 n_repeat_start=n_repeat_start,
                 save_folds=save_bag_folds,
                 groups=groups,
+                custom_splitter=cv_splitter,
                 **kwargs,
             )
             # FIXME: Cleanup self
@@ -834,6 +846,7 @@ class BaggedEnsembleModel(AbstractModel):
         sample_weight=None,
         save_folds: bool = True,
         groups=None,
+        custom_splitter=None,
         num_cpus: int = None,
         num_gpus: float = None,
         **kwargs,
@@ -845,14 +858,14 @@ class BaggedEnsembleModel(AbstractModel):
         if k_fold_start != 0:
             cv_splitter = self._cv_splitters[n_repeat_start]
         else:
-            cv_splitter = self._get_cv_splitter(n_splits=k_fold, n_repeats=n_repeats, groups=groups)
+            cv_splitter = self._get_cv_splitter(n_splits=k_fold, n_repeats=n_repeats, groups=groups, cv_splitter=custom_splitter)
         if k_fold != cv_splitter.n_splits:
             k_fold = cv_splitter.n_splits
         if k_fold_end is None:
             k_fold_end = k_fold
         if cv_splitter.n_repeats < n_repeats:
             # If current cv_splitter doesn't have enough n_repeats for all folds, then create a new one.
-            cv_splitter = self._get_cv_splitter(n_splits=k_fold, n_repeats=n_repeats, groups=groups)
+            cv_splitter = self._get_cv_splitter(n_splits=k_fold, n_repeats=n_repeats, groups=groups, cv_splitter=custom_splitter)
 
         fold_fit_args_list, n_repeats_started, n_repeats_finished = self._generate_fold_configs(
             X=X,

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -858,14 +858,18 @@ class BaggedEnsembleModel(AbstractModel):
         if k_fold_start != 0:
             cv_splitter = self._cv_splitters[n_repeat_start]
         else:
-            cv_splitter = self._get_cv_splitter(n_splits=k_fold, n_repeats=n_repeats, groups=groups, cv_splitter=custom_splitter)
+            cv_splitter = self._get_cv_splitter(
+                n_splits=k_fold, n_repeats=n_repeats, groups=groups, cv_splitter=custom_splitter
+            )
         if k_fold != cv_splitter.n_splits:
             k_fold = cv_splitter.n_splits
         if k_fold_end is None:
             k_fold_end = k_fold
         if cv_splitter.n_repeats < n_repeats:
             # If current cv_splitter doesn't have enough n_repeats for all folds, then create a new one.
-            cv_splitter = self._get_cv_splitter(n_splits=k_fold, n_repeats=n_repeats, groups=groups, cv_splitter=custom_splitter)
+            cv_splitter = self._get_cv_splitter(
+                n_splits=k_fold, n_repeats=n_repeats, groups=groups, cv_splitter=custom_splitter
+            )
 
         fold_fit_args_list, n_repeats_started, n_repeats_finished = self._generate_fold_configs(
             X=X,

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -326,7 +326,7 @@ class BaggedEnsembleModel(AbstractModel):
         """
         use_child_oof = self.params.get("use_child_oof", False)
         if use_child_oof and (groups is not None or cv_splitter is not None):
-            logger.log(20, f"\tForcing `use_child_oof=False` because `groups` or `cv_splitter` is specified")
+            logger.log(20, "\tForcing `use_child_oof=False` because `groups` or `cv_splitter` is specified")
             use_child_oof = False
         if use_child_oof:
             if self.is_fit():
@@ -539,13 +539,13 @@ class BaggedEnsembleModel(AbstractModel):
         ):
             logger.log(
                 30,
-                f"\tWARNING: Fitting bagged model with `k_fold=1`, "
-                f"but this model doesn't support getting out-of-fold predictions from training data!\n"
-                f"\t\tThe model will be fit on 100% of the training data without any validation split.\n"
-                f"\t\tIt will then predict on the same data used to train for generating out-of-fold predictions. "
-                f"This will likely be EXTREMELY overfit and produce terrible results.\n"
-                f"\t\tWe strongly recommend not forcing bagged models to use `k_fold=1`. "
-                f"Instead, specify `use_child_oof=True` if the model supports this option.",
+                "\tWARNING: Fitting bagged model with `k_fold=1`, "
+                "but this model doesn't support getting out-of-fold predictions from training data!\n"
+                "\t\tThe model will be fit on 100% of the training data without any validation split.\n"
+                "\t\tIt will then predict on the same data used to train for generating out-of-fold predictions. "
+                "This will likely be EXTREMELY overfit and produce terrible results.\n"
+                "\t\tWe strongly recommend not forcing bagged models to use `k_fold=1`. "
+                "Instead, specify `use_child_oof=True` if the model supports this option.",
             )
 
     def predict_proba_children(
@@ -693,7 +693,7 @@ class BaggedEnsembleModel(AbstractModel):
         else:
             X_fit = X
             y_fit = y
-        log_resources_prefix = f"Fitting 1 model on all data"
+        log_resources_prefix = "Fitting 1 model on all data"
         if use_child_oof:
             log_resources_prefix += f" (use_child_oof={use_child_oof})"
         log_resources_prefix += " | "
@@ -1146,7 +1146,7 @@ class BaggedEnsembleModel(AbstractModel):
                     time_left = time_limit - (time_now - time_start)
                     time_child_average = (time_now - time_start) / children_completed
                     if time_left < (time_child_average * 1.1):
-                        log_final_suffix = f" (Early stopping due to lack of time...)"
+                        log_final_suffix = " (Early stopping due to lack of time...)"
                         early_stop = True
                         break
             if early_stop:

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -52,6 +52,7 @@ class AbstractTabularLearner(AbstractLearner):
         sample_weight: str | None = None,
         weight_evaluation: bool = False,
         groups: str | None = None,
+        cv_splitter=None,
     ):
         super().__init__(path_context=path_context, random_state=random_state)
         self.label = label
@@ -96,6 +97,7 @@ class AbstractTabularLearner(AbstractLearner):
         self.sample_weight = sample_weight
         self.weight_evaluation = weight_evaluation
         self.groups = groups
+        self.cv_splitter = cv_splitter
         if sample_weight is not None and not isinstance(sample_weight, str):
             raise ValueError(
                 "sample_weight must be a string indicating the name of the column that contains sample weights. If you have a vector of sample weights, first add these as an extra column to your data."
@@ -106,6 +108,8 @@ class AbstractTabularLearner(AbstractLearner):
             raise ValueError(
                 "groups must be a string indicating the name of the column that contains the split groups. If you have a vector of split groups, first add these as an extra column to your data."
             )
+        if groups is not None and cv_splitter is not None:
+            raise ValueError("groups and cv_splitter are mutually exclusive. Specify only one.")
 
     @property
     def original_features(self) -> List[str]:

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -974,7 +974,7 @@ class AbstractTabularLearner(AbstractLearner):
                 if not self.eval_metric.greater_is_better_internal:
                     logger.log(
                         20,
-                        f"\tNote: Scores are always higher_is_better. This metric score can be multiplied by -1 to get the metric value.",
+                        "\tNote: Scores are always higher_is_better. This metric score can be multiplied by -1 to get the metric value.",
                     )
             logger.log(20, "Evaluations on test data:")
             logger.log(20, json.dumps(performance_dict, indent=4))

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -90,6 +90,14 @@ class DefaultLearner(AbstractTabularLearner):
         if self.groups is not None:
             num_bag_sets = 1
             num_bag_folds = len(X[self.groups].unique())
+        elif self.cv_splitter is not None:
+            num_bag_sets = 1
+            num_bag_folds = self.cv_splitter.get_n_splits()
+            logger.log(
+                20,
+                f"Custom cv_splitter specified with {num_bag_folds} splits. "
+                f"Bagged models will use the provided splitter instead of the default KFold strategy.",
+            )
         X_og = None if infer_limit_batch_size is None else X
         logger.log(20, "Preprocessing data ...")
         X, y, X_val, y_val, X_test, y_test, X_unlabeled, holdout_frac, num_bag_folds, groups = (
@@ -154,6 +162,7 @@ class DefaultLearner(AbstractTabularLearner):
             infer_limit=infer_limit,
             infer_limit_batch_size=infer_limit_batch_size,
             groups=groups,
+            cv_splitter=self.cv_splitter,
             label_cleaner=copy.deepcopy(self.label_cleaner),
             **trainer_fit_kwargs,
         )

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -217,9 +217,9 @@ class DefaultLearner(AbstractTabularLearner):
                 infer_limit_new = 0
                 logger.log(
                     30,
-                    f"WARNING: Impossible to satisfy inference constraint, budget is exceeded during data preprocessing!\n"
-                    f"\tAutoGluon will be unable to satisfy the constraint, but will return the fastest model it can.\n"
-                    f"\tConsider using fewer features, relaxing the inference constraint, or simplifying the feature generator.",
+                    "WARNING: Impossible to satisfy inference constraint, budget is exceeded during data preprocessing!\n"
+                    "\tAutoGluon will be unable to satisfy the constraint, but will return the fastest model it can.\n"
+                    "\tConsider using fewer features, relaxing the inference constraint, or simplifying the feature generator.",
                 )
             infer_limit = infer_limit_new
         return infer_limit
@@ -293,7 +293,7 @@ class DefaultLearner(AbstractTabularLearner):
 
         self._original_features = list(X.columns)
         # TODO: Move this up to top of data before removing data, this way our feature generator is better
-        logger.log(20, f"Using Feature Generators to preprocess the data ...")
+        logger.log(20, "Using Feature Generators to preprocess the data ...")
 
         if X_test is not None:
             logger.log(

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -161,6 +161,19 @@ class TabularPredictor:
         Bugs may arise from edge cases if the provided groups are not valid to properly train models, such as if not all classes are present during training in multiclass classification. It is up to the user to sanitize their groups.
 
         As an example, if you want your data folds to preserve adjacent rows in the table without shuffling, then for 3 fold bagging with 6 rows of data, the groups column values should be [0, 0, 1, 1, 2, 2].
+    cv_splitter : BaseCrossValidator, default = None
+        [Experimental] A pre-configured sklearn-compatible cross-validator instance to use for bagging splits.
+        For example, pass ``sklearn.model_selection.TimeSeriesSplit(n_splits=5)`` to use forward-chaining CV,
+        which prevents data leakage when training on temporally ordered data.
+        This parameter is ignored if bagging is not enabled.
+        Mutually exclusive with ``groups``.
+
+        Example usage::
+
+            from sklearn.model_selection import TimeSeriesSplit
+            predictor = TabularPredictor(label="target", cv_splitter=TimeSeriesSplit(n_splits=5))
+            predictor.fit(train_data, num_bag_folds=5)
+
     positive_class : str or int, default = None
         Used to determine the positive class in binary classification.
         This is used for certain metrics such as 'f1' which produce different scores depending on which class is considered the positive class.
@@ -211,6 +224,7 @@ class TabularPredictor:
         sample_weight: str = None,
         weight_evaluation: bool = False,
         groups: str = None,
+        cv_splitter=None,
         positive_class: int | str | None = None,
         **kwargs,
     ):
@@ -247,6 +261,7 @@ class TabularPredictor:
             sample_weight=self.sample_weight,
             weight_evaluation=self.weight_evaluation,
             groups=groups,
+            cv_splitter=cv_splitter,
             **learner_kwargs,
         )
         self._learner_type = type(self._learner)

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -3421,7 +3421,6 @@ class TabularPredictor:
             if stacking_used:
                 num_stack_str = f" (with {results['max_stack_level']} levels)"
             print("Multi-layer stack-ensembling used: %s %s" % (stacking_used, num_stack_str))
-            hpo_str = ""
             # if hpo_used and verbosity <= 2:
             #     hpo_str = " (call fit_summary() with verbosity >= 3 to see detailed HPO info)"
             # print("Hyperparameter-tuning used: %s %s" % (hpo_used, hpo_str))
@@ -4507,7 +4506,7 @@ class TabularPredictor:
                     "Detected duplicate indices... This means that data rows may have been duplicated during training. "
                     "Removing all duplicates except for the first instance.",
                 )
-                y_pred_proba_oof_transformed = y_pred_proba_oof_transformed[is_duplicate_index == False]
+                y_pred_proba_oof_transformed = y_pred_proba_oof_transformed[~is_duplicate_index]
             if self._learner._pre_X_rows is not None and len(y_pred_proba_oof_transformed) < self._learner._pre_X_rows:
                 len_diff = self._learner._pre_X_rows - len(y_pred_proba_oof_transformed)
                 if train_data is None:
@@ -4961,7 +4960,7 @@ class TabularPredictor:
             primary_model = self.model_best
         all_models = self.model_names()
         assert primary_model in all_models, f'Unknown model "{primary_model}"! Valid models: {all_models}'
-        if prune_unused_nodes == True:
+        if prune_unused_nodes:
             models_to_keep = self._trainer.get_minimum_model_set(model=primary_model)
             G = nx.subgraph(G, models_to_keep)
 
@@ -5736,9 +5735,9 @@ class TabularPredictor:
         params : dict
             The learning curves parameters in ag_params format.
         """
-        if learning_curves is None or learning_curves == False:
+        if learning_curves is None or not learning_curves:
             return {}
-        elif type(learning_curves) != dict and type(learning_curves) != bool:
+        elif not isinstance(learning_curves, (dict, bool)):
             raise ValueError("Learning curves parameter must be a boolean or dict!")
 
         # metrics defaults to self.eval_metric if not specified

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -1627,7 +1627,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
     ) -> list[str]:
         if fit_strategy == "parallel":
             logger.log(
-                30, f"Note: refit_full does not yet support fit_strategy='parallel', switching to 'sequential'..."
+                30, "Note: refit_full does not yet support fit_strategy='parallel', switching to 'sequential'..."
             )
             fit_strategy = "sequential"
         if X is None:
@@ -2038,7 +2038,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         if not model_names:
             logger.log(
                 30,
-                f"No valid unpersisted models were specified to be persisted, so no change in model persistence was performed.",
+                "No valid unpersisted models were specified to be persisted, so no change in model persistence was performed.",
             )
             return []
         if max_memory is not None:
@@ -2061,7 +2061,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
                     )
                     logger.log(
                         30,
-                        f"\tModels will be loaded on-demand from disk to maintain safe memory usage, increasing inference latency. If inference latency is a concern, try to use smaller models or increase the value of max_memory.",
+                        "\tModels will be loaded on-demand from disk to maintain safe memory usage, increasing inference latency. If inference latency is a concern, try to use smaller models or increase the value of max_memory.",
                     )
                     return False
                 else:
@@ -2103,7 +2103,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         else:
             logger.log(
                 30,
-                f"No valid persisted models were specified to be unpersisted, so no change in model persistence was performed.",
+                "No valid persisted models were specified to be unpersisted, so no change in model persistence was performed.",
             )
         return unpersisted_models
 
@@ -2352,7 +2352,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
             model_fit_kwargs["y"] = y
             if level > 1:
                 if X_pseudo is not None and y_pseudo is not None:
-                    logger.log(15, f"Dropping pseudo in stacking layer due to missing out-of-fold predictions")
+                    logger.log(15, "Dropping pseudo in stacking layer due to missing out-of-fold predictions")
             else:
                 model_fit_kwargs["X_pseudo"] = X_pseudo
                 model_fit_kwargs["y_pseudo"] = y_pseudo
@@ -2473,7 +2473,6 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         predict_1_child_time = model.predict_1_time / num_children if model.predict_1_time is not None else None
         fit_metadata = model.get_fit_metadata()
 
-        model_param_aux = getattr(model, "_params_aux_child", model.params_aux)
         model_metadata = dict(
             fit_time=model.fit_time,
             compile_time=model.compile_time,
@@ -2634,7 +2633,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
             logger.log(log_level, f"\tEnsemble Weights: {{{msg_weights}}}")
         if model.val_score is not None:
             if model.eval_metric.name != self.eval_metric.name:
-                logger.log(log_level, f"\tNote: model has different eval_metric than default.")
+                logger.log(log_level, "\tNote: model has different eval_metric than default.")
             if not model.eval_metric.greater_is_better_internal:
                 sign_str = "-"
             else:
@@ -4714,7 +4713,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
 
         # FIXME: Sample weight `extract_column` is a hack, have to compute feature_metadata here because sample weight column could be in X upstream, extract sample weight column upstream instead.
         if "feature_metadata" not in model_fit_kwargs:
-            raise AssertionError(f"Missing expected parameter 'feature_metadata'.")
+            raise AssertionError("Missing expected parameter 'feature_metadata'.")
         return model_fit_kwargs
 
     def _get_bagged_model_fit_kwargs(

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -232,6 +232,9 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         #: custom split indices
         self._groups = None
 
+        #: custom sklearn-compatible CV splitter (e.g. TimeSeriesSplit)
+        self._cv_splitter = None
+
         #: whether to treat regression predictions as class-probabilities (during distillation)
         self._regress_preds_asprobas = False
 
@@ -3585,6 +3588,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         num_stack_levels=0,
         time_limit=None,
         groups=None,
+        cv_splitter=None,
         **kwargs,
     ) -> list[str]:
         """Identical to self.train_multi_levels, but also saves the data to disk. This should only ever be called once."""
@@ -3606,6 +3610,8 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
             self.is_data_saved = True
         if self._groups is None:
             self._groups = groups
+        if self._cv_splitter is None:
+            self._cv_splitter = cv_splitter
         self._num_rows_train = len(X)
         if X_val is not None:
             self._num_rows_val = len(X_val)
@@ -4699,6 +4705,9 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         if self._groups is not None and "groups" not in model_fit_kwargs:
             if k_fold == self.k_fold:  # don't do this on refit full
                 model_fit_kwargs["groups"] = self._groups
+        if self._cv_splitter is not None and "cv_splitter" not in model_fit_kwargs:
+            if k_fold == self.k_fold:  # don't do this on refit full
+                model_fit_kwargs["cv_splitter"] = self._cv_splitter
 
         if label_cleaner is not None:
             model_fit_kwargs["label_cleaner"] = label_cleaner

--- a/tabular/src/autogluon/tabular/trainer/auto_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/auto_trainer.py
@@ -58,6 +58,7 @@ class AutoTrainer(AbstractTabularTrainer):
         infer_limit_batch_size=None,
         use_bag_holdout=False,
         groups=None,
+        cv_splitter=None,
         callbacks: list[callable] = None,
         label_cleaner=None,
         **kwargs,
@@ -78,9 +79,9 @@ class AutoTrainer(AbstractTabularTrainer):
 
         if (y_val is None) or (X_val is None):
             if not self.bagged_mode or use_bag_holdout:
-                if groups is not None:
+                if groups is not None or cv_splitter is not None:
                     raise AssertionError(
-                        f"Validation data must be manually specified if use_bag_holdout and groups are both specified."
+                        f"Validation data must be manually specified if use_bag_holdout and groups/cv_splitter are both specified."
                     )
                 if self.bagged_mode:
                     # Need at least 2 samples of each class in train data after split for downstream k-fold splits
@@ -162,6 +163,7 @@ class AutoTrainer(AbstractTabularTrainer):
             infer_limit=infer_limit,
             infer_limit_batch_size=infer_limit_batch_size,
             groups=groups,
+            cv_splitter=cv_splitter,
             callbacks=callbacks,
         )
 

--- a/tabular/src/autogluon/tabular/trainer/auto_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/auto_trainer.py
@@ -81,7 +81,7 @@ class AutoTrainer(AbstractTabularTrainer):
             if not self.bagged_mode or use_bag_holdout:
                 if groups is not None or cv_splitter is not None:
                     raise AssertionError(
-                        f"Validation data must be manually specified if use_bag_holdout and groups/cv_splitter are both specified."
+                        "Validation data must be manually specified if use_bag_holdout and groups/cv_splitter are both specified."
                     )
                 if self.bagged_mode:
                     # Need at least 2 samples of each class in train data after split for downstream k-fold splits

--- a/tabular/tests/unittests/test_cv_splitter.py
+++ b/tabular/tests/unittests/test_cv_splitter.py
@@ -7,7 +7,6 @@ temporally ordered data is split without leakage.
 
 from __future__ import annotations
 
-import shutil
 import tempfile
 
 import numpy as np

--- a/tabular/tests/unittests/test_cv_splitter.py
+++ b/tabular/tests/unittests/test_cv_splitter.py
@@ -1,0 +1,109 @@
+"""Tests for custom cv_splitter support in TabularPredictor (issue #4492).
+
+Verifies that a user can pass a pre-configured sklearn-compatible cross-validator
+(e.g. TimeSeriesSplit) via ``TabularPredictor(cv_splitter=...)`` so that
+temporally ordered data is split without leakage.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.model_selection import KFold, TimeSeriesSplit
+
+from autogluon.tabular import TabularPredictor
+
+
+def _make_temporal_dataset(n_samples: int = 30):
+    """Small regression dataset with an explicit temporal ordering."""
+    rng = np.random.default_rng(42)
+    X = pd.DataFrame(
+        {
+            "feature1": rng.standard_normal(n_samples),
+            "feature2": rng.standard_normal(n_samples),
+        }
+    )
+    y = pd.Series(rng.standard_normal(n_samples), name="target")
+    data = pd.concat([X, y], axis=1)
+    return data, "target"
+
+
+def test_cv_splitter_timeseries_split():
+    """TabularPredictor trains successfully when cv_splitter=TimeSeriesSplit is given."""
+    data, label = _make_temporal_dataset(n_samples=30)
+    n_splits = 3
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        predictor = TabularPredictor(
+            label=label,
+            path=tmpdir,
+            cv_splitter=TimeSeriesSplit(n_splits=n_splits),
+        )
+        predictor.fit(
+            train_data=data,
+            num_bag_folds=n_splits,
+            hyperparameters={"GBM": {"num_boost_round": 5}},
+            ag_args_ensemble={"fold_fitting_strategy": "sequential_local"},
+        )
+        preds = predictor.predict(data)
+        assert len(preds) == len(data)
+
+
+def test_cv_splitter_n_splits_matches():
+    """The number of bagged models equals the splitter's n_splits."""
+    data, label = _make_temporal_dataset(n_samples=30)
+    n_splits = 4
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        predictor = TabularPredictor(
+            label=label,
+            path=tmpdir,
+            cv_splitter=TimeSeriesSplit(n_splits=n_splits),
+        )
+        predictor.fit(
+            train_data=data,
+            num_bag_folds=n_splits,
+            hyperparameters={"GBM": {"num_boost_round": 5}},
+            ag_args_ensemble={"fold_fitting_strategy": "sequential_local"},
+        )
+        # Each bagged model produces one fold; leaderboard should list the ensemble and its children
+        leaderboard = predictor.leaderboard(silent=True)
+        assert len(leaderboard) > 0
+
+
+def test_cv_splitter_arbitrary_sklearn_splitter():
+    """Any sklearn BaseCrossValidator instance is accepted (e.g. KFold)."""
+    data, label = _make_temporal_dataset(n_samples=30)
+    n_splits = 3
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        predictor = TabularPredictor(
+            label=label,
+            path=tmpdir,
+            cv_splitter=KFold(n_splits=n_splits, shuffle=True, random_state=0),
+        )
+        predictor.fit(
+            train_data=data,
+            num_bag_folds=n_splits,
+            hyperparameters={"GBM": {"num_boost_round": 5}},
+            ag_args_ensemble={"fold_fitting_strategy": "sequential_local"},
+        )
+        preds = predictor.predict(data)
+        assert len(preds) == len(data)
+
+
+def test_cv_splitter_and_groups_mutually_exclusive():
+    """Specifying both cv_splitter and groups raises a ValueError."""
+    data, label = _make_temporal_dataset(n_samples=30)
+    data["group_col"] = [i % 3 for i in range(len(data))]
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        TabularPredictor(
+            label=label,
+            groups="group_col",
+            cv_splitter=TimeSeriesSplit(n_splits=3),
+        )


### PR DESCRIPTION
## Summary

Closes #4492

Adds a `cv_splitter` parameter to `TabularPredictor.__init__()` that accepts any sklearn-compatible `BaseCrossValidator` instance. This allows users with temporally ordered tabular data to use forward-chaining CV (e.g. `TimeSeriesSplit`) without data leakage, which is not possible with the current `groups` / `LeaveOneGroupOut` approach.

**Usage:**
```python
from sklearn.model_selection import TimeSeriesSplit
from autogluon.tabular import TabularPredictor

predictor = TabularPredictor(label="target", cv_splitter=TimeSeriesSplit(n_splits=5))
predictor.fit(train_data, num_bag_folds=5)
```

## Changes

- `CVSplitter`: new `splitter` param accepts a pre-built `BaseCrossValidator`; when provided, skips all class-based logic and calls `splitter.split(X, y)` directly, inferring `n_splits` via `splitter.get_n_splits()`
- `BaggedEnsembleModel._get_cv_splitter()` / `_fit()`: accept and thread `cv_splitter` through to `CVSplitter`
- `AbstractTabularTrainer`: stores `_cv_splitter` and injects it into `model_fit_kwargs` (same pattern as `_groups`)
- `AutoTrainer.fit()`: accepts and forwards `cv_splitter`
- `AbstractLearner.__init__()`: stores `cv_splitter`; raises `ValueError` if both `groups` and `cv_splitter` are specified
- `DefaultLearner.fit()`: infers `num_bag_folds` from `cv_splitter.get_n_splits()` and passes splitter to trainer
- `TabularPredictor.__init__()`: exposes `cv_splitter` param with docstring and usage example

## Test plan

- [x] `test_cv_splitter_timeseries_split` - fits with `TimeSeriesSplit`, predicts successfully
- [x] `test_cv_splitter_n_splits_matches` - leaderboard is non-empty with correct fold count
- [x] `test_cv_splitter_arbitrary_sklearn_splitter` - works with `KFold` instance
- [x] `test_cv_splitter_and_groups_mutually_exclusive` - raises `ValueError` when both are set