### PR TITLE
[Break Change] Gate fork-PR CI behind maintainer 'safe to test' label

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -18,7 +18,50 @@ defaults:
     shell: bash
 
 jobs:
+  # Security gate for the privileged pull_request_target context (CWE-77 mitigation).
+  # Fork PRs must be reviewed and approved by a maintainer (via the 'safe to test' label)
+  # before any job with access to secrets / the AutoGluonCiRole OIDC role runs. Every other
+  # job transitively depends on this gate through branch_check, so when the gate is skipped
+  # (unapproved fork PR) all downstream privileged jobs are skipped cleanly.
+  fork_pr_gate:
+    # Allowed when: this is a push, an internal (same-repo) PR, or a fork PR that a
+    # maintainer just approved by adding the 'safe to test' label. Fork approval is honored
+    # only on the 'labeled' action so a subsequent fork commit cannot ride on a stale label.
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
+      (github.event.action == 'labeled' && contains(github.event.pull_request.labels.*.name, 'safe to test'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approved for CI
+        run: echo "Approved for CI (push, internal PR, or 'safe to test' label on a fork PR)."
+
+  # Revoke the approval whenever a fork PR receives a new commit, so that each new commit
+  # must be re-reviewed. Pairs with the 'labeled'-only approval in fork_pr_gate above.
+  revoke_safe_label:
+    if: github.event_name == 'pull_request_target' && github.event.action == 'synchronize'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Remove 'safe to test' label on new commits
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'safe to test',
+              });
+            } catch (e) {
+              // 404 simply means the label was not present; anything else is a real error.
+              if (e.status !== 404) throw e;
+            }
+
   branch_check:
+    needs: fork_pr_gate
     runs-on: ubuntu-latest
     steps:
       - name: Fail on restricted branch


### PR DESCRIPTION
continuous_integration.yml runs on pull_request_target with id-token: write and pull-requests: write, exposing repo secrets and the AutoGluonCiRole OIDC role to PR-triggered runs (CWE-77). pull_request_target is kept so fork PRs can still submit jobs to AWS Batch; instead of dropping it, gate it behind maintainer review.

Add a fork_pr_gate job that all other jobs transitively depend on via branch_check. It runs only for pushes, internal (same-repo) PRs, or fork PRs a maintainer has approved by adding the 'safe to test' label (honored only on the 'labeled' action so a later fork commit cannot ride a stale label). When the gate is skipped, every downstream privileged job is skipped cleanly, so unapproved fork code never reaches secrets or AWS.

Add a revoke_safe_label job that removes the label on every new fork commit (synchronize), forcing per-commit re-review.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
