### PR TITLE
EnsembleSelection hygiene: no caller mutation, predict problem_type override

### DIFF
--- a/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py
+++ b/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py
@@ -16,9 +16,18 @@ logger = logging.getLogger(__name__)
 
 
 class AbstractWeightedEnsemble:
-    def predict(self, X):
+    def predict(self, X, problem_type: str | None = None):
+        """Predict labels from the weighted prediction probabilities.
+
+        problem_type overrides self.problem_type for the proba -> label conversion,
+        for callers that fit on a transformed prediction space (e.g. TabArena's
+        metric-preprocessed ensemble simulation) but need label-space output for the
+        original problem.
+        """
         y_pred_proba = self.predict_proba(X)
-        return get_pred_from_proba(y_pred_proba=y_pred_proba, problem_type=self.problem_type)
+        if problem_type is None:
+            problem_type = self.problem_type
+        return get_pred_from_proba(y_pred_proba=y_pred_proba, problem_type=problem_type)
 
     def predict_proba(self, X):
         return self.weight_pred_probas(X, weights=self.weights_)
@@ -92,8 +101,8 @@ class EnsembleSelection(AbstractWeightedEnsemble):
             logger.log(15, f"Subsampling to {self.subsample_size} samples to speedup ensemble selection...")
             subsample_indices = self.random_state.choice(num_samples_total, self.subsample_size, replace=False)
             labels = labels[subsample_indices]
-            for i in range(self.num_input_models_):
-                predictions[i] = predictions[i][subsample_indices]
+            # rebuild rather than assign into `predictions`, which would mutate the caller's list
+            predictions = [pred[subsample_indices] for pred in predictions]
 
         # if self.sorted_initialization:
         #     n_best = 20


### PR DESCRIPTION
## Description

Two small fixes for external drivers of `EnsembleSelection` (e.g. TabArena's ensemble simulation, which fits it thousands of times over cached predictions):

1. **`_fit` no longer mutates the caller's `predictions` list.** When `subsample_size` triggers, the subsampled predictions were assigned back into the passed-in list (`predictions[i] = predictions[i][subsample_indices]`), silently corrupting any caller that reuses the list — a footgun next to prediction caches. The subsampled list is now rebuilt locally.

2. **`AbstractWeightedEnsemble.predict` takes an optional `problem_type` override** for the proba -> label conversion. Callers that fit on a transformed prediction space (e.g. TabArena feeds ground-truth-class probabilities with `problem_type="binary"` for log_loss ensembling) previously had to reassign `ensemble.problem_type` around the call; now they can pass the original problem type explicitly. Default behavior is unchanged.

Both changes are backwards compatible for the internal consumers (`GreedyWeightedEnsembleModel`, tabular `abstract_learner`, multimodal ensemble learner, timeseries `TimeSeriesEnsembleSelection`): existing call signatures and behavior are preserved.

## Verification

Verified directly that (a) with `subsample_size` set, the caller's list and arrays are unchanged after `fit` while producing the same weights as before, and (b) `predict(X)` and `predict(X, problem_type=<same>)` return identical outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi