### PR TITLE
[tabular] Fix TabPrep running the feature generator twice

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabprep/prep_mixin.py
+++ b/tabular/src/autogluon/tabular/models/tabprep/prep_mixin.py
@@ -163,7 +163,7 @@ class ModelAgnosticPrepMixin:
         else:
             raise ValueError(f"Invalid value for prep_param: {prep_param}")
 
-    def get_preprocessor(self) -> AbstractFeatureGenerator | None:
+    def get_preprocessor_tabprep(self) -> AbstractFeatureGenerator | None:
         ag_params = self._get_ag_params()
         prep_params = ag_params.get("prep_params", None)
         passthrough_types = ag_params.get("prep_params.passthrough_types", None)
@@ -192,7 +192,7 @@ class ModelAgnosticPrepMixin:
 
     def _preprocess(self, X: pd.DataFrame, y=None, is_train: bool = False, **kwargs):
         if is_train:
-            self.preprocessor = self.get_preprocessor()
+            self.preprocessor = self.get_preprocessor_tabprep()
             if self.preprocessor is not None:
                 assert y is not None, (
                     f"y must be specified to fit preprocessors... Likely the inheriting class isn't passing `y` in its `preprocess` call."


### PR DESCRIPTION
*Issue #, if available:*

Bug originated in #5588 (Feb 10th)

*Description of changes:*

As part of the logic post-1.5 to enable TabPrep for any model, the method `get_preprocessor` was created for AbstractModel which creates the TabPrep feature generator.

This silently changed PrepLightGBM's behavior because PrepLightGBM wraps `ModelAgnosticPrepMixin` which also has a `get_preprocessor` method used to create the TabPrep feature generator.

This caused the call in AbstractModel to call ModelAgnosticPrepMixin.get_preprocessor for PrepLightGBM, leading to a scenario where the original data is transformed by TabPrep, and then the transformed data is transformed again, leading to a huge increase in feature count and worse performance.

This PR fixes this bug by renaming ModelAgnosticPrepMixin.get_preprocessor to `get_preprocessor_tabprep` so it doesn't overwrite the `get_preprocessor` method.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
