### PR TITLE
Use new Chronos-2 preprocess API for fine-tuning

### DIFF
--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -40,7 +40,7 @@ install_requires = [
     "tqdm",
     "orjson~=3.9",  # use faster JSON implementation in GluonTS
     "einops>=0.7,<1",  # required by Chronos-2 and Toto
-    "chronos-forecasting>=2.2.2,<2.4",
+    "chronos-forecasting>=2.3.1,<2.4",
     "peft>=0.13.0,<0.18",  # version range same as in chronos-forecasting[extras]
     "tensorboard>=2.9,<3",  # fixes https://github.com/autogluon/autogluon/issues/3612
     f"autogluon.core=={version}",

--- a/timeseries/src/autogluon/timeseries/models/chronos/chronos2.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/chronos2.py
@@ -303,34 +303,28 @@ class Chronos2Model(AbstractTimeSeriesModel):
         time_limit: float | None = None,
         verbosity: int = 2,
     ):
-        from chronos.df_utils import convert_df_input_to_list_of_dicts_input
+        from chronos.chronos2 import preprocess
 
         from .utils import LoggerCallback, TimeLimitCallback
 
         def convert_data(df: TimeSeriesDataFrame):
             past_df = df.reset_index().to_data_frame()
             past_df, _ = self._remove_disabled_covariates(past_df, None)
+            if (
+                self.get_hyperparameter("disable_known_covariates")
+                or len(self.covariate_metadata.known_covariates) == 0
+            ):
+                known_covariates_names = None
+            else:
+                known_covariates_names = self.covariate_metadata.known_covariates
 
