### PR TITLE
[experimental] Prototype GPU support for fit_strategy='parallel' (behind AG_PARALLEL_GPU)

### DIFF
--- a/core/src/autogluon/core/ray/distributed_jobs_managers.py
+++ b/core/src/autogluon/core/ray/distributed_jobs_managers.py
@@ -180,6 +180,26 @@ class ParallelFitManager:
         else:
             return self.num_splits
 
+    def _num_concurrent_children(self, model: AbstractModel | str, num_children: int) -> int:
+        """Number of folds resident simultaneously, for CPU/GPU/memory reservation & gating.
+
+        For the EXPERIMENTAL GPU-parallel prototype, ``sequential_local`` fits every fold (and the
+        refit) one-at-a-time IN the single model-worker -- there are no nested fold-workers, so at
+        most ONE fold is ever resident. Its concurrent footprint is therefore 1 fold, not
+        ``num_children`` (= num_splits). Reporting 1 stops the scheduler from reserving
+        ``num_splits x`` the per-fold CPUs/GPUs and from deferring the model to "fit all folds in
+        parallel" -- neither applies when folds are sequential. Every other strategy fits
+        ``num_children`` folds in parallel, so the count is unchanged (also a no-op when the flag
+        is off, preserving historical behavior).
+        """
+        if (
+            gpu_parallel_fit_enabled()
+            and isinstance(model, AbstractModel)
+            and model._user_params.get("fold_fitting_strategy") == "sequential_local"
+        ):
+            return 1
+        return num_children
+
     def _num_gpus_per_child(self, model: AbstractModel | str) -> float:
         """Per-child (fold) GPU requirement for the EXPERIMENTAL GPU-parallel prototype.
 
@@ -298,7 +318,14 @@ class ParallelFitManager:
                 models_to_schedule_later.append(model)
                 continue
             num_children = self.num_children_model(model=model)
-            if (num_children > self.available_num_cpus_virtual) and (self.total_num_cpus >= num_children):
+            # EXPERIMENTAL (AG_PARALLEL_GPU): the number of folds resident at once. `sequential_local`
+            # fits folds one-at-a-time, so its concurrency is 1 (not `num_children` = num_splits);
+            # used for the reservation + "fit all folds in parallel" gating below. `num_children`
+            # stays the true fold count for the per-fold memory estimate and logs.
+            num_concurrent_children = self._num_concurrent_children(model, num_children)
+            if (num_concurrent_children > self.available_num_cpus_virtual) and (
+                self.total_num_cpus >= num_concurrent_children
+            ):
                 # try to wait to schedule later when all folds can be fit in parallel
                 num_models_delay_to_fit_all += 1
                 models_to_schedule_later.append(model)
@@ -336,9 +363,9 @@ class ParallelFitManager:
                 max_safe_children_gpu = math.floor(self.available_num_gpus / num_gpus_per_child)
                 max_safe_children = min(max_safe_children, max_safe_children_gpu)
 
-            safe_children = max(min(max_safe_children, num_children), 0)
+            safe_children = max(min(max_safe_children, num_concurrent_children), 0)
 
-            if safe_children < num_children:
+            if safe_children < num_concurrent_children:
                 # FIXME: Make this better, do real successive halving rather than this hack code that only works for 8 or fewer
                 if safe_children >= 8:
                     safe_children = 8
@@ -362,9 +389,9 @@ class ParallelFitManager:
                 model=model, mem_usage_child=model_child_memory_estimate, num_children=safe_children
             )
 
-            if safe_children < num_children:
-                if ((num_children * model_child_memory_estimate) < self.max_mem) and (
-                    self.total_num_cpus >= num_children
+            if safe_children < num_concurrent_children:
+                if ((num_concurrent_children * model_child_memory_estimate) < self.max_mem) and (
+                    self.total_num_cpus >= num_concurrent_children
                 ):
                     # try to wait to schedule later when all folds can be fit in parallel
                     logger.log(
@@ -455,6 +482,13 @@ class ParallelFitManager:
                 model_memory_estimate=model_memory_estimate,
             )
 
+            # Only report GPU allocation when the cluster actually has GPUs (allocation may be
+            # fractional, so format with :g to drop trailing zeros / float noise).
+            gpus_allocated_str = (
+                f"\t| {self.total_num_gpus - self.available_num_gpus:g}/{self.total_num_gpus} Allocated GPUS"
+                if self.total_num_gpus > 0
+                else ""
+            )
             logger.log(
                 20,
                 f"Scheduled {model_name}: "
@@ -462,6 +496,7 @@ class ParallelFitManager:
                 f"{len(self.job_refs_to_allocated_resources)} jobs running"
                 f"\n\t{model_resources.num_cpus_for_fold_worker if num_children != 1 else model_resources.num_cpus_for_model_worker} CPUs each for {num_children} folds, fitting {safe_children} in parallel"
                 f"\n\t{self.total_num_cpus - self.available_num_cpus}/{self.total_num_cpus} Allocated CPUS"
+                f"{gpus_allocated_str}"
                 f"\t| {(self.total_mem - self.available_mem) * 1e-9:.1f}/{self.total_mem * 1e-9:.1f} GB Allocated Memory",
             )
             if self.delay_between_jobs > 0:

--- a/core/src/autogluon/core/ray/distributed_jobs_managers.py
+++ b/core/src/autogluon/core/ray/distributed_jobs_managers.py
@@ -718,7 +718,14 @@ def prepare_model_resources_for_fit(
         num_gpus = num_gpus_worker
     else:
         num_cpus_parent = num_cpus * num_parallel
-        num_gpus_parent = num_gpus * num_parallel
+        # EXPERIMENTAL (AG_PARALLEL_GPU): unlike CPUs, do NOT multiply GPUs by num_parallel. The
+        # parent here (the bagged orchestrator / refit_full fit) is a single fit that uses
+        # `num_gpus` GPUs, and `get_resources_for_model_fit` reserves its GPUs from the per-child
+        # count -- not this aggregate. Multiplying would tell the model it has `num_gpus *
+        # num_parallel` GPUs while Ray only makes `num_gpus` visible, which crashes models that
+        # select devices by absolute index (e.g. TabPFN-3's `cuda:{i} for i in range(num_gpus)`)
+        # with "CUDA error: invalid device ordinal". (No effect on CPU runs, where num_gpus == 0.)
+        num_gpus_parent = num_gpus
 
         model_aux = model._user_params_aux
         if "num_cpus" not in model_aux:

--- a/core/src/autogluon/core/ray/distributed_jobs_managers.py
+++ b/core/src/autogluon/core/ray/distributed_jobs_managers.py
@@ -613,8 +613,20 @@ class ParallelFitManager:
             num_cpus_for_fold_worker = 0
             num_gpus_for_fold_worker = 0
             total_num_cpus = num_cpus_for_model_worker
+        elif gpu_parallel_fit_enabled() and model._user_params.get("fold_fitting_strategy") == "sequential_local":
+            # EXPERIMENTAL (AG_PARALLEL_GPU), strategy-aware GPU reservation:
+            # `sequential_local` fits every fold AND the refit IN-PROCESS in the single model-worker
+            # -- there are no nested fold-workers. So the model-worker itself needs the per-fold GPU
+            # (regardless of `refit_folds`), and no GPUs are reserved for (non-existent) fold-workers.
+            # This stops over-reserving `num_gpus * num_splits` GPUs (which idled GPUs and capped
+            # parallelism) and ensures even non-refit models get a GPU on the worker.
+            num_gpus_for_model_worker = num_gpus_for_fold_worker
+            num_gpus_for_fold_worker = 0  # no nested fold-workers -> total_num_gpus == model-worker's
+            num_cpus_for_model_worker = 1
+            total_num_cpus = model._user_params_aux["num_cpus"]
         else:
-            # If refit_folds is True, we need to pass GPU resources to the model-worker
+            # parallel_local / auto: nested fold-workers hold the GPUs; the model-worker only needs
+            # GPU resources for the refit_full step (if any).
             num_gpus_for_model_worker = (
                 num_gpus_for_fold_worker
                 if ((num_gpus_for_fold_worker > 0) and model._user_params.get("refit_folds", False))

--- a/core/src/autogluon/core/ray/distributed_jobs_managers.py
+++ b/core/src/autogluon/core/ray/distributed_jobs_managers.py
@@ -25,6 +25,7 @@ def gpu_parallel_fit_enabled() -> bool:
     """
     return os.environ.get("AG_PARALLEL_GPU", "False") == "True"
 
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_REMOTE_KWARGS = dict(max_calls=1, retry_exceptions=False, max_retries=0)

