### PR TITLE
Fix multimodal tests

### DIFF
--- a/multimodal/tests/unittests/others_2/test_config.py
+++ b/multimodal/tests/unittests/others_2/test_config.py
@@ -81,7 +81,7 @@ def test_get_config():
 
 
 @pytest.mark.parametrize(
-    "model_names,",
+    "model_names",
     [
         ["timm_image"],
         ["hf_text"],
@@ -102,7 +102,7 @@ def test_model_config_selection(model_names):
 
 
 @pytest.mark.parametrize(
-    "model_names,",
+    "model_names",
     [
         ["image"],
         ["text"],


### PR DESCRIPTION
## What is fixed

Two `@pytest.mark.parametrize` decorators in `multimodal/tests/unittests/others_2/test_config.py` had a trailing comma in the argnames string: `"model_names,"` instead of `"model_names"`.

The trailing comma makes pytest parse the argnames as a two-element tuple `("model_names", "")`. Older pytest versions tolerated the empty name, but **pytest 9** treats it strictly and expects each value row to unpack into two arguments. Rows like `["timm_image", "hf_text", "clip", "fusion_mlp"]` then fail with:

```
in "parametrize" the number of names (1) must be equal to the number of values (4)
```

This is a **collection-time** error, so it aborts the entire `test_config.py` module.

## Fix

Drop the trailing comma in both decorators. Behavior is unchanged on older pytest and correct on pytest 9+.