### PR TITLE
Validate download host resolves to a public address

### DIFF
--- a/multimodal/src/autogluon/multimodal/utils/download.py
+++ b/multimodal/src/autogluon/multimodal/utils/download.py
@@ -1,12 +1,15 @@
 import functools
 import hashlib
+import ipaddress
 import logging
 import os
 import re
+import socket
 import sys
 import uuid
 import warnings
 from typing import Dict, List, Optional, Tuple, Union
+from urllib.parse import urlparse
 
 import boto3
 import requests
@@ -44,6 +47,51 @@ def is_url(url_like: str):
     if not isinstance(url_like, str):
         return False
     return re.match(_URL_REGEX, url_like) is not None
+
+
+def _check_url_points_to_public_host(url: str) -> None:
+    """
+    Ensure the URL's host resolves only to public IP addresses before fetching it.
+
+    ``download`` accepts any URL-shaped string and passes it straight to an HTTP GET. Without
+    this check a URL pointing at ``localhost``, a link-local address (e.g. the cloud metadata
+    endpoint ``169.254.169.254``), or a private/internal address would be fetched from the
+    machine running the download. This restricts downloads to publicly-routable hosts.
+
+    Parameters
+    ----------
+    url
+        The URL that is about to be downloaded.
+
+    Raises
+    ------
+    ValueError
+        If the URL has no resolvable host, or if any resolved address is loopback, link-local,
+        private, multicast, reserved, or otherwise not a public address.
+    """
+    host = urlparse(url).hostname
+    if not host:
+        raise ValueError(f"Could not determine the host of url={url!r}.")
+
+    try:
+        addr_infos = socket.getaddrinfo(host, None)
+    except socket.gaierror as e:
+        raise ValueError(f"Could not resolve the host {host!r} of url={url!r}: {e}")
+
+    for addr_info in addr_infos:
+        ip = ipaddress.ip_address(addr_info[4][0])
+        if (
+            ip.is_loopback
+            or ip.is_link_local
+            or ip.is_private
+            or ip.is_multicast
+            or ip.is_reserved
+            or ip.is_unspecified
+        ):
+            raise ValueError(
+                f"Refusing to download from url={url!r}: the host {host!r} resolves to the "
+                f"non-public address {ip}. Only publicly-routable hosts are allowed."
+            )
 
 
 def download(
@@ -177,6 +225,8 @@ def download(
             raise ValueError("Invalid S3 url. Received url={}".format(url))
         s3_bucket_name = components[0]
         s3_key = "/".join(components[1:])
+    else:
+        _check_url_points_to_public_host(url)
     if path is None:
         fname = url.split("/")[-1]
         # Empty filenames are invalid

--- a/multimodal/tests/unittests/others/test_download.py
+++ b/multimodal/tests/unittests/others/test_download.py
@@ -1,0 +1,102 @@
+import os
+import tempfile
+from unittest import mock
+
+import pytest
+
+from autogluon.multimodal.utils.download import (
+    _check_url_points_to_public_host,
+    download,
+    is_url,
+)
+
+# URLs whose host resolves to a non-public address. These must never be fetched.
+NON_PUBLIC_URLS = [
+    "http://127.0.0.1:9999/internal/secret",  # loopback (IPv4)
+    "http://localhost:8080/admin",  # loopback (hostname)
+    "http://169.254.169.254/latest/meta-data/",  # link-local / cloud metadata endpoint
+    "http://169.254.169.254/latest/meta-data/iam/security-credentials/",  # metadata credentials
+    "http://10.0.0.1/admin",  # private (10.0.0.0/8)
+    "http://192.168.1.1/api",  # private (192.168.0.0/16)
+    "http://172.16.0.1/api",  # private (172.16.0.0/12)
+    "http://[::1]:8000/",  # loopback (IPv6)
+    "http://0.0.0.0/",  # unspecified
+    "http://224.0.0.1/",  # multicast
+]
+
+
+@pytest.mark.parametrize("url", NON_PUBLIC_URLS)
+def test_check_url_points_to_public_host_rejects_non_public(url):
+    with pytest.raises(ValueError):
+        _check_url_points_to_public_host(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:9999/internal/secret",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://10.0.0.1/admin",
+    ],
+)
+def test_download_rejects_non_public_host(url):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        dest = os.path.join(tmp_dir, "result.bin")
+        with pytest.raises(ValueError):
+            download(url, path=dest, retries=0)
+        # Nothing should have been written to disk.
+        assert not os.path.exists(dest)
+
+
+def test_download_does_not_request_non_public_host():
+    """A rejected URL must be blocked before any HTTP request is issued."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        dest = os.path.join(tmp_dir, "result.bin")
+        with mock.patch("autogluon.multimodal.utils.download.requests.get") as mock_get:
+            with pytest.raises(ValueError):
+                download("http://169.254.169.254/latest/meta-data/", path=dest, retries=3)
+        mock_get.assert_not_called()
+
+
+def test_check_url_points_to_public_host_allows_public():
+    # A well-known public host should pass. getaddrinfo is patched so the test does not
+    # depend on live DNS.
+    with mock.patch(
+        "autogluon.multimodal.utils.download.socket.getaddrinfo",
+        return_value=[(0, 0, 0, "", ("93.184.216.34", 0))],
+    ):
+        _check_url_points_to_public_host("http://example.com/dataset.zip")
+
+
+def test_check_url_points_to_public_host_rejects_dns_resolving_to_private():
+    # Even a normal-looking hostname must be rejected if it resolves to a private address.
+    with mock.patch(
+        "autogluon.multimodal.utils.download.socket.getaddrinfo",
+        return_value=[(0, 0, 0, "", ("10.1.2.3", 0))],
+    ):
+        with pytest.raises(ValueError):
+            _check_url_points_to_public_host("http://sneaky.example.com/dataset.zip")
+
+
+def test_check_url_points_to_public_host_rejects_unresolvable():
+    import socket as _socket
+
+    with mock.patch(
+        "autogluon.multimodal.utils.download.socket.getaddrinfo",
+        side_effect=_socket.gaierror("name resolution failed"),
+    ):
+        with pytest.raises(ValueError):
+            _check_url_points_to_public_host("http://does-not-resolve.invalid/x.zip")
+
+
+def test_check_url_points_to_public_host_rejects_missing_host():
+    with pytest.raises(ValueError):
+        _check_url_points_to_public_host("not-a-url")
+
+
+def test_is_url_still_recognizes_url_shapes():
+    # is_url is unchanged: it only checks URL shape, not host reachability.
+    assert is_url("http://example.com/data.zip") is True
+    assert is_url("http://127.0.0.1:9999/internal/secret") is True
+    assert is_url("/local/path/to/file.zip") is False
+    assert is_url(1234) is False


### PR DESCRIPTION
## Description

`download()` in `multimodal/utils/download.py` accepted any URL-shaped string (anything `is_url()` matched) and passed it straight to an HTTP GET. This adds a small validation step that resolves the URL's host and confirms it points to a publicly-routable address before fetching.

Hosts that resolve to loopback, link-local, private, multicast, reserved, or unspecified addresses are now rejected with a clear `ValueError`. The check runs once, before the retry loop, and only for the HTTP path (S3 downloads are unaffected). No behavior change for normal downloads from public dataset/model hosts.

## Changes

- Add `_check_url_points_to_public_host()` (stdlib `ipaddress` + `socket`, no new dependencies) and call it before the HTTP GET in `download()`.
- Add `multimodal/tests/unittests/others/test_download.py` covering rejected hosts (loopback, `169.254.169.254`, private ranges, IPv6 loopback, multicast, unspecified), a mocked public host passing, a hostname that resolves to a private address being rejected, unresolvable/missing hosts, and that no HTTP request is issued for a rejected URL.

## Testing

`pytest multimodal/tests/unittests/others/test_download.py` — 19 passed.
