### PR TITLE
cleanup: declare undeclared runtime deps (packaging, typing-extensions)

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -33,6 +33,10 @@ jobs:
           TWINE_USERNAME: ${{ secrets. PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets. PYPI_PASSWORD }}
         run: |
+          # Nightly pre-release: stamp one shared date suffix across all submodule builds so
+          # their autogluon.<sub>==<version> pins match. Stable releases (pypi_release.yml) leave
+          # this unset and publish the base version.
+          export AUTOGLUON_VERSION_SUFFIX="b$(date -u +%Y%m%d)"
           for v in common core features tabular multimodal timeseries autogluon
           do
             cd "$v"/

--- a/.gitignore
+++ b/.gitignore
@@ -135,4 +135,3 @@ multimodal/src/autogluon/multimodal/version.py
 
 AutogluonModels
 lightning_logs
-VERSION.minor

--- a/common/setup.py
+++ b/common/setup.py
@@ -18,7 +18,7 @@ spec.loader.exec_module(ag)  # type: ignore
 ###########################
 
 version = ag.load_version_file()
-version = ag.update_version(version, use_file_if_exists=False, create_file=True)
+version = ag.update_version(version)
 
 submodule = "common"
 install_requires = [

--- a/common/setup.py
+++ b/common/setup.py
@@ -32,6 +32,7 @@ install_requires = [
     "requests",
     "joblib",  # version range defined in `core/_setup_utils.py`
     "pyyaml",  # version range defined in `core/_setup_utils.py`
+    "packaging",  # version range defined in `core/_setup_utils.py`
     # s3fs is removed due to doubling install time due to version range resolution
     # "s3fs",  # version range defined in `core/_setup_utils.py`
     "scikit-learn",  # version range defined in `core/_setup_utils.py`

--- a/core/setup.py
+++ b/core/setup.py
@@ -29,6 +29,7 @@ install_requires = [
     "requests",
     "matplotlib",
     "boto3",
+    "typing-extensions",
     f"autogluon.common=={version}",
     f"autogluon.features=={version}",
 ]

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -35,6 +35,7 @@ DEPENDENT_PACKAGES = {
     "typing-extensions": ">=4.14.0,<5",
     "joblib": ">=1.2,<1.7",  # <{N+1} upper cap
     "pyyaml": ">=5.0",  # Uncapped to maximize compatibility
+    "packaging": ">=20",  # Uncapped to maximize compatibility (stable API)
 }
 
 DEPENDENT_PACKAGES = {package: package + version for package, version in DEPENDENT_PACKAGES.items()}

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -51,30 +51,21 @@ def get_dependency_version_ranges(packages: list) -> list:
     return [package if package not in DEPENDENT_PACKAGES else DEPENDENT_PACKAGES[package] for package in packages]
 
 
-def update_version(version, use_file_if_exists=True, create_file=False):
-    """
-    To release a new stable version on PyPi, simply tag the release on github, and the Github CI will automatically publish
-    a new stable version to PyPi using the configurations in .github/workflows/pypi_release.yml .
-    You need to increase the version number after stable release, so that the nightly pypi can work properly.
-    """
-    try:
-        if not os.getenv("RELEASE"):
-            from datetime import date
+def update_version(version):
+    """Return the build version: the base ``VERSION`` plus an optional pre-release suffix.
 
-            minor_version_file_path = os.path.join(AUTOGLUON_ROOT_PATH, "VERSION.minor")
-            if use_file_if_exists and os.path.isfile(minor_version_file_path):
-                with open(minor_version_file_path) as f:
-                    day = f.read().strip()
-            else:
-                today = date.today()
-                day = today.strftime("b%Y%m%d")
-            version += day
-    except Exception:
-        pass
-    if create_file and not os.getenv("RELEASE"):
-        with open(os.path.join(AUTOGLUON_ROOT_PATH, "VERSION.minor"), "w") as f:
-            f.write(day)
-    return version
+    Local / source / editable / ``uv`` installs use the base version as-is (e.g. ``1.5.1``).
+
+    The nightly PyPI pre-release sets ``AUTOGLUON_VERSION_SUFFIX`` (e.g. ``b20260605``) so each
+    nightly is a unique, ordered pre-release. The suffix is computed once in
+    ``.github/workflows/pythonpublish.yml`` and exported for the whole build loop, so every
+    submodule shares the same value and their ``autogluon.<sub>==<version>`` pins line up.
+
+    To release a stable version, tag the release on GitHub; ``.github/workflows/pypi_release.yml``
+    publishes with no suffix (the base version). Bump ``VERSION`` after a stable release so the
+    next nightlies sort correctly.
+    """
+    return version + os.getenv("AUTOGLUON_VERSION_SUFFIX", "")
 
 
 def create_version_file(*, version, submodule):


### PR DESCRIPTION
> **Stacked on #5681 → #5680 → #5679.** Base auto-retargets to `master` as the chain merges.

## Summary
Declares two runtime dependencies that are imported but were never listed in any `install_requires`. They were only ever satisfied transitively (via torch/transformers/etc.), so a **minimal** install (e.g. just `autogluon.core`, or `autogluon.tabular` with no extras) fails to import. Surfaced while testing source/git/uv installs.

- **`packaging`** — imported in `common` (`deprecated_utils`/`try_import`/`utils`). Declared in **`common`** (the base every package depends on) and added to `DEPENDENT_PACKAGES` (`>=20`, uncapped — stable API).
- **`typing-extensions`** — imported in `core`/`tabular`/`timeseries` (`from typing_extensions import Self`). Declared in **`core`** (it already had a range in `DEPENDENT_PACKAGES`); `tabular`/`timeseries` inherit it via `core`.

**3 files, +3.**

## Verification
A minimal `pip install ./common ./features ./core` (no extras) in a fresh venv now auto-pulls `packaging` + `typing-extensions`, and `import autogluon.core` works **with no manual deps** — the exact scenario that failed before. Metadata confirmed: `packaging>=20`, `typing-extensions<5,>=4.14.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
