### PR TITLE
feat: relax strict requirements for patch version when loading predictor

### DIFF
--- a/common/src/autogluon/common/utils/utils.py
+++ b/common/src/autogluon/common/utils/utils.py
@@ -11,6 +11,7 @@ from typing import Any, Optional
 
 import numpy as np
 import pandas as pd
+from packaging.version import InvalidVersion, Version
 
 from ..version import __version__
 from .random import get_numpy_seed as _get_numpy_seed
@@ -199,7 +200,28 @@ def compare_autogluon_metadata(*, original: dict, current: dict, check_packages=
     og = original
     cu = current
     if og["version"] != cu["version"]:
-        logs.append((30, f"WARNING: AutoGluon version mismatch (original={og['version']}, current={cu['version']})"))
+        try:
+            v_og = Version(og["version"])
+            v_cu = Version(cu["version"])
+            if (
+                v_og.major == v_cu.major
+                and v_og.minor == v_cu.minor
+                and v_og.pre is None
+                and v_cu.pre is None
+                and v_og.dev is None
+                and v_cu.dev is None
+            ):
+                logs.append(
+                    (20, f"INFO: AutoGluon patch version mismatch (original={og['version']}, current={cu['version']})")
+                )
+            else:
+                logs.append(
+                    (30, f"WARNING: AutoGluon version mismatch (original={og['version']}, current={cu['version']})")
+                )
+        except InvalidVersion:
+            logs.append(
+                (30, f"WARNING: AutoGluon version mismatch (original={og['version']}, current={cu['version']})")
+            )
     if og["py_version"] != cu["py_version"]:
         logs.append(
             (
@@ -228,8 +250,10 @@ def compare_autogluon_metadata(*, original: dict, current: dict, check_packages=
             if k not in og_pac:
                 logs.append((30, f"INFO: New package '{k}=={cu_pac[k]}'"))
 
-    if len(logs) > 0:
-        logger.log(30, f"Found {len(logs)} mismatches between original and current metadata:")
+    if logs:
+        logger.log(
+            max(level for level, _ in logs), f"Found {len(logs)} mismatches between original and current metadata:"
+        )
     for log in logs:
         logger.log(log[0], f"\t{log[1]}")
 
@@ -249,8 +273,31 @@ def check_saved_predictor_version(
 ) -> None:
     if logger is None:
         logger = logging.getLogger(__name__)
-
     if version_saved != version_current:
+        patch_only = False
+        try:
+            v_saved = Version(version_saved)
+            v_current = Version(version_current)
+            patch_only = (
+                v_saved.major == v_current.major
+                and v_saved.minor == v_current.minor
+                and v_saved.pre is None
+                and v_current.pre is None
+                and v_saved.dev is None
+                and v_current.dev is None
+            )
+        except InvalidVersion:
+            pass  # unparseable version → treat conservatively as major/minor mismatch
+
+        if patch_only:
+            logger.info(
+                f"AutoGluon patch version differs between the saved predictor "
+                f"(version={version_saved}) and the currently installed version "
+                f"(version={version_current}). Patch versions are expected to be "
+                f"compatible; loading will proceed."
+            )
+            return
+
         logger.warning("")
         logger.warning("############################## WARNING ##############################")
         logger.warning(

--- a/common/tests/unittests/utils/test_compare_autogluon_metadata.py
+++ b/common/tests/unittests/utils/test_compare_autogluon_metadata.py
@@ -1,7 +1,11 @@
 import copy
 import unittest
 
-from autogluon.common.utils.utils import compare_autogluon_metadata, get_autogluon_metadata
+from autogluon.common.utils.utils import (
+    check_saved_predictor_version,
+    compare_autogluon_metadata,
+    get_autogluon_metadata,
+)
 
 
 class CompareAutoGluonMetadataTestCase(unittest.TestCase):
@@ -80,6 +84,72 @@ class CompareAutoGluonMetadataTestCase(unittest.TestCase):
         logs = compare_autogluon_metadata(original=metadata_og, current=metadata_cu)
         assert len(logs) == 1
         assert logs[0] == (30, "INFO: New package 'dummy_package==0.3'")
+
+
+class CheckSavedPredictorVersionTestCase(unittest.TestCase):
+    def test_exact_match_does_not_raise(self):
+        check_saved_predictor_version("1.2.0", "1.2.0", require_version_match=True)
+
+    def test_patch_version_mismatch_does_not_raise(self):
+        check_saved_predictor_version("1.2.1", "1.2.0", require_version_match=True)
+
+    def test_patch_version_mismatch_reverse_does_not_raise(self):
+        check_saved_predictor_version("1.2.0", "1.2.1", require_version_match=True)
+
+    def test_minor_version_mismatch_raises(self):
+        with self.assertRaises(AssertionError):
+            check_saved_predictor_version("1.3.0", "1.2.0", require_version_match=True)
+
+    def test_major_version_mismatch_raises(self):
+        with self.assertRaises(AssertionError):
+            check_saved_predictor_version("2.0.0", "1.2.0", require_version_match=True)
+
+    def test_unparseable_version_raises(self):
+        with self.assertRaises(AssertionError):
+            check_saved_predictor_version("1.2.0", "Unknown (Likely <=0.7.0)", require_version_match=True)
+
+    def test_prerelease_version_mismatch_raises(self):
+        with self.assertRaises(AssertionError):
+            check_saved_predictor_version("1.2.0", "1.2.0a1", require_version_match=True)
+
+    def test_minor_version_mismatch_no_raise_when_require_false(self):
+        check_saved_predictor_version("1.3.0", "1.2.0", require_version_match=False)
+
+    def test_patch_version_mismatch_metadata_is_info(self):
+        metadata_og = get_autogluon_metadata()
+        metadata_cu = copy.deepcopy(metadata_og)
+        metadata_og["version"] = "1.2.0"
+        metadata_cu["version"] = "1.2.1"
+        logs = compare_autogluon_metadata(original=metadata_og, current=metadata_cu)
+        assert len(logs) == 1
+        assert logs[0][0] == 20  # INFO level
+
+    def test_minor_version_mismatch_metadata_is_warning(self):
+        metadata_og = get_autogluon_metadata()
+        metadata_cu = copy.deepcopy(metadata_og)
+        metadata_og["version"] = "1.2.0"
+        metadata_cu["version"] = "1.3.0"
+        logs = compare_autogluon_metadata(original=metadata_og, current=metadata_cu)
+        assert len(logs) == 1
+        assert logs[0][0] == 30  # WARNING level
+
+    def test_unparseable_version_metadata_is_warning(self):
+        metadata_og = get_autogluon_metadata()
+        metadata_cu = copy.deepcopy(metadata_og)
+        metadata_og["version"] = "1.2.0"
+        metadata_cu["version"] = "Unknown (Likely <=0.7.0)"
+        logs = compare_autogluon_metadata(original=metadata_og, current=metadata_cu)
+        assert len(logs) == 1
+        assert logs[0][0] == 30  # WARNING level
+
+    def test_prerelease_version_metadata_is_warning(self):
+        metadata_og = get_autogluon_metadata()
+        metadata_cu = copy.deepcopy(metadata_og)
+        metadata_og["version"] = "1.2.0"
+        metadata_cu["version"] = "1.2.0a1"
+        logs = compare_autogluon_metadata(original=metadata_og, current=metadata_cu)
+        assert len(logs) == 1
+        assert logs[0][0] == 30  # WARNING level
 
 
 if __name__ == "__main__":

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -5272,7 +5272,8 @@ class TabularPredictor:
             Specify larger values to see more information printed when using Predictor during inference, smaller values to see less information.
             Refer to TabularPredictor init for more information.
         require_version_match : bool, default = True
-            If True, will raise an AssertionError if the `autogluon.tabular` version of the loaded predictor does not match the installed version of `autogluon.tabular`.
+            If True, raises an error if the saved predictor's major or minor version differs from the installed AutoGluon version.
+            Patch version differences (e.g., 1.2.0 vs 1.2.1) are always permitted and logged at INFO level.
             If False, will allow loading of models trained on incompatible versions, but is NOT recommended. Users may run into numerous issues if attempting this.
         require_py_version_match : bool, default = True
             If True, will raise an AssertionError if the Python version of the loaded predictor does not match the installed Python version.

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -1482,8 +1482,9 @@ class TimeSeriesPredictor:
         path : str or pathlib.Path
             Path where the predictor was saved via :meth:`~autogluon.timeseries.TimeSeriesPredictor.save`.
         require_version_match : bool, default = True
-            If True, will raise an AssertionError if the ``autogluon.timeseries`` version of the loaded predictor does
-            not match the installed version of ``autogluon.timeseries``.
+            If True, raises an error if the saved predictor's major or minor version differs from the installed
+            AutoGluon version. Patch version differences (e.g., 1.2.0 vs 1.2.1) are always permitted and logged
+            at INFO level.
             If False, will allow loading of models trained on incompatible versions, but is NOT recommended. Users may
             run into numerous issues if attempting this.
 


### PR DESCRIPTION
Assisted-by: Claude Code

*Issue #, if available:*
https://github.com/autogluon/autogluon/issues/5662

*Description of changes:*

`check_saved_predictor_version `previously raised AssertionError on any version mismatch, including patch-only differences (e.g. 1.2.0 →
   1.2.1). This forced users to choose between retraining after every patch release or disabling all version protection with
  `require_version_match=False`.

  The check is now two-tier, consistent with the existing Python version check:

  - Patch-only difference between two stable releases (same major.minor, no pre-release or dev marker) — logs at INFO, load proceeds.
  - Major/minor difference, pre-release, dev, or unparseable version — WARNING banner + AssertionError as before.
  - require_version_match=False — bypasses all checks as before.

  compare_autogluon_metadata applies the same logic: patch-only version differences are logged at INFO (level 20) rather than WARNING
  (level 30), and the summary header level is now the maximum of the individual entry levels rather than always WARNING.

  Files changed:
  - common/src/autogluon/common/utils/utils.py — updated check_saved_predictor_version and compare_autogluon_metadata
  - tabular/src/autogluon/tabular/predictor/predictor.py — updated require_version_match docstring in TabularPredictor.load()
  - timeseries/src/autogluon/timeseries/predictor.py — updated require_version_match docstring in TimeSeriesPredictor.load()
  - common/tests/unittests/utils/test_compare_autogluon_metadata.py — added CheckSavedPredictorVersionTestCase covering exact match,
  patch-only (both directions), minor/major/pre-release/unparseable version mismatches, and metadata log-level assertions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