--- a/core/src/autogluon/core/ray/distributed_jobs_managers.py
+++ b/core/src/autogluon/core/ray/distributed_jobs_managers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import logging
 import math
+import os
 import time
 from dataclasses import dataclass
 from typing import Callable, Literal
@@ -11,6 +12,18 @@ import pandas as pd
 
 from autogluon.common.utils.resource_utils import get_resource_manager
 from autogluon.core.models import AbstractModel, BaggedEnsembleModel
+
+
+def gpu_parallel_fit_enabled() -> bool:
+    """EXPERIMENTAL prototype flag for GPU support in ``fit_strategy='parallel'``.
+
+    Enabled by setting the ``AG_PARALLEL_GPU=True`` environment variable. When off (default),
+    ``fit_strategy='parallel'`` falls back to ``'sequential'`` if any GPUs are requested (the
+    historical behavior). When on, each model must declare its per-model ``num_gpus`` (e.g. via
+    ``ag_args_fit``); the parallel scheduler then sizes GPU reservations and caps the number of
+    concurrently-fit (children) by the available GPUs. Treat results as experimental.
+    """
+    return os.environ.get("AG_PARALLEL_GPU", "False") == "True"
 
 logger = logging.getLogger(__name__)
 
@@ -167,6 +180,17 @@ class ParallelFitManager:
         else:
             return self.num_splits
 
