### PR TITLE
[Security Fix] Add security warning to TimeSeriesDataFrame.from_pickle()

### DIFF
--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -774,6 +774,12 @@ class TimeSeriesDataFrame(pd.DataFrame):
         """Convenience method to read pickled time series dataframes. If the read pickle
         file refers to a plain pandas DataFrame, it will be cast to a TimeSeriesDataFrame.
 
+        .. warning::
+            Loading pickled data uses the Python :mod:`pickle` module under the hood, which can execute
+            arbitrary code during deserialization. Only load pickle files that you created yourself or
+            obtained from a fully trusted source. Never load pickle files from untrusted or unauthenticated
+            sources, as a maliciously crafted file can compromise your system.
+
         Parameters
         ----------
         filepath_or_buffer: Any
@@ -784,6 +790,10 @@ class TimeSeriesDataFrame(pd.DataFrame):
         ts_df : TimeSeriesDataFrame
             The pickled time series dataframe.
         """
+        logger.warning(
+            "Loading a pickle file with TimeSeriesDataFrame.from_pickle() can execute arbitrary code. "
+            "Only load pickle files from trusted sources."
+        )
         try:
             data = pd.read_pickle(filepath_or_buffer)
             return data if isinstance(data, cls) else cls(data)


### PR DESCRIPTION
from_pickle() passes a caller-supplied path to pd.read_pickle(), which deserializes arbitrary Python objects and can execute arbitrary code during unpickling (CWE-502). A maliciously crafted pickle file can compromise the host.

Pickle cannot be made safe without breaking the format, so document the risk prominently in the docstring and emit a runtime warning advising users to only load pickle files from trusted sources.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
