### PR TITLE
feat: align timeseries eval_metric format with tabular

### DIFF
--- a/timeseries/src/autogluon/timeseries/metrics/__init__.py
+++ b/timeseries/src/autogluon/timeseries/metrics/__init__.py
@@ -24,6 +24,8 @@ __all__ = [
     "WAPE",
     "WCD",
     "WQL",
+    "AVAILABLE_METRICS",
+    "METRIC_ALIASES",
 ]
 
 DEFAULT_METRIC_NAME = "WQL"
@@ -40,6 +42,23 @@ AVAILABLE_METRICS: dict[str, Type[TimeSeriesScorer]] = {
     "WQL": WQL,
     "MSE": MSE,
     "MAE": MAE,
+}
+
+# Maps full lowercase metric names (as used in autogluon.tabular) to their canonical uppercase acronyms.
+# When multiple time series metrics share the same tabular equivalent (e.g. MAE/MASE/WAPE all map to
+# mean_absolute_error), the simplest non-scaled metric is preferred here.
+METRIC_ALIASES: dict[str, str] = {
+    "mean_absolute_error": "MAE",
+    "mean_squared_error": "MSE",
+    "root_mean_squared_error": "RMSE",
+    "root_mean_squared_logarithmic_error": "RMSLE",
+    "mean_absolute_percentage_error": "MAPE",
+    "symmetric_mean_absolute_percentage_error": "SMAPE",
+    "mean_absolute_scaled_error": "MASE",
+    "root_mean_squared_scaled_error": "RMSSE",
+    "weighted_absolute_percentage_error": "WAPE",
+    "weighted_quantile_loss": "WQL",
+    "scaled_quantile_loss": "SQL",
 }
 
 # For backward compatibility
@@ -91,7 +110,7 @@ def check_get_evaluation_metric(
         # e.g., user passed `eval_metric=CustomMetric` instead of `eval_metric=CustomMetric()`
         scorer = eval_metric(**metric_kwargs)
     elif isinstance(eval_metric, str):
-        metric_name = DEPRECATED_METRICS.get(eval_metric, eval_metric).upper()
+        metric_name = METRIC_ALIASES.get(eval_metric, DEPRECATED_METRICS.get(eval_metric, eval_metric)).upper()
         if metric_name in AVAILABLE_METRICS:
             scorer = AVAILABLE_METRICS[metric_name](**metric_kwargs)
         elif metric_name in EXPERIMENTAL_METRICS:

--- a/timeseries/src/autogluon/timeseries/metrics/__init__.py
+++ b/timeseries/src/autogluon/timeseries/metrics/__init__.py
@@ -44,9 +44,7 @@ AVAILABLE_METRICS: dict[str, Type[TimeSeriesScorer]] = {
     "MAE": MAE,
 }
 
-# Maps full lowercase metric names (as used in autogluon.tabular) to their canonical uppercase acronyms.
-# When multiple time series metrics share the same tabular equivalent (e.g. MAE/MASE/WAPE all map to
-# mean_absolute_error), the simplest non-scaled metric is preferred here.
+# Provide lowercase aliases for metrics for consistency with autogluon.tabular
 METRIC_ALIASES: dict[str, str] = {
     "mean_absolute_error": "MAE",
     "mean_squared_error": "MSE",

--- a/timeseries/tests/unittests/test_metrics.py
+++ b/timeseries/tests/unittests/test_metrics.py
@@ -21,6 +21,7 @@ from autogluon.timeseries import TimeSeriesPredictor
 from autogluon.timeseries.metrics import (
     AVAILABLE_METRICS,
     DEFAULT_METRIC_NAME,
+    METRIC_ALIASES,
     TimeSeriesScorer,
     check_get_evaluation_metric,
 )
@@ -212,6 +213,12 @@ def test_given_correct_input_check_get_eval_metric_output_correct(check_input, e
 def test_given_unavailable_input_and_raise_check_get_eval_metric_raises():
     with pytest.raises(ValueError):
         check_get_evaluation_metric("some_nonsense_eval_metric", prediction_length=1)
+
+
+@pytest.mark.parametrize("full_name, expected_acronym", METRIC_ALIASES.items())
+def test_given_tabular_style_full_name_check_get_eval_metric_resolves_to_correct_acronym(full_name, expected_acronym):
+    metric = check_get_evaluation_metric(full_name, prediction_length=1)
+    assert metric.name == expected_acronym
 
 
 @pytest.mark.parametrize("eval_metric", ["MASE", "RMSSE", "SQL"])


### PR DESCRIPTION
Assisted-by: Claude Code

*Issue # , if available:*
#5660 

*Description of changes:*
Adds `METRIC_ALIASES` to `autogluon.timeseries.metrics` — a dict that maps full lowercase metric names (as used in AutoGluon-Tabular) to their canonical uppercase timeseries acronyms. `check_get_evaluation_metric()` now consults this dict first, so users can pass either style interchangeably.

### Changes

**`timeseries/src/autogluon/timeseries/metrics/__init__.py`**

- Added `METRIC_ALIASES: dict[str, str]` constant mapping 11 full lowercase names to their acronyms:

  | Full name (tabular style) | Acronym (timeseries style) |
  |---|---|
  | `mean_absolute_error` | `MAE` |
  | `mean_squared_error` | `MSE` |
  | `root_mean_squared_error` | `RMSE` |
  | `root_mean_squared_logarithmic_error` | `RMSLE` |
  | `mean_absolute_percentage_error` | `MAPE` |
  | `symmetric_mean_absolute_percentage_error` | `SMAPE` |
  | `mean_absolute_scaled_error` | `MASE` |
  | `root_mean_squared_scaled_error` | `RMSSE` |
  | `weighted_absolute_percentage_error` | `WAPE` |
  | `weighted_quantile_loss` | `WQL` |
  | `scaled_quantile_loss` | `SQL` |

  When multiple timeseries metrics share the same tabular equivalent (e.g. `MAE`, `MASE`, and `WAPE` all correspond to `mean_absolute_error`), the simplest non-scaled metric is chosen as the alias target.

- One-line change in `check_get_evaluation_metric()` to consult `METRIC_ALIASES` before the existing `.upper()` + `DEPRECATED_METRICS` lookup:

  ```python
  # Before
  metric_name = DEPRECATED_METRICS.get(eval_metric, eval_metric).upper()

  # After
  metric_name = METRIC_ALIASES.get(eval_metric, DEPRECATED_METRICS.get(eval_metric, eval_metric)).upper()
  ```

- `METRIC_ALIASES` added to `__all__` so it is part of the public API.

**`timeseries/tests/unittests/test_metrics.py`**

- Added `test_given_tabular_style_full_name_check_get_eval_metric_resolves_to_correct_acronym` — 11 parametrized cases, one per alias entry, asserting that each full name resolves to the expected acronym.

### Why there is no regression

- `METRIC_ALIASES` keys are exclusively lowercase full names. None of them were valid inputs before this change (all raised `ValueError`), so no existing call site is affected.
- Existing acronym inputs (`"MAE"`, `"mae"`, `"Mae"`) miss the `METRIC_ALIASES` lookup and fall through to the unchanged `.upper()` path.
- `DEPRECATED_METRICS` is still consulted in the same position in the lookup chain.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