-            inputs, _, _ = convert_df_input_to_list_of_dicts_input(
-                df=past_df,
-                future_df=None,
+            return preprocess.from_data_frame(
+                past_df,
                 target_columns=[self.target],
                 prediction_length=self.prediction_length,
                 validate_inputs=False,
+                known_covariates_names=known_covariates_names,
             )
-
-            # The above utility will only split the dataframe into target and past_covariates, where past_covariates contains
-            # past values of both past-only and known-future covariates. We need to add future_covariates to enable fine-tuning
-            # with known covariates by indicating which covariates are known in the future.
-            if not self.get_hyperparameter("disable_known_covariates"):
-                known_covariates = self.covariate_metadata.known_covariates
-                if len(known_covariates) > 0:
-                    for input_dict in inputs:
-                        # NOTE: the covariates are empty because the actual values are not used
-                        # This only indicates which covariates are known in the future
-                        input_dict["future_covariates"] = {name: np.array([]) for name in known_covariates}
-
-            return inputs
 
         assert self._model_pipeline is not None
         hyperparameters = self.get_hyperparameters()

--- a/timeseries/tests/unittests/models/chronos/test_chronos2.py
+++ b/timeseries/tests/unittests/models/chronos/test_chronos2.py
@@ -313,9 +313,7 @@ class TestChronos2FineTuning:
                 expected_n_covariates -= len(covariate_metadata.past_covariates)
             if disable_known:
                 expected_n_covariates -= len(covariate_metadata.known_covariates)
-            expected_n_future_covariates = (
-                0 if disable_known else len(covariate_metadata.known_covariates)
-            )
+            expected_n_future_covariates = 0 if disable_known else len(covariate_metadata.known_covariates)
 
             for input_dict in inputs:
                 assert input_dict["n_covariates"] == expected_n_covariates

--- a/timeseries/tests/unittests/models/chronos/test_chronos2.py
+++ b/timeseries/tests/unittests/models/chronos/test_chronos2.py
@@ -253,8 +253,8 @@ class TestChronos2FineTuning:
         data, covariate_metadata = df_with_covariates
         past_data = data.slice_by_timestep(None, -5)
 
-        expected_past_covariates = set(covariate_metadata.covariates)
-        expected_future_covariates = set(covariate_metadata.known_covariates)
+        expected_n_covariates = len(covariate_metadata.covariates)
+        expected_n_future_covariates = len(covariate_metadata.known_covariates)
 
         tmp_dir = tmp_path / "mocked_chronos2"
         tmp_dir.mkdir()
@@ -276,11 +276,8 @@ class TestChronos2FineTuning:
             inputs = mocked_pipeline_fit.call_args.kwargs["inputs"]
 
             for input_dict in inputs:
-                past_covariates = set(input_dict["past_covariates"].keys())
-                future_covariates = set(input_dict["future_covariates"].keys())
-
-                assert past_covariates == expected_past_covariates
-                assert future_covariates == expected_future_covariates
+                assert input_dict["n_covariates"] == expected_n_covariates
+                assert input_dict["n_future_covariates"] == expected_n_future_covariates
 
     @pytest.mark.parametrize(
         "disable_past,disable_known",
@@ -311,12 +308,18 @@ class TestChronos2FineTuning:
             model.fit(data)
             inputs = mocked_pipeline_fit.call_args.kwargs["inputs"]
 
+            expected_n_covariates = len(covariate_metadata.covariates)
+            if disable_past:
+                expected_n_covariates -= len(covariate_metadata.past_covariates)
+            if disable_known:
+                expected_n_covariates -= len(covariate_metadata.known_covariates)
+            expected_n_future_covariates = (
+                0 if disable_known else len(covariate_metadata.known_covariates)
+            )
+
             for input_dict in inputs:
-                if disable_past:
-                    for col in covariate_metadata.past_covariates:
-                        assert col not in input_dict.get("past_covariates", {})
-                if disable_known:
-                    assert "future_covariates" not in input_dict
+                assert input_dict["n_covariates"] == expected_n_covariates
+                assert input_dict["n_future_covariates"] == expected_n_future_covariates
 
     @pytest.mark.parametrize(
         "disable_past,disable_known",

--- a/uv.lock
+++ b/uv.lock
@@ -832,7 +832,7 @@ requires-dist = [
     { name = "autogluon-core", extras = ["raytune"], marker = "extra == 'ray'", editable = "core" },
     { name = "autogluon-features", editable = "features" },
     { name = "autogluon-tabular", extras = ["catboost", "lightgbm", "xgboost"], editable = "tabular" },
-    { name = "chronos-forecasting", specifier = ">=2.2.2,<2.4" },
+    { name = "chronos-forecasting", specifier = ">=2.3.1,<2.4" },
     { name = "coreforecast", specifier = ">=0.0.12,<0.0.17" },
     { name = "einops", specifier = ">=0.7,<1" },
     { name = "flaky", marker = "extra == 'tests'", specifier = ">=3.7,<4" },
@@ -1153,19 +1153,19 @@ wheels = [
 
 [[package]]
 name = "chronos-forecasting"
-version = "2.2.2"
+version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "accelerate" },
     { name = "einops" },
     { name = "numpy" },
-    { name = "scikit-learn" },
+    { name = "pandas" },
     { name = "torch" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/a6/b214932e9249aa0fb9638802cd2718dbe4cb2efd5118dc3ce2f02d7dfac4/chronos_forecasting-2.2.2.tar.gz", hash = "sha256:3611bc0f31fa5a77ef710a10857772f80bef20f537ee87f959b0a949dbecd8d0", size = 702413, upload-time = "2025-12-17T18:13:51.416Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/71/609ff332069de0580a8a1fa357558975a91be786d612ce179c2797a00a52/chronos_forecasting-2.3.1.tar.gz", hash = "sha256:785116f3f10aaac44a315700c5e4de71a5fe6385c9c771722d688f402fe75083", size = 726426, upload-time = "2026-07-02T08:22:58.672Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/d9/ca38acd7a34c9ee6ed8bd05c2824d3fcc789a93ebdb185e56f81b89fa783/chronos_forecasting-2.2.2-py3-none-any.whl", hash = "sha256:1ff681451361f8c0a5fd6920cc1a0d8139f46c85f77a7d6d34fd554390bc76d9", size = 72663, upload-time = "2025-12-17T18:13:49.874Z" },
+    { url = "https://files.pythonhosted.org/packages/79/50/41e712bb9fa93a2d4cb18e68f2667e544d46750756c808fe754180e8aba2/chronos_forecasting-2.3.1-py3-none-any.whl", hash = "sha256:d9d00ec9b1621235bfb26685638bf054885f4c000863678f1c775dfab2697496", size = 80559, upload-time = "2026-07-02T08:22:57.296Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Use `preprocess.from_data_frame` instead of `convert_df_input_to_list_of_dicts_input` when building finetuning inputs for Chronos-2


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
