### PR TITLE
Bump pyarrow, Pillow, ray, skl2onnx

### DIFF
--- a/common/src/autogluon/common/utils/try_import.py
+++ b/common/src/autogluon/common/utils/try_import.py
@@ -31,7 +31,7 @@ def try_import_mxboard():
 
 
 def try_import_ray() -> ModuleType:
-    RAY_MAX_VERSION = "2.54.0"  # sync with core/setup.py
+    RAY_MAX_VERSION = "2.57.0"  # sync with core/setup.py
     ray_max_version_os_map = dict(
         Darwin=RAY_MAX_VERSION,
         Windows=RAY_MAX_VERSION,

--- a/core/setup.py
+++ b/core/setup.py
@@ -39,11 +39,11 @@ install_requires = [
 extras_require = {
     "ray": [
         # Ray<=2.53 does not support py313 on Windows
-        "ray[default]>=2.43.0,<2.54; platform_system != 'Windows' or python_version != '3.13'",  # sync with common/src/autogluon/common/utils/try_import.py
+        "ray[default]>=2.43.0,<2.57; platform_system != 'Windows' or python_version != '3.13'",  # sync with common/src/autogluon/common/utils/try_import.py
     ],
     "raytune": [
         "pyarrow>=15.0.0",  # cap Pyarrow to fix source installation - https://github.com/autogluon/autogluon/issues/4519
-        "ray[default,tune]>=2.43.0,<2.54; platform_system != 'Windows' or python_version != '3.13'",  # sync with common/src/autogluon/common/utils/try_import.py
+        "ray[default,tune]>=2.43.0,<2.57; platform_system != 'Windows' or python_version != '3.13'",  # sync with common/src/autogluon/common/utils/try_import.py
         # TODO: consider alternatives as hyperopt is not actively maintained.
         "hyperopt>=0.2.7,<0.2.8",  # This is needed for the bayes search to work.
         # 'GPy>=1.10.0,<1.11.0'  # TODO: Enable this once PBT/PB2 are supported by ray lightning

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -15,7 +15,7 @@ DEPENDENT_PACKAGES = {
     "boto3": ">=1.10,<2",  # <2 because unlikely to introduce breaking changes in minor releases. >=1.10 because 1.10 is 3 years old, no need to support older
     "numpy": ">=1.25.0,<2.5.0",  # "<{N+1}" upper cap, where N is the latest released minor version, assuming no warnings using N
     "pandas": ">=2.0.0,<2.4.0",  # "<{N+3}" upper cap
-    "pyarrow": ">=7.0.0,<21.0.0",  # "<{N=1}.0.0" upper cap
+    "pyarrow": ">=7.0.0,<25.0.0",  # "<{N=1}.0.0" upper cap
     "scikit-learn": ">=1.4.0,<1.8.0",  # <{N+1} upper cap
     "scipy": ">=1.5.4,<1.17",  # "<{N+2}" upper cap
     "matplotlib": ">=3.7.0,<3.11",  # "<{N+2}" upper cap
@@ -23,7 +23,7 @@ DEPENDENT_PACKAGES = {
     "s3fs": ">=2024.2,<2026",  # Yearly cap
     "networkx": ">=3.0,<4",  # Major version cap
     "tqdm": ">=4.38,<5",  # Major version cap
-    "Pillow": ">=10.0.1,<12",  # Major version cap
+    "Pillow": ">=10.0.1,<13",  # Major version cap
     "torch": ">=2.6,<2.10",  # Major version cap, sync with common/src/autogluon/common/utils/try_import.py. torchvision version in multimodelal/setup.py can effectively constrain version as well
     "lightning": ">=2.5.1,<2.6",  # Major version cap
     "async_timeout": ">=4.0,<6",  # Major version cap

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -88,7 +88,7 @@ extras_require = {
         "imodels>=1.3.10,<2.1.0",  # 1.3.8/1.3.9 either remove/renamed attribute `complexity_` causing failures. https://github.com/csinva/imodels/issues/147
     ],
     "skl2onnx": [
-        "skl2onnx>=1.15.0,<1.20.0",
+        "skl2onnx>=1.15.0,<1.21.0",
         # Sync ONNX requirements with multimodal/setup.py
         "onnx>=1.13.0,!=1.16.2,<1.21.0;platform_system=='Windows'",  # exclude 1.16.2 for issue https://github.com/onnx/onnx/issues/6267
         "onnx>=1.13.0,<1.21.0;platform_system!='Windows'",


### PR DESCRIPTION
Related issue: #5697

**Summary**

Bumped these packages to the following version ranges:

| Package | New range |
|---|---|
| pyarrow | `<25.0.0` |
| Pillow | `<13` |
| ray | `<2.57` |
| skl2onnx | `<1.21` |
