### PR TITLE
Validate zip entries before extraction

### DIFF
--- a/common/src/autogluon/common/loaders/_utils.py
+++ b/common/src/autogluon/common/loaders/_utils.py
@@ -2,6 +2,7 @@ import functools
 import hashlib
 import logging
 import os
+import stat
 import sys
 import uuid
 import warnings
@@ -251,6 +252,18 @@ def path_expander(path, base_folder):
     return ";".join([os.path.join(base_folder, path) for path in path_l])
 
 
+def safe_extractall(zf, dest_dir):
+    """Extract zip file with path traversal and symlink validation."""
+    dest_dir = os.path.realpath(dest_dir)
+    for member in zf.infolist():
+        member_path = os.path.realpath(os.path.join(dest_dir, member.filename))
+        if not member_path.startswith(dest_dir + os.sep) and member_path != dest_dir:
+            raise ValueError(f"Zip Slip detected: {member.filename} would extract outside {dest_dir}")
+        if stat.S_ISLNK(member.external_attr >> 16):
+            raise ValueError(f"Zip contains symlink: {member.filename}")
+    zf.extractall(dest_dir)
+
+
 def protected_zip_extraction(zipfile_path, sha1_hash, folder):
     """Extract zip file to the folder.
 
@@ -276,7 +289,7 @@ def protected_zip_extraction(zipfile_path, sha1_hash, folder):
     # Extract the file
     logging.info("Extract files...")
     with zipfile.ZipFile(zipfile_path, "r") as zip_ref:
-        zip_ref.extractall(folder)
+        safe_extractall(zip_ref, folder)
 
     if signature:
         # Create the signature

--- a/common/src/autogluon/common/loaders/_utils.py
+++ b/common/src/autogluon/common/loaders/_utils.py
@@ -2,7 +2,6 @@ import functools
 import hashlib
 import logging
 import os
-import stat
 import sys
 import uuid
 import warnings
@@ -252,18 +251,6 @@ def path_expander(path, base_folder):
     return ";".join([os.path.join(base_folder, path) for path in path_l])
 
 
-def safe_extractall(zf, dest_dir):
-    """Extract zip file with path traversal and symlink validation."""
-    dest_dir = os.path.realpath(dest_dir)
-    for member in zf.infolist():
-        member_path = os.path.realpath(os.path.join(dest_dir, member.filename))
-        if not member_path.startswith(dest_dir + os.sep) and member_path != dest_dir:
-            raise ValueError(f"Zip Slip detected: {member.filename} would extract outside {dest_dir}")
-        if stat.S_ISLNK(member.external_attr >> 16):
-            raise ValueError(f"Zip contains symlink: {member.filename}")
-    zf.extractall(dest_dir)
-
-
 def protected_zip_extraction(zipfile_path, sha1_hash, folder):
     """Extract zip file to the folder.
 
@@ -288,6 +275,8 @@ def protected_zip_extraction(zipfile_path, sha1_hash, folder):
 
     # Extract the file
     logging.info("Extract files...")
+    from .load_zip import safe_extractall
+
     with zipfile.ZipFile(zipfile_path, "r") as zip_ref:
         safe_extractall(zip_ref, folder)
 

--- a/common/src/autogluon/common/loaders/load_zip.py
+++ b/common/src/autogluon/common/loaders/load_zip.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import stat
-import zipfile
 
 logger = logging.getLogger(__name__)
 

--- a/common/src/autogluon/common/loaders/load_zip.py
+++ b/common/src/autogluon/common/loaders/load_zip.py
@@ -1,11 +1,12 @@
 import logging
 import os
 import stat
+import zipfile
 
 logger = logging.getLogger(__name__)
 
 
-def safe_extractall(zf, dest_dir):
+def safe_extractall(zf: zipfile.ZipFile, dest_dir: str) -> None:
     """Extract zip file with path traversal and symlink validation."""
     dest_dir = os.path.realpath(dest_dir)
     for member in zf.infolist():

--- a/common/src/autogluon/common/loaders/load_zip.py
+++ b/common/src/autogluon/common/loaders/load_zip.py
@@ -1,7 +1,21 @@
 import logging
 import os
+import stat
+import zipfile
 
 logger = logging.getLogger(__name__)