+    def _num_gpus_per_child(self, model: AbstractModel | str) -> float:
+        """Per-child (fold) GPU requirement for the EXPERIMENTAL GPU-parallel prototype.
+
+        Returns 0 unless ``AG_PARALLEL_GPU`` is enabled, GPUs are available, and the model declares
+        a per-model ``num_gpus`` in its ``_user_params_aux`` (e.g. via ``ag_args_fit``). CPU-only
+        models (no declared GPUs) return 0 and are scheduled exactly as before.
+        """
+        if not gpu_parallel_fit_enabled() or self.total_num_gpus <= 0 or not isinstance(model, AbstractModel):
+            return 0
+        return getattr(model, "model_base", model)._user_params_aux.get("num_gpus", 0) or 0
+
     @property
     def max_mem_per_core(self):
         return self.max_mem / self.total_num_cpus
@@ -295,6 +319,23 @@ class ParallelFitManager:
             # FIXME: Not accurate, due to oversubscription, this is dangerous for memory...
             max_safe_children = math.floor(num_cpus_avail / num_cpus_per_child_safe)
 
+            # EXPERIMENTAL (AG_PARALLEL_GPU): also cap parallel children by available GPUs so a
+            # model's concurrently-fit folds never oversubscribe GPUs. No effect for CPU-only models
+            # (num_gpus_per_child == 0); requires the model to declare its per-model `num_gpus`.
+            num_gpus_per_child = self._num_gpus_per_child(model)
+            if num_gpus_per_child > self.total_num_gpus:
+                # Can never fit even a single fold -> skip rather than delay forever (mirrors the
+                # insufficient-memory skip above).
+                logger.log(
+                    20,
+                    f"Insufficient total GPUs ({self.total_num_gpus}) to fit even a single fold of "
+                    f"{model_name} (needs {num_gpus_per_child} per fold). Skipping...",
+                )
+                continue
+            if num_gpus_per_child > 0:
+                max_safe_children_gpu = math.floor(self.available_num_gpus / num_gpus_per_child)
+                max_safe_children = min(max_safe_children, max_safe_children_gpu)
+
             safe_children = max(min(max_safe_children, num_children), 0)
 
             if safe_children < num_children:
