### PR TITLE
fix(docs): disable sphinx-llm in per-tutorial CI builds (#5716 followup)

### DIFF
--- a/.github/workflow_scripts/build_all_docs.sh
+++ b/.github/workflow_scripts/build_all_docs.sh
@@ -54,6 +54,11 @@ else
 fi
 
 setup_build_contrib_env
+# Enable sphinx-llm (emits llms.txt + llms-full.txt). Disabled by default in
+# conf.py to avoid the parallel markdown build racing tutorial CI jobs that
+# run jupyter notebook execution. This is the only job that produces the
+# deployed llms.txt artifacts (auto.gluon.ai/llms.txt).
+export AUTOGLUON_BUILD_ALL_DOCS=1
 install_all_no_tests
 
 LOCAL_DOC_PATH=_build/html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,20 @@ llms_txt_description = (
     "text and multimodal data."
 )
 
+# sphinx-llm runs a second sphinx-build subprocess (markdown builder) in
+# parallel with the main HTML build. On CI runners with constrained memory /
+# CPU this can race the parent process and either timeout or OOM during the
+# expensive jupyter notebook execution phase (tutorials/*.ipynb).
+# Disable llms.txt on the per-tutorial CI jobs — it is only needed for the
+# `build_all_docs` job that builds the final deployed site. Per-tutorial
+# tutorial build scripts pass `-t <tutorial_name>`, so we can detect this:
+import os as _llms_os
+if not _llms_os.environ.get("AUTOGLUON_BUILD_ALL_DOCS"):
+    llms_txt_enabled = False
+    # Tell the extension to skip launching the markdown subprocess entirely.
+    # `build_all_docs` workflow sets this env var, where llms.txt is wanted.
+del _llms_os
+
 # See https://myst-parser.readthedocs.io/en/latest/syntax/optional.html
 myst_enable_extensions = [
     "colon_fence",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,24 @@ extensions = [
     "sphinx.ext.napoleon",  # www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
     "sphinx.ext.viewcode",  # www.sphinx-doc.org/en/master/usage/extensions/viewcode.html
     "sphinxcontrib.googleanalytics",  # github.com/sphinx-contrib/googleanalytics
+    "sphinx_llm.txt",  # github.com/NVIDIA/sphinx-llm — emit llms.txt + llms-full.txt (markdown) alongside HTML
 ]
+
+# --- llms.txt configuration (https://github.com/NVIDIA/sphinx-llm) ---
+# During the normal HTML build this extension also runs a markdown builder in
+# parallel and emits, next to the HTML output:
+#   - llms.txt        markdown index of all doc pages (the llms.txt standard)
+#   - llms-full.txt   all pages concatenated into one markdown file
+#   - <page>.html.md  a per-page markdown version of each page
+# Crucially (and unlike sphinx-llms-txt) it runs the *full* Sphinx pipeline, so
+# dynamic directives that AutoGluon relies on under docs/api/ — autosummary,
+# automodule, autoclass — are fully expanded in the markdown. No unrendered rST
+# placeholders reach the agent.
+llms_txt_description = (
+    "AutoGluon automates machine learning tasks, enabling strong predictive "
+    "performance in a few lines of code across tabular, time-series, image, "
+    "text and multimodal data."
+)
 
 # See https://myst-parser.readthedocs.io/en/latest/syntax/optional.html
 myst_enable_extensions = [

--- a/docs/index.md
+++ b/docs/index.md
@@ -264,6 +264,7 @@ GitHub <https://github.com/autogluon/autogluon>
 Tabular FAQ <tutorials/tabular/tabular-faq.md>
 Time Series FAQ <tutorials/timeseries/forecasting-faq.md>
 Multimodal FAQ <tutorials/multimodal/multimodal-faq.md>
+Docs for AI Agents (llms.txt) <llms-txt>
 ```
 
 

--- a/docs/llms-txt.md
+++ b/docs/llms-txt.md
@@ -60,6 +60,26 @@ llms_txt_description = "AutoGluon automates machine learning tasks..."
 runs automatically as part of the HTML build — no separate build step is
 required. The `llms_txt_enabled` option can be set to `False` to disable it.
 
+### When `llms.txt` is generated
+
+`sphinx-llm` runs a second `sphinx-build` subprocess in parallel with the
+main HTML build. On CI runners with constrained CPU/memory this **races the
+parent process** during the expensive `nbsphinx` / `myst-nb` notebook
+execution phase (`tutorials/*.ipynb`). Per-tutorial CI jobs therefore
+**skip** the markdown build by default — they set no flag.
+
+To opt back in for a one-off build, set the `AUTOGLUON_BUILD_ALL_DOCS`
+environment variable:
+
+```bash
+export AUTOGLUON_BUILD_ALL_DOCS=1
+sphinx-build -b html . _build/html
+```
+
+The `build_all_docs.sh` workflow script sets this automatically (it is the
+only job that produces the deployed llms.txt artifacts served from
+`auto.gluon.ai/llms.txt`).
+
 ## How an agent uses it
 
 1. Fetch `https://auto.gluon.ai/llms.txt` to get the curated index of doc pages.

--- a/docs/llms-txt.md
+++ b/docs/llms-txt.md
@@ -1,0 +1,71 @@
+# `llms.txt` — agent-friendly documentation
+
+> This page documents the machine-readable documentation output, not a
+> user-facing tutorial. It is intended for AI agent tooling and maintainers.
+
+## What this is
+
+AutoGluon's documentation is built with [Sphinx](https://www.sphinx-doc.org/)
+and rendered to HTML for human reading. As of this change, the same build also
+emits a **markdown mirror** of the documentation following the
+[llms.txt convention](https://llmstxt.org/), so that AI coding agents and LLMs
+can consume the docs without scraping HTML (which wastes tokens on navigation,
+scripts and styling, and obscures the actual content).
+
+The markdown is produced by [`sphinx-llm`](https://github.com/NVIDIA/sphinx-llm)
+(the `sphinx_llm.txt` extension), registered in [`conf.py`](./conf.py).
+
+## Outputs
+
+A normal `sphinx-build -b html . _build/html/` (see
+[`build_doc.sh`](./build_doc.sh)) now also writes, under `_build/html/`:
+
+| file | contents |
+|------|----------|
+| `llms.txt` | a markdown index of all documentation pages, grouped by section, with one-line descriptions — the entry point an agent reads first |
+| `llms-full.txt` | every documentation page concatenated into a single markdown file, for long-context models that want the whole corpus in one shot |
+| `<page>.html.md` | a per-page markdown rendering of each page |
+
+These files are served alongside the HTML site, so `https://auto.gluon.ai/llms.txt`
+and `https://auto.gluon.ai/llms-full.txt` become available once deployed.
+
+## Why sphinx-llm (and not sphinx-llms-txt)
+
+AutoGluon's API reference under [`api/`](./api/) is generated dynamically via
+`autosummary` / `automodule` / `autoclass` directives (see e.g.
+[`api/tabular.rst`](./api/tabular.rst)). The simpler `sphinx-llms-txt` extension
+reads the raw `.rst` source files and therefore leaves those directives
+**unexpanded** — an agent would see literal `.. autoclass:: TabularPredictor`
+placeholders instead of the rendered API.
+
+`sphinx-llm` instead runs the full Sphinx build pipeline (autodoc, autosummary,
+napoleon, myst-nb) and renders the *resolved* content to markdown. This means
+docstrings, parameter tables, and type information are fully expanded in the
+agent-facing output.
+
+## Configuration
+
+In [`conf.py`](./conf.py):
+
+```python
+extensions = [
+    ...,
+    "sphinx_llm.txt",
+]
+
+llms_txt_description = "AutoGluon automates machine learning tasks..."
+```
+
+`sphinx-llm` is added to [`requirements_doc.txt`](./requirements_doc.txt). It
+runs automatically as part of the HTML build — no separate build step is
+required. The `llms_txt_enabled` option can be set to `False` to disable it.
+
+## How an agent uses it
+
+1. Fetch `https://auto.gluon.ai/llms.txt` to get the curated index of doc pages.
+2. Either follow links to individual `*.html.md` pages for targeted context, or
+3. Fetch `llms-full.txt` for the complete corpus (suitable for models with a
+   large context window).
+
+See the root [`AGENTS.md`](../AGENTS.md) for the companion code-level agent
+assets (dependency graph, API surface, AST chunks) under `.agents/`.

--- a/docs/requirements_doc.txt
+++ b/docs/requirements_doc.txt
@@ -8,3 +8,4 @@ sphinx-inline-tabs
 sphinx-togglebutton
 sphinxext-opengraph
 sphinxcontrib-googleanalytics
+sphinx-llm


### PR DESCRIPTION
## What
Fixes the failing docs CI jobs in PR #5716 by disabling the sphinx-llm
markdown build in the per-tutorial CI jobs. The `build_all_docs` job,
which produces the deployed llms.txt artifacts, is unaffected — it gets
the markdown build back via a new `AUTOGLUON_BUILD_ALL_DOCS=1` env
var that `build_all_docs.sh` sets.

## Why PR #5716 fails
sphinx-llm launches a markdown `sphinx-build` subprocess in parallel
with the main HTML build. The per-tutorial CI jobs (tabular / cloud /
timeseries) all run with notebook execution enabled (no `-D
nb_execution_mode=off`), so the parent process is busy executing
tutorials/*.ipynb while the markdown subprocess is also building the
docs. On the constrained CI runners the two processes race for CPU
and memory and the markdown subprocess times out, leaving the parent
waiting forever:

```
Waiting for markdown build subprocess to finish...
================================================================================
Job [AutoGluon-BuildTimeseries-PR5716] FAILED
##[error]Process completed with exit code 1.
```

This is purely a CI scheduling problem; the `build_all_docs` job
which is the one that actually deploys llms.txt, succeeds because it
sets `sphinx-build -D nb_execution_mode=off` so the parent has no
work to do while the markdown subprocess runs.

## Fix
- `docs/conf.py`: detect the env var and set
  `llms_txt_enabled = False` when it is not present.
- `.github/workflow_scripts/build_all_docs.sh`: set
  `AUTOGLUON_BUILD_ALL_DOCS=1` so the all-docs build keeps emitting
  llms.txt / llms-full.txt.
- `docs/llms-txt.md`: document when llms.txt is generated and how
  to opt back in for one-off builds.

## Verification
- Local sphinx-build with the env var unset: no 'Waiting for markdown
  build subprocess to finish' line, no `llms.txt` / `llms-full.txt`
  emitted (matches the per-tutorial CI behaviour).
- Local sphinx-build with the env var set: markdown subprocess runs,
  `llms.txt` and `llms-full.txt` are emitted (matches the
  build_all_docs behaviour).
- Minimal sphinx-llm test project (single .rst + .py): builds llms.txt
  end-to-end, confirming the extension itself is healthy.

## Relationship to #5716
This is a followup to #5716. The first PR introduced the sphinx-llm
extension; this PR fixes the CI integration so it can actually merge.
Once this lands, the auto.gluon.ai/llms.txt artifacts will start being
deployed.