### PR TITLE
Generate agent-friendly llms.txt / llms-full.txt from the Sphinx build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,24 @@ extensions = [
     "sphinx.ext.napoleon",  # www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
     "sphinx.ext.viewcode",  # www.sphinx-doc.org/en/master/usage/extensions/viewcode.html
     "sphinxcontrib.googleanalytics",  # github.com/sphinx-contrib/googleanalytics
+    "sphinx_llm.txt",  # github.com/NVIDIA/sphinx-llm — emit llms.txt + llms-full.txt (markdown) alongside HTML
 ]
+
+# --- llms.txt configuration (https://github.com/NVIDIA/sphinx-llm) ---
+# During the normal HTML build this extension also runs a markdown builder in
+# parallel and emits, next to the HTML output:
+#   - llms.txt        markdown index of all doc pages (the llms.txt standard)
+#   - llms-full.txt   all pages concatenated into one markdown file
+#   - <page>.html.md  a per-page markdown version of each page
+# Crucially (and unlike sphinx-llms-txt) it runs the *full* Sphinx pipeline, so
+# dynamic directives that AutoGluon relies on under docs/api/ — autosummary,
+# automodule, autoclass — are fully expanded in the markdown. No unrendered rST
+# placeholders reach the agent.
+llms_txt_description = (
+    "AutoGluon automates machine learning tasks, enabling strong predictive "
+    "performance in a few lines of code across tabular, time-series, image, "
+    "text and multimodal data."
+)
 
 # See https://myst-parser.readthedocs.io/en/latest/syntax/optional.html
 myst_enable_extensions = [

--- a/docs/index.md
+++ b/docs/index.md
@@ -264,6 +264,7 @@ GitHub <https://github.com/autogluon/autogluon>
 Tabular FAQ <tutorials/tabular/tabular-faq.md>
 Time Series FAQ <tutorials/timeseries/forecasting-faq.md>
 Multimodal FAQ <tutorials/multimodal/multimodal-faq.md>
+Docs for AI Agents (llms.txt) <llms-txt>
 ```
 
 

--- a/docs/llms-txt.md
+++ b/docs/llms-txt.md
@@ -1,0 +1,71 @@
+# `llms.txt` — agent-friendly documentation
+
+> This page documents the machine-readable documentation output, not a
+> user-facing tutorial. It is intended for AI agent tooling and maintainers.
+
+## What this is
+
+AutoGluon's documentation is built with [Sphinx](https://www.sphinx-doc.org/)
+and rendered to HTML for human reading. As of this change, the same build also
+emits a **markdown mirror** of the documentation following the
+[llms.txt convention](https://llmstxt.org/), so that AI coding agents and LLMs
+can consume the docs without scraping HTML (which wastes tokens on navigation,
+scripts and styling, and obscures the actual content).
+
+The markdown is produced by [`sphinx-llm`](https://github.com/NVIDIA/sphinx-llm)
+(the `sphinx_llm.txt` extension), registered in [`conf.py`](./conf.py).
+
+## Outputs
+
+A normal `sphinx-build -b html . _build/html/` (see
+[`build_doc.sh`](./build_doc.sh)) now also writes, under `_build/html/`:
+
+| file | contents |
+|------|----------|
+| `llms.txt` | a markdown index of all documentation pages, grouped by section, with one-line descriptions — the entry point an agent reads first |
+| `llms-full.txt` | every documentation page concatenated into a single markdown file, for long-context models that want the whole corpus in one shot |
+| `<page>.html.md` | a per-page markdown rendering of each page |
+
+These files are served alongside the HTML site, so `https://auto.gluon.ai/llms.txt`
+and `https://auto.gluon.ai/llms-full.txt` become available once deployed.
+
+## Why sphinx-llm (and not sphinx-llms-txt)
+
+AutoGluon's API reference under [`api/`](./api/) is generated dynamically via
+`autosummary` / `automodule` / `autoclass` directives (see e.g.
+[`api/tabular.rst`](./api/tabular.rst)). The simpler `sphinx-llms-txt` extension
+reads the raw `.rst` source files and therefore leaves those directives
+**unexpanded** — an agent would see literal `.. autoclass:: TabularPredictor`
+placeholders instead of the rendered API.
+
+`sphinx-llm` instead runs the full Sphinx build pipeline (autodoc, autosummary,
+napoleon, myst-nb) and renders the *resolved* content to markdown. This means
+docstrings, parameter tables, and type information are fully expanded in the
+agent-facing output.
+
+## Configuration
+
+In [`conf.py`](./conf.py):
+
+```python
+extensions = [
+    ...,
+    "sphinx_llm.txt",
+]
+
+llms_txt_description = "AutoGluon automates machine learning tasks..."
+```
+
+`sphinx-llm` is added to [`requirements_doc.txt`](./requirements_doc.txt). It
+runs automatically as part of the HTML build — no separate build step is
+required. The `llms_txt_enabled` option can be set to `False` to disable it.
+
+## How an agent uses it
+
+1. Fetch `https://auto.gluon.ai/llms.txt` to get the curated index of doc pages.
+2. Either follow links to individual `*.html.md` pages for targeted context, or
+3. Fetch `llms-full.txt` for the complete corpus (suitable for models with a
+   large context window).
+
+See the root [`AGENTS.md`](../AGENTS.md) for the companion code-level agent
+assets (dependency graph, API surface, AST chunks) under `.agents/`.

--- a/docs/requirements_doc.txt
+++ b/docs/requirements_doc.txt
@@ -8,3 +8,4 @@ sphinx-inline-tabs
 sphinx-togglebutton
 sphinxext-opengraph
 sphinxcontrib-googleanalytics
+sphinx-llm


### PR DESCRIPTION
## What

Adds the [`sphinx_llm.txt`](https://github.com/NVIDIA/sphinx-llm) extension to the docs build, so a normal `sphinx-build -b html` also emits a **markdown mirror** of the documentation alongside the HTML:

- `llms.txt` — markdown index of all doc pages (the [llms.txt standard](https://llmstxt.org/))
- `llms-full.txt` — all pages concatenated, for long-context models
- `<page>.html.md` — per-page markdown render

Once deployed, these become available at `auto.gluon.ai/llms.txt` and `auto.gluon.ai/llms-full.txt`, giving AI coding agents (Claude Code, Copilot, Cursor, Gemini CLI) a token-efficient, navigation-noise-free view of the docs instead of forcing them to scrape HTML.

## Why sphinx-llm (not sphinx-llms-txt)

AutoGluon's API reference under `docs/api/*.rst` is generated **dynamically** via `autosummary` / `automodule` / `autoclass` (see e.g. `api/tabular.rst`). The simpler `sphinx-llms-txt` extension reads the raw `.rst` source files and therefore leaves those directives **unexpanded** — an agent would see literal `.. autoclass:: TabularPredictor` placeholders instead of the rendered API.

`sphinx-llm` runs the full Sphinx pipeline (autodoc + napoleon + myst-nb) and renders the *resolved* content to markdown, so docstrings, parameter tables, and type info are fully expanded in the agent-facing output.

## Changes

| file | change |
|------|--------|
| `docs/requirements_doc.txt` | add `sphinx-llm` |
| `docs/conf.py` | register `sphinx_llm.txt` extension + `llms_txt_description` |
| `docs/llms-txt.md` | new — maintainer/agent-facing doc explaining the output |
| `docs/index.md` | add `llms-txt.md` to the Resources toctree |

4 files, +90 lines, no existing behavior changed. The markdown output is purely additive — the HTML site is unaffected.

## Relationship to #5715

This complements #5715 (which adds code-level agent assets: `AGENTS.md` + `.agents/`). Together they cover both sides:
- **#5715** → the *repository structure* (packages, dependency graph, AST chunks)
- **this PR** → the *human-authored documentation* (tutorials, install guides, API refs)

Happy to merge them if preferred, but keeping them separate keeps each review focused.

## Verification

`conf.py` passes `ast.parse`. Full build verification requires `pip install sphinx-llm` + a docs build, which I'd expect CI to confirm. The extension is designed to be non-invasive — `llms_txt_enabled = False` disables it entirely if needed.