@@ -350,7 +391,12 @@ class ParallelFitManager:
                 model = prepare_model_resources_for_fit(
                     model=model,
                     num_cpus=num_cpus_per_child_safe,
-                    num_gpus=0,
+                    # EXPERIMENTAL (AG_PARALLEL_GPU): forward the per-child GPU requirement instead
+                    # of hardcoding 0, so GPU models get GPU reservations in parallel fit. The
+                    # downstream `get_resources_for_model_fit` keeps the bagged orchestrator at 0
+                    # GPUs and reserves GPUs on the (nested) fold-workers, avoiding the Ray
+                    # nested-GPU reservation deadlock.
+                    num_gpus=num_gpus_per_child,
                     num_parallel=safe_children,
                     num_children=num_children,
                     total_num_cpus=self.total_num_cpus,

--- a/core/tests/unittests/ray/test_parallel_gpu_prototype.py
+++ b/core/tests/unittests/ray/test_parallel_gpu_prototype.py
@@ -235,9 +235,14 @@ def test_sequential_local_reserves_one_fold_cpu_not_num_splits(_restore_flag):
 
     # num_parallel=1 is what schedule_jobs now passes for sequential_local (was num_splits).
     prepare_model_resources_for_fit(
-        model=bag, total_num_cpus=192, total_num_gpus=8,
-        num_cpus=7, num_gpus=1, num_parallel=1, num_children=8,
+        model=bag,
+        total_num_cpus=192,
+        total_num_gpus=8,
+        num_cpus=7,
+        num_gpus=1,
+        num_parallel=1,
+        num_children=8,
     )
     res = _resources_for_fit(bag, num_splits=8)
-    assert res.total_num_cpus == 7   # one fold's worth; was 7 * 8 = 56 before the fix
+    assert res.total_num_cpus == 7  # one fold's worth; was 7 * 8 = 56 before the fix
     assert res.total_num_gpus == 1

--- a/core/tests/unittests/ray/test_parallel_gpu_prototype.py
+++ b/core/tests/unittests/ray/test_parallel_gpu_prototype.py
@@ -1,0 +1,85 @@
+"""Tests for the EXPERIMENTAL GPU-parallel prototype (``AG_PARALLEL_GPU``).
+
+Covers the flag gate and the per-child GPU sizing used by ``ParallelFitManager.schedule_jobs`` to
+cap concurrent fits by available GPUs. The end-to-end parallel-fit-on-GPU path requires Ray, GPU
+models, and real GPUs, so it is not exercised here.
+"""
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from autogluon.core.models import AbstractModel
+from autogluon.core.ray.distributed_jobs_managers import (
+    ParallelFitManager,
+    gpu_parallel_fit_enabled,
+)
+
+
+@pytest.fixture
+def _restore_flag():
+    """Save/restore AG_PARALLEL_GPU so tests don't leak the env var."""
+    prev = os.environ.get("AG_PARALLEL_GPU")
+    os.environ.pop("AG_PARALLEL_GPU", None)
+    yield
+    if prev is None:
+        os.environ.pop("AG_PARALLEL_GPU", None)
+    else:
+        os.environ["AG_PARALLEL_GPU"] = prev
+
+
+def test_flag_disabled_by_default(_restore_flag):
+    assert gpu_parallel_fit_enabled() is False
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("True", True), ("False", False), ("true", False), ("1", False), ("", False)],
+)
+def test_flag_only_true_string_enables(_restore_flag, value, expected):
+    # Matches the AG_FORCE_PARALLEL convention: strictly the string "True" enables it.
+    os.environ["AG_PARALLEL_GPU"] = value
+    assert gpu_parallel_fit_enabled() is expected
+
+
+class _DummyModel(AbstractModel):
+    pass
+
+
+def _model(num_gpus=None) -> _DummyModel:
+    # Skip AbstractModel.__init__; _num_gpus_per_child only needs isinstance + _user_params_aux.
+    model = object.__new__(_DummyModel)
+    model._user_params_aux = {} if num_gpus is None else {"num_gpus": num_gpus}
+    return model
+
+
+def _num_gpus_per_child(total_num_gpus, model):
+    # Call the unbound method with a minimal stub for `self`.
+    return ParallelFitManager._num_gpus_per_child(SimpleNamespace(total_num_gpus=total_num_gpus), model)
+
+
+def test_num_gpus_per_child_reads_declared_gpus_when_enabled(_restore_flag):
+    os.environ["AG_PARALLEL_GPU"] = "True"
+    assert _num_gpus_per_child(total_num_gpus=8, model=_model(num_gpus=2)) == 2
+
+
+def test_num_gpus_per_child_zero_when_flag_off(_restore_flag):
+    os.environ.pop("AG_PARALLEL_GPU", None)
+    assert _num_gpus_per_child(total_num_gpus=8, model=_model(num_gpus=2)) == 0
+
+
+def test_num_gpus_per_child_zero_when_no_gpus_available(_restore_flag):
+    os.environ["AG_PARALLEL_GPU"] = "True"
+    assert _num_gpus_per_child(total_num_gpus=0, model=_model(num_gpus=2)) == 0
+
+
+def test_num_gpus_per_child_zero_when_model_declares_none(_restore_flag):
+    os.environ["AG_PARALLEL_GPU"] = "True"
+    assert _num_gpus_per_child(total_num_gpus=8, model=_model(num_gpus=None)) == 0
+
+
+def test_num_gpus_per_child_zero_for_non_model(_restore_flag):
+    # refit mode passes a model name (str), which must not be treated as GPU-bound.
+    os.environ["AG_PARALLEL_GPU"] = "True"
+    assert _num_gpus_per_child(total_num_gpus=8, model="SomeModel_name") == 0

