### PR TITLE
[Prototype/RFC] Opt-in git+subdirectory installs for AutoGluon from source (full monorepo)

### DIFF
--- a/autogluon/setup.py
+++ b/autogluon/setup.py
@@ -20,21 +20,21 @@ version = ag.update_version(version)
 
 submodule = None  # None since this module is special (it isn't a real submodule)
 install_requires = [
-    f'autogluon.core[all]=={version}',
-    f'autogluon.features=={version}',
-    f'autogluon.tabular[all]=={version}',
-    f'autogluon.multimodal=={version}',
-    f'autogluon.timeseries[all]=={version}',
+    ag.get_submodule_dependency("core", version, extras="all"),
+    ag.get_submodule_dependency("features", version),
+    ag.get_submodule_dependency("tabular", version, extras="all"),
+    ag.get_submodule_dependency("multimodal", version),
+    ag.get_submodule_dependency("timeseries", version, extras="all"),
 ] if not ag.LITE_MODE else [
-    f'{ag.PACKAGE_NAME}.core=={version}',
-    f'{ag.PACKAGE_NAME}.features=={version}',
-    f'{ag.PACKAGE_NAME}.tabular=={version}',
+    ag.get_submodule_dependency("core", version),
+    ag.get_submodule_dependency("features", version),
+    ag.get_submodule_dependency("tabular", version),
 ]
 
 install_requires = ag.get_dependency_version_ranges(install_requires)
 
 extras_require = {
-    "tabarena": [f'autogluon.tabular[tabarena]=={version}']
+    "tabarena": [ag.get_submodule_dependency("tabular", version, extras="tabarena")]
 }
 if __name__ == '__main__':
     ag.create_version_file(version=version, submodule=submodule)

--- a/core/setup.py
+++ b/core/setup.py
@@ -30,6 +30,7 @@ install_requires = (
         "requests",
         "matplotlib",
         "boto3",
+        "typing-extensions",  # used at import time in core (e.g. `from typing_extensions import Self`)
         ag.get_submodule_dependency("common", version),
         ag.get_submodule_dependency("features", version),
     ]
@@ -42,6 +43,7 @@ install_requires = (
         "pandas",
         "tqdm",
         "matplotlib",
+        "typing-extensions",  # used at import time in core (e.g. `from typing_extensions import Self`)
         ag.get_submodule_dependency("common", version),
         ag.get_submodule_dependency("features", version),
     ]

--- a/core/setup.py
+++ b/core/setup.py
@@ -30,8 +30,8 @@ install_requires = (
         "requests",
         "matplotlib",
         "boto3",
-        f"autogluon.common=={version}",
-        f"autogluon.features=={version}",
+        ag.get_submodule_dependency("common", version),
+        ag.get_submodule_dependency("features", version),
     ]
     if not ag.LITE_MODE
     else [
@@ -42,8 +42,8 @@ install_requires = (
         "pandas",
         "tqdm",
         "matplotlib",
-        f"{ag.PACKAGE_NAME}.common=={version}",
-        f"{ag.PACKAGE_NAME}.features=={version}",
+        ag.get_submodule_dependency("common", version),
+        ag.get_submodule_dependency("features", version),
     ]
 )
 

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -76,6 +76,45 @@ def use_git_install() -> bool:
     return os.getenv("AUTOGLUON_GIT_INSTALL", "").strip().lower() in ("1", "true", "yes", "on")
 
 
