### PR TITLE
cleanup: simplify versioning (opt-in nightly suffix, drop VERSION.minor)

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -33,6 +33,10 @@ jobs:
           TWINE_USERNAME: ${{ secrets. PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets. PYPI_PASSWORD }}
         run: |
+          # Nightly pre-release: stamp one shared date suffix across all submodule builds so
+          # their autogluon.<sub>==<version> pins match. Stable releases (pypi_release.yml) leave
+          # this unset and publish the base version.
+          export AUTOGLUON_VERSION_SUFFIX="b$(date -u +%Y%m%d)"
           for v in common core features tabular multimodal timeseries autogluon
           do
             cd "$v"/

--- a/.gitignore
+++ b/.gitignore
@@ -135,4 +135,3 @@ multimodal/src/autogluon/multimodal/version.py
 
 AutogluonModels
 lightning_logs
-VERSION.minor

--- a/common/setup.py
+++ b/common/setup.py
@@ -18,7 +18,7 @@ spec.loader.exec_module(ag)  # type: ignore
 ###########################
 
 version = ag.load_version_file()
-version = ag.update_version(version, use_file_if_exists=False, create_file=True)
+version = ag.update_version(version)
 
 submodule = "common"
 install_requires = [

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -51,30 +51,21 @@ def get_dependency_version_ranges(packages: list) -> list:
     return [package if package not in DEPENDENT_PACKAGES else DEPENDENT_PACKAGES[package] for package in packages]
 
 
-def update_version(version, use_file_if_exists=True, create_file=False):
-    """
-    To release a new stable version on PyPi, simply tag the release on github, and the Github CI will automatically publish
-    a new stable version to PyPi using the configurations in .github/workflows/pypi_release.yml .
-    You need to increase the version number after stable release, so that the nightly pypi can work properly.
-    """
-    try:
-        if not os.getenv("RELEASE"):
-            from datetime import date
+def update_version(version):
+    """Return the build version: the base ``VERSION`` plus an optional pre-release suffix.
 
-            minor_version_file_path = os.path.join(AUTOGLUON_ROOT_PATH, "VERSION.minor")
-            if use_file_if_exists and os.path.isfile(minor_version_file_path):
-                with open(minor_version_file_path) as f:
-                    day = f.read().strip()
-            else:
-                today = date.today()
-                day = today.strftime("b%Y%m%d")
-            version += day
-    except Exception:
-        pass
-    if create_file and not os.getenv("RELEASE"):
-        with open(os.path.join(AUTOGLUON_ROOT_PATH, "VERSION.minor"), "w") as f:
-            f.write(day)
-    return version
+    Local / source / editable / ``uv`` installs use the base version as-is (e.g. ``1.5.1``).
+
+    The nightly PyPI pre-release sets ``AUTOGLUON_VERSION_SUFFIX`` (e.g. ``b20260605``) so each
+    nightly is a unique, ordered pre-release. The suffix is computed once in
+    ``.github/workflows/pythonpublish.yml`` and exported for the whole build loop, so every
+    submodule shares the same value and their ``autogluon.<sub>==<version>`` pins line up.
+
+    To release a stable version, tag the release on GitHub; ``.github/workflows/pypi_release.yml``
+    publishes with no suffix (the base version). Bump ``VERSION`` after a stable release so the
+    next nightlies sort correctly.
+    """
+    return version + os.getenv("AUTOGLUON_VERSION_SUFFIX", "")
 
 
 def create_version_file(*, version, submodule):


### PR DESCRIPTION
> **Stacked on #5682 → #5681 → #5680 → #5679.** Base auto-retargets to `master` as the chain merges.

## Summary
Inverts the dev-version logic so the date suffix is used **only** for the nightly PyPI pre-release, not for local/source installs. This is the prerequisite that unblocks the PEP 621 / uv-workspace version mapping.

Today, *any* non-`RELEASE` build appends `bYYYYMMDD`, and a `VERSION.minor` file (written by `common`, read by the rest) coordinates one shared date — which forces `common` to build first. That build-order coupling is exactly what blocks per-package PEP 621 metadata.

### Change
- **`update_version(version)`** → `base + os.getenv("AUTOGLUON_VERSION_SUFFIX", "")`. Drops the date computation, the `VERSION.minor` read/write, and the build-order dependency.
- **`pythonpublish.yml`** (nightly): `export AUTOGLUON_VERSION_SUFFIX="b$(date -u +%Y%m%d)"` once before the build loop, so every submodule gets the same suffix and their `autogluon.<sub>==<version>` pins match (previously coordinated via `VERSION.minor`).
- Drop `VERSION.minor` from `.gitignore`; update `common/setup.py` to the new single-arg signature.

### Resulting behavior
| build | version |
|---|---|
| local / dev / uv / source | `1.5.1` (clean base) |
| nightly (`pythonpublish.yml`) | `1.5.1b<UTC-date>`, shared across all submodules |
| stable (`pypi_release.yml`) | `1.5.1` (unchanged) |

`RELEASE` no longer affects the version (default is already clean); it still drives the dev-status classifier.

## Verification
`egg_info`: default build → `1.5.1` with `autogluon.common==1.5.1`; with `AUTOGLUON_VERSION_SUFFIX=b20260605` → `1.5.1b20260605` with matching sibling pins; **no `VERSION.minor` written**. Runtime imports unaffected (build-only files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
