### PR TITLE
Fix remote filesystem collision on artifact directory creation

### DIFF
--- a/common/src/autogluon/common/utils/utils.py
+++ b/common/src/autogluon/common/utils/utils.py
@@ -102,7 +102,8 @@ def setup_outputdir(
                     if os.path.isdir(path):
                         raise FileExistsError
                     break
-            except FileExistsError:
+            except (FileExistsError, PermissionError):
+                # PermissionError can happen for shared filesystems such as on GCP
                 pass
         else:
             raise RuntimeError("more than 1000 jobs launched in the same second")

--- a/common/src/autogluon/common/utils/utils.py
+++ b/common/src/autogluon/common/utils/utils.py
@@ -102,11 +102,10 @@ def setup_outputdir(
                     if os.path.isdir(path):
                         raise FileExistsError
                     break
-            except (FileExistsError, PermissionError):
-                # PermissionError can happen for shared filesystems such as on GCP
+            except FileExistsError:
                 pass
         else:
-            raise RuntimeError("more than 1000 jobs launched in the same second")
+            raise RuntimeError(f"more than 1000 jobs launched in the same second: {path}")
         logger.log(25, f'No path specified. Models will be saved in: "{path}"')
         warn_if_exist = False  # Don't warn about the folder existing since we just created it
 

--- a/common/src/autogluon/common/utils/utils.py
+++ b/common/src/autogluon/common/utils/utils.py
@@ -85,10 +85,15 @@ def setup_outputdir(
     else:
         utcnow = datetime.now(timezone.utc)
         timestamp = utcnow.strftime("%Y%m%d_%H%M%S")
-        path = os.path.join(default_base_path, f"ag-{timestamp}")
-        if path_suffix:
-            path = os.path.join(path, path_suffix)
-        for i in range(1, 1000):
+        base_name = f"ag-{timestamp}"
+
+        for i in range(1000):
+            ag_dir_name = base_name
+            if i >= 1:
+                ag_dir_name = f"{ag_dir_name}-{i:03d}"
+            path = os.path.join(default_base_path, ag_dir_name)
+            if path_suffix:
+                path = os.path.join(path, path_suffix)
             try:
                 if create_dir:
                     os.makedirs(path, exist_ok=False)
@@ -98,9 +103,7 @@ def setup_outputdir(
                         raise FileExistsError
                     break
             except FileExistsError:
-                path = os.path.join(default_base_path, f"ag-{timestamp}-{i:03d}")
-                if path_suffix:
-                    path = os.path.join(path, path_suffix)
+                pass
         else:
             raise RuntimeError("more than 1000 jobs launched in the same second")
         logger.log(25, f'No path specified. Models will be saved in: "{path}"')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fix remote filesystem collision on GCP when two nodes try to create an AutoGluon dir in the same shared location within the same second. Because this raises a PermissionError rather than a FileExistsError, the previous code crashed instead of handling this properly by adding a suffix to the directory.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
