### PR TITLE
[tabular] Fix LightGBM feature name collision

### DIFF
--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -489,7 +489,7 @@ class LGBModel(AbstractModel):
         """Clean column names while keeping most semantic meaning."""
         if not isinstance(column_name, str):
             return column_name
-        for symbol in ['"', ",", ":", "{", "}", "[", "]"]:
+        for symbol in ['"', ",", ":", "{", "}", "[", "]", " "]:
             column_name = column_name.replace(symbol, "_")
         return column_name
 
@@ -557,7 +557,7 @@ class LGBModel(AbstractModel):
             self._requires_remap = False
             for column in X.columns:
                 if isinstance(column, str):
-                    new_column = re.sub(r'[",:{}[\]]', "", column)
+                    new_column = re.sub(r'[",:{}[\]\s]', "", column)
                     if new_column != column:
                         self._requires_remap = True
                         break


### PR DESCRIPTION
*Issue #, if available:*

Refer to https://github.com/lightgbm-org/LightGBM/issues/7230

*Description of changes:*

- Fix LightGBM feature name collision, especially common for text datasets.

Found a very fun bug in LightGBM that was hiding in AG code: https://github.com/lightgbm-org/LightGBM/issues/7230

Turns out LightGBM converts all ` ` (space) into _ for feature names internally, and my original regex check wasn't actually catching this scenario because it didn't check spaces. This rarely mattered because my original logic was to convert all features to numeric IDs if we saw any weird symbols in the feature names (such as for text special features). However, a more recent update changed the logic to instead rename to something human readable via 

```python
        for symbol in ['"', ",", ":", "{", "}", "[", "]"]:
            column_name = column_name.replace(symbol, "_")
```

but because it didn't replace the " " , this would cause a conflict for features such as item_description.symbol_ratio._ and `item_description.symbol_ratio. `, which resolve to the same feature name internally in LightGBM, causing:

```
lightgbm.basic.LightGBMError: Feature (item_description.symbol_ratio._) appears more than one time.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
