### PR TITLE
[tabular] Reduce feature importance mem usage by 25x

### DIFF
--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -1099,7 +1099,14 @@ def _compute_mean_stddev_and_p_value(values: list):
     return mean, stddev, p_value, n
 
 
-def _get_safe_fi_batch_count(X, num_features, X_transformed=None, max_memory_ratio=0.1, max_feature_batch_count=None, max_rows_per_batch=100_000):
+def _get_safe_fi_batch_count(
+    X,
+    num_features,
+    X_transformed=None,
+    max_memory_ratio=0.1,
+    max_feature_batch_count=None,
+    max_rows_per_batch=100_000,
+):
     if max_rows_per_batch is None:
         max_rows_per_batch = 100000
     # calculating maximum number of features that are safe to process in parallel

--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -770,6 +770,9 @@ def compute_permutation_feature_importance(
     log_prefix="",
     importance_as_list=False,
     random_state=0,
+    max_memory_ratio=0.1,
+    max_feature_batch_count=None,
+    max_rows_per_batch=None,
     **kwargs,
 ) -> pd.DataFrame:
     """
@@ -925,10 +928,21 @@ def compute_permutation_feature_importance(
                     )
 
                 if transform_func is None:
-                    feature_batch_count = _get_safe_fi_batch_count(X=X, num_features=num_features)
+                    feature_batch_count = _get_safe_fi_batch_count(
+                        X=X,
+                        num_features=num_features,
+                        max_memory_ratio=max_memory_ratio,
+                        max_feature_batch_count=max_feature_batch_count,
+                        max_rows_per_batch=max_rows_per_batch,
+                    )
                 else:
                     feature_batch_count = _get_safe_fi_batch_count(
-                        X=X, num_features=num_features, X_transformed=X_transformed
+                        X=X,
+                        num_features=num_features,
+                        X_transformed=X_transformed,
+                        max_memory_ratio=max_memory_ratio,
+                        max_feature_batch_count=max_feature_batch_count,
+                        max_rows_per_batch=max_rows_per_batch,
                     )
 
             # creating copy of original data N=feature_batch_count times for parallel processing
@@ -1085,15 +1099,16 @@ def _compute_mean_stddev_and_p_value(values: list):
     return mean, stddev, p_value, n
 
 
-def _get_safe_fi_batch_count(X, num_features, X_transformed=None, max_memory_ratio=0.2, max_feature_batch_count=None):
+def _get_safe_fi_batch_count(X, num_features, X_transformed=None, max_memory_ratio=0.1, max_feature_batch_count=None, max_rows_per_batch=100_000):
+    if max_rows_per_batch is None:
+        max_rows_per_batch = 100000
     # calculating maximum number of features that are safe to process in parallel
     if max_feature_batch_count is None:
-        # If None, use a heuristic: limit total rows*features processed in one batch to ~2,500,000.
+        # If None, use a heuristic: limit total rows*features processed in one batch to ~100,000.
         # This balances memory usage and vectorization speed.
-        # For example, if X has 100 rows, batch size will be capped at 10,000 features (hard cap).
-        # If X has 1,000 rows, batch size can include 2,500 features.
-        # If X has 1,000,000 rows, batch size can be 2 features.
-        max_rows_per_batch = 2500000
+        # For example, if X has 5 rows, batch size will be capped at 10,000 features (hard cap).
+        # If X has 1,000 rows, batch size can include 100 features.
+        # If X has 1,000,000 rows, batch size will be 1 features.
         num_rows = X.shape[0] if hasattr(X, "shape") else len(X)
         max_feature_batch_count = max(1, max_rows_per_batch // num_rows)
         max_feature_batch_count = min(max_feature_batch_count, 10000)

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -3616,6 +3616,8 @@ class TabularPredictor:
         num_shuffle_sets: int = None,
         include_confidence_band: bool = True,
         confidence_level: float = 0.99,
+        max_rows_per_batch: int = 100_000,
+        max_memory_ratio: float = 0.1,
         silent: bool = False,
     ):
         """
@@ -3690,6 +3692,15 @@ class TabularPredictor:
             This argument is only considered when `include_confidence_band` is True, and can be used to specify the confidence level used for constructing confidence intervals.
             For example, if `confidence_level` is set to 0.99, then the returned DataFrame will include columns 'p99_high' and 'p99_low' which indicates that the true feature importance will be between 'p99_high' and 'p99_low' 99% of the time (99% confidence interval).
             More generally, if `confidence_level` = 0.XX, then the columns containing the XX% confidence interval will be named 'pXX_high' and 'pXX_low'.
+        max_rows_per_batch : int, default = 100000
+            The maximum amount of rows to process per feature batch.
+            This directly translates to maximum memory usage and inference throughput.
+            Use lower values to reduce memory usage, or specify a lower max_memory_ratio.
+        max_memory_ratio : float, default = 0.1
+            Determines the max memory usage of the batched input data to use per feature batch relative to available memory.
+            Use lower values to reduce the chance of running out of memory in exchange for slightly longer runtimes.
+            Will use the lower of max_rows_per_batch and the value determined by max_memory_ratio and available memory.
+
         silent : bool, default = False
             Whether to suppress logging output.
 
@@ -3727,6 +3738,8 @@ class TabularPredictor:
             subsample_size=subsample_size,
             time_limit=time_limit,
             num_shuffle_sets=num_shuffle_sets,
+            max_rows_per_batch=max_rows_per_batch,
+            max_memory_ratio=max_memory_ratio,
             silent=silent,
         )
 

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -3700,7 +3700,6 @@ class TabularPredictor:
             Determines the max memory usage of the batched input data to use per feature batch relative to available memory.
             Use lower values to reduce the chance of running out of memory in exchange for slightly longer runtimes.
             Will use the lower of max_rows_per_batch and the value determined by max_memory_ratio and available memory.
-
         silent : bool, default = False
             Whether to suppress logging output.
 


### PR DESCRIPTION
*Issue #, if available:*

Replaces #5642
Resolves #5641

*Description of changes:*

- Previously, TabularPredictor.feature_importance would generate batches of up to 2.5M samples for inference at a time, causing a large memory usage in cases where later in the pipeline the data is given many additional features, such as with PrepLightGBM. This caused OOM errors for users.
- Added max_rows_per_batch as an argument to the feature_importance method so users can control this value. Also made the default 100,000 (25x lower), for a 25x reduction in memory usage by default. Also added max_memory_usage argument and reduced default to 0.1 from 0.2. This should now require <5GB memory even in extreme cases.

This change actually speeds up feature_importance by ~50% in my testing, because 2.5M rows was actually slower to process in some cases than 25 batches of 100k rows, while reducing peak memory usage by 25x. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