+DEFAULT_GIT_REPO = "https://github.com/autogluon/autogluon.git"
+DEFAULT_GIT_REF = "master"
+_GIT_SOURCE_CACHE = {}
+
+
+def _run_git(*args):
+    """Run a git command at the repo root, returning stripped stdout or None on any failure."""
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["git", "-C", AUTOGLUON_ROOT_PATH, *args],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def detect_git_source():
+    """Best-effort ``(repo_url, ref)`` of the git checkout currently being built.
+
+    Used so sibling git URLs inherit the *same* fork/branch/commit as the package being installed,
+    instead of hard-coding upstream/master. ``ref`` is the exact ``HEAD`` commit (most reproducible
+    and identical across the per-sibling clones); ``repo_url`` is the ``origin`` remote. Each element
+    falls back to its default when it can't be detected (git missing, source copied without ``.git``,
+    no ``origin`` remote). Cached so git is only invoked once per build.
+    """
+    if "value" not in _GIT_SOURCE_CACHE:
+        repo = _run_git("remote", "get-url", "origin") or DEFAULT_GIT_REPO
+        ref = _run_git("rev-parse", "HEAD") or DEFAULT_GIT_REF
+        _GIT_SOURCE_CACHE["value"] = (repo, ref)
+    return _GIT_SOURCE_CACHE["value"]
+
+
 def get_submodule_dependency(submodule, version, extras=None):
     """Dependency spec for an AutoGluon sibling package (e.g. ``autogluon.core``).
 
@@ -83,22 +122,26 @@ def get_submodule_dependency(submodule, version, extras=None):
     releases. When ``use_git_install()`` is true, returns a PEP 508 direct-reference URL pointing at
     the same submodule in the AutoGluon monorepo, e.g.::
 
-        autogluon.core @ git+https://github.com/autogluon/autogluon.git@master#subdirectory=core
+        autogluon.core @ git+https://github.com/autogluon/autogluon.git@<commit>#subdirectory=core
 
     This lets the whole sibling dependency chain be installed from a single git checkout, e.g.::
 
         AUTOGLUON_GIT_INSTALL=1 pip install \\
-            "autogluon.tabular @ git+https://github.com/autogluon/autogluon.git#subdirectory=tabular"
+            "autogluon.tabular @ git+https://github.com/<you>/autogluon.git@<branch>#subdirectory=tabular"
 
-    Configurable via env vars (only consulted when ``AUTOGLUON_GIT_INSTALL`` is set):
-      - ``AUTOGLUON_GIT_REPO``: repo URL (default ``https://github.com/autogluon/autogluon.git``).
-      - ``AUTOGLUON_GIT_REF``: branch/tag/commit to install from (default ``master``).
+    The repo URL and ref are auto-detected from the checkout being built (its ``origin`` remote and
+    ``HEAD`` commit), so installs from a fork or branch resolve their siblings from that same source
+    with no extra configuration. Override the detection via env vars (only consulted when
+    ``AUTOGLUON_GIT_INSTALL`` is set):
+      - ``AUTOGLUON_GIT_REPO``: repo URL (default: detected ``origin``, else the upstream repo).
+      - ``AUTOGLUON_GIT_REF``: branch/tag/commit (default: detected ``HEAD`` commit, else ``master``).
     """
     name = f"{PACKAGE_NAME}.{submodule}"
     extras_str = f"[{extras}]" if extras else ""
     if use_git_install():
-        repo = os.getenv("AUTOGLUON_GIT_REPO", "https://github.com/autogluon/autogluon.git")
-        ref = os.getenv("AUTOGLUON_GIT_REF", "master")
+        repo_detected, ref_detected = detect_git_source()
+        repo = os.getenv("AUTOGLUON_GIT_REPO") or repo_detected
+        ref = os.getenv("AUTOGLUON_GIT_REF") or ref_detected
         return f"{name}{extras_str} @ git+{repo}@{ref}#subdirectory={submodule}"
     return f"{name}{extras_str}=={version}"
 

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -64,6 +64,45 @@ def get_dependency_version_ranges(packages: list) -> list:
     return [package if package not in DEPENDENT_PACKAGES else DEPENDENT_PACKAGES[package] for package in packages]
 
 
