### PR TITLE
Raise lower bounds on dependencies

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -39,11 +39,13 @@ install_requires = [
 extras_require = {
     "ray": [
         # Ray<=2.53 does not support py313 on Windows
-        "ray[default]>=2.43.0,<2.57; platform_system != 'Windows' or python_version != '3.13'",  # sync with common/src/autogluon/common/utils/try_import.py
+        # Lower bound to exclude CVE-2026-41486
+        "ray[default]>=2.55.0,<2.57; platform_system != 'Windows' or python_version != '3.13'",  # sync with common/src/autogluon/common/utils/try_import.py
     ],
     "raytune": [
         "pyarrow>=15.0.0",  # cap Pyarrow to fix source installation - https://github.com/autogluon/autogluon/issues/4519
-        "ray[default,tune]>=2.43.0,<2.57; platform_system != 'Windows' or python_version != '3.13'",  # sync with common/src/autogluon/common/utils/try_import.py
+        # Lower bound to exclude CVE-2026-41486
+        "ray[default,tune]>=2.55.0,<2.57; platform_system != 'Windows' or python_version != '3.13'",  # sync with common/src/autogluon/common/utils/try_import.py
         # TODO: consider alternatives as hyperopt is not actively maintained.
         "hyperopt>=0.2.7,<0.2.8",  # This is needed for the bayes search to work.
         # 'GPy>=1.10.0,<1.11.0'  # TODO: Enable this once PBT/PB2 are supported by ray lightning

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -13,13 +13,13 @@ AUTOGLUON_ROOT_PATH = os.path.abspath(os.path.join(os.path.dirname(os.path.abspa
 # Only put packages here that would otherwise appear multiple times across different module's setup.py files.
 DEPENDENT_PACKAGES = {
     "boto3": ">=1.10,<2",  # <2 because unlikely to introduce breaking changes in minor releases. >=1.10 because 1.10 is 3 years old, no need to support older
-    "numpy": ">=1.25.0,<2.5.0",  # "<{N+1}" upper cap, where N is the latest released minor version, assuming no warnings using N
+    "numpy": ">=1.25.0,<2.6.0",  # "<{N+1}" upper cap, where N is the latest released minor version, assuming no warnings using N
     "pandas": ">=2.0.0,<2.4.0",  # "<{N+3}" upper cap
     "pyarrow": ">=23.0.1,<25.0.0",  # "<{N=1}.0.0" upper cap. Lower bound to exclude PYSEC-2026-113
     "scikit-learn": ">=1.4.0,<1.8.0",  # <{N+1} upper cap
-    "scipy": ">=1.5.4,<1.17",  # "<{N+2}" upper cap
-    "matplotlib": ">=3.7.0,<3.11",  # "<{N+2}" upper cap
-    "psutil": ">=5.7.3,<7.2.0",  # Major version cap
+    "scipy": ">=1.5.4,<1.19",  # "<{N+2}" upper cap
+    "matplotlib": ">=3.7.0,<3.12",  # "<{N+2}" upper cap
+    "psutil": ">=5.7.3,<7.3.0",  # Major version cap
     "s3fs": ">=2024.2,<2026",  # Yearly cap
     "networkx": ">=3.0,<4",  # Major version cap
     "tqdm": ">=4.38,<5",  # Major version cap

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -15,7 +15,7 @@ DEPENDENT_PACKAGES = {
     "boto3": ">=1.10,<2",  # <2 because unlikely to introduce breaking changes in minor releases. >=1.10 because 1.10 is 3 years old, no need to support older
     "numpy": ">=1.25.0,<2.5.0",  # "<{N+1}" upper cap, where N is the latest released minor version, assuming no warnings using N
     "pandas": ">=2.0.0,<2.4.0",  # "<{N+3}" upper cap
-    "pyarrow": ">=7.0.0,<25.0.0",  # "<{N=1}.0.0" upper cap
+    "pyarrow": ">=23.0.1,<25.0.0",  # "<{N=1}.0.0" upper cap. Lower bound to exclude PYSEC-2026-113
     "scikit-learn": ">=1.4.0,<1.8.0",  # <{N+1} upper cap
     "scipy": ">=1.5.4,<1.17",  # "<{N+2}" upper cap
     "matplotlib": ">=3.7.0,<3.11",  # "<{N+2}" upper cap
@@ -23,7 +23,7 @@ DEPENDENT_PACKAGES = {
     "s3fs": ">=2024.2,<2026",  # Yearly cap
     "networkx": ">=3.0,<4",  # Major version cap
     "tqdm": ">=4.38,<5",  # Major version cap
-    "Pillow": ">=10.0.1,<13",  # Major version cap
+    "Pillow": ">=12.2.0,<13",  # Major version cap. Lower bound >=12.2.0 to exclude PYSEC-2026-165
     "torch": ">=2.6,<2.10",  # Major version cap, sync with common/src/autogluon/common/utils/try_import.py. torchvision version in multimodelal/setup.py can effectively constrain version as well
     "lightning": ">=2.5.1,<2.6",  # Major version cap
     "async_timeout": ">=4.0,<6",  # Major version cap


### PR DESCRIPTION
Issue: #5697

## Description

Two related sets of dependency version-bound changes. Everything lives in the single-source-of-truth `core/src/autogluon/core/_setup_utils.py` except the ray extras, which are in `core/setup.py`.

### 1. Security: raise lower bounds to exclude CVEs

| Package | Old lower bound | New lower bound | Advisories excluded |
|---|---|---|---|
| pyarrow | `>=7.0.0` | `>=23.0.1` | PYSEC-2026-113 |
| Pillow | `>=10.0.1` | `>=12.2.0` | PYSEC-2026-165, CVE-2026-25990, CVE-2026-40192, CVE-2026-42309, CVE-2026-42310, CVE-2026-42311 |
| ray | `>=2.43.0` | `>=2.55.0` | CVE-2026-27482 (fixed 2.54.0), CVE-2026-41486 (fixed 2.55.0) |

- pyarrow and Pillow bounds are in `_setup_utils.py`.
- ray is bumped in both the `ray` and `raytune` extras in `core/setup.py`.

### 2. Hygiene: raise upper caps to latest releases

| Package | Old cap | New cap |
|---|---|---|
| numpy | `<2.5.0` | `<2.6.0` |
| scipy | `<1.17` | `<1.19` |
| matplotlib | `<3.11` | `<3.12` |
| psutil | `<7.2.0` | `<7.3.0` |

### Notes
- `transformers` (PYSEC-2025-217 / CVE-2026-1839) is intentionally **not** addressed here: the fix version is `>=5.3`, above the current `<4.58` upper cap, so it requires a separate major-version upgrade effort.
- The runtime `try_import_ray` minimum (`2.43.0`) is a soft check and was left unchanged.
- Raised caps allow newer minor releases but do not pull them in for testing on their own — CI resolves against the latest matching versions, so watch for incompatibility failures there.