--- a/core/tests/unittests/ray/test_parallel_gpu_prototype.py
+++ b/core/tests/unittests/ray/test_parallel_gpu_prototype.py
@@ -179,3 +179,65 @@ def test_sequential_local_unchanged_when_flag_off(_restore_flag):
     res = _resources_for_fit(_bagged_model(num_gpus=1, fold_fitting_strategy="sequential_local", refit_folds=True))
     # Falls through to the parallel branch: 1 (refit) + 1*num_splits.
     assert res.total_num_gpus == 1 + 1 * 2
+
+
+# ---------------------------------------------------------------------------
+# Concurrent-children sizing (CPU/GPU/memory reservation for sequential_local)
+# ---------------------------------------------------------------------------
+def _concurrent(model, num_children=8):
+    # `self` is unused by _num_concurrent_children; a bare stub suffices.
+    return ParallelFitManager._num_concurrent_children(SimpleNamespace(), model, num_children)
+
+
+def _bag_with_strategy(strategy):
+    bag = object.__new__(BaggedEnsembleModel)
+    bag._user_params = {} if strategy is None else {"fold_fitting_strategy": strategy}
+    return bag
+
+
+def test_concurrent_children_sequential_local_is_one(_restore_flag):
+    # sequential_local fits folds one-at-a-time -> concurrent footprint is 1, not num_splits.
+    os.environ["AG_PARALLEL_GPU"] = "True"
+    assert _concurrent(_bag_with_strategy("sequential_local"), num_children=8) == 1
+
+
+def test_concurrent_children_parallel_local_unchanged(_restore_flag):
+    os.environ["AG_PARALLEL_GPU"] = "True"
+    assert _concurrent(_bag_with_strategy("parallel_local"), num_children=8) == 8
+
+
+def test_concurrent_children_default_strategy_unchanged(_restore_flag):
+    os.environ["AG_PARALLEL_GPU"] = "True"
+    assert _concurrent(_bag_with_strategy(None), num_children=8) == 8
+
+
+def test_concurrent_children_sequential_local_noop_when_flag_off(_restore_flag):
+    os.environ.pop("AG_PARALLEL_GPU", None)
+    assert _concurrent(_bag_with_strategy("sequential_local"), num_children=8) == 8
+
+
+def test_concurrent_children_non_model_unchanged(_restore_flag):
+    # refit mode passes a model name (str), which must not be special-cased.
+    os.environ["AG_PARALLEL_GPU"] = "True"
+    assert _concurrent("SomeModel_name", num_children=8) == 8
+
+
+def test_sequential_local_reserves_one_fold_cpu_not_num_splits(_restore_flag):
+    """End-to-end: with the scheduler's sequential num_parallel=1, the model reserves ONE fold's
+    CPUs (memory pressure is a single resident fold) -- not num_cpus * num_splits."""
+    os.environ["AG_PARALLEL_GPU"] = "True"
+    bag = object.__new__(BaggedEnsembleModel)
+    bag._user_params = {"fold_fitting_strategy": "sequential_local", "refit_folds": True}
+    bag._user_params_aux = {}
+    child = object.__new__(_DummyModel)
+    child._user_params_aux = {}
+    bag.model_base = child
+
+    # num_parallel=1 is what schedule_jobs now passes for sequential_local (was num_splits).
+    prepare_model_resources_for_fit(
+        model=bag, total_num_cpus=192, total_num_gpus=8,
+        num_cpus=7, num_gpus=1, num_parallel=1, num_children=8,
+    )
+    res = _resources_for_fit(bag, num_splits=8)
+    assert res.total_num_cpus == 7   # one fold's worth; was 7 * 8 = 56 before the fix
+    assert res.total_num_gpus == 1