+def use_git_install() -> bool:
+    """Whether sibling autogluon packages should be referenced as git+subdirectory URLs.
+
+    Enabled by setting ``AUTOGLUON_GIT_INSTALL`` to a truthy value (1/true/yes/on). Must never be
+    enabled for a release build (direct-reference URLs are rejected by PyPI), so it is force-disabled
+    when ``RELEASE`` is set.
+    """
+    if os.getenv("RELEASE"):
+        return False
+    return os.getenv("AUTOGLUON_GIT_INSTALL", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def get_submodule_dependency(submodule, version, extras=None):
+    """Dependency spec for an AutoGluon sibling package (e.g. ``autogluon.core``).
+
+    By default returns the standard pinned form ``autogluon.<submodule>==<version>`` used for PyPI
+    releases. When ``use_git_install()`` is true, returns a PEP 508 direct-reference URL pointing at
+    the same submodule in the AutoGluon monorepo, e.g.::
+
+        autogluon.core @ git+https://github.com/autogluon/autogluon.git@master#subdirectory=core
+
+    This lets the whole sibling dependency chain be installed from a single git checkout, e.g.::
+
+        AUTOGLUON_GIT_INSTALL=1 pip install \\
+            "autogluon.tabular @ git+https://github.com/autogluon/autogluon.git#subdirectory=tabular"
+
+    Configurable via env vars (only consulted when ``AUTOGLUON_GIT_INSTALL`` is set):
+      - ``AUTOGLUON_GIT_REPO``: repo URL (default ``https://github.com/autogluon/autogluon.git``).
+      - ``AUTOGLUON_GIT_REF``: branch/tag/commit to install from (default ``master``).
+    """
+    name = f"{PACKAGE_NAME}.{submodule}"
+    extras_str = f"[{extras}]" if extras else ""
+    if use_git_install():
+        repo = os.getenv("AUTOGLUON_GIT_REPO", "https://github.com/autogluon/autogluon.git")
+        ref = os.getenv("AUTOGLUON_GIT_REF", "master")
+        return f"{name}{extras_str} @ git+{repo}@{ref}#subdirectory={submodule}"
+    return f"{name}{extras_str}=={version}"
+
+
 def update_version(version, use_file_if_exists=True, create_file=False):
     """
     To release a new stable version on PyPi, simply tag the release on github, and the Github CI will automatically publish

--- a/eda/setup.py
+++ b/eda/setup.py
@@ -37,10 +37,10 @@ install_requires = [
     "pyod>=1.1,<1.2",
     "suod>=0.0.8,<0.1",
     "ipython>7.16,<8.13",  # IPython 8.13+ supports Python 3.9 and above; Python 3.7 is supported with IPython >7.16
-    f"autogluon.core=={version}",
-    f"autogluon.common=={version}",
-    f"autogluon.features=={version}",
-    f"autogluon.tabular=={version}",
+    ag.get_submodule_dependency("core", version),
+    ag.get_submodule_dependency("common", version),
+    ag.get_submodule_dependency("features", version),
+    ag.get_submodule_dependency("tabular", version),
 ]
 
 extras_require = dict()

--- a/features/setup.py
+++ b/features/setup.py
@@ -27,7 +27,7 @@ install_requires = (
         "numpy",  # version range defined in `core/_setup_utils.py`
         "pandas",  # version range defined in `core/_setup_utils.py`
         "scikit-learn",  # version range defined in `core/_setup_utils.py`
-        f"autogluon.common=={version}",
+        ag.get_submodule_dependency("common", version),
     ]
     if not ag.LITE_MODE
     else [
@@ -35,7 +35,7 @@ install_requires = (
         "numpy",  # version range defined in `core/_setup_utils.py`
         "pandas",  # version range defined in `core/_setup_utils.py`
         "scikit-learn",  # version range defined in `core/_setup_utils.py`
-        f"{ag.PACKAGE_NAME}.common=={version}",
+        ag.get_submodule_dependency("common", version),
     ]
 )
 

--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -46,9 +46,9 @@ install_requires = [
     "text-unidecode>=1.3,<1.4",
     "torchmetrics>=1.2.0,<1.8",
     "omegaconf>=2.1.1,<2.4.0",
-    f"autogluon.core[raytune]=={version}",
-    f"autogluon.features=={version}",
-    f"autogluon.common=={version}",
+    ag.get_submodule_dependency("core", version, extras="raytune"),
+    ag.get_submodule_dependency("features", version),
+    ag.get_submodule_dependency("common", version),
     "pytorch-metric-learning>=1.3.0,<2.9",
     "nlpaug>=1.1.10,<1.2.0",
     "nltk>=3.4.5,<3.10",  # Updated upper bound to address CVE-2024-39705

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -32,8 +32,8 @@ install_requires = [
     "pandas",  # version range defined in `core/_setup_utils.py`
     "scikit-learn",  # version range defined in `core/_setup_utils.py`
     "networkx",  # version range defined in `core/_setup_utils.py`
-    f"{ag.PACKAGE_NAME}.core=={version}",
-    f"{ag.PACKAGE_NAME}.features=={version}",
+    ag.get_submodule_dependency("core", version),
+    ag.get_submodule_dependency("features", version),
 ]
 
 extras_require = {
@@ -84,7 +84,7 @@ extras_require = {
         "tabicl>=2.0,<2.1",
     ],
     "ray": [
-        f"{ag.PACKAGE_NAME}.core[all]=={version}",
+        ag.get_submodule_dependency("core", version, extras="all"),
     ],
     "skex": [
         "scikit-learn-intelex>=2025.0,<2025.10",  # <{N+1} upper cap, where N is the latest released minor version

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -45,10 +45,10 @@ install_requires = [
     "chronos-forecasting>=2.2.2,<2.4",
     "peft>=0.13.0,<0.18",  # version range same as in chronos-forecasting[extras]
     "tensorboard>=2.9,<3",  # fixes https://github.com/autogluon/autogluon/issues/3612
-    f"autogluon.core=={version}",
-    f"autogluon.common=={version}",
-    f"autogluon.features=={version}",
-    f"autogluon.tabular[catboost,lightgbm,xgboost]=={version}",
+    ag.get_submodule_dependency("core", version),
+    ag.get_submodule_dependency("common", version),
+    ag.get_submodule_dependency("features", version),
+    ag.get_submodule_dependency("tabular", version, extras="catboost,lightgbm,xgboost"),
 ]
 
 extras_require = {
@@ -59,7 +59,7 @@ extras_require = {
         "pytest-timeout>=2.1,<3",
     ],
     "ray": [
-        f"autogluon.core[raytune]=={version}",
+        ag.get_submodule_dependency("core", version, extras="raytune"),
     ],
 }
 


### PR DESCRIPTION
> **Status: prototype / RFC.** Opening for discussion of the approach, not as ready-to-merge. See "Open questions" below.

## Motivation

Today AutoGluon can't be installed from a git checkout in one line the way a single-package repo can, e.g. tabarena's:

```bash
pip install "tabarena @ git+https://github.com/autogluon/tabarena.git#subdirectory=tabarena"
```

AutoGluon is a multi-distribution monorepo: each package declares its siblings as pinned PyPI deps (`autogluon.core==<version>`, …). `pip install "…#subdirectory=tabular"` builds only `tabular/` and then resolves `core`/`features` **from PyPI** — at a dev version (`bYYYYMMDD`) that isn't published — so it fails. (The local `full_install.sh` only works because it builds all subdirs in one `pip install` invocation.)

This PR prototypes **Option 1**: make sibling references resolvable as `git+subdirectory` URLs, opt-in via an env var, so the whole chain installs from a single git checkout — while leaving PyPI releases completely unchanged.

## What this does

Adds `get_submodule_dependency()` to `core/_setup_utils.py`:

- **Default (unchanged):** emits the usual pinned `autogluon.<sub>==<version>` (and `autogluon.<sub>[extras]==<version>`).
- **When `AUTOGLUON_GIT_INSTALL` is truthy:** emits a PEP 508 direct-reference URL instead:
  ```
  autogluon.core @ git+<repo>@<commit>#subdirectory=core
  ```
- **Force-disabled when `RELEASE` is set** (direct-reference URLs are rejected by PyPI), so release builds can never accidentally emit them.

### The top-level URL is the single source of truth (auto-detection)

The sibling URL's **repo and ref are auto-detected from the checkout being built** — its `origin` remote URL and exact `HEAD` commit. So you only specify the source once, in the install URL, and the siblings follow:

```bash
# upstream
AUTOGLUON_GIT_INSTALL=1 pip install \
  "autogluon.tabular @ git+https://github.com/autogluon/autogluon.git#subdirectory=tabular"

# a fork + branch — siblings resolve from the SAME fork/branch automatically, no other config
AUTOGLUON_GIT_INSTALL=1 pip install \
  "autogluon[tabarena] @ git+https://github.com/<you>/autogluon.git@<branch>#subdirectory=autogluon"
```

Detecting the resolved **commit** (rather than re-using a branch name) also pins every per-sibling clone to one identical revision — and it's what lets extras compose (see below). Detection falls back cleanly to the upstream repo / `master` if git or `.git` isn't available (e.g. source copied without `.git` under build isolation). Env vars remain as explicit overrides (only consulted when `AUTOGLUON_GIT_INSTALL` is set): `AUTOGLUON_GIT_REPO`, `AUTOGLUON_GIT_REF`.

### Coverage: the whole monorepo

All sibling specs are converted (`install_requires` **and** extras), so any package — including the meta `autogluon` and `autogluon[tabarena]` — installs from git:

| package | siblings converted |
|---|---|
| `tabular` | core, features; `[ray]`→core[all] |
| `core` | common, features |
| `features` | common |
| `autogluon` (meta) | core[all], features, tabular[all], multimodal, timeseries[all]; `[tabarena]`→tabular[tabarena] |
| `multimodal` | core[raytune], features, common |
| `timeseries` | core, common, features, tabular[catboost,lightgbm,xgboost]; `[ray]`→core[raytune] |
| `eda` | core, common, features, tabular |

### Optional dependencies (extras) work

Because every reference to a given sibling resolves to the **identical** commit-pinned URL, pip unifies them — e.g. base `core`, `core[all]`, and `core[raytune]` all collapse to one `autogluon.core[...] @ git+…@<commit>#subdirectory=core` requirement instead of erroring on a *conflicting direct URL*. (This consistency is precisely why the auto-detected commit matters; a branch name re-resolved per-build could diverge.) Third-party extras (`[lightgbm]`, `[tabpfn]`, …) are unaffected — they just resolve from PyPI.

## Also included: a real bug fix

While verifying the minimal install, I found a pre-existing latent bug (independent of this mechanism): `autogluon.core` does `from typing_extensions import Self` unconditionally in `abstract_model.py`, and a version range is defined in `_setup_utils.DEPENDENT_PACKAGES`, **but `typing-extensions` was never listed in any `install_requires`** — it was only ever satisfied transitively (torch/transformers/etc.). A minimal install (`autogluon.tabular` with no extras) therefore fails to import. Fixed in a separate commit (`core/setup.py`); it can be cherry-picked/merged on its own regardless of the rest of this PR.

## Verification (fresh venv each)

1. **`autogluon.tabular`, one command** (`AUTOGLUON_GIT_INSTALL=1` + `#subdirectory=tabular`): pip recursively cloned (`--filter=blob:none`) and built all four packages from git, and `from autogluon.tabular import TabularPredictor` worked with **no manual steps**.
2. **Auto-detection from a non-`master` branch**, with **only `AUTOGLUON_GIT_INSTALL=1`** (no `REF`/`REPO`): all siblings were cloned at the branch's exact HEAD commit (`to revision <sha>`, identical across siblings) — confirming siblings inherit the source automatically and `.git` is present in pip's build dir. Import OK.
3. **Extras / meta** (`autogluon[tabarena] @ …#subdirectory=autogluon`, `--dry-run`, only `AUTOGLUON_GIT_INSTALL=1`): resolved cleanly with **no conflict** — all 6 siblings (`common/core/features/tabular/multimodal/timeseries`) + meta from git at **one** commit, and the heavy payloads resolved (`torch`, `transformers`, `gluonts`, `chronos-forecasting`, `ray`, `lightgbm`, …). The `tabular[ray]→core[all]` path was separately dry-run-verified the same way.
4. **Default build** (no env var): emitted metadata is byte-for-byte the usual pinned `==version` form — confirmed via `egg_info`.

## Open questions / caveats

1. **Direct-URL deps are PyPI-forbidden**, so this must remain strictly opt-in/env-gated (it is). Is an env-var toggle the interface we want, or something more explicit?
2. **One clone per sibling** (up to 7× for the meta package). Partial clones (`--filter=blob:none`) mitigate the cost, but it's heavier than a single-package install.
3. **Dev version date-suffix skew:** non-release versions embed the build date (`bYYYYMMDD`). Because siblings are pinned by immutable commit, pip can reuse a cached sibling wheel built on a different day, so package version *strings* can differ across a midnight/cache boundary even though the code is the same commit (and there are no `==` pins to conflict). A `RELEASE`-style fixed version is cleaner for fully reproducible multi-package git installs.
4. **SSH remotes / detection edge cases:** auto-detection reconstitutes `git+<origin-url>`; an `https` origin works directly. Exotic remote forms may need the `AUTOGLUON_GIT_REPO` override.
5. **Alternative — Option 2:** a single aggregate "fat" distribution (no sibling self-refs) would mirror tabarena most closely, at the cost of the deliberate split-distribution model. Worth weighing against this approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
