### PR TITLE
Switch to yaml.full_load when loading config

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -32,7 +32,7 @@ DEPENDENT_PACKAGES = {
     "accelerate": ">=0.34.0,<2.0",
     "typing-extensions": ">=4.14.0,<5",
     "joblib": ">=1.2,<1.7",  # <{N+1} upper cap
-    "pyyaml": ">=5.0",  # Uncapped to maximize compatibility
+    "pyyaml": ">=5.4",  # Uncapped to maximize compatibility
     "packaging": ">=20",  # Uncapped to maximize compatibility (stable API)
 }
 

--- a/tabular/src/autogluon/tabular/models/mitra/_internal/config/config_pretrain.py
+++ b/tabular/src/autogluon/tabular/models/mitra/_internal/config/config_pretrain.py
@@ -105,8 +105,7 @@ class ConfigSaveLoadMixin(yaml.YAMLObject):
     @classmethod
     def load(cls, path: Path) -> Self:
         with open(path, "r") as f:
-            # It's unsafe, but not unsafer than the pickle module
-            config = yaml.unsafe_load(f)
+            config = yaml.full_load(f)
 
         return config
 


### PR DESCRIPTION
*Issue #, if available:*
- Switch to yaml.full_load when loading Mitra config
- Bump pyyaml lower bound to >=5.4

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
