### PR TITLE
docs: source install via the uv workspace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,8 +42,7 @@ GitHub provides additional documentation on [forking a repository](https://help.
 
 ## Tips for Modifying the Source Code
 
-- Using a fresh virtualenv, install the package via [these instructions](https://auto.gluon.ai/dev/install.html).
-Be sure to select the *Source* option from the installation preferences.
+- Install the package from source. The quickest path is the uv workspace: `git clone` the repo and run `uv sync --all-extras` from the root (installs all `autogluon.*` packages editable). See [Installing from source](./docs/install-from-source.md) for details and options. Alternatively, follow [these instructions](https://auto.gluon.ai/dev/install.html) and select the *Source* option from the installation preferences.
 
 - We recommend developing on Linux as this is the primary OS we develop on and is the primary OS used by our users. We also support Windows and MacOS. Try to avoid introducing changes that will only work on a particular OS. Changes to existing code that improve cross-platform compatibility are most welcome!
 

--- a/docs/build_pip_install.sh
+++ b/docs/build_pip_install.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 python3 -m pip uninstall -y autogluon
-python3 -m pip uninstall -y autogluon.fair
 python3 -m pip uninstall -y autogluon.timeseries
 python3 -m pip uninstall -y autogluon.multimodal
 python3 -m pip uninstall -y autogluon.tabular
@@ -21,8 +20,6 @@ python3 -m pip install -e .[all]
 cd ..
 
 cd tabular/
-# Python 3.7 bug workaround: https://github.com/python/typing/issues/573
-python3 -m pip uninstall -y typing
 python3 -m pip install -e .[all,tests]
 cd ..
 

--- a/docs/install-cpu-source.md
+++ b/docs/install-cpu-source.md
@@ -1,6 +1,5 @@
 ```console
-pip install uv
-python -m uv pip install -U torch torchvision --extra-index-url https://download.pytorch.org/whl/cpu
+pip install -U uv
 git clone https://github.com/autogluon/autogluon
-./autogluon/full_install.sh
+cd autogluon && uv sync --all-extras --index https://download.pytorch.org/whl/cpu
 ```

--- a/docs/install-from-source.md
+++ b/docs/install-from-source.md
@@ -1,0 +1,118 @@
+# Installing AutoGluon from source
+
+This is the workflow for installing AutoGluon locally from a git clone — for development, or to
+run the latest unreleased code. AutoGluon is a [uv workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/),
+so the entire monorepo installs editable in **one command**.
+
+## Prerequisites
+
+- **Python 3.10–3.13**
+- **git**
+- **[uv](https://docs.astral.sh/uv/)** — install with:
+  ```bash
+  curl -LsSf https://astral.sh/uv/install.sh | sh   # or: pip install -U uv
+  ```
+
+## Quickstart (recommended)
+
+```bash
+git clone https://github.com/autogluon/autogluon
+cd autogluon
+uv sync --all-extras
+```
+
+`uv sync` creates a `.venv/` at the repo root and installs **all 7 `autogluon.*` packages editable**
+(`common`, `core`, `features`, `tabular`, `timeseries`, `multimodal`, and the meta `autogluon`),
+resolved deterministically from the committed `uv.lock`.
+
+Run code in the environment without activating it:
+```bash
+uv run python -c "from autogluon.tabular import TabularPredictor; print('ok')"
+```
+…or activate it:
+```bash
+source .venv/bin/activate        # Windows: .venv\Scripts\activate
+```
+
+**Extras:**
+- `uv sync` (no flags) → base dependencies only (skeleton install, no optional models).
+- `uv sync --all-extras` → the full optional set across every package (equivalent to
+  `pip install autogluon` plus all submodule extras).
+
+## CPU-only (no CUDA)
+
+The default resolution pulls the standard PyTorch build (CUDA on Linux). For a CPU-only machine,
+point at the PyTorch CPU index:
+```bash
+uv sync --all-extras --index https://download.pytorch.org/whl/cpu
+```
+(On macOS, PyTorch is CPU-only by default, so `uv sync --all-extras` is enough.)
+
+## Installing a single submodule
+
+Sync just one package with chosen extras — sibling `autogluon.*` packages resolve automatically
+from the workspace:
+```bash
+# tabular with only LightGBM + CatBoost
+uv sync --package autogluon.tabular --extra lightgbm --extra catboost
+
+# tabular with the full model set  (== pip install "autogluon.tabular[all]")
+uv sync --package autogluon.tabular --extra all
+```
+Tabular extras in `all`: `lightgbm, catboost, xgboost, fastai, tabm, mitra, ray`.
+Additional extras: `tabicl, tabpfn, tabdpt, realmlp, interpret, imodels, skex, skl2onnx, tabpfnmix`,
+and the benchmark bundle `tabarena`.
+
+## Installing directly from GitHub (no clone)
+
+You can install a package straight from the repository using a
+[PEP 508 direct reference](https://peps.python.org/pep-0508/#examples) with `#subdirectory=`
+pointing at the submodule's folder — handy for a one-off install of an unreleased version without
+cloning the workspace:
+
+```bash
+# meta package (full stack), latest master
+pip install "autogluon @ git+https://github.com/autogluon/autogluon.git#subdirectory=autogluon"
+
+# a single submodule, with extras
+pip install "autogluon.tabular[all] @ git+https://github.com/autogluon/autogluon.git#subdirectory=tabular"
+
+# pin a branch, tag, or commit with @<ref>
+pip install "autogluon.tabular @ git+https://github.com/autogluon/autogluon.git@master#subdirectory=tabular"
+```
+(`uv pip install "<same spec>"` works too.)
+
+> **Note:** this builds only the requested subdirectory, so its sibling `autogluon.*` dependencies
+> (e.g. `autogluon.core`, `autogluon.features`) are resolved from **PyPI** at the exact pinned
+> build version — not from git. It therefore works cleanly when that version is already published.
+> To get *every* `autogluon.*` package from the same git source, use the `uv sync` clone flow above
+> (its workspace sources resolve the siblings locally).
+
+## Development workflow
+
+```bash
+uv run pytest tabular/tests          # run a package's tests
+uv run pre-commit install            # one-time: enable formatting hooks
+uv run pre-commit run --all-files    # lint/format like CI (ruff)
+```
+
+Pick a specific interpreter with `uv sync -p 3.12` (or `uv python pin 3.12`).
+
+## Keeping in sync
+
+`uv.lock` is committed, so installs are reproducible. After pulling changes, re-run
+`uv sync --all-extras`. If you **change a package's dependencies**, refresh and commit the lockfile:
+```bash
+uv lock
+```
+
+## Alternative: pip / convenience script
+
+The workspace is recommended, but the per-package editable install still works:
+```bash
+./full_install.sh                    # editable install of all packages (auto-installs uv)
+# or, manually with pip:
+pip install -e common/[tests] -e features/ -e core/[all,tests] \
+            -e tabular/[all,tests] -e multimodal/[tests] \
+            -e timeseries/[all,tests] -e autogluon/
+```

--- a/docs/install-from-source.md
+++ b/docs/install-from-source.md
@@ -106,13 +106,12 @@ Pick a specific interpreter with `uv sync -p 3.12` (or `uv python pin 3.12`).
 uv lock
 ```
 
-## Alternative: pip / convenience script
+## Alternative: `uv pip install` / convenience script
 
-The workspace is recommended, but the per-package editable install still works:
+`uv pip install` also honors the workspace, so it builds a package and resolves its
+`autogluon.*` siblings from the local source automatically — no need to list them:
 ```bash
-./full_install.sh                    # editable install of all packages (auto-installs uv)
-# or, manually with pip:
-pip install -e common/[tests] -e features/ -e core/[all,tests] \
-            -e tabular/[all,tests] -e multimodal/[tests] \
-            -e timeseries/[all,tests] -e autogluon/
+uv pip install "./autogluon"        # full stack
+uv pip install "./tabular[all]"     # just tabular + its stack
 ```
+For an editable install of every package in one go, `./full_install.sh` also works.

--- a/docs/install-gpu-source.md
+++ b/docs/install-gpu-source.md
@@ -1,4 +1,5 @@
 ```console
+pip install -U uv
 git clone https://github.com/autogluon/autogluon
-./autogluon/full_install.sh
+cd autogluon && uv sync --all-extras
 ```

--- a/docs/install-mac-cpu-source.md
+++ b/docs/install-mac-cpu-source.md
@@ -1,7 +1,5 @@
 ```console
-pip install -U pip
-pip install -U setuptools wheel
-
+pip install -U uv
 git clone https://github.com/autogluon/autogluon
-./autogluon/full_install.sh
+cd autogluon && uv sync --all-extras
 ```

--- a/docs/install-modules.md
+++ b/docs/install-modules.md
@@ -20,9 +20,9 @@ AutoGluon is modularized into [sub-modules](https://packaging.python.org/guides/
 - `autogluon.core` - only core functionality (Searcher/Scheduler) useful for hyperparameter tuning of arbitrary code/models.
 - `autogluon.features` - only functionality for feature generation / feature preprocessing pipelines (primarily related to Tabular data).
 
-To install a submodule from source, follow the instructions for installing the entire package from source but replace the line `./autogluon/full_install.sh` with `cd autogluon && pip install -e {SUBMODULE_NAME}/{OPTIONAL_DEPENDENCIES}`
+To install a submodule from source, follow the instructions for installing the entire package from source but replace the final `uv sync --all-extras` line with `uv sync --package autogluon.{SUBMODULE_NAME} --extra {OPTIONAL_DEPENDENCY} ...` (sibling `autogluon.*` packages resolve automatically from the workspace). See [Installing from source](https://github.com/autogluon/autogluon/blob/master/docs/install-from-source.md) for details.
 
-- For example, to install `autogluon.tabular[lightgbm,catboost]` from source, the command would be: `cd autogluon && pip install -e tabular/[lightgbm,catboost]`
+- For example, to install `autogluon.tabular[lightgbm,catboost]` from source, the command would be: `cd autogluon && uv sync --package autogluon.tabular --extra lightgbm --extra catboost`
 
 To install all AutoGluon optional dependencies:
 

--- a/docs/install-modules.md
+++ b/docs/install-modules.md
@@ -26,4 +26,4 @@ To install a submodule from source, follow the instructions for installing the e
 
 To install all AutoGluon optional dependencies:
 
-`pip install autogluon && pip install autogluon.tabular[all,test]`
+`pip install autogluon && pip install autogluon.tabular[all,tests]`

--- a/full_install.bat
+++ b/full_install.bat
@@ -1,8 +1,4 @@
-
-python -m pip install -e common/[tests]
-python -m pip install -e features/
-python -m pip install -e core/[all,tests]
-python -m pip install -e tabular/[all,tests]
-python -m pip install -e multimodal/[tests]
-python -m pip install -e timeseries/[all,tests]
-python -m pip install -e autogluon/
+REM Install all AutoGluon packages from source via the uv workspace (creates .venv/).
+REM See docs/install-from-source.md for details and options.
+python -m pip install -U uv
+python -m uv sync --all-extras

--- a/full_install.sh
+++ b/full_install.sh
@@ -91,7 +91,9 @@ fi
 uvpip() { "${UV_LAUNCH[@]}" pip "$@"; }
 
 # Use uv to install packages
-# TODO: We should simplify this by having a single setup.py at project root, and let user call `pip install -e .`
+# NOTE: The repo is now a uv workspace, so the recommended path is `uv sync --all-extras` from the
+# repo root (installs all members editable from the committed uv.lock; see docs/install-from-source.md).
+# This script remains as a pip-style fallback (and handles the Colab non-editable case).
 if [ "$EDITABLE" == "true" ]; then
   # Editable install (used outside Colab)
   uvpip install --refresh -e "common/[tests]"

--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -56,7 +56,7 @@ install_requires = [
     "jinja2>=3.0.3,<3.2",
     "tensorboard>=2.9,<3",
     "pytesseract>=0.3.9,<0.4",
-    "nvidia-ml-py3>=7.352.0, <8.0",
+    "nvidia-ml-py3>=7.352.0,<8.0",
     "pdf2image>=1.17.0,<1.19",
 ]
 


### PR DESCRIPTION
Stacked on #5688 (base = `cleanup/pep621-uv-workspace`). **Merge this into #5688 first**, then #5688 into `master`.

Documents local/source installation for the PEP 621 + uv workspace and updates the existing source-install entry points.

For an example colab notebook, refer here: https://colab.research.google.com/drive/1Y7bcojKd11ZugW7L2pfb3CrhyJRjLqL5?usp=sharing

## Changes
- **`docs/install-from-source.md`** (new): `git clone` + `uv sync --all-extras` installs all 7 `autogluon.*` packages editable from the committed `uv.lock`. Covers extras, CPU-only (`--index https://download.pytorch.org/whl/cpu`), per-submodule `uv sync --package …`, a **direct git install** (`pkg @ git+https://github.com/autogluon/autogluon.git#subdirectory=<dir>`), the dev workflow, and the pip/`full_install.sh` fallback.
- **`docs/install-{cpu,gpu,mac-cpu}-source.md`**: switched to the `uv sync` flow (CPU adds `--index https://download.pytorch.org/whl/cpu`).
- **`docs/install-modules.md`**: submodule-from-source uses `uv sync --package autogluon.<sub> --extra …`.
- **`full_install.sh`**: refreshed the stale TODO (workspace `uv sync` is now recommended; script kept as the pip/Colab fallback — no logic change).
- **`CONTRIBUTING.md`**: points contributors at the new guide.

## Follow-up cleanups (small, surfaced while writing the docs)
  - **`docs/install-modules.md`**: fix nonexistent extra `autogluon.tabular[all,test]` → `[all,tests]`.
  - **`full_install.bat`**: install via the uv workspace (`uv sync --all-extras`) instead of the old per-package pip loop (Windows parity with `full_install.sh`).
  - **`docs/build_pip_install.sh`**: drop the stale `autogluon.fair` uninstall (no such package) and the obsolete Python-3.7 `pip uninstall typing` workaround (min Python is 3.10).
  - **`multimodal/setup.py`**: remove a stray space in the `nvidia-ml-py3>=7.352.0,<8.0` requirement.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
