### PR TITLE
Silence spurious warnings on degenerate (constant / all-NaN) columns during fit

### DIFF
--- a/features/src/autogluon/features/generators/oof_target_encoder.py
+++ b/features/src/autogluon/features/generators/oof_target_encoder.py
@@ -179,7 +179,13 @@ class OOFTargetEncodingFeatureGenerator(AbstractFeatureGenerator):
 
             # global_mean as in original _transform:
             # mean of per-category means
-            global_mean = np.nanmean(mean_all, axis=0)  # (n_targets,)
+            if n_cat == 0:
+                # All-NaN categorical column -> zero categories, so `mean_all` has shape
+                # (0, n_targets) and `np.nanmean(..., axis=0)` averages an empty slice (a
+                # RuntimeWarning, returning NaN). Produce the same all-NaN global mean directly.
+                global_mean = np.full(self.n_targets, np.nan)
+            else:
+                global_mean = np.nanmean(mean_all, axis=0)  # (n_targets,)
 
             # Smoothed per-category encodings used at inference
             denom_all = count_all[:, None] + alpha

--- a/features/src/autogluon/features/generators/selection.py
+++ b/features/src/autogluon/features/generators/selection.py
@@ -25,6 +25,10 @@ class SpearmanFeatureSelector(AbstractFeatureGenerator):
         # TODO: Add option for AUC for binary
         # TODO: Properly handle multiclass targets
         # X.columns[X.isna().mean()<0.99]
+        # Spearman correlation is undefined for constant (<= 1 distinct non-null value) columns:
+        # scipy returns NaN and emits a ConstantInputWarning. Drop such columns up front so they are
+        # excluded cleanly without the warning -- the `.dropna()` below would drop them anyway.
+        X = X.loc[:, X.nunique(dropna=True) > 1]
         corr = X.corrwith(y, method="spearman")
         abs_corr = corr.abs().sort_values(ascending=False).dropna()
 

--- a/features/tests/features/generators/test_oof_target_encoder.py
+++ b/features/tests/features/generators/test_oof_target_encoder.py
@@ -308,3 +308,49 @@ def test_oof_target_encoding_estimate_no_of_new_features(data_helper):
     # Multiclass: num_cat_cols * num_classes
     assert n_multi == num_cat_cols * num_classes
     assert cols_multi == ["obj", "cat"]
+
+
+def _fit_capture_warnings(gen, X, y):
+    import warnings
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        gen._fit(X, y)
+    return [str(w.message).lower() for w in caught]
+
+
+def test_oof_target_encoding_all_nan_categorical_does_not_warn_empty_slice():
+    """An all-NaN categorical has zero categories -> empty per-category mean matrix.
+
+    Previously ``np.nanmean(mean_all, axis=0)`` averaged an empty slice (a RuntimeWarning). The
+    global mean is NaN for such a column regardless; this verifies it is produced without warning.
+    """
+    n = 20
+    X = pd.DataFrame(
+        {
+            "all_nan_cat": pd.Series([np.nan] * n, dtype="object"),
+            "real_cat": pd.Series((["a", "b"] * n)[:n], dtype="object"),
+        }
+    )
+    y = pd.Series(([0, 1] * n)[:n])
+    gen = OOFTargetEncodingFeatureGenerator(target_type="binary", n_splits=2)
+
+    messages = _fit_capture_warnings(gen, X, y)
+    assert not any("empty slice" in m for m in messages), messages
+
+    # All-NaN column -> no categories -> NaN global mean (degenerate but valid, no crash/warning).
+    assert np.isnan(gen.encodings_["all_nan_cat"]["global_mean"]).all()
+    assert gen.encodings_["all_nan_cat"]["enc_matrix"].shape[0] == 0
+    # The real categorical still gets a finite global mean.
+    assert np.isfinite(gen.encodings_["real_cat"]["global_mean"]).all()
+
+
+def test_oof_target_encoding_normal_categorical_global_mean_finite_no_warning():
+    n = 30
+    X = pd.DataFrame({"cat": pd.Series((["a", "b", "c"] * n)[:n], dtype="object")})
+    y = pd.Series(([0, 1] * n)[:n])
+    gen = OOFTargetEncodingFeatureGenerator(target_type="binary", n_splits=2)
+
+    messages = _fit_capture_warnings(gen, X, y)
+    assert not any("empty slice" in m for m in messages), messages
+    assert np.isfinite(gen.encodings_["cat"]["global_mean"]).all()

--- a/features/tests/features/generators/test_selection.py
+++ b/features/tests/features/generators/test_selection.py
@@ -1,0 +1,52 @@
+"""Tests for ``SpearmanFeatureSelector``.
+
+Spearman correlation is undefined for a constant column; scipy returns NaN and emits a
+``ConstantInputWarning``. The selector already drops the resulting NaN correlations, so a constant
+column is never selected -- this just verifies it happens without the spurious warning.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pandas as pd
+
+from autogluon.features.generators.selection import SpearmanFeatureSelector
+
+
+def test_spearman_selector_excludes_constant_columns_without_warning():
+    n = 50
+    X = pd.DataFrame(
+        {
+            "const": np.ones(n),  # zero-variance -> undefined Spearman correlation
+            "all_nan": pd.Series([np.nan] * n, dtype=float),
+            "varying": np.arange(n, dtype=float),
+        }
+    )
+    y = pd.Series(np.arange(n, dtype=float))
+    gen = SpearmanFeatureSelector(max_features=10)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        gen._fit(X, y)
+    messages = [str(w.message).lower() for w in caught]
+    assert not any("constant" in m or "not defined" in m for m in messages), messages
+
+    # Constant / all-NaN columns are not selected; the informative column is.
+    assert "const" not in gen.selected_features_
+    assert "all_nan" not in gen.selected_features_
+    assert "varying" in gen.selected_features_
+
+
+def test_spearman_selector_happy_path_still_selects_correlated_features():
+    n = 40
+    base = np.arange(n, dtype=float)
+    X = pd.DataFrame({"pos": base, "neg": -base, "noise": (base * 0) + np.tile([0.0, 1.0], n // 2)})
+    y = pd.Series(base)
+    gen = SpearmanFeatureSelector(max_features=2)
+
+    gen._fit(X, y)
+
+    # Perfectly (anti-)correlated features rank first.
+    assert set(gen.selected_features_) == {"pos", "neg"}

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -436,7 +436,9 @@ class DefaultLearner(AbstractTabularLearner):
             X = copy.deepcopy(X)
 
             # treat None, NaN, INF, NINF as NA
-            X[self.label] = X[self.label].replace([np.inf, -np.inf], np.nan)
+            # `.infer_objects(copy=False)` retains the pre-pandas-2.2 dtype behavior of `replace`
+            # explicitly, avoiding the "Downcasting behavior in `replace` is deprecated" FutureWarning.
+            X[self.label] = X[self.label].replace([np.inf, -np.inf], np.nan).infer_objects(copy=False)
             invalid_labels = X[self.label].isna()
             if invalid_labels.any():
                 first_invalid_label_idx = invalid_labels.idxmax()


### PR DESCRIPTION
## Description

Fitting feature generators / the learner on data with constant or all-NaN columns emitted three benign-but-noisy warnings. These show up in practice on datasets with (near-)all-missing categorical columns — e.g. when such a column lands entirely NaN in the 1000-row subsample AutoGluon uses for model memory estimation. All three fixes are behavior-preserving (the produced values are unchanged); they only remove the warnings.

## Warnings fixed

1. **`OOFTargetEncodingFeatureGenerator`** — `RuntimeWarning: Mean of empty slice`
   An all-NaN categorical column has zero categories after `pd.factorize` (`n_cat == 0`), so the per-category mean matrix has shape `(0, n_targets)` and `np.nanmean(mean_all, axis=0)` averages an empty slice. The global mean is NaN for such a column regardless; compute it directly when `n_cat == 0`.

2. **`SpearmanFeatureSelector`** — `scipy ConstantInputWarning: An input array is constant; the correlation coefficient is not defined`
   Spearman correlation is undefined for a constant column (scipy returns NaN). Drop columns with `<= 1` distinct non-null value before `corrwith(method="spearman")` — the subsequent `.dropna()` already discarded them, so selection is unchanged.

3. **`DefaultLearner._check_for_non_finite_values`** — `FutureWarning: Downcasting behavior in `replace` is deprecated`
   Append `.infer_objects(copy=False)` to `replace([np.inf, -np.inf], np.nan)` to retain the pre-pandas-2.2 dtype behavior explicitly (the migration-recommended idiom).

## Test plan

- New `features/tests/features/generators/test_selection.py` (constant / all-NaN columns excluded without warning; happy path).
- New cases in `features/tests/features/generators/test_oof_target_encoder.py` (all-NaN categorical → NaN global mean, no empty-slice warning; normal categorical finite, no warning).
- `pytest features/tests/features/generators/` → 57 passed (no regressions).
- Verified each warning is silenced under `warnings.simplefilter("error", ...)` / capture.

Related: same all-NaN-categorical root cause as #5700 (GroupByFeatureGenerator crash); this PR is warning hygiene only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)