### PR TITLE
[CI] Fix copy-docs job being skipped when multimodal is skipped

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -421,6 +421,7 @@ jobs:
           command: chmod +x ./.github/workflow_scripts/build_all_docs.sh && ./.github/workflow_scripts/build_all_docs.sh '${{ env.BRANCH }}' '${{ env.GIT_REPO }}' '${{ env.SHORT_SHA }}' '${{ env.PR_NUMBER }}'
   copy-docs:
     needs: build_all_docs
+    if: always() && !cancelled() && needs.build_all_docs.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix the problem introduced in #5669 that caused `copy_docs` to be skipped if no `run-multimodal` label was present


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