+
+
+def safe_extractall(zf, dest_dir):
+    """Extract zip file with path traversal and symlink validation."""
+    dest_dir = os.path.realpath(dest_dir)
+    for member in zf.infolist():
+        member_path = os.path.realpath(os.path.join(dest_dir, member.filename))
+        if not member_path.startswith(dest_dir + os.sep) and member_path != dest_dir:
+            raise ValueError(f"Zip Slip detected: {member.filename} would extract outside {dest_dir}")
+        if stat.S_ISLNK(member.external_attr >> 16):
+            raise ValueError(f"Zip contains symlink: {member.filename}")
+    zf.extractall(dest_dir)
 
 
 def unzip(path, sha1sum=None, unzip_dir=None):

--- a/common/tests/unittests/test_safe_extractall.py
+++ b/common/tests/unittests/test_safe_extractall.py
@@ -1,0 +1,64 @@
+import os
+import tempfile
+import zipfile
+
+import pytest
+
+from autogluon.common.loaders.load_zip import safe_extractall
+
+
+def test_normal_zip_extracts_successfully():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        zip_path = os.path.join(tmp_dir, "test.zip")
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("data/file.txt", "hello")
+            zf.writestr("data/nested/file2.txt", "world")
+
+        extract_dir = os.path.join(tmp_dir, "extract")
+        os.makedirs(extract_dir)
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            safe_extractall(zf, extract_dir)
+
+        assert os.path.exists(os.path.join(extract_dir, "data", "file.txt"))
+        assert os.path.exists(os.path.join(extract_dir, "data", "nested", "file2.txt"))
+
+
+def test_path_traversal_blocked():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        zip_path = os.path.join(tmp_dir, "test.zip")
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("../../etc/passwd", "pwned")
+
+        extract_dir = os.path.join(tmp_dir, "extract")
+        os.makedirs(extract_dir)
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            with pytest.raises(ValueError, match="Zip Slip detected"):
+                safe_extractall(zf, extract_dir)
+
+
+def test_absolute_path_blocked():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        zip_path = os.path.join(tmp_dir, "test.zip")
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("/tmp/file.txt", "pwned")
+
+        extract_dir = os.path.join(tmp_dir, "extract")
+        os.makedirs(extract_dir)
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            with pytest.raises(ValueError, match="Zip Slip detected"):
+                safe_extractall(zf, extract_dir)
+
+
+def test_symlink_blocked():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        zip_path = os.path.join(tmp_dir, "test.zip")
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            info = zipfile.ZipInfo("link")
+            info.external_attr = 0o120777 << 16
+            zf.writestr(info, "/etc")
+
+        extract_dir = os.path.join(tmp_dir, "extract")
+        os.makedirs(extract_dir)
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            with pytest.raises(ValueError, match="Zip contains symlink"):
+                safe_extractall(zf, extract_dir)

--- a/core/src/autogluon/core/utils/files.py
+++ b/core/src/autogluon/core/utils/files.py
@@ -7,6 +7,8 @@ import tempfile
 import zipfile
 from pathlib import Path
 
+from autogluon.common.loaders._utils import safe_extractall
+
 logger = logging.getLogger(__name__)
 
 __all__ = ["unzip", "download"]
@@ -16,7 +18,7 @@ def unzip(zip_file_path, root=os.path.expanduser("./")):
     """Unzips files located at `zip_file_path` into parent directory specified by `root`."""
     folders = []
     with zipfile.ZipFile(zip_file_path) as zf:
-        zf.extractall(root)
+        safe_extractall(zf, root)
         for name in zf.namelist():
             folder = Path(name).parts[0]
             if folder not in folders:

--- a/core/src/autogluon/core/utils/files.py
+++ b/core/src/autogluon/core/utils/files.py
@@ -7,7 +7,7 @@ import tempfile
 import zipfile
 from pathlib import Path
 
-from autogluon.common.loaders._utils import safe_extractall
+from autogluon.common.loaders.load_zip import safe_extractall
 
 logger = logging.getLogger(__name__)
 

--- a/examples/automm/text_prediction/prepare_glue.py
+++ b/examples/automm/text_prediction/prepare_glue.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pyarrow
 import pyarrow.json
 
-from autogluon.common.loaders._utils import safe_extractall
+from autogluon.common.loaders.load_zip import safe_extractall
 from autogluon_contrib_nlp.utils.misc import download, load_checksum_stats
 from autogluon_contrib_nlp.base import get_data_home_dir
 from autogluon_contrib_nlp.data.tokenizers import WhitespaceTokenizer

--- a/examples/automm/text_prediction/prepare_glue.py
+++ b/examples/automm/text_prediction/prepare_glue.py
@@ -10,6 +10,8 @@ import json
 import pandas as pd
 import pyarrow
 import pyarrow.json
