### PR TITLE
[tabular] add core_kwargs and aux_kwargs fit params

### DIFF
--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -5629,7 +5629,15 @@ class TabularPredictor:
         kwargs_sanitized.update(kwargs)
 
         # Deepcopy args to avoid altering outer context
-        deepcopy_args = ["ag_args", "ag_args_fit", "ag_args_ensemble", "included_model_types", "excluded_model_types", "core_kwargs", "aux_kwargs"]
+        deepcopy_args = [
+            "ag_args",
+            "ag_args_fit",
+            "ag_args_ensemble",
+            "included_model_types",
+            "excluded_model_types",
+            "core_kwargs",
+            "aux_kwargs",
+        ]
         for deepcopy_arg in deepcopy_args:
             kwargs_sanitized[deepcopy_arg] = copy.deepcopy(kwargs_sanitized[deepcopy_arg])
 

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -915,6 +915,14 @@ class TabularPredictor:
                 See the `ag_args_ensemble` argument from "Advanced functionality: Custom AutoGluon model arguments" in the `hyperparameters` argument documentation for valid values.
                 Identical to specifying `ag_args_ensemble` parameter for all models in `hyperparameters`.
                 If a key in `ag_args_ensemble` is already specified for a model in `hyperparameters`, it will not be altered through this argument.
+            core_kwargs : dict, default = None
+                [Advanced] Keyword arguments to pass to models.
+                More precisely, these kwargs are passed to Trainer's stack_new_level_core method.
+                Values specified here have priority over all other arguments.
+            aux_kwargs : dict, default = None
+                [Advanced] Keyword arguments to pass to aux models (such as the weighted ensemble).
+                More precisely, these kwargs are passed to Trainer's stack_new_level_aux method.
+                Values specified here have priority over all other arguments.
             ds_args : dict, see below for default
                 Keyword arguments for dynamic stacking, only used if `dynamic_stacking=True`. These keyword arguments control the behavior of dynamic stacking
                 and determine how AutoGluon tries to detect stacked overfitting. To detect stacked overfitting, AutoGluon will fit itself (so called sub-fits)
@@ -1187,6 +1195,8 @@ class TabularPredictor:
         ag_args = kwargs["ag_args"]
         ag_args_fit = kwargs["ag_args_fit"]
         ag_args_ensemble = kwargs["ag_args_ensemble"]
+        core_kwargs = kwargs["core_kwargs"]
+        aux_kwargs = kwargs["aux_kwargs"]
         included_model_types = kwargs["included_model_types"]
         excluded_model_types = kwargs["excluded_model_types"]
         use_bag_holdout = kwargs["use_bag_holdout"]
@@ -1388,7 +1398,7 @@ class TabularPredictor:
                     "\tConsider setting `time_limit` to ensure training finishes within an expected duration or experiment with a small portion of `train_data` to identify an ideal `presets` and `hyperparameters` configuration.",
                 )
 
-        core_kwargs = {
+        core_kwargs_defaults = {
             "total_resources": {
                 "num_cpus": num_cpus,
                 "num_gpus": num_gpus,
@@ -1402,16 +1412,27 @@ class TabularPredictor:
             "delay_bag_sets": delay_bag_sets,
             "fit_strategy": fit_strategy,
         }
-        aux_kwargs = {
+
+        if core_kwargs is None:
+            core_kwargs = {}
+        # Overwrite core_kwargs_defaults with core_kwargs values in case of shared keys
+        core_kwargs = {**core_kwargs_defaults, **core_kwargs}
+
+        aux_kwargs_defaults = {
             "total_resources": {
                 "num_cpus": num_cpus,
                 "num_gpus": num_gpus,
             },
         }
         if fit_weighted_ensemble is False:
-            aux_kwargs["fit_weighted_ensemble"] = False
-        aux_kwargs["fit_full_last_level_weighted_ensemble"] = fit_full_last_level_weighted_ensemble
-        aux_kwargs["full_weighted_ensemble_additionally"] = full_weighted_ensemble_additionally
+            aux_kwargs_defaults["fit_weighted_ensemble"] = False
+        aux_kwargs_defaults["fit_full_last_level_weighted_ensemble"] = fit_full_last_level_weighted_ensemble
+        aux_kwargs_defaults["full_weighted_ensemble_additionally"] = full_weighted_ensemble_additionally
+
+        if aux_kwargs is None:
+            aux_kwargs = {}
+        # Overwrite aux_kwargs_defaults with aux_kwargs values in case of shared keys
+        aux_kwargs = {**aux_kwargs_defaults, **aux_kwargs}
 
         ag_fit_kwargs = dict(
             X=train_data,
@@ -2117,6 +2138,8 @@ class TabularPredictor:
         ag_args = kwargs["ag_args"]
         ag_args_fit = kwargs["ag_args_fit"]
         ag_args_ensemble = kwargs["ag_args_ensemble"]
+        core_kwargs = kwargs["core_kwargs"]
+        aux_kwargs = kwargs["aux_kwargs"]
         excluded_model_types = kwargs["excluded_model_types"]
         pseudo_data = kwargs.get("pseudo_data", None)
 
@@ -2137,16 +2160,21 @@ class TabularPredictor:
         )
 
         fit_new_weighted_ensemble = False  # TODO: Add as option
-        aux_kwargs = {
+        aux_kwargs_defaults = {
             "total_resources": {
                 "num_cpus": num_cpus,
                 "num_gpus": num_gpus,
             },
         }
         if fit_weighted_ensemble is False:
-            aux_kwargs = {"fit_weighted_ensemble": False}
-        aux_kwargs["fit_full_last_level_weighted_ensemble"] = fit_full_last_level_weighted_ensemble
-        aux_kwargs["full_weighted_ensemble_additionally"] = full_weighted_ensemble_additionally
+            aux_kwargs_defaults = {"fit_weighted_ensemble": False}
+        aux_kwargs_defaults["fit_full_last_level_weighted_ensemble"] = fit_full_last_level_weighted_ensemble
+        aux_kwargs_defaults["full_weighted_ensemble_additionally"] = full_weighted_ensemble_additionally
+
+        if aux_kwargs is None:
+            aux_kwargs = {}
+        # Overwrite aux_kwargs_defaults with aux_kwargs values in case of shared keys
+        aux_kwargs = {**aux_kwargs_defaults, **aux_kwargs}
 
         if isinstance(hyperparameters, str):
             hyperparameters = get_hyperparameter_config(hyperparameters)
@@ -2159,8 +2187,7 @@ class TabularPredictor:
                     highest_level = max(key, highest_level)
             num_stack_levels = highest_level - 1
 
-        # TODO: make core_kwargs a kwargs argument to predictor.fit, add aux_kwargs to predictor.fit
-        core_kwargs = {
+        core_kwargs_defaults = {
             "total_resources": {
                 "num_cpus": num_cpus,
                 "num_gpus": num_gpus,
@@ -2174,8 +2201,13 @@ class TabularPredictor:
 
         # FIXME: v1.2 pseudo_data can be passed in `fit()` but it is ignored!
         if X_pseudo is not None and y_pseudo is not None:
-            core_kwargs["X_pseudo"] = X_pseudo
-            core_kwargs["y_pseudo"] = y_pseudo
+            core_kwargs_defaults["X_pseudo"] = X_pseudo
+            core_kwargs_defaults["y_pseudo"] = y_pseudo
+
+        if core_kwargs is None:
+            core_kwargs = {}
+        # Overwrite core_kwargs_defaults with core_kwargs values in case of shared keys
+        core_kwargs = {**core_kwargs_defaults, **core_kwargs}
 
         # TODO: Add special error message if called and training/val data was not cached.
         X, y, X_val, y_val = self._trainer.load_data()
@@ -5484,13 +5516,13 @@ class TabularPredictor:
             delay_bag_sets=False,
             num_stack_levels=None,
             hyperparameter_tune_kwargs=None,
-            # core_kwargs -> +1 nest
             ag_args=None,
             ag_args_fit=None,
             ag_args_ensemble=None,
+            core_kwargs=None,
+            aux_kwargs=None,
             included_model_types=None,
             excluded_model_types=None,
-            # aux_kwargs -> +1 nest
             # post_fit_kwargs -> +1 nest
             set_best_to_refit_full=False,
             keep_only_best=False,
@@ -5597,7 +5629,7 @@ class TabularPredictor:
         kwargs_sanitized.update(kwargs)
 
         # Deepcopy args to avoid altering outer context
-        deepcopy_args = ["ag_args", "ag_args_fit", "ag_args_ensemble", "included_model_types", "excluded_model_types"]
+        deepcopy_args = ["ag_args", "ag_args_fit", "ag_args_ensemble", "included_model_types", "excluded_model_types", "core_kwargs", "aux_kwargs"]
         for deepcopy_arg in deepcopy_args:
             kwargs_sanitized[deepcopy_arg] = copy.deepcopy(kwargs_sanitized[deepcopy_arg])
 

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -995,6 +995,9 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         fit_weighted_ensemble: bool = True,
         name_extra: str | None = None,
         total_resources: dict | None = None,
+        child_hyperparameters: dict | None = None,
+        ag_args_fit: dict | None = None,
+        **kwargs,
     ) -> list[str]:
         """
         Trains auxiliary models (currently a single weighted ensemble) using the provided base models.
@@ -1015,6 +1018,10 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
             logger.log(20, f"No base models to train on, skipping auxiliary stack level {level}...")
             return []
 
+        if ag_args_fit is None:
+            ag_args_fit = dict()
+        ag_args_fit = copy.deepcopy(ag_args_fit)
+
         if isinstance(level, str):
             assert level == "auto", f"level must be 'auto' if str, found: {level}"
             levels_dict = self.get_models_attribute_dict(attribute="level", models=base_model_names)
@@ -1025,10 +1032,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
             level = base_model_level_max + 1
 
         if infer_limit_batch_size is not None:
-            ag_args_fit = dict()
             ag_args_fit["predict_1_batch_size"] = infer_limit_batch_size
-        else:
-            ag_args_fit = None
         X_stack_preds = self.get_inputs_to_stacker(
             X, base_models=base_model_names, fit=fit, use_orig_features=False, use_val_cache=use_val_cache
         )
@@ -1038,9 +1042,13 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
             )  # TODO: consider redesign with w as separate arg instead of bundled inside X
             if w is not None:
                 X_stack_preds[self.sample_weight] = w.values / w.mean()
-        child_hyperparameters = None
+        if child_hyperparameters is None:
+            child_hyperparameters = {}
+        child_hyperparameters = copy.deepcopy(child_hyperparameters)
         if name_extra is not None:
-            child_hyperparameters = {"ag_args": {"name_suffix": name_extra}}
+            if "ag_args" not in child_hyperparameters:
+                child_hyperparameters["ag_args"] = {}
+            child_hyperparameters["ag_args"].setdefault("name_suffix", name_extra)
         return self.generate_weighted_ensemble(
             X=X_stack_preds,
             y=y,
@@ -1056,6 +1064,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
             check_if_best=check_if_best,
             child_hyperparameters=child_hyperparameters,
             total_resources=total_resources,
+            **kwargs,
         )
 
     def predict(self, X: pd.DataFrame, model: str | None = None) -> np.ndarray:
@@ -2115,10 +2124,13 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         stack_name=None,
         hyperparameters=None,
         ag_args_fit=None,
+        ag_args_ensemble=None,
         time_limit=None,
         name_suffix: str | None = None,
         save_bag_folds=None,
         check_if_best=True,
+        ensemble_type=WeightedEnsembleModel,
+        child_cls="ENS_WEIGHTED",
         child_hyperparameters=None,
         get_models_func=None,
         total_resources: dict | None = None,
@@ -2128,6 +2140,10 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         if len(base_model_names) == 0:
             logger.log(20, "No base models to train on, skipping weighted ensemble...")
             return []
+
+        if ag_args_ensemble is None:
+            ag_args_ensemble = {}
+        ag_args_ensemble = copy.deepcopy(ag_args_ensemble)
 
         if child_hyperparameters is None:
             child_hyperparameters = {}
@@ -2139,6 +2155,8 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
             else:
                 save_bag_folds = True
 
+        ag_args_ensemble.setdefault("save_bag_folds", save_bag_folds)
+
         feature_metadata = self.get_feature_metadata(use_orig_features=False, base_models=base_model_names)
 
         base_model_paths_dict = self.get_models_attribute_dict(attribute="path", models=base_model_names)
@@ -2146,10 +2164,10 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         weighted_ensemble_model, _ = get_models_func(
             hyperparameters={
                 "default": {
-                    "ENS_WEIGHTED": [child_hyperparameters],
+                    child_cls: [child_hyperparameters],
                 }
             },
-            ensemble_type=WeightedEnsembleModel,
+            ensemble_type=ensemble_type,
             ensemble_kwargs=dict(
                 base_model_names=base_model_names,
                 base_model_paths_dict=base_model_paths_dict,
@@ -2165,7 +2183,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
             ),
             ag_args={"name_bag_suffix": ""},
             ag_args_fit=ag_args_fit,
-            ag_args_ensemble={"save_bag_folds": save_bag_folds},
+            ag_args_ensemble=ag_args_ensemble,
             name_suffix=name_suffix,
             level=level,
         )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- add core_kwargs and aux_kwargs fit params
- These were planned for v1.0 release but never finished.
- Now the user can specify advanced arguments with these params.

For example, the following lets the user change the weighted ensemble model class, the number of greedy ensembling steps from the default of 25 to 40, and alter the amount of models considered per model type in the ensemble to 5:

```python
aux_kwargs = {
    "ag_args_ensemble": {"max_base_models_per_type": 5},
    "child_cls": MyCustomWeightedEnsembleModel,
    "child_hyperparameters": {"ensemble_size": 40},
}
```

Here, the user could even replace the entire stack ensembling implementation with their own class:

```python
core_kwargs = {
    "ensemble_type": MyCustomStackerEnsembleModel,
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
