### PR TITLE
Scope CI push trigger to master to avoid duplicate PR runs

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - stable
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -2,6 +2,8 @@ name: Continuous Integration
 
 on:
   push:
+    branches:
+      - master
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]
 


### PR DESCRIPTION
## Description

The `Continuous Integration` workflow currently triggers on **all** `push` events plus `pull_request_target`. As a result, PRs opened from a branch within `autogluon/autogluon` (non-fork) run every job twice — once as `(push)` and once as `(pull_request_target)`. Fork PRs are unaffected because the push happens in the contributor's fork, which upstream never sees.

This scopes the `push` trigger to the `master` branch only, eliminating the duplicate runs on same-repo branch PRs.