+
+from autogluon.common.loaders._utils import safe_extractall
 from autogluon_contrib_nlp.utils.misc import download, load_checksum_stats
 from autogluon_contrib_nlp.base import get_data_home_dir
 from autogluon_contrib_nlp.data.tokenizers import WhitespaceTokenizer
@@ -652,7 +654,7 @@ def main(args):
                     reader = TASK2READER[key]
                     download(url, data_file, sha1_hash=_URL_FILE_STATS[url])
                     with zipfile.ZipFile(data_file) as zipdata:
-                        zipdata.extractall(args.data_dir)
+                        safe_extractall(zipdata, args.data_dir)
                     df = reader(os.path.join(args.data_dir, name))
                     df.to_parquet(os.path.join(args.data_dir, name, '{}.parquet'.format(name)))
         elif task == 'mrpc':
@@ -679,7 +681,7 @@ def main(args):
             with zipfile.ZipFile(data_file) as zipdata:
                 if zip_dir_name is None:
                     zip_dir_name = os.path.dirname(zipdata.infolist()[0].filename)
-                zipdata.extractall(args.data_dir)
+                safe_extractall(zipdata, args.data_dir)
             shutil.move(os.path.join(args.data_dir, zip_dir_name),
                         base_dir)
             df_dict, meta_data = reader(base_dir)

--- a/multimodal/src/autogluon/multimodal/data/templates.py
+++ b/multimodal/src/autogluon/multimodal/data/templates.py
@@ -241,7 +241,7 @@ LANGUAGES = {
 def download_sourceprompt_templates():
     import zipfile
 
-    from autogluon.common.loaders._utils import safe_extractall
+    from autogluon.common.loaders.load_zip import safe_extractall
     from autogluon.multimodal.utils import download
 
     from ..constants import SOURCEPROMPT_SHA1, SOURCEPROMPT_URL

--- a/multimodal/src/autogluon/multimodal/data/templates.py
+++ b/multimodal/src/autogluon/multimodal/data/templates.py
@@ -241,6 +241,7 @@ LANGUAGES = {
 def download_sourceprompt_templates():
     import zipfile
 
+    from autogluon.common.loaders._utils import safe_extractall
     from autogluon.multimodal.utils import download
 
     from ..constants import SOURCEPROMPT_SHA1, SOURCEPROMPT_URL
@@ -248,7 +249,7 @@ def download_sourceprompt_templates():
     temporary_zip_file = pkg_resources.resource_filename(__name__, "templates.zip")
     temporary_zip_file = download(url=SOURCEPROMPT_URL, path=temporary_zip_file, sha1_hash=SOURCEPROMPT_SHA1)
     with zipfile.ZipFile(temporary_zip_file, "r") as zip_ref:
-        zip_ref.extractall(os.path.join(TEMPLATES_FOLDER_PATH, ".."))
+        safe_extractall(zip_ref, os.path.join(TEMPLATES_FOLDER_PATH, ".."))
     os.remove(temporary_zip_file)
 
 

--- a/multimodal/src/autogluon/multimodal/utils/load.py
+++ b/multimodal/src/autogluon/multimodal/utils/load.py
@@ -2,6 +2,8 @@ import logging
 import os
 import zipfile
 
+from autogluon.common.loaders._utils import safe_extractall
+
 from ..constants import LAST_CHECKPOINT, MODEL_CHECKPOINT
 
 logger = logging.getLogger(__name__)
@@ -119,7 +121,7 @@ def protected_zip_extraction(zipfile_path, sha1_hash, folder):
     # Extract the file
     logging.info("Extract files...")
     with zipfile.ZipFile(zipfile_path, "r") as zip_ref:
-        zip_ref.extractall(folder)
+        safe_extractall(zip_ref, folder)
 
     if signature:
         # Create the signature

--- a/multimodal/src/autogluon/multimodal/utils/load.py
+++ b/multimodal/src/autogluon/multimodal/utils/load.py
@@ -2,7 +2,7 @@ import logging
 import os
 import zipfile
 
-from autogluon.common.loaders._utils import safe_extractall
+from autogluon.common.loaders.load_zip import safe_extractall
 
 from ..constants import LAST_CHECKPOINT, MODEL_CHECKPOINT
 


### PR DESCRIPTION
*Issue #, if available:*
- Adds path traversal and symlink validation before zip extraction at all extractall call sites


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