--- a/core/tests/unittests/ray/test_parallel_gpu_prototype.py
+++ b/core/tests/unittests/ray/test_parallel_gpu_prototype.py
@@ -14,6 +14,7 @@ from autogluon.core.models import AbstractModel
 from autogluon.core.ray.distributed_jobs_managers import (
     ParallelFitManager,
     gpu_parallel_fit_enabled,
+    prepare_model_resources_for_fit,
 )
 
 
@@ -83,3 +84,33 @@ def test_num_gpus_per_child_zero_for_non_model(_restore_flag):
     # refit mode passes a model name (str), which must not be treated as GPU-bound.
     os.environ["AG_PARALLEL_GPU"] = "True"
     assert _num_gpus_per_child(total_num_gpus=8, model="SomeModel_name") == 0
+
+
+def test_prepare_model_resources_does_not_multiply_gpus_by_num_parallel():
+    """Parent (bagged orchestrator / refit_full) GPU count must equal the per-fit count, not the
+    CPU-style ``num_gpus * num_parallel`` aggregate.
+
+    Multiplying made the parent fit see more GPUs than Ray actually made visible to it -> a model
+    that selects devices by absolute index (e.g. TabPFN-3) crashed with "invalid device ordinal".
+    """
+    parent = object.__new__(_DummyModel)
+    parent._user_params_aux = {}
+    child = object.__new__(_DummyModel)
+    child._user_params_aux = {}
+    parent.model_base = child  # bagged: parent orchestrates a separate child model
+
+    prepare_model_resources_for_fit(
+        model=parent,
+        total_num_cpus=64,
+        total_num_gpus=8,
+        num_cpus=4,
+        num_gpus=1,
+        num_parallel=2,
+        num_children=2,
+    )
+
+    # CPUs ARE aggregated across the parallel folds the parent orchestrates...
+    assert parent._user_params_aux["num_cpus"] == 4 * 2
+    # ...but GPUs are NOT: the parent fit uses the per-child count, matching its reservation.
+    assert parent._user_params_aux["num_gpus"] == 1
+    assert child._user_params_aux["num_gpus"] == 1

--- a/core/tests/unittests/ray/test_parallel_gpu_prototype.py
+++ b/core/tests/unittests/ray/test_parallel_gpu_prototype.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from autogluon.core.models import AbstractModel
+from autogluon.core.models import AbstractModel, BaggedEnsembleModel
 from autogluon.core.ray.distributed_jobs_managers import (
     ParallelFitManager,
     gpu_parallel_fit_enabled,
@@ -114,3 +114,68 @@ def test_prepare_model_resources_does_not_multiply_gpus_by_num_parallel():
     # ...but GPUs are NOT: the parent fit uses the per-child count, matching its reservation.
     assert parent._user_params_aux["num_gpus"] == 1
     assert child._user_params_aux["num_gpus"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Strategy-aware GPU reservation in get_resources_for_model_fit
+# ---------------------------------------------------------------------------
+def _bagged_model(*, num_gpus=1, fold_fitting_strategy=None, refit_folds=False, num_cpus=4):
+    """A minimal bagged-model stub for get_resources_for_model_fit (no __init__/ray)."""
+    bag = object.__new__(BaggedEnsembleModel)
+    bag._user_params = {"refit_folds": refit_folds}
+    if fold_fitting_strategy is not None:
+        bag._user_params["fold_fitting_strategy"] = fold_fitting_strategy
+    bag._user_params_aux = {"num_cpus": num_cpus * 2}  # parent (post prepare *num_parallel)
+    child = object.__new__(_DummyModel)
+    child._user_params_aux = {"num_cpus": num_cpus, "num_gpus": num_gpus}
+    bag.model_base = child
+    return bag
+
+
+def _resources_for_fit(model, *, num_splits=2):
+    stub = SimpleNamespace(num_splits=num_splits, max_cpu_resources_per_node=64, total_num_cpus=64)
+    return ParallelFitManager.get_resources_for_model_fit(stub, model=model)
+
+
+def test_sequential_local_reserves_only_model_worker_gpu(_restore_flag):
+    """sequential_local (flag on): no nested fold-workers, so total GPUs == the model-worker's
+    per-fold GPU (not num_gpus * num_splits)."""
+    os.environ["AG_PARALLEL_GPU"] = "True"
+    res = _resources_for_fit(_bagged_model(num_gpus=1, fold_fitting_strategy="sequential_local", refit_folds=True))
+    assert res.num_gpus_for_model_worker == 1
+    assert res.num_gpus_for_fold_worker == 0
+    assert res.total_num_gpus == 1  # was 1 + 1*num_splits = 3 before the fix
+
+
+def test_sequential_local_gives_gpu_even_without_refit(_restore_flag):
+    """sequential_local + refit_folds=False (flag on): the in-process model-worker still gets a GPU
+    (previously it reserved 0 -> CUDA error for the in-process folds)."""
+    os.environ["AG_PARALLEL_GPU"] = "True"
+    res = _resources_for_fit(_bagged_model(num_gpus=1, fold_fitting_strategy="sequential_local", refit_folds=False))
+    assert res.num_gpus_for_model_worker == 1
+    assert res.total_num_gpus == 1
+
+
+def test_parallel_local_reservation_unchanged(_restore_flag):
+    """parallel_local keeps the nested-fold-worker reservation (model-worker GPU only for refit)."""
+    os.environ["AG_PARALLEL_GPU"] = "True"
+    res_refit = _resources_for_fit(
+        _bagged_model(num_gpus=1, fold_fitting_strategy="parallel_local", refit_folds=True), num_splits=2
+    )
+    assert res_refit.num_gpus_for_model_worker == 1  # refit_full on the worker
+    assert res_refit.num_gpus_for_fold_worker == 1
+    assert res_refit.total_num_gpus == 1 + 1 * 2  # = 3
+
+    res_norefit = _resources_for_fit(
+        _bagged_model(num_gpus=1, fold_fitting_strategy="parallel_local", refit_folds=False), num_splits=2
+    )
+    assert res_norefit.num_gpus_for_model_worker == 0
+    assert res_norefit.total_num_gpus == 0 + 1 * 2  # = 2
+
+
+def test_sequential_local_unchanged_when_flag_off(_restore_flag):
+    """With the flag off, sequential_local is NOT special-cased (historical parallel reservation)."""
+    os.environ.pop("AG_PARALLEL_GPU", None)
+    res = _resources_for_fit(_bagged_model(num_gpus=1, fold_fitting_strategy="sequential_local", refit_folds=True))
+    # Falls through to the parallel branch: 1 (refit) + 1*num_splits.
+    assert res.total_num_gpus == 1 + 1 * 2

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -36,7 +36,7 @@ from autogluon.core.models import (
     WeightedEnsembleModel,
 )
 from autogluon.core.pseudolabeling.pseudolabeling import assert_pseudo_column_match
-from autogluon.core.ray.distributed_jobs_managers import ParallelFitManager
+from autogluon.core.ray.distributed_jobs_managers import ParallelFitManager, gpu_parallel_fit_enabled
 from autogluon.core.trainer import AbstractTrainer
 from autogluon.core.trainer.utils import process_hyperparameters
 from autogluon.core.utils import (
@@ -3272,13 +3272,25 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
             if isinstance(num_gpus, str) and num_gpus == "auto":
                 num_gpus = get_resource_manager().get_gpu_count()
             if isinstance(num_gpus, (float, int)) and num_gpus > 0:
-                logger.log(
-                    30,
-                    f"WARNING: fit_strategy='parallel', but `num_gpus={num_gpus}` is specified. "
-                    f"GPU is not yet supported for `parallel` fit_strategy. To enable parallel, ensure you specify `num_gpus=0` in the fit call. "
-                    f"Falling back to fit_strategy='sequential' ... ",
-                )
-                fit_strategy = "sequential"
+                if gpu_parallel_fit_enabled():
+                    # EXPERIMENTAL prototype (AG_PARALLEL_GPU=True): allow GPUs in parallel fit.
+                    # Each model must declare its per-model `num_gpus` (e.g. via ag_args_fit); the
+                    # parallel scheduler reserves GPUs accordingly and caps concurrent fits by the
+                    # available GPUs. Validate results carefully -- this path is not yet hardened.
+                    logger.log(
+                        30,
+                        f"EXPERIMENTAL: fit_strategy='parallel' with `num_gpus={num_gpus}` enabled via "
+                        f"AG_PARALLEL_GPU=True. GPU support for parallel fitting is a prototype.",
+                    )
+                else:
+                    logger.log(
+                        30,
+                        f"WARNING: fit_strategy='parallel', but `num_gpus={num_gpus}` is specified. "
+                        f"GPU is not yet supported for `parallel` fit_strategy. To enable parallel, ensure you specify `num_gpus=0` in the fit call. "
+                        f'You can try the experimental GPU prototype with `os.environ["AG_PARALLEL_GPU"] = "True"`. '
+                        f"Falling back to fit_strategy='sequential' ... ",
+                    )
+                    fit_strategy = "sequential"
         if fit_strategy == "parallel":
             try:
                 try_import_ray()


### PR DESCRIPTION
## Summary

**Experimental / draft.** Prototype GPU support for `TabularPredictor.fit(..., fit_strategy="parallel")`, which today only schedules CPU model-workers. The entire change is gated behind the `AG_PARALLEL_GPU=True` environment variable and is a **no-op when unset** — existing parallel-fit (CPU) behavior is unchanged.

With the flag on, GPU models that declare a per-model `num_gpus` (via `ag_args_fit`) are scheduled across the available GPUs and fit concurrently, instead of `fit_strategy="parallel"` falling back to sequential whenever `num_gpus > 0`.

## Motivation

`fit_strategy="parallel"` (Ray model-workers via `ParallelFitManager`) parallelizes across bagged model fits, but GPU resources were hardcoded to 0 for the parallel path, so any GPU run silently degraded to sequential. On multi-GPU machines this leaves most of the hardware idle when fitting several GPU models (foundation models like TabPFN/TabICL, torch models like TabM/RealMLP).

## What's in this PR (all behind `AG_PARALLEL_GPU`)

- **Flag + plumbing** — `gpu_parallel_fit_enabled()`; the trainer's `num_gpus > 0 → sequential` fallback is gated by the flag; `ParallelFitManager` reads each model's declared per-fold `num_gpus` and caps concurrent children by available GPUs.
- **`invalid device ordinal` fix** — the bagged orchestrator / refit fit no longer multiplies its GPU count by `num_parallel` (Ray only makes `num_gpus` visible; models that select devices by absolute index, e.g. TabPFN-3, crashed otherwise).
- **Strategy-aware reservation** — `sequential_local` (folds fit in-process in the single model-worker) reserves the per-fold GPU on the model-worker and **no** nested-fold-worker GPUs, so total reserved GPUs == the per-fold count (not `num_gpus × num_splits`); `parallel_local` keeps the nested-fold-worker reservation.
- **Concurrency-aware CPU/GPU reservation** — `sequential_local`'s concurrent footprint is 1 fold (not `num_splits`), so it reserves one fold's CPUs/GPUs and is no longer deferred waiting to "fit all folds in parallel." `parallel_local`/`auto` are unchanged.
- **Logging** — the scheduler line now reports `Allocated GPUS` alongside `Allocated CPUS` (only when GPUs > 0; fractional-safe formatting).

## Validation

Exercised empirically on a 8× GPU machine across: TabPFN-3, TabICLv2, TabM, RealMLP (GPU) mixed with LightGBM / XGBoost / CatBoost (CPU); bagged and non-bagged; `sequential_local` and `parallel_local` fold fitting; and fractional per-fold GPU (e.g. RealMLP at `0.25` GPU/fold packing several folds per device — note foundation-model wrappers floor `num_gpus` at 1 via `get_minimum_resources`, so they can't be packed fractionally). Unit tests added in `core/tests/unittests/ray/test_parallel_gpu_prototype.py` for the flag gate, per-child GPU sizing, strategy-aware reservation, and the concurrency logic.

## Status / open questions

- Draft — the flag name, default-off posture, and resource-reservation heuristics are up for discussion before this would be merge-ready.
- `parallel_local` GPU models reserve a per-fold GPU for each of `num_splits` folds, so a single such model effectively wants the whole GPU pool — worth deciding whether that should be capped.
- No CI coverage of the end-to-end Ray-on-GPU path (requires real GPUs); only the scheduler/reservation logic is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
