### PR TITLE
Add validation_structure fit kwarg for grouped/temporal validation splits

### DIFF
--- a/common/src/autogluon/common/constants.py
+++ b/common/src/autogluon/common/constants.py
@@ -1,0 +1,21 @@
+"""Vocabulary shared across AutoGluon packages.
+
+Problem types live here rather than in ``autogluon.core`` so that utilities which are
+themselves shared -- such as ``autogluon.common.utils.cv_splitter`` and
+``autogluon.common.utils.validation_structure`` -- can reason about them without
+``autogluon.common`` depending on ``autogluon.core``. ``autogluon.core.constants``
+re-exports them, so existing imports from there keep working.
+"""
+
+# Do not change these!
+BINARY = "binary"
+MULTICLASS = "multiclass"
+REGRESSION = "regression"
+SOFTCLASS = (
+    "softclass"  # classification with soft-target (rather than classes, labels are probabilities of each class).
+)
+QUANTILE = "quantile"  # quantile regression (over multiple quantile levels, which are between 0.0 and 1.0)
+
+PROBLEM_TYPES_CLASSIFICATION = [BINARY, MULTICLASS]
+PROBLEM_TYPES_REGRESSION = [REGRESSION]
+PROBLEM_TYPES = PROBLEM_TYPES_CLASSIFICATION + PROBLEM_TYPES_REGRESSION + [SOFTCLASS] + [QUANTILE]

--- a/common/src/autogluon/common/utils/validation_structure.py
+++ b/common/src/autogluon/common/utils/validation_structure.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, fields
 import numpy as np
 import pandas as pd
 
-from autogluon.core.constants import BINARY, MULTICLASS
+from autogluon.common.constants import BINARY, MULTICLASS
 
 logger = logging.getLogger(__name__)
 

--- a/core/src/autogluon/core/constants.py
+++ b/core/src/autogluon/core/constants.py
@@ -1,15 +1,16 @@
-# Do not change these!
-BINARY = "binary"
-MULTICLASS = "multiclass"
-REGRESSION = "regression"
-SOFTCLASS = (
-    "softclass"  # classification with soft-target (rather than classes, labels are probabilities of each class).
+# Problem types are defined in `autogluon.common` so that shared utilities can use them
+# without `autogluon.common` depending on `autogluon.core`; re-exported here because this is
+# where the rest of AutoGluon imports them from.
+from autogluon.common.constants import (  # noqa: F401
+    BINARY,
+    MULTICLASS,
+    PROBLEM_TYPES,
+    PROBLEM_TYPES_CLASSIFICATION,
+    PROBLEM_TYPES_REGRESSION,
+    QUANTILE,
+    REGRESSION,
+    SOFTCLASS,
 )
-QUANTILE = "quantile"  # quantile regression (over multiple quantile levels, which are between 0.0 and 1.0)
-
-PROBLEM_TYPES_CLASSIFICATION = [BINARY, MULTICLASS]
-PROBLEM_TYPES_REGRESSION = [REGRESSION]
-PROBLEM_TYPES = PROBLEM_TYPES_CLASSIFICATION + PROBLEM_TYPES_REGRESSION + [SOFTCLASS] + [QUANTILE]
 
 PSEUDO_MODEL_SUFFIX = "_PSEUDO_{iter}"
 

--- a/core/src/autogluon/core/models/dummy/dummy_model.py
+++ b/core/src/autogluon/core/models/dummy/dummy_model.py
@@ -13,6 +13,11 @@ class DummyModel(AbstractModel):
     Useful for tests and calculating worst-case performance.
     """
 
+    # A constant predictor gains nothing from parallel fold workers and pays their full
+    # startup cost (fresh processes via Ray), which dominates the runtime of the tests this
+    # model exists to serve.
+    _default_ag_args_ensemble_extra = {"fold_fitting_strategy": "sequential_local"}
+
     ag_key = "DUMMY"
     ag_name = "Dummy"
     _supported_problem_types = ["binary", "multiclass", "regression", "quantile"]

--- a/core/src/autogluon/core/utils/validation_structure.py
+++ b/core/src/autogluon/core/utils/validation_structure.py
@@ -314,11 +314,14 @@ class ValidationStructure:
                 )
             return order[:cut], order[cut:]
 
-        from sklearn.model_selection import GroupShuffleSplit
-
-        splitter = GroupShuffleSplit(n_splits=1, test_size=holdout_frac, random_state=random_state)
-        train_idx, val_idx = next(splitter.split(X, y, groups=self._group_values(X)))
-        return train_idx, val_idx
+        # Grouped holdout: one fold of the same split the bagged path would build, so the
+        # holdout inherits the group-disjointness *and* the stratification handling rather
+        # than re-deriving them (GroupShuffleSplit cannot stratify at all). The fold count
+        # is chosen so a single fold is ~holdout_frac of the data; with coarse grouping the
+        # realised size can differ, because whole groups cannot be subdivided.
+        n_splits = max(2, int(round(1 / max(holdout_frac, 1e-9))))
+        splits, _, _ = self.custom_splits(X, y, num_folds=n_splits, num_repeats=1, random_state=random_state)
+        return splits[0]
 
 
 def _splits_from_labels(labels: pd.Series) -> list[tuple[np.ndarray, np.ndarray]]:

--- a/core/src/autogluon/core/utils/validation_structure.py
+++ b/core/src/autogluon/core/utils/validation_structure.py
@@ -15,10 +15,10 @@ logger = logging.getLogger(__name__)
 class ValidationStructure:
     """Declarative description of a dataset's validation-relevant structure.
 
-    Users specify only the semantic columns; fold counts, interval blocking, and
-    clamping are derived. Consumed by the learner (bagged path: fold-id labels routed
-    through the existing ``groups`` channel) and the trainer (holdout path: a
-    group-disjoint or temporally-forward train/validation split).
+    Users specify only the semantic columns; fold counts, interval blocking, and clamping
+    are derived. The learner resolves the bagged splits (:meth:`custom_splits`) and the
+    trainer the non-bagged holdout (:meth:`holdout_split_indices`), both on the raw cleaned
+    frame, before feature transformation can alter the columns named here.
 
     Parameters
     ----------
@@ -33,8 +33,12 @@ class ValidationStructure:
         to the label for classification when combined with ``group_on``; for time-based
         splits it only influences how the contiguous blocks are assigned to fold indices,
         never the block boundaries themselves.
-
-    Specifying both ``group_on`` and ``time_on`` is not supported.
+    group_time_on : str, optional
+        Column identifying groups that are *also* ordered in time (e.g. a session id whose
+        sessions arrive in sequence). Whole groups are blocked in time order, so the splits
+        are simultaneously group-disjoint and forward in time, and the non-bagged holdout is
+        the latest groups. Use this for data that is both grouped and temporal; combining
+        ``group_on`` with ``time_on`` is not supported, as their semantics would be ambiguous.
     """
 
     group_on: str | list[str] | None = None
@@ -69,8 +73,20 @@ class ValidationStructure:
             return cls(**value)
         raise ValueError(f"`validation_structure` must be a dict or ValidationStructure, got: {type(value)}")
 
-    def _is_per_group(self, X: pd.DataFrame, y: pd.Series, problem_type: str | None = None) -> bool:
-        """True when each group has a single stratification value (group-level labelling)."""
+    def _can_split_group_table(self, X: pd.DataFrame, y: pd.Series, problem_type: str | None = None) -> bool:
+        """Whether the folds can be built from the group table rather than from the samples.
+
+        True only when a stratification signal exists *and* is constant within every group:
+        the group table holds one row per group, so it can only carry one stratification
+        value per group. Splitting it then balances the stratification across folds without
+        letting group sizes skew it.
+
+        This is therefore always False without a stratification signal -- notably for
+        regression, which does not stratify -- and such tasks fall through to the
+        sample-level ``GroupKFold`` / ``StratifiedGroupKFold`` path. That matches the
+        grouped-validation protocol this mirrors, whose group-table branch likewise requires
+        a stratification column.
+        """
         stratify = self._resolve_stratify_for_folds(X, y, problem_type)
         if stratify is None:
             return False
@@ -155,7 +171,7 @@ class ValidationStructure:
                     )
                     num_folds, num_repeats = max(2, minority), 1
 
-        if self.group_on is not None and self._is_per_group(X, y, problem_type):
+        if self.group_on is not None and self._can_split_group_table(X, y, problem_type):
             # Every group carries one stratification value: split the *group table* (one row
             # per group) and expand back to rows, so group sizes do not skew stratification.
             splits = _per_group_splits(

--- a/core/src/autogluon/core/utils/validation_structure.py
+++ b/core/src/autogluon/core/utils/validation_structure.py
@@ -344,9 +344,10 @@ def _validate_splits(splits: list[tuple[np.ndarray, np.ndarray]], n_rows: int, s
         if train_idx.max(initial=-1) >= n_rows or val_idx.max(initial=-1) >= n_rows:
             raise ValueError("validation_structure produced out-of-range split indices.")
     if stratify is not None:
-        expected = set(pd.unique(stratify.astype(str)))
+        stratify_str = stratify.astype(str).to_numpy()
+        expected = set(pd.unique(stratify_str))
         for _, val_idx in splits:
-            present = set(pd.unique(stratify.astype(str).to_numpy()[val_idx]))
+            present = set(pd.unique(stratify_str[val_idx]))
             if not present:
                 raise ValueError("validation_structure produced a validation split with no rows.")
             missing = expected - present
@@ -360,18 +361,21 @@ def _validate_splits(splits: list[tuple[np.ndarray, np.ndarray]], n_rows: int, s
 def _per_group_splits(
     groups: pd.Series, stratify: pd.Series | None, n_splits: int, n_repeats: int, random_state: int
 ) -> list[tuple[np.ndarray, np.ndarray]]:
-    """Repeated (stratified) K-fold over the group table, expanded to row indices."""
+    """Repeated (stratified) K-fold over the group table, expanded to row indices.
+
+    Groups are numbered by first appearance (``pd.factorize``) so the group table's row
+    order — and therefore the splitter's output — does not depend on group sizes or values.
+    """
     from sklearn.model_selection import RepeatedKFold, RepeatedStratifiedKFold
 
-    g = np.asarray(groups)
-    unique_groups, group_rows = [], []
-    for value in pd.unique(g):
-        unique_groups.append(value)
-        group_rows.append(np.flatnonzero(g == value))
+    codes, uniques = pd.factorize(groups, sort=False)
+    n_groups = len(uniques)
+
     group_target = None
     if stratify is not None:
-        s = np.asarray(stratify)
-        group_target = np.array([s[rows[0]] for rows in group_rows])
+        # each group carries one stratification value: read it off the group's first row
+        _, first_row_of_group = np.unique(codes, return_index=True)
+        group_target = np.asarray(stratify)[first_row_of_group]
 
     if group_target is not None:
         splitter = RepeatedStratifiedKFold(n_splits=n_splits, n_repeats=n_repeats, random_state=random_state)
@@ -379,11 +383,13 @@ def _per_group_splits(
         splitter = RepeatedKFold(n_splits=n_splits, n_repeats=n_repeats, random_state=random_state)
 
     splits = []
-    dummy = np.zeros(len(unique_groups))
-    for train_groups, val_groups in splitter.split(dummy, group_target):
-        train_idx = np.concatenate([group_rows[i] for i in train_groups])
-        val_idx = np.concatenate([group_rows[i] for i in val_groups])
-        splits.append((np.sort(train_idx), np.sort(val_idx)))
+    dummy = np.zeros(n_groups)
+    for _, val_groups in splitter.split(dummy, group_target):
+        # expand group membership to rows with one boolean lookup instead of per-group scans
+        is_val_group = np.zeros(n_groups, dtype=bool)
+        is_val_group[val_groups] = True
+        val_mask = is_val_group[codes]
+        splits.append((np.flatnonzero(~val_mask), np.flatnonzero(val_mask)))
     return splits
 
 

--- a/core/src/autogluon/core/utils/validation_structure.py
+++ b/core/src/autogluon/core/utils/validation_structure.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, fields
 import numpy as np
 import pandas as pd
 
+from autogluon.core.constants import BINARY, MULTICLASS
+
 logger = logging.getLogger(__name__)
 
 
@@ -67,9 +69,9 @@ class ValidationStructure:
             return cls(**value)
         raise ValueError(f"`validation_structure` must be a dict or ValidationStructure, got: {type(value)}")
 
-    def _is_per_group(self, X: pd.DataFrame, y: pd.Series) -> bool:
+    def _is_per_group(self, X: pd.DataFrame, y: pd.Series, problem_type: str | None = None) -> bool:
         """True when each group has a single stratification value (group-level labelling)."""
-        stratify = self._resolve_stratify_for_folds(X, y)
+        stratify = self._resolve_stratify_for_folds(X, y, problem_type)
         if stratify is None:
             return False
         groups = self._group_values(X)
@@ -92,6 +94,7 @@ class ValidationStructure:
         num_folds: int | None = None,
         num_repeats: int | None = None,
         random_state: int = 0,
+        problem_type: str | None = None,
     ) -> tuple[list[tuple[np.ndarray, np.ndarray]], int, int]:
         """Explicit ``(train_idx, val_idx)`` splits honoring the declared structure.
 
@@ -141,7 +144,7 @@ class ValidationStructure:
                     f"setting num_folds={n_groups} and num_repeats=1.",
                 )
                 num_folds, num_repeats = n_groups, 1
-            stratify = self._resolve_stratify_for_folds(X, y)
+            stratify = self._resolve_stratify_for_folds(X, y, problem_type)
             if stratify is not None:
                 minority = int(stratify.value_counts().min())
                 if minority < num_folds:
@@ -152,7 +155,7 @@ class ValidationStructure:
                     )
                     num_folds, num_repeats = max(2, minority), 1
 
-        if self.group_on is not None and self._is_per_group(X, y):
+        if self.group_on is not None and self._is_per_group(X, y, problem_type):
             # Every group carries one stratification value: split the *group table* (one row
             # per group) and expand back to rows, so group sizes do not skew stratification.
             splits = _per_group_splits(
@@ -167,7 +170,9 @@ class ValidationStructure:
 
         splits: list[tuple[np.ndarray, np.ndarray]] = []
         for repeat in range(num_repeats):
-            labels = self.fold_ids(X, y, n_splits=num_folds, random_state=random_state + repeat)
+            labels = self.fold_ids(
+                X, y, n_splits=num_folds, random_state=random_state + repeat, problem_type=problem_type
+            )
             repeat_splits = _splits_from_labels(labels)
             if len(repeat_splits) != num_folds:
                 # a splitter produced fewer folds than asked; adopt what the data supports
@@ -240,7 +245,9 @@ class ValidationStructure:
 
     # ── bagged path ──────────────────────────────────────────────────────────────
 
-    def fold_ids(self, X: pd.DataFrame, y: pd.Series, n_splits: int, random_state: int = 0) -> pd.Series:
+    def fold_ids(
+        self, X: pd.DataFrame, y: pd.Series, n_splits: int, random_state: int = 0, problem_type: str | None = None
+    ) -> pd.Series:
         """Per-row fold labels honoring the declared structure.
 
         Rows sharing a label form one validation fold (consumed as ``groups`` by the
@@ -255,7 +262,7 @@ class ValidationStructure:
         elif self.group_on is not None:
             labels = _group_folds(
                 groups=self._group_values(X),
-                stratify=self._resolve_stratify_for_folds(X, y),
+                stratify=self._resolve_stratify_for_folds(X, y, problem_type),
                 n_splits=n_splits,
                 random_state=random_state,
             )
@@ -269,18 +276,32 @@ class ValidationStructure:
             )
         return pd.Series(labels, index=X.index, name="__fold_id__")
 
-    def _resolve_stratify_for_folds(self, X: pd.DataFrame, y: pd.Series) -> pd.Series | None:
+    def _resolve_stratify_for_folds(
+        self, X: pd.DataFrame, y: pd.Series, problem_type: str | None = None
+    ) -> pd.Series | None:
+        """The stratification signal for fold construction, or None to not stratify.
+
+        With no explicit ``stratify_on``, the label is used for classification, mirroring
+        AutoGluon's default label-stratified splitting so that declaring ``group_on`` does
+        not silently cost the stratification a user gets for free. This needs the caller's
+        ``problem_type``: guessing it from the label's cardinality misjudges both directions
+        -- high-cardinality multiclass looks continuous, and a coarse numeric target looks
+        categorical -- and the callers all know the answer already.
+        """
         stratify = self._stratify_values(X, y)
-        if stratify is None and y.nunique() <= max(20, int(np.sqrt(len(y)))):
-            # No explicit stratification column: fall back to the label when it looks
-            # categorical (mirrors AutoGluon's default label-stratified splitting).
+        if stratify is None and problem_type in (BINARY, MULTICLASS):
             stratify = y
         return stratify
 
     # ── holdout path ─────────────────────────────────────────────────────────────
 
     def holdout_split_indices(
-        self, X: pd.DataFrame, y: pd.Series, holdout_frac: float, random_state: int = 0
+        self,
+        X: pd.DataFrame,
+        y: pd.Series,
+        holdout_frac: float,
+        random_state: int = 0,
+        problem_type: str | None = None,
     ) -> tuple[np.ndarray, np.ndarray] | None:
         """A single structure-aware ``(train_idx, val_idx)`` positional split.
 
@@ -314,7 +335,9 @@ class ValidationStructure:
         # is chosen so a single fold is ~holdout_frac of the data; with coarse grouping the
         # realised size can differ, because whole groups cannot be subdivided.
         n_splits = max(2, int(round(1 / max(holdout_frac, 1e-9))))
-        splits, _, _ = self.custom_splits(X, y, num_folds=n_splits, num_repeats=1, random_state=random_state)
+        splits, _, _ = self.custom_splits(
+            X, y, num_folds=n_splits, num_repeats=1, random_state=random_state, problem_type=problem_type
+        )
         return splits[0]
 
 

--- a/core/src/autogluon/core/utils/validation_structure.py
+++ b/core/src/autogluon/core/utils/validation_structure.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 
 import numpy as np
 import pandas as pd
@@ -37,26 +37,147 @@ class ValidationStructure:
     group_on: str | list[str] | None = None
     time_on: str | None = None
     stratify_on: str | None = None
+    group_time_on: str | None = None
+
+    #: At or below this many group instances (distinct groups, or rows when ungrouped) the
+    #: tiny-data regime applies: more folds and repeats, since each fold is small and noisy.
+    max_instances_for_tiny_data: int = 500
+    tiny_data_num_folds: int = 5
+    tiny_data_num_repeats: int = 5
+    default_num_folds: int = 8
+    default_num_repeats: int = 1
 
     def __post_init__(self):
         if self.group_on is not None and self.time_on is not None:
-            raise NotImplementedError("Specifying both `group_on` and `time_on` is not supported.")
-        if self.group_on is None and self.time_on is None and self.stratify_on is None:
-            raise ValueError("ValidationStructure requires at least one of `group_on`, `time_on`, `stratify_on`.")
+            raise NotImplementedError(
+                "Specifying both `group_on` and `time_on` is not supported. To express data that is "
+                "both grouped and temporal, use `group_time_on` (groups ordered by time)."
+            )
+        if self.group_time_on is not None and (self.group_on is not None or self.time_on is not None):
+            raise ValueError("`group_time_on` is mutually exclusive with `group_on` / `time_on`.")
+        if all(v is None for v in (self.group_on, self.time_on, self.stratify_on, self.group_time_on)):
+            raise ValueError(
+                "ValidationStructure requires at least one of `group_on`, `time_on`, `stratify_on`, `group_time_on`."
+            )
 
     @classmethod
     def from_input(cls, value: ValidationStructure | dict | None) -> ValidationStructure | None:
         if value is None or isinstance(value, ValidationStructure):
             return value
         if isinstance(value, dict):
-            invalid = set(value) - {"group_on", "time_on", "stratify_on"}
+            valid = {f.name for f in fields(cls)}
+            invalid = set(value) - valid
             if invalid:
                 raise ValueError(
-                    f"Invalid `validation_structure` keys: {sorted(invalid)}. "
-                    "Valid keys: ['group_on', 'time_on', 'stratify_on']"
+                    f"Invalid `validation_structure` keys: {sorted(invalid)}. Valid keys: {sorted(valid)}"
                 )
             return cls(**value)
         raise ValueError(f"`validation_structure` must be a dict or ValidationStructure, got: {type(value)}")
+
+    # ── split-count policy ───────────────────────────────────────────────────────
+
+    def resolve_num_splits(
+        self, X: pd.DataFrame, num_folds: int | None = None, num_repeats: int | None = None
+    ) -> tuple[int, int]:
+        """Fold/repeat counts to use for this data, derived when not given.
+
+        Counts *group instances* rather than rows (a grouped task's effective sample size is
+        its number of groups): at or below :attr:`max_instances_for_tiny_data` the tiny-data
+        regime applies, otherwise the defaults. Explicit user values always win.
+        """
+        n_instances = self._num_group_instances(X)
+        if num_folds is not None and num_repeats is not None:
+            return num_folds, num_repeats
+        if n_instances <= self.max_instances_for_tiny_data:
+            folds, repeats = self.tiny_data_num_folds, self.tiny_data_num_repeats
+            logger.log(
+                20,
+                f"validation_structure: tiny data ({n_instances} <= {self.max_instances_for_tiny_data} "
+                f"instances): using num_bag_folds={folds}, num_bag_sets={repeats}.",
+            )
+        else:
+            folds, repeats = self.default_num_folds, self.default_num_repeats
+        return (num_folds if num_folds is not None else folds, num_repeats if num_repeats is not None else repeats)
+
+    def _num_group_instances(self, X: pd.DataFrame) -> int:
+        """Effective sample size: distinct groups when grouped, else row count."""
+        if self.group_on is not None:
+            return int(self._group_values(X).nunique())
+        if self.group_time_on is not None:
+            return int(self._group_time_values(X).nunique())
+        return len(X)
+
+    # ── explicit splits (the bagged path) ────────────────────────────────────────
+
+    def custom_splits(
+        self,
+        X: pd.DataFrame,
+        y: pd.Series,
+        num_folds: int | None = None,
+        num_repeats: int | None = None,
+        random_state: int = 0,
+    ) -> tuple[list[tuple[np.ndarray, np.ndarray]], int, int]:
+        """Explicit ``(train_idx, val_idx)`` splits honoring the declared structure.
+
+        Returns ``(splits, num_folds, num_repeats)`` with ``len(splits) == num_folds *
+        num_repeats``; the returned counts may be clamped below what was requested (see
+        below), so callers must adopt them rather than assume their originals held.
+
+        Explicit splits (rather than per-row group labels routed through the ``groups``
+        channel) are what make repeated grouped cross-validation possible: the ``groups``
+        channel forces leave-one-group-out with ``n_repeats == 1``.
+
+        Clamping rules, each of which also forces ``num_repeats = 1`` because the resulting
+        partition is deterministic and repeating it would only duplicate work:
+
+        * temporal (``time_on`` / ``group_time_on``): blocks are contiguous in time, so
+          there is exactly one valid partition;
+        * fewer groups than folds: folds drop to the group count;
+        * a stratification value rarer than the fold count: folds drop to that count.
+        """
+        num_folds, num_repeats = self.resolve_num_splits(X, num_folds, num_repeats)
+        num_folds = max(2, num_folds)
+        num_repeats = max(1, num_repeats)
+
+        if self.time_on is not None or self.group_time_on is not None:
+            labels = self._temporal_labels(X, n_blocks=num_folds)
+            splits = _splits_from_labels(labels)
+            return splits, len(splits), 1
+
+        if self.group_on is not None:
+            groups = self._group_values(X)
+            n_groups = int(groups.nunique())
+            if n_groups < num_folds:
+                logger.log(
+                    20,
+                    f"validation_structure: {n_groups} groups < num_folds ({num_folds}); "
+                    f"setting num_folds={n_groups} and num_repeats=1.",
+                )
+                num_folds, num_repeats = n_groups, 1
+            stratify = self._resolve_stratify_for_folds(X, y)
+            if stratify is not None:
+                minority = int(stratify.value_counts().min())
+                if minority < num_folds:
+                    logger.log(
+                        20,
+                        f"validation_structure: rarest stratification value occurs {minority} times "
+                        f"< num_folds ({num_folds}); setting num_folds={minority} and num_repeats=1.",
+                    )
+                    num_folds, num_repeats = max(2, minority), 1
+
+        splits: list[tuple[np.ndarray, np.ndarray]] = []
+        for repeat in range(num_repeats):
+            labels = self.fold_ids(X, y, n_splits=num_folds, random_state=random_state + repeat)
+            repeat_splits = _splits_from_labels(labels)
+            if len(repeat_splits) != num_folds:
+                # a splitter produced fewer folds than asked; adopt what the data supports
+                num_folds = len(repeat_splits)
+                splits, num_repeats = [], 1
+                splits.extend(repeat_splits)
+                break
+            splits.extend(repeat_splits)
+        _validate_splits(splits, n_rows=len(X), stratify=self._stratify_values(X, y))
+        return splits, num_folds, num_repeats
 
     # ── column access helpers ────────────────────────────────────────────────────
 
@@ -83,6 +204,30 @@ class ValidationStructure:
             raise ValueError(f"`time_on` column {self.time_on!r} must be datetime or numeric.")
         return values
 
+    def _group_time_values(self, X: pd.DataFrame) -> pd.Series:
+        """Group ids for ``group_time_on`` (groups are the unit ordered in time)."""
+        if self.group_time_on not in X.columns:
+            raise KeyError(f"`group_time_on` column {self.group_time_on!r} not found in the training data.")
+        values = X[self.group_time_on]
+        if values.isna().any():
+            raise ValueError(f"`group_time_on` column {self.group_time_on!r} contains NaN values.")
+        return values
+
+    def _temporal_labels(self, X: pd.DataFrame, n_blocks: int) -> pd.Series:
+        """Contiguous time-block labels; ``group_time_on`` blocks whole groups in time order.
+
+        ``time_on`` blocks rows by their time value (ties never split). ``group_time_on``
+        treats each group as an indivisible unit ordered by its first appearance, so a block
+        boundary never cuts through a group: the result is both group-disjoint and forward
+        in time.
+        """
+        if self.group_time_on is not None:
+            groups = self._group_time_values(X)
+            # order groups by first appearance, then block the ordered group sequence
+            order = {g: i for i, g in enumerate(groups.drop_duplicates())}
+            return _time_blocks(groups.map(order), n_blocks=n_blocks)
+        return _time_blocks(self._time_values(X), n_blocks=n_blocks)
+
     def _stratify_values(self, X: pd.DataFrame, y: pd.Series) -> pd.Series | None:
         if self.stratify_on is None:
             return None
@@ -102,8 +247,8 @@ class ValidationStructure:
         labels may be lower than ``n_splits`` when the data cannot support it.
         """
         assert n_splits >= 2
-        if self.time_on is not None:
-            labels = _time_blocks(self._time_values(X), n_blocks=n_splits)
+        if self.time_on is not None or self.group_time_on is not None:
+            labels = self._temporal_labels(X, n_blocks=n_splits)
         elif self.group_on is not None:
             labels = _group_folds(
                 groups=self._group_values(X),
@@ -141,8 +286,17 @@ class ValidationStructure:
         future information into training). Returns None when only ``stratify_on`` is
         set: AutoGluon's default label-stratified holdout needs no correction.
         """
-        if self.time_on is None and self.group_on is None:
+        if self.time_on is None and self.group_on is None and self.group_time_on is None:
             return None
+        if self.group_time_on is not None:
+            # whole groups, ordered by first appearance: the latest groups form the holdout
+            labels = self._temporal_labels(X, n_blocks=max(2, int(round(1 / max(holdout_frac, 1e-9))))).to_numpy()
+            last = labels.max()
+            val_idx = np.flatnonzero(labels == last)
+            train_idx = np.flatnonzero(labels != last)
+            if len(train_idx) == 0 or len(val_idx) == 0:
+                raise ValueError(f"`group_time_on` column {self.group_time_on!r} cannot produce a forward holdout.")
+            return train_idx, val_idx
         if self.time_on is not None:
             values = self._time_values(X).to_numpy()
             order = np.argsort(values, kind="stable")
@@ -162,6 +316,42 @@ class ValidationStructure:
         splitter = GroupShuffleSplit(n_splits=1, test_size=holdout_frac, random_state=random_state)
         train_idx, val_idx = next(splitter.split(X, y, groups=self._group_values(X)))
         return train_idx, val_idx
+
+
+def _splits_from_labels(labels: pd.Series) -> list[tuple[np.ndarray, np.ndarray]]:
+    """Leave-one-label-out positional ``(train_idx, val_idx)`` splits, in label order."""
+    values = np.asarray(labels)
+    splits = []
+    for label in sorted(pd.unique(values)):
+        val_idx = np.flatnonzero(values == label)
+        train_idx = np.flatnonzero(values != label)
+        if len(train_idx) == 0 or len(val_idx) == 0:
+            continue
+        splits.append((train_idx, val_idx))
+    return splits
+
+
+def _validate_splits(splits: list[tuple[np.ndarray, np.ndarray]], n_rows: int, stratify: pd.Series | None) -> None:
+    """Assert the splits are usable: non-empty, positional, and stratification-preserving."""
+    if not splits:
+        raise ValueError("validation_structure produced no usable validation splits.")
+    for train_idx, val_idx in splits:
+        if len(train_idx) == 0 or len(val_idx) == 0:
+            raise ValueError("validation_structure produced an empty train or validation split.")
+        if train_idx.max(initial=-1) >= n_rows or val_idx.max(initial=-1) >= n_rows:
+            raise ValueError("validation_structure produced out-of-range split indices.")
+    if stratify is not None:
+        expected = set(pd.unique(stratify.astype(str)))
+        for _, val_idx in splits:
+            present = set(pd.unique(stratify.astype(str).to_numpy()[val_idx]))
+            if not present:
+                raise ValueError("validation_structure produced a validation split with no rows.")
+            missing = expected - present
+            if missing and len(expected) == 2:
+                # binary stratification with an absent class makes the fold unscorable
+                logger.warning(
+                    f"validation_structure: a validation fold is missing stratification value(s) {sorted(missing)}."
+                )
 
 
 def _time_blocks(values: pd.Series, n_blocks: int) -> pd.Series:
@@ -206,7 +396,7 @@ def _stratified_folds(stratify: pd.Series, n_splits: int, random_state: int) -> 
 
     n_splits = min(n_splits, int(stratify.value_counts().min()))
     if n_splits < 2:
-        raise ValueError(f"`stratify_on` minority value occurs fewer than 2 times; cannot build stratified folds.")
+        raise ValueError("`stratify_on` minority value occurs fewer than 2 times; cannot build stratified folds.")
     splitter = StratifiedKFold(n_splits=n_splits, shuffle=True, random_state=random_state)
     labels = np.full(len(stratify), -1, dtype=int)
     for fold, (_, test_idx) in enumerate(splitter.split(np.zeros(len(stratify)), stratify)):

--- a/core/src/autogluon/core/utils/validation_structure.py
+++ b/core/src/autogluon/core/utils/validation_structure.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ValidationStructure:
+    """Declarative description of a dataset's validation-relevant structure.
+
+    Users specify only the semantic columns; fold counts, interval blocking, and
+    clamping are derived. Consumed by the learner (bagged path: fold-id labels routed
+    through the existing ``groups`` channel) and the trainer (holdout path: a
+    group-disjoint or temporally-forward train/validation split).
+
+    Parameters
+    ----------
+    group_on : str | list[str], optional
+        Column(s) identifying groups that must not span both a training and a
+        validation split (e.g. a customer or session id).
+    time_on : str, optional
+        Column encoding time (datetime or numeric). Validation splits become
+        contiguous time blocks; the non-bagged holdout is the latest block.
+    stratify_on : str, optional
+        Column to stratify splits on. Defaults to the label for classification when
+        combined with ``group_on``; ignored for time-based splits (stratification is
+        not meaningful across a temporal cut).
+
+    Specifying both ``group_on`` and ``time_on`` is not supported.
+    """
+
+    group_on: str | list[str] | None = None
+    time_on: str | None = None
+    stratify_on: str | None = None
+
+    def __post_init__(self):
+        if self.group_on is not None and self.time_on is not None:
+            raise NotImplementedError("Specifying both `group_on` and `time_on` is not supported.")
+        if self.group_on is None and self.time_on is None and self.stratify_on is None:
+            raise ValueError("ValidationStructure requires at least one of `group_on`, `time_on`, `stratify_on`.")
+
+    @classmethod
+    def from_input(cls, value: ValidationStructure | dict | None) -> ValidationStructure | None:
+        if value is None or isinstance(value, ValidationStructure):
+            return value
+        if isinstance(value, dict):
+            invalid = set(value) - {"group_on", "time_on", "stratify_on"}
+            if invalid:
+                raise ValueError(
+                    f"Invalid `validation_structure` keys: {sorted(invalid)}. "
+                    "Valid keys: ['group_on', 'time_on', 'stratify_on']"
+                )
+            return cls(**value)
+        raise ValueError(f"`validation_structure` must be a dict or ValidationStructure, got: {type(value)}")
+
+    # ── column access helpers ────────────────────────────────────────────────────
+
+    def _group_values(self, X: pd.DataFrame) -> pd.Series:
+        columns = [self.group_on] if isinstance(self.group_on, str) else list(self.group_on)
+        for column in columns:
+            if column not in X.columns:
+                raise KeyError(f"`group_on` column {column!r} not found in the training data.")
+            if X[column].isna().any():
+                raise ValueError(f"`group_on` column {column!r} contains NaN values.")
+        if len(columns) == 1:
+            return X[columns[0]]
+        return X[columns].astype(str).agg("||".join, axis=1)
+
+    def _time_values(self, X: pd.DataFrame) -> pd.Series:
+        if self.time_on not in X.columns:
+            raise KeyError(f"`time_on` column {self.time_on!r} not found in the training data.")
+        values = X[self.time_on]
+        if values.isna().any():
+            raise ValueError(f"`time_on` column {self.time_on!r} contains NaN values.")
+        if pd.api.types.is_datetime64_any_dtype(values):
+            values = values.astype("int64")
+        if not pd.api.types.is_numeric_dtype(values):
+            raise ValueError(f"`time_on` column {self.time_on!r} must be datetime or numeric.")
+        return values
+
+    def _stratify_values(self, X: pd.DataFrame, y: pd.Series) -> pd.Series | None:
+        if self.stratify_on is None:
+            return None
+        if self.stratify_on in X.columns:
+            return X[self.stratify_on].astype("category")
+        raise KeyError(f"`stratify_on` column {self.stratify_on!r} not found in the training data.")
+
+    # ── bagged path ──────────────────────────────────────────────────────────────
+
+    def fold_ids(self, X: pd.DataFrame, y: pd.Series, n_splits: int, random_state: int = 0) -> pd.Series:
+        """Per-row fold labels honoring the declared structure.
+
+        Rows sharing a label form one validation fold (consumed as ``groups`` by the
+        bagging ``CVSplitter``, i.e. leave-one-fold-out). Time produces contiguous
+        blocks that never split ties; groups are assigned to folds group-disjointly
+        (stratified when a stratification signal exists). The number of distinct
+        labels may be lower than ``n_splits`` when the data cannot support it.
+        """
+        assert n_splits >= 2
+        if self.time_on is not None:
+            labels = _time_blocks(self._time_values(X), n_blocks=n_splits)
+        elif self.group_on is not None:
+            labels = _group_folds(
+                groups=self._group_values(X),
+                stratify=self._resolve_stratify_for_folds(X, y),
+                n_splits=n_splits,
+                random_state=random_state,
+            )
+        else:
+            labels = _stratified_folds(self._stratify_values(X, y), n_splits=n_splits, random_state=random_state)
+        n_folds = labels.nunique()
+        if n_folds < n_splits:
+            logger.log(
+                20,
+                f"validation_structure: data supports only {n_folds} folds (requested {n_splits}).",
+            )
+        return pd.Series(labels, index=X.index, name="__fold_id__")
+
+    def _resolve_stratify_for_folds(self, X: pd.DataFrame, y: pd.Series) -> pd.Series | None:
+        stratify = self._stratify_values(X, y)
+        if stratify is None and y.nunique() <= max(20, int(np.sqrt(len(y)))):
+            # No explicit stratification column: fall back to the label when it looks
+            # categorical (mirrors AutoGluon's default label-stratified splitting).
+            stratify = y
+        return stratify
+
+    # ── holdout path ─────────────────────────────────────────────────────────────
+
+    def holdout_split_indices(
+        self, X: pd.DataFrame, y: pd.Series, holdout_frac: float, random_state: int = 0
+    ) -> tuple[np.ndarray, np.ndarray] | None:
+        """A single structure-aware ``(train_idx, val_idx)`` positional split.
+
+        Group structure yields a group-disjoint split; time structure yields a
+        *forward* holdout (the latest contiguous block — a random fold would leak
+        future information into training). Returns None when only ``stratify_on`` is
+        set: AutoGluon's default label-stratified holdout needs no correction.
+        """
+        if self.time_on is None and self.group_on is None:
+            return None
+        if self.time_on is not None:
+            values = self._time_values(X).to_numpy()
+            order = np.argsort(values, kind="stable")
+            cut = len(X) - max(1, int(round(len(X) * holdout_frac)))
+            # never split rows with identical time stamps across the boundary
+            while 0 < cut < len(X) and values[order[cut - 1]] == values[order[cut]]:
+                cut -= 1
+            if cut == 0:
+                raise ValueError(
+                    f"`time_on` column {self.time_on!r} cannot produce a non-empty forward holdout "
+                    f"(all rows in the holdout block share the earliest time value)."
+                )
+            return order[:cut], order[cut:]
+
+        from sklearn.model_selection import GroupShuffleSplit
+
+        splitter = GroupShuffleSplit(n_splits=1, test_size=holdout_frac, random_state=random_state)
+        train_idx, val_idx = next(splitter.split(X, y, groups=self._group_values(X)))
+        return train_idx, val_idx
+
+
+def _time_blocks(values: pd.Series, n_blocks: int) -> pd.Series:
+    """Contiguous, tie-preserving time blocks of near-equal row counts (labels 0..k-1)."""
+    counts = values.value_counts().sort_index()
+    n_rows = int(counts.sum())
+    target = n_rows / n_blocks
+    block_of_value = {}
+    block, filled = 0, 0
+    for value, count in counts.items():
+        # close the current block once it reached its share, keeping later blocks feasible
+        if filled >= target * (block + 1) and block < n_blocks - 1:
+            block += 1
+        block_of_value[value] = block
+        filled += int(count)
+    return values.map(block_of_value)
+
+
+def _group_folds(groups: pd.Series, stratify: pd.Series | None, n_splits: int, random_state: int) -> pd.Series:
+    """Group-disjoint fold labels via (Stratified)GroupKFold test-fold membership."""
+    from sklearn.model_selection import GroupKFold, StratifiedGroupKFold
+
+    n_splits = min(n_splits, groups.nunique())
+    if n_splits < 2:
+        raise ValueError(f"`group_on` needs at least 2 distinct groups, found {groups.nunique()}.")
+    if stratify is not None:
+        splitter = StratifiedGroupKFold(n_splits=n_splits, shuffle=True, random_state=random_state)
+        split_target = stratify
+    else:
+        splitter = GroupKFold(n_splits=n_splits)
+        split_target = np.zeros(len(groups))
+    labels = np.full(len(groups), -1, dtype=int)
+    for fold, (_, test_idx) in enumerate(splitter.split(np.zeros(len(groups)), split_target, groups=groups)):
+        labels[test_idx] = fold
+    assert (labels >= 0).all()
+    return pd.Series(labels, index=groups.index)
+
+
+def _stratified_folds(stratify: pd.Series, n_splits: int, random_state: int) -> pd.Series:
+    """Fold labels stratified on an explicit column (plain IID otherwise handled by AutoGluon)."""
+    from sklearn.model_selection import StratifiedKFold
+
+    n_splits = min(n_splits, int(stratify.value_counts().min()))
+    if n_splits < 2:
+        raise ValueError(f"`stratify_on` minority value occurs fewer than 2 times; cannot build stratified folds.")
+    splitter = StratifiedKFold(n_splits=n_splits, shuffle=True, random_state=random_state)
+    labels = np.full(len(stratify), -1, dtype=int)
+    for fold, (_, test_idx) in enumerate(splitter.split(np.zeros(len(stratify)), stratify)):
+        labels[test_idx] = fold
+    assert (labels >= 0).all()
+    return pd.Series(labels, index=stratify.index)

--- a/core/src/autogluon/core/utils/validation_structure.py
+++ b/core/src/autogluon/core/utils/validation_structure.py
@@ -39,14 +39,6 @@ class ValidationStructure:
     stratify_on: str | None = None
     group_time_on: str | None = None
 
-    #: At or below this many group instances (distinct groups, or rows when ungrouped) the
-    #: tiny-data regime applies: more folds and repeats, since each fold is small and noisy.
-    max_instances_for_tiny_data: int = 500
-    tiny_data_num_folds: int = 5
-    tiny_data_num_repeats: int = 5
-    default_num_folds: int = 8
-    default_num_repeats: int = 1
-
     def __post_init__(self):
         if self.group_on is not None and self.time_on is not None:
             raise NotImplementedError(
@@ -74,30 +66,13 @@ class ValidationStructure:
             return cls(**value)
         raise ValueError(f"`validation_structure` must be a dict or ValidationStructure, got: {type(value)}")
 
-    # ── split-count policy ───────────────────────────────────────────────────────
-
-    def resolve_num_splits(
-        self, X: pd.DataFrame, num_folds: int | None = None, num_repeats: int | None = None
-    ) -> tuple[int, int]:
-        """Fold/repeat counts to use for this data, derived when not given.
-
-        Counts *group instances* rather than rows (a grouped task's effective sample size is
-        its number of groups): at or below :attr:`max_instances_for_tiny_data` the tiny-data
-        regime applies, otherwise the defaults. Explicit user values always win.
-        """
-        n_instances = self._num_group_instances(X)
-        if num_folds is not None and num_repeats is not None:
-            return num_folds, num_repeats
-        if n_instances <= self.max_instances_for_tiny_data:
-            folds, repeats = self.tiny_data_num_folds, self.tiny_data_num_repeats
-            logger.log(
-                20,
-                f"validation_structure: tiny data ({n_instances} <= {self.max_instances_for_tiny_data} "
-                f"instances): using num_bag_folds={folds}, num_bag_sets={repeats}.",
-            )
-        else:
-            folds, repeats = self.default_num_folds, self.default_num_repeats
-        return (num_folds if num_folds is not None else folds, num_repeats if num_repeats is not None else repeats)
+    def _is_per_group(self, X: pd.DataFrame, y: pd.Series) -> bool:
+        """True when each group has a single stratification value (group-level labelling)."""
+        stratify = self._resolve_stratify_for_folds(X, y)
+        if stratify is None:
+            return False
+        groups = self._group_values(X)
+        return bool(pd.Series(np.asarray(stratify)).groupby(np.asarray(groups)).nunique().max() == 1)
 
     def _num_group_instances(self, X: pd.DataFrame) -> int:
         """Effective sample size: distinct groups when grouped, else row count."""
@@ -121,7 +96,9 @@ class ValidationStructure:
 
         Returns ``(splits, num_folds, num_repeats)`` with ``len(splits) == num_folds *
         num_repeats``; the returned counts may be clamped below what was requested (see
-        below), so callers must adopt them rather than assume their originals held.
+        below), so callers must adopt them rather than assume their originals held. The
+        requested counts are otherwise honored as given -- deriving them from data size is
+        the caller's decision, not this class's.
 
         Explicit splits (rather than per-row group labels routed through the ``groups``
         channel) are what make repeated grouped cross-validation possible: the ``groups``
@@ -135,8 +112,7 @@ class ValidationStructure:
         * fewer groups than folds: folds drop to the group count;
         * a stratification value rarer than the fold count: folds drop to that count.
         """
-        num_folds, num_repeats = self.resolve_num_splits(X, num_folds, num_repeats)
-        num_folds = max(2, num_folds)
+        num_folds = max(2, num_folds if num_folds is not None else 8)
         num_repeats = max(1, num_repeats)
 
         if self.time_on is not None or self.group_time_on is not None:
@@ -164,6 +140,19 @@ class ValidationStructure:
                         f"< num_folds ({num_folds}); setting num_folds={minority} and num_repeats=1.",
                     )
                     num_folds, num_repeats = max(2, minority), 1
+
+        if self.group_on is not None and self._is_per_group(X, y):
+            # Every group carries one stratification value: split the *group table* (one row
+            # per group) and expand back to rows, so group sizes do not skew stratification.
+            splits = _per_group_splits(
+                groups=self._group_values(X),
+                stratify=self._resolve_stratify_for_folds(X, y),
+                n_splits=num_folds,
+                n_repeats=num_repeats,
+                random_state=random_state,
+            )
+            _validate_splits(splits, n_rows=len(X), stratify=self._stratify_values(X, y))
+            return splits, num_folds, num_repeats
 
         splits: list[tuple[np.ndarray, np.ndarray]] = []
         for repeat in range(num_repeats):
@@ -233,7 +222,10 @@ class ValidationStructure:
             return None
         if self.stratify_on in X.columns:
             return X[self.stratify_on].astype("category")
-        raise KeyError(f"`stratify_on` column {self.stratify_on!r} not found in the training data.")
+        if y is not None and getattr(y, "name", None) == self.stratify_on:
+            # stratifying on the label itself: it is not a feature column
+            return y.astype("category")
+        raise KeyError(f"`stratify_on` column {self.stratify_on!r} is neither a feature column nor the label.")
 
     # ── bagged path ──────────────────────────────────────────────────────────────
 
@@ -354,6 +346,36 @@ def _validate_splits(splits: list[tuple[np.ndarray, np.ndarray]], n_rows: int, s
                 )
 
 
+def _per_group_splits(
+    groups: pd.Series, stratify: pd.Series | None, n_splits: int, n_repeats: int, random_state: int
+) -> list[tuple[np.ndarray, np.ndarray]]:
+    """Repeated (stratified) K-fold over the group table, expanded to row indices."""
+    from sklearn.model_selection import RepeatedKFold, RepeatedStratifiedKFold
+
+    g = np.asarray(groups)
+    unique_groups, group_rows = [], []
+    for value in pd.unique(g):
+        unique_groups.append(value)
+        group_rows.append(np.flatnonzero(g == value))
+    group_target = None
+    if stratify is not None:
+        s = np.asarray(stratify)
+        group_target = np.array([s[rows[0]] for rows in group_rows])
+
+    if group_target is not None:
+        splitter = RepeatedStratifiedKFold(n_splits=n_splits, n_repeats=n_repeats, random_state=random_state)
+    else:
+        splitter = RepeatedKFold(n_splits=n_splits, n_repeats=n_repeats, random_state=random_state)
+
+    splits = []
+    dummy = np.zeros(len(unique_groups))
+    for train_groups, val_groups in splitter.split(dummy, group_target):
+        train_idx = np.concatenate([group_rows[i] for i in train_groups])
+        val_idx = np.concatenate([group_rows[i] for i in val_groups])
+        splits.append((np.sort(train_idx), np.sort(val_idx)))
+    return splits
+
+
 def _time_blocks(values: pd.Series, n_blocks: int) -> pd.Series:
     """Contiguous, tie-preserving time blocks of near-equal row counts (labels 0..k-1)."""
     counts = values.value_counts().sort_index()
@@ -381,7 +403,7 @@ def _group_folds(groups: pd.Series, stratify: pd.Series | None, n_splits: int, r
         splitter = StratifiedGroupKFold(n_splits=n_splits, shuffle=True, random_state=random_state)
         split_target = stratify
     else:
-        splitter = GroupKFold(n_splits=n_splits)
+        splitter = GroupKFold(n_splits=n_splits, shuffle=True, random_state=random_state)
         split_target = np.zeros(len(groups))
     labels = np.full(len(groups), -1, dtype=int)
     for fold, (_, test_idx) in enumerate(splitter.split(np.zeros(len(groups)), split_target, groups=groups)):

--- a/core/src/autogluon/core/utils/validation_structure.py
+++ b/core/src/autogluon/core/utils/validation_structure.py
@@ -27,9 +27,10 @@ class ValidationStructure:
         Column encoding time (datetime or numeric). Validation splits become
         contiguous time blocks; the non-bagged holdout is the latest block.
     stratify_on : str, optional
-        Column to stratify splits on. Defaults to the label for classification when
-        combined with ``group_on``; ignored for time-based splits (stratification is
-        not meaningful across a temporal cut).
+        Column to stratify splits on (may name the label rather than a feature). Defaults
+        to the label for classification when combined with ``group_on``; for time-based
+        splits it only influences how the contiguous blocks are assigned to fold indices,
+        never the block boundaries themselves.
 
     Specifying both ``group_on`` and ``time_on`` is not supported.
     """
@@ -113,11 +114,21 @@ class ValidationStructure:
         * a stratification value rarer than the fold count: folds drop to that count.
         """
         num_folds = max(2, num_folds if num_folds is not None else 8)
-        num_repeats = max(1, num_repeats)
+        num_repeats = max(1, num_repeats if num_repeats is not None else 1)
 
         if self.time_on is not None or self.group_time_on is not None:
             labels = self._temporal_labels(X, n_blocks=num_folds)
-            splits = _splits_from_labels(labels)
+            # Route the block labels through GroupKFold rather than emitting them in
+            # chronological order: the partition set is the same either way, but this
+            # matches the fold ordering the benchmark protocol produces.
+            splits = _splits_from_labels(
+                _group_folds(
+                    groups=labels,
+                    stratify=self._stratify_values(X, y),
+                    n_splits=int(labels.nunique()),
+                    random_state=random_state,
+                )
+            )
             return splits, len(splits), 1
 
         if self.group_on is not None:
@@ -377,19 +388,45 @@ def _per_group_splits(
 
 
 def _time_blocks(values: pd.Series, n_blocks: int) -> pd.Series:
-    """Contiguous, tie-preserving time blocks of near-equal row counts (labels 0..k-1)."""
-    counts = values.value_counts().sort_index()
-    n_rows = int(counts.sum())
-    target = n_rows / n_blocks
-    block_of_value = {}
-    block, filled = 0, 0
-    for value, count in counts.items():
-        # close the current block once it reached its share, keeping later blocks feasible
-        if filled >= target * (block + 1) and block < n_blocks - 1:
-            block += 1
-        block_of_value[value] = block
-        filled += int(count)
-    return values.map(block_of_value)
+    """Contiguous, tie-preserving time blocks of near-equal row counts (labels 0..k-1).
+
+    Splits the *observed* time values (not equal-width spans) into contiguous intervals:
+    identical time values always land in the same block, larger values are always later,
+    and each cut is placed where the cumulative row count is closest to that block's share
+    of the total. Fewer blocks than requested are produced when there are too few distinct
+    time values to support them.
+    """
+    counts = values.value_counts(dropna=False).sort_index()
+    n_unique = len(counts)
+    if n_unique < 2:
+        raise ValueError("`time_on` needs at least 2 distinct time values to form validation blocks.")
+    n_blocks = min(n_blocks, n_unique)
+
+    weights = counts.to_numpy()
+    cumulative = np.cumsum(weights)
+    total = int(weights.sum())
+
+    # Greedy contiguous partition of the sorted unique values: each cut goes where the
+    # cumulative weight lands closest to the target, bounded so the remaining blocks
+    # still have at least one unique value each.
+    cut_positions: list[int] = []
+    start = 0
+    for block in range(1, n_blocks):
+        target = block * total / n_blocks
+        max_j = n_unique - (n_blocks - block) - 1
+        candidates = np.arange(start, max_j + 1)
+        j = int(candidates[np.argmin(np.abs(cumulative[candidates] - target))])
+        cut_positions.append(j)
+        start = j + 1
+
+    labels_for_unique = np.empty(n_unique, dtype=int)
+    prev = 0
+    for block, cut in enumerate(cut_positions):
+        labels_for_unique[prev : cut + 1] = block
+        prev = cut + 1
+    labels_for_unique[prev:] = len(cut_positions)
+
+    return values.map(pd.Series(labels_for_unique, index=counts.index))
 
 
 def _group_folds(groups: pd.Series, stratify: pd.Series | None, n_splits: int, random_state: int) -> pd.Series:

--- a/core/src/autogluon/core/utils/validation_structure.py
+++ b/core/src/autogluon/core/utils/validation_structure.py
@@ -291,28 +291,22 @@ class ValidationStructure:
         """
         if self.time_on is None and self.group_on is None and self.group_time_on is None:
             return None
-        if self.group_time_on is not None:
-            # whole groups, ordered by first appearance: the latest groups form the holdout
-            labels = self._temporal_labels(X, n_blocks=max(2, int(round(1 / max(holdout_frac, 1e-9))))).to_numpy()
-            last = labels.max()
-            val_idx = np.flatnonzero(labels == last)
-            train_idx = np.flatnonzero(labels != last)
+        if self.time_on is not None or self.group_time_on is not None:
+            # Forward holdout: the latest block of the *same* blocking the bagged path uses,
+            # so cut placement and tie handling are defined in exactly one place and the
+            # holdout boundary always coincides with a bagged fold boundary. The block count
+            # follows from holdout_frac; the realised size is the nearest block boundary to
+            # it, which tracks the request more closely than cutting at the fraction and
+            # walking the boundary back over ties (that can only move one way, so a large
+            # tie block at the boundary overshoots badly).
+            n_blocks = max(2, int(round(1 / max(holdout_frac, 1e-9))))
+            labels = self._temporal_labels(X, n_blocks=n_blocks).to_numpy()
+            val_idx = np.flatnonzero(labels == labels.max())
+            train_idx = np.flatnonzero(labels != labels.max())
             if len(train_idx) == 0 or len(val_idx) == 0:
-                raise ValueError(f"`group_time_on` column {self.group_time_on!r} cannot produce a forward holdout.")
+                column = self.time_on if self.time_on is not None else self.group_time_on
+                raise ValueError(f"column {column!r} cannot produce a non-empty forward holdout.")
             return train_idx, val_idx
-        if self.time_on is not None:
-            values = self._time_values(X).to_numpy()
-            order = np.argsort(values, kind="stable")
-            cut = len(X) - max(1, int(round(len(X) * holdout_frac)))
-            # never split rows with identical time stamps across the boundary
-            while 0 < cut < len(X) and values[order[cut - 1]] == values[order[cut]]:
-                cut -= 1
-            if cut == 0:
-                raise ValueError(
-                    f"`time_on` column {self.time_on!r} cannot produce a non-empty forward holdout "
-                    f"(all rows in the holdout block share the earliest time value)."
-                )
-            return order[:cut], order[cut:]
 
         # Grouped holdout: one fold of the same split the bagged path would build, so the
         # holdout inherits the group-disjointness *and* the stratification handling rather

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -161,9 +161,11 @@ class DefaultLearner(AbstractTabularLearner):
             # Every bagged model consumes the same structure-aware splits (CVSplitter reads
             # `custom_splits` from ag_args_ensemble), so repeats are honored unlike the
             # groups channel, which forces leave-one-group-out with n_repeats == 1.
-            ag_args_ensemble = dict(trainer_fit_kwargs.get("ag_args_ensemble") or {})
+            core_kwargs = dict(trainer_fit_kwargs.get("core_kwargs") or {})
+            ag_args_ensemble = dict(core_kwargs.get("ag_args_ensemble") or {})
             ag_args_ensemble.setdefault("custom_splits", structure_splits)
-            trainer_fit_kwargs["ag_args_ensemble"] = ag_args_ensemble
+            core_kwargs["ag_args_ensemble"] = ag_args_ensemble
+            trainer_fit_kwargs["core_kwargs"] = core_kwargs
         if X_og is not None:
             infer_limit = self._update_infer_limit(
                 X=X_og, infer_limit_batch_size=infer_limit_batch_size, infer_limit=infer_limit

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -55,6 +55,7 @@ class DefaultLearner(AbstractTabularLearner):
         verbosity: int = 2,
         raise_on_model_failure: bool = False,
         time_limit_preprocessing: float | None = None,
+        validation_structure=None,
         **trainer_fit_kwargs,
     ):
         """Arguments:
@@ -141,6 +142,7 @@ class DefaultLearner(AbstractTabularLearner):
                 holdout_frac=holdout_frac,
                 num_bag_folds=num_bag_folds,
                 time_limit=time_limit_for_preprocessing,
+                validation_structure=validation_structure,
             )
         )
         if X_og is not None:
@@ -198,6 +200,7 @@ class DefaultLearner(AbstractTabularLearner):
             infer_limit=infer_limit,
             infer_limit_batch_size=infer_limit_batch_size,
             groups=groups,
+            validation_structure=validation_structure,
             label_cleaner=copy.deepcopy(self.label_cleaner),
             **trainer_fit_kwargs,
         )
@@ -269,6 +272,7 @@ class DefaultLearner(AbstractTabularLearner):
         holdout_frac: float = 1,
         num_bag_folds: int = 0,
         time_limit: float | None = None,
+        validation_structure=None,
     ):
         """General data processing steps used for all models."""
         X = self._check_for_non_finite_values(X, name="train", is_train=True)
@@ -307,6 +311,14 @@ class DefaultLearner(AbstractTabularLearner):
         X = self.set_predefined_weights(X, y)
         X, w = extract_column(X, self.sample_weight)
         X, groups = extract_column(X, self.groups)
+        if validation_structure is not None and num_bag_folds >= 2:
+            # Structure-aware bagging: per-row fold-id labels ride the existing `groups`
+            # channel (leave-one-fold-out in CVSplitter). Computed on the raw cleaned
+            # frame, before feature transformation can alter the referenced columns.
+            if groups is not None:
+                raise ValueError("Specify either `groups` or `validation_structure`, not both.")
+            groups = validation_structure.fold_ids(X, y, n_splits=num_bag_folds, random_state=self.random_state)
+            num_bag_folds = int(groups.nunique())
         if self.label_cleaner.num_classes is not None and self.problem_type != BINARY:
             logger.log(20, f"Train Data Class Count: {self.label_cleaner.num_classes}")
 

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -154,6 +154,7 @@ class DefaultLearner(AbstractTabularLearner):
             holdout_frac=holdout_frac,
             num_bag_folds=num_bag_folds,
             num_bag_sets=num_bag_sets,
+            use_bag_holdout=trainer_fit_kwargs.get("use_bag_holdout", False),
             time_limit=time_limit_for_preprocessing,
             validation_structure=validation_structure,
         )
@@ -293,6 +294,7 @@ class DefaultLearner(AbstractTabularLearner):
         holdout_frac: float = 1,
         num_bag_folds: int = 0,
         num_bag_sets: int = 1,
+        use_bag_holdout: bool = False,
         time_limit: float | None = None,
         validation_structure=None,
     ):
@@ -334,6 +336,7 @@ class DefaultLearner(AbstractTabularLearner):
         X, w = extract_column(X, self.sample_weight)
         X, groups = extract_column(X, self.groups)
         structure_splits = None
+        bag_holdout = None
         if validation_structure is not None and num_bag_folds >= 2:
             # Structure-aware bagging: explicit (train_idx, val_idx) splits, computed on the
             # raw cleaned frame before feature transformation can alter the referenced
@@ -341,6 +344,25 @@ class DefaultLearner(AbstractTabularLearner):
             # forces leave-one-group-out with n_repeats == 1, ruling out repeated bagging.
             if groups is not None:
                 raise ValueError("Specify either `groups` or `validation_structure`, not both.")
+            if use_bag_holdout and X_val is None:
+                # Carve the bag-holdout here, before the splits are resolved, so the split
+                # indices address the rows that actually reach bagging. Resolving splits first
+                # and letting the trainer remove rows afterwards leaves indices pointing past
+                # the end of the reduced frame.
+                bag_holdout_split = validation_structure.holdout_split_indices(
+                    X, y, holdout_frac=holdout_frac, random_state=self.random_state
+                )
+                if bag_holdout_split is not None:
+                    train_idx, val_idx = bag_holdout_split
+                    bag_holdout = (X.iloc[val_idx].copy(), y.iloc[val_idx].copy())
+                    X, y = X.iloc[train_idx].copy(), y.iloc[train_idx].copy()
+                    if w is not None:
+                        w = w.iloc[train_idx].copy()
+                    logger.log(
+                        20,
+                        f"use_bag_holdout with validation_structure: holding out {len(val_idx)} rows "
+                        f"(structure-aware, holdout_frac={holdout_frac}); bagging over {len(X)} rows.",
+                    )
             custom_splits, num_bag_folds, num_bag_sets = validation_structure.custom_splits(
                 X,
                 y,
@@ -360,6 +382,10 @@ class DefaultLearner(AbstractTabularLearner):
             name="val",
             is_test=False,
         )
+        if bag_holdout is not None:
+            # Already label-cleaned (carved off the cleaned frame above), so it skips the
+            # cleaner transform and is handed to the trainer as its bag-holdout directly.
+            X_val, y_val = bag_holdout
         X_test, y_test, w_test, _ = self._apply_cleaner_transform(
             X=X_test,
             y_uncleaned=y_uncleaned,

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -350,7 +350,11 @@ class DefaultLearner(AbstractTabularLearner):
                 # and letting the trainer remove rows afterwards leaves indices pointing past
                 # the end of the reduced frame.
                 bag_holdout_split = validation_structure.holdout_split_indices(
-                    X, y, holdout_frac=holdout_frac, random_state=self.random_state
+                    X,
+                    y,
+                    holdout_frac=holdout_frac,
+                    random_state=self.random_state,
+                    problem_type=self.problem_type,
                 )
                 if bag_holdout_split is not None:
                     train_idx, val_idx = bag_holdout_split
@@ -369,6 +373,7 @@ class DefaultLearner(AbstractTabularLearner):
                 num_folds=num_bag_folds,
                 num_repeats=num_bag_sets,
                 random_state=self.random_state,
+                problem_type=self.problem_type,
             )
             structure_splits = custom_splits
         if self.label_cleaner.num_classes is not None and self.problem_type != BINARY:

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -133,18 +133,37 @@ class DefaultLearner(AbstractTabularLearner):
         elif time_limit_for_preprocessing is not None:
             log_time_str = f" for up to {time_limit_for_preprocessing}s"
         logger.log(20, f"Preprocessing data{log_time_str}...")
-        X, y, X_val, y_val, X_test, y_test, X_unlabeled, holdout_frac, num_bag_folds, groups = (
-            self.general_data_processing(
-                X=X,
-                X_val=X_val,
-                X_test=X_test,
-                X_unlabeled=X_unlabeled,
-                holdout_frac=holdout_frac,
-                num_bag_folds=num_bag_folds,
-                time_limit=time_limit_for_preprocessing,
-                validation_structure=validation_structure,
-            )
+        (
+            X,
+            y,
+            X_val,
+            y_val,
+            X_test,
+            y_test,
+            X_unlabeled,
+            holdout_frac,
+            num_bag_folds,
+            num_bag_sets,
+            groups,
+            structure_splits,
+        ) = self.general_data_processing(
+            X=X,
+            X_val=X_val,
+            X_test=X_test,
+            X_unlabeled=X_unlabeled,
+            holdout_frac=holdout_frac,
+            num_bag_folds=num_bag_folds,
+            num_bag_sets=num_bag_sets,
+            time_limit=time_limit_for_preprocessing,
+            validation_structure=validation_structure,
         )
+        if structure_splits is not None:
+            # Every bagged model consumes the same structure-aware splits (CVSplitter reads
+            # `custom_splits` from ag_args_ensemble), so repeats are honored unlike the
+            # groups channel, which forces leave-one-group-out with n_repeats == 1.
+            ag_args_ensemble = dict(trainer_fit_kwargs.get("ag_args_ensemble") or {})
+            ag_args_ensemble.setdefault("custom_splits", structure_splits)
+            trainer_fit_kwargs["ag_args_ensemble"] = ag_args_ensemble
         if X_og is not None:
             infer_limit = self._update_infer_limit(
                 X=X_og, infer_limit_batch_size=infer_limit_batch_size, infer_limit=infer_limit
@@ -255,9 +274,9 @@ class DefaultLearner(AbstractTabularLearner):
                 infer_limit_new = 0
                 logger.log(
                     30,
-                    f"WARNING: Impossible to satisfy inference constraint, budget is exceeded during data preprocessing!\n"
-                    f"\tAutoGluon will be unable to satisfy the constraint, but will return the fastest model it can.\n"
-                    f"\tConsider using fewer features, relaxing the inference constraint, or simplifying the feature generator.",
+                    "WARNING: Impossible to satisfy inference constraint, budget is exceeded during data preprocessing!\n"
+                    "\tAutoGluon will be unable to satisfy the constraint, but will return the fastest model it can.\n"
+                    "\tConsider using fewer features, relaxing the inference constraint, or simplifying the feature generator.",
                 )
             infer_limit = infer_limit_new
         return infer_limit
@@ -271,6 +290,7 @@ class DefaultLearner(AbstractTabularLearner):
         X_unlabeled: DataFrame = None,
         holdout_frac: float = 1,
         num_bag_folds: int = 0,
+        num_bag_sets: int = 1,
         time_limit: float | None = None,
         validation_structure=None,
     ):
@@ -311,14 +331,22 @@ class DefaultLearner(AbstractTabularLearner):
         X = self.set_predefined_weights(X, y)
         X, w = extract_column(X, self.sample_weight)
         X, groups = extract_column(X, self.groups)
+        structure_splits = None
         if validation_structure is not None and num_bag_folds >= 2:
-            # Structure-aware bagging: per-row fold-id labels ride the existing `groups`
-            # channel (leave-one-fold-out in CVSplitter). Computed on the raw cleaned
-            # frame, before feature transformation can alter the referenced columns.
+            # Structure-aware bagging: explicit (train_idx, val_idx) splits, computed on the
+            # raw cleaned frame before feature transformation can alter the referenced
+            # columns. Explicit splits rather than the `groups` channel because that channel
+            # forces leave-one-group-out with n_repeats == 1, ruling out repeated bagging.
             if groups is not None:
                 raise ValueError("Specify either `groups` or `validation_structure`, not both.")
-            groups = validation_structure.fold_ids(X, y, n_splits=num_bag_folds, random_state=self.random_state)
-            num_bag_folds = int(groups.nunique())
+            custom_splits, num_bag_folds, num_bag_sets = validation_structure.custom_splits(
+                X,
+                y,
+                num_folds=num_bag_folds,
+                num_repeats=num_bag_sets,
+                random_state=self.random_state,
+            )
+            structure_splits = custom_splits
         if self.label_cleaner.num_classes is not None and self.problem_type != BINARY:
             logger.log(20, f"Train Data Class Count: {self.label_cleaner.num_classes}")
 
@@ -341,7 +369,7 @@ class DefaultLearner(AbstractTabularLearner):
 
         self._original_features = list(X.columns)
         # TODO: Move this up to top of data before removing data, this way our feature generator is better
-        logger.log(20, f"Using Feature Generators to preprocess the data ...")
+        logger.log(20, "Using Feature Generators to preprocess the data ...")
 
         if X_test is not None:
             logger.log(
@@ -401,7 +429,20 @@ class DefaultLearner(AbstractTabularLearner):
         X = self.bundle_weights(X, w, "X", is_train=True)
         X_val = self.bundle_weights(X_val, w_val, "X_val", is_train=False)
         X_test = self.bundle_weights(X_test, w_test, "X_test", is_train=False)
-        return X, y, X_val, y_val, X_test, y_test, X_unlabeled, holdout_frac, num_bag_folds, groups
+        return (
+            X,
+            y,
+            X_val,
+            y_val,
+            X_test,
+            y_test,
+            X_unlabeled,
+            holdout_frac,
+            num_bag_folds,
+            num_bag_sets,
+            groups,
+            structure_splits,
+        )
 
     def bundle_weights(self, X: DataFrame | None, w: Series | None, name: str, is_train=False) -> DataFrame:
         if is_train:

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -54,6 +54,7 @@ from autogluon.core.constants import (
 from autogluon.core.data.label_cleaner import LabelCleanerMulticlassToBinary
 from autogluon.core.metrics import Scorer, get_metric
 from autogluon.core.problem_type import problem_type_info
+from autogluon.core.utils.validation_structure import ValidationStructure
 from autogluon.core.pseudolabeling.pseudolabeling import filter_ensemble_pseudo, filter_pseudo
 from autogluon.core.scheduler.scheduler_factory import scheduler_factory
 from autogluon.core.stacked_overfitting.utils import check_stacked_overfitting_from_leaderboard
@@ -834,6 +835,14 @@ class TabularPredictor:
                 Values greater than 1 will result in superior predictive performance, especially on smaller problems and with stacking enabled (reduces overall variance).
                 Be warned: This will drastically increase overall runtime, and if using a time limit, can very commonly lead to worse performance.
                 It is recommended to increase this value only as a last resort, as it is the least computationally efficient method to improve performance.
+            validation_structure : dict | ValidationStructure, default = None
+                Declarative description of the dataset's validation-relevant structure, as a dict with keys
+                `group_on` (str | list[str]), `time_on` (str), and/or `stratify_on` (str).
+                When specified, validation splits honor the structure instead of assuming IID rows:
+                bagging folds become group-disjoint (`group_on`) or contiguous time blocks (`time_on`),
+                and the non-bagged holdout becomes group-disjoint or temporally forward (the latest time block).
+                Referenced columns remain features. `group_on` and `time_on` cannot be combined.
+                Mutually exclusive with the `groups` init argument.
             num_stack_levels : int, default = None
                 Number of stacking levels to use in stack ensemble. Roughly increases model training time by factor of `num_stack_levels+1` (set = 0 to disable stack ensembling).
                 Disabled by default (0), but we recommend `num_stack_levels=1` to maximize predictive performance.
@@ -1433,6 +1442,14 @@ class TabularPredictor:
         # Overwrite aux_kwargs_defaults with aux_kwargs values in case of shared keys
         aux_kwargs = {**aux_kwargs_defaults, **aux_kwargs}
 
+        # Structure-aware validation splitting (group-disjoint / temporal). See
+        # `autogluon.core.utils.validation_structure.ValidationStructure`.
+        validation_structure = ValidationStructure.from_input(kwargs["validation_structure"])
+        if validation_structure is not None and self._learner.groups is not None:
+            raise ValueError(
+                "Specify either `groups` (TabularPredictor init) or `validation_structure` (fit), not both."
+            )
+
         ag_fit_kwargs = dict(
             X=train_data,
             X_val=tuning_data,
@@ -1453,6 +1470,7 @@ class TabularPredictor:
             callbacks=callbacks,
             raise_on_model_failure=raise_on_model_failure,
             time_limit_preprocessing=time_limit_preprocessing,
+            validation_structure=validation_structure,
         )
         ag_post_fit_kwargs = dict(
             keep_only_best=kwargs["keep_only_best"],
@@ -5528,6 +5546,7 @@ class TabularPredictor:
             num_bag_sets=None,
             delay_bag_sets=False,
             num_stack_levels=None,
+            validation_structure=None,
             hyperparameter_tune_kwargs=None,
             ag_args=None,
             ag_args_fit=None,

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -40,6 +40,7 @@ from autogluon.common.utils.utils import (
     get_autogluon_metadata,
     setup_outputdir,
 )
+from autogluon.common.utils.validation_structure import ValidationStructure
 from autogluon.core.callbacks import AbstractCallback
 from autogluon.core.constants import (
     AUTO_WEIGHT,
@@ -66,7 +67,6 @@ from autogluon.core.utils import (
 from autogluon.core.utils.loaders import load_pkl, load_str
 from autogluon.core.utils.savers import save_pkl, save_str
 from autogluon.core.utils.utils import generate_train_test_split_combined
-from autogluon.core.utils.validation_structure import ValidationStructure
 
 from ..configs.feature_generator_presets import get_default_feature_generator
 from ..configs.hyperparameter_configs import get_hyperparameter_config
@@ -837,7 +837,8 @@ class TabularPredictor:
                 It is recommended to increase this value only as a last resort, as it is the least computationally efficient method to improve performance.
             validation_structure : dict | ValidationStructure, default = None
                 Declarative description of the dataset's validation-relevant structure, as a dict with keys
-                `group_on` (str | list[str]), `time_on` (str), and/or `stratify_on` (str).
+                `group_on` (str | list[str]), `time_on` (str), `group_time_on` (str, for data that is both
+                grouped and temporal), and/or `stratify_on` (str).
                 When specified, validation splits honor the structure instead of assuming IID rows:
                 bagging folds become group-disjoint (`group_on`) or contiguous time blocks (`time_on`),
                 and the non-bagged holdout becomes group-disjoint or temporally forward (the latest time block).
@@ -1443,7 +1444,7 @@ class TabularPredictor:
         aux_kwargs = {**aux_kwargs_defaults, **aux_kwargs}
 
         # Structure-aware validation splitting (group-disjoint / temporal). See
-        # `autogluon.core.utils.validation_structure.ValidationStructure`.
+        # `autogluon.common.utils.validation_structure.ValidationStructure`.
         validation_structure = ValidationStructure.from_input(kwargs["validation_structure"])
         if validation_structure is not None and self._learner.groups is not None:
             raise ValueError(

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -54,7 +54,6 @@ from autogluon.core.constants import (
 from autogluon.core.data.label_cleaner import LabelCleanerMulticlassToBinary
 from autogluon.core.metrics import Scorer, get_metric
 from autogluon.core.problem_type import problem_type_info
-from autogluon.core.utils.validation_structure import ValidationStructure
 from autogluon.core.pseudolabeling.pseudolabeling import filter_ensemble_pseudo, filter_pseudo
 from autogluon.core.scheduler.scheduler_factory import scheduler_factory
 from autogluon.core.stacked_overfitting.utils import check_stacked_overfitting_from_leaderboard
@@ -67,6 +66,7 @@ from autogluon.core.utils import (
 from autogluon.core.utils.loaders import load_pkl, load_str
 from autogluon.core.utils.savers import save_pkl, save_str
 from autogluon.core.utils.utils import generate_train_test_split_combined
+from autogluon.core.utils.validation_structure import ValidationStructure
 
 from ..configs.feature_generator_presets import get_default_feature_generator
 from ..configs.hyperparameter_configs import get_hyperparameter_config

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1594,9 +1594,28 @@ class TabularPredictor:
         # -- Validation Method
         if validation_procedure == "holdout":
             if holdout_data is None:
-                ds_fit_kwargs.update(
-                    dict(holdout_frac=holdout_frac, ds_fit_context=os.path.join(ds_fit_context, "sub_fit_ho"))
+                ds_fit_kwargs["ds_fit_context"] = os.path.join(ds_fit_context, "sub_fit_ho")
+                # A random holdout would leak across groups / forward in time exactly as the
+                # validation this sub-fit audits, so honor the declared structure. Reuses the
+                # train_indices/val_indices channel the CV procedure already goes through, so
+                # the sub-fit itself needs no change. `holdout_split_indices` returns None for
+                # stratify-only structures, where the default split needs no correction.
+                validation_structure = ag_fit_kwargs.get("validation_structure")
+                structure_holdout = (
+                    None
+                    if validation_structure is None
+                    else validation_structure.holdout_split_indices(
+                        X.drop(self.label, axis=1),
+                        X[self.label],
+                        holdout_frac=holdout_frac,
+                        random_state=42,
+                    )
                 )
+                if structure_holdout is not None:
+                    train_indices, val_indices = structure_holdout
+                    ds_fit_kwargs.update(dict(train_indices=train_indices, val_indices=val_indices))
+                else:
+                    ds_fit_kwargs["holdout_frac"] = holdout_frac
             else:
                 _, holdout_data, _, _ = self._validate_fit_data(train_data=X, tuning_data=holdout_data)
                 ds_fit_kwargs["ds_fit_context"] = os.path.join(ds_fit_context, "sub_fit_custom_ho")

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1609,6 +1609,7 @@ class TabularPredictor:
                         X[self.label],
                         holdout_frac=holdout_frac,
                         random_state=42,
+                        problem_type=self.problem_type,
                     )
                 )
                 if structure_holdout is not None:
@@ -1646,6 +1647,7 @@ class TabularPredictor:
                     num_folds=n_folds,
                     num_repeats=n_repeats,
                     random_state=42,
+                    problem_type=self.problem_type,
                 )
             else:
                 splits = CVSplitter(

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1615,18 +1615,35 @@ class TabularPredictor:
             is_stratified = self.problem_type in [BINARY, MULTICLASS]
             is_binned = self.problem_type in [REGRESSION, QUANTILE]
             self._learner._validate_groups(X=X, X_val=X_val)  # Validate splits before splitting
-            splits = CVSplitter(
-                n_splits=n_folds,
-                n_repeats=n_repeats,
-                groups=self._learner.groups,
-                stratify=is_stratified,
-                bin=is_binned,
-                random_state=42,
-            ).split(X=X.drop(self.label, axis=1), y=X[self.label])
+            validation_structure = ag_fit_kwargs.get("validation_structure")
+            if validation_structure is not None:
+                # Honor the declared grouped/temporal structure here too. A random sub-fit split
+                # would leak across groups or forward in time exactly as the validation it is
+                # meant to audit, so the leakage detector would be blind on the data where
+                # structure-aware validation matters most.
+                splits, _, _ = validation_structure.custom_splits(
+                    X.drop(self.label, axis=1),
+                    X[self.label],
+                    num_folds=n_folds,
+                    num_repeats=n_repeats,
+                    random_state=42,
+                )
+            else:
+                splits = CVSplitter(
+                    n_splits=n_folds,
+                    n_repeats=n_repeats,
+                    groups=self._learner.groups,
+                    stratify=is_stratified,
+                    bin=is_binned,
+                    random_state=42,
+                ).split(X=X.drop(self.label, axis=1), y=X[self.label])
+            # `splits` may hold fewer than n_folds x n_repeats entries: the structure can clamp
+            # the fold count (few groups, a rare stratification value), so budget off the actual
+            # number rather than the requested one.
             n_splits = len(splits)
             logger.info(
                 f'\tStarting (repeated-)cross-validation-based sub-fits for dynamic stacking. Context path: "{ds_fit_context}"'
-                f"Run at most {n_splits} sub-fits based on {n_repeats}-repeated {n_folds}-fold cross-validation."
+                f"Run at most {n_splits} sub-fits."
             )
             np.random.RandomState(42).shuffle(
                 splits

--- a/tabular/src/autogluon/tabular/trainer/auto_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/auto_trainer.py
@@ -58,6 +58,7 @@ class AutoTrainer(AbstractTabularTrainer):
         infer_limit_batch_size=None,
         use_bag_holdout=False,
         groups=None,
+        validation_structure=None,
         callbacks: list[callable] = None,
         label_cleaner=None,
         **kwargs,
@@ -88,18 +89,34 @@ class AutoTrainer(AbstractTabularTrainer):
                     min_cls_count_train = 2
                 else:
                     min_cls_count_train = 1
-                X, X_val, y, y_val = generate_train_test_split(
-                    X,
-                    y,
-                    problem_type=self.problem_type,
-                    test_size=holdout_frac,
-                    random_state=self.random_state,
-                    min_cls_count_train=min_cls_count_train,
-                )
-                logger.log(
-                    20,
-                    f"Automatically generating train/validation split with holdout_frac={holdout_frac}, Train Rows: {len(X)}, Val Rows: {len(X_val)}",
-                )
+                structure_split = None
+                if validation_structure is not None:
+                    # Group-disjoint or temporally-forward holdout; None when the
+                    # structure needs no correction (stratify-only).
+                    structure_split = validation_structure.holdout_split_indices(
+                        X, y, holdout_frac=holdout_frac, random_state=self.random_state
+                    )
+                if structure_split is not None:
+                    train_idx, val_idx = structure_split
+                    X, X_val, y, y_val = X.iloc[train_idx], X.iloc[val_idx], y.iloc[train_idx], y.iloc[val_idx]
+                    logger.log(
+                        20,
+                        f"Generating structure-aware train/validation split with holdout_frac={holdout_frac}, "
+                        f"Train Rows: {len(X)}, Val Rows: {len(X_val)}",
+                    )
+                else:
+                    X, X_val, y, y_val = generate_train_test_split(
+                        X,
+                        y,
+                        problem_type=self.problem_type,
+                        test_size=holdout_frac,
+                        random_state=self.random_state,
+                        min_cls_count_train=min_cls_count_train,
+                    )
+                    logger.log(
+                        20,
+                        f"Automatically generating train/validation split with holdout_frac={holdout_frac}, Train Rows: {len(X)}, Val Rows: {len(X_val)}",
+                    )
         elif self.bagged_mode:
             if not use_bag_holdout:
                 # TODO: User could be intending to blend instead. Add support for blend stacking.

--- a/tabular/src/autogluon/tabular/trainer/auto_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/auto_trainer.py
@@ -94,7 +94,11 @@ class AutoTrainer(AbstractTabularTrainer):
                     # Group-disjoint or temporally-forward holdout; None when the
                     # structure needs no correction (stratify-only).
                     structure_split = validation_structure.holdout_split_indices(
-                        X, y, holdout_frac=holdout_frac, random_state=self.random_state
+                        X,
+                        y,
+                        holdout_frac=holdout_frac,
+                        random_state=self.random_state,
+                        problem_type=self.problem_type,
                     )
                 if structure_split is not None:
                     train_idx, val_idx = structure_split

--- a/tabular/tests/unittests/test_validation_structure.py
+++ b/tabular/tests/unittests/test_validation_structure.py
@@ -173,9 +173,10 @@ def test__validation_structure__group_time_on():
     groups = X["gid"].to_numpy()
     for train_idx, val_idx in splits:
         assert not (set(groups[train_idx]) & set(groups[val_idx]))
-    # blocks advance in time: each fold's groups are later than the previous fold's
-    fold_max = [groups[val_idx].max() for _, val_idx in splits]
-    assert fold_max == sorted(fold_max)
+    # each fold is one contiguous block of groups in time; blocks tile the timeline
+    ranges = sorted((groups[val_idx].min(), groups[val_idx].max()) for _, val_idx in splits)
+    for (_, prev_max), (next_min, _) in zip(ranges, ranges[1:]):
+        assert prev_max < next_min
 
     train_idx, val_idx = vs.holdout_split_indices(X, y, holdout_frac=0.25)
     assert groups[val_idx].min() > groups[train_idx].max()  # forward holdout
@@ -189,3 +190,38 @@ def test__validation_structure__group_and_time_guidance():
         ValidationStructure(group_on="g", time_on="t")
     with pytest.raises(ValueError, match="mutually exclusive"):
         ValidationStructure(group_time_on="g", group_on="g2")
+
+
+def test__validation_structure__time_blocks_are_contiguous_and_tie_safe():
+    """Time blocks split observed values, keep ties together, and balance row counts."""
+    from autogluon.core.utils.validation_structure import ValidationStructure
+
+    # heavily tied timestamps: 4 distinct values, uneven row counts
+    times = np.repeat([10, 20, 30, 40], [50, 10, 10, 30])
+    X = pd.DataFrame({"f1": np.arange(len(times), dtype=float), "t": times})
+    y = pd.Series(np.zeros(len(times)))
+
+    splits, folds, repeats = ValidationStructure(time_on="t").custom_splits(X, y, num_folds=3, num_repeats=4)
+    assert repeats == 1  # temporal partition is deterministic
+    assert folds == 3
+
+    t = X["t"].to_numpy()
+    seen = set()
+    for _, val_idx in splits:
+        block_values = set(t[val_idx])
+        # a block never splits rows sharing a timestamp
+        for value in block_values:
+            assert set(np.flatnonzero(t == value)) <= set(val_idx)
+        assert not (block_values & seen)  # blocks are disjoint in time
+        seen |= block_values
+    assert seen == set(t)  # every timestamp is validated exactly once
+    # blocks are contiguous in time (fold order itself is not meaningful)
+    ranges = sorted((t[val_idx].min(), t[val_idx].max()) for _, val_idx in splits)
+    for (_, prev_max), (next_min, _) in zip(ranges, ranges[1:]):
+        assert prev_max < next_min
+
+    # fewer distinct time values than requested blocks: fold count drops to what exists
+    X_few = pd.DataFrame({"f1": [0.0, 1.0, 2.0, 3.0], "t": [1, 1, 2, 2]})
+    y_few = pd.Series([0, 1, 0, 1])
+    _, folds_few, _ = ValidationStructure(time_on="t").custom_splits(X_few, y_few, num_folds=5)
+    assert folds_few == 2

--- a/tabular/tests/unittests/test_validation_structure.py
+++ b/tabular/tests/unittests/test_validation_structure.py
@@ -298,9 +298,9 @@ def _captured_splits(monkeypatch) -> list[dict]:
     captured: list[dict] = []
     original = ValidationStructure.custom_splits
 
-    def spy(self, X, y, num_folds=None, num_repeats=None, random_state=0):
+    def spy(self, X, y, num_folds=None, num_repeats=None, random_state=0, **kwargs):
         splits, folds, repeats = original(
-            self, X, y, num_folds=num_folds, num_repeats=num_repeats, random_state=random_state
+            self, X, y, num_folds=num_folds, num_repeats=num_repeats, random_state=random_state, **kwargs
         )
         captured.append({"n_rows": len(X), "splits": splits, "random_state": random_state})
         return splits, folds, repeats
@@ -352,8 +352,8 @@ def test__predictor_fit__dynamic_stacking__honors_the_structure(validation_proce
     holdouts: list[tuple[np.ndarray, np.ndarray]] = []
     original_holdout = ValidationStructure.holdout_split_indices
 
-    def holdout_spy(self, X, y, holdout_frac, random_state=0):
-        split = original_holdout(self, X, y, holdout_frac=holdout_frac, random_state=random_state)
+    def holdout_spy(self, X, y, holdout_frac, random_state=0, **kwargs):
+        split = original_holdout(self, X, y, holdout_frac=holdout_frac, random_state=random_state, **kwargs)
         if split is not None:
             holdouts.append(split)
         return split

--- a/tabular/tests/unittests/test_validation_structure.py
+++ b/tabular/tests/unittests/test_validation_structure.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from autogluon.core.utils.validation_structure import ValidationStructure
+from autogluon.common.utils.validation_structure import ValidationStructure
 
 
 def _toy_grouped(n_groups: int = 20, rows_per_group: int = 10, seed: int = 0) -> tuple[pd.DataFrame, pd.Series]:
@@ -134,7 +134,7 @@ def test__predictor_fit__groups_and_structure__raises():
 
 def test__validation_structure__repeats_and_clamping():
     """Repeated grouped bagging, which the groups channel cannot express."""
-    from autogluon.core.utils.validation_structure import ValidationStructure
+    from autogluon.common.utils.validation_structure import ValidationStructure
 
     rng = np.random.default_rng(0)
     n = 120
@@ -161,7 +161,7 @@ def test__validation_structure__repeats_and_clamping():
 
 def test__validation_structure__group_time_on():
     """`group_time_on` splits are simultaneously group-disjoint and forward in time."""
-    from autogluon.core.utils.validation_structure import ValidationStructure
+    from autogluon.common.utils.validation_structure import ValidationStructure
 
     n_groups = 12
     X = pd.DataFrame({"f1": np.arange(n_groups * 5, dtype=float), "gid": np.repeat(np.arange(n_groups), 5)})
@@ -184,7 +184,7 @@ def test__validation_structure__group_time_on():
 
 def test__validation_structure__group_and_time_guidance():
     """`group_on` + `time_on` points at `group_time_on` instead of inventing semantics."""
-    from autogluon.core.utils.validation_structure import ValidationStructure
+    from autogluon.common.utils.validation_structure import ValidationStructure
 
     with pytest.raises(NotImplementedError, match="group_time_on"):
         ValidationStructure(group_on="g", time_on="t")
@@ -194,7 +194,7 @@ def test__validation_structure__group_and_time_guidance():
 
 def test__validation_structure__time_blocks_are_contiguous_and_tie_safe():
     """Time blocks split observed values, keep ties together, and balance row counts."""
-    from autogluon.core.utils.validation_structure import ValidationStructure
+    from autogluon.common.utils.validation_structure import ValidationStructure
 
     # heavily tied timestamps: 4 distinct values, uneven row counts
     times = np.repeat([10, 20, 30, 40], [50, 10, 10, 30])
@@ -293,7 +293,7 @@ def _grouped_toy_data(n: int = 90, n_groups: int = 15, seed: int = 0) -> pd.Data
 
 def _captured_splits(monkeypatch) -> list[dict]:
     """Record every `custom_splits` resolution, so tests can assert on what was actually used."""
-    from autogluon.core.utils.validation_structure import ValidationStructure
+    from autogluon.common.utils.validation_structure import ValidationStructure
 
     captured: list[dict] = []
     original = ValidationStructure.custom_splits
@@ -343,7 +343,7 @@ def test__predictor_fit__use_bag_holdout__splits_index_the_bagged_rows(monkeypat
 @pytest.mark.parametrize("validation_procedure", ["cv", "holdout"])
 def test__predictor_fit__dynamic_stacking__honors_the_structure(validation_procedure, monkeypatch):
     """DyStack audits for stacked overfitting, so its own sub-fit splits must not leak either."""
-    from autogluon.core.utils.validation_structure import ValidationStructure
+    from autogluon.common.utils.validation_structure import ValidationStructure
     from autogluon.tabular import TabularPredictor
 
     df = _grouped_toy_data(n=60, n_groups=10)

--- a/tabular/tests/unittests/test_validation_structure.py
+++ b/tabular/tests/unittests/test_validation_structure.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from autogluon.core.utils.validation_structure import ValidationStructure
+
+
+def _toy_grouped(n_groups: int = 20, rows_per_group: int = 10, seed: int = 0) -> tuple[pd.DataFrame, pd.Series]:
+    rng = np.random.default_rng(seed)
+    group = np.repeat(np.arange(n_groups), rows_per_group)
+    X = pd.DataFrame(
+        {
+            "num": rng.normal(size=len(group)),
+            "gid": [f"g{g}" for g in group],
+        }
+    )
+    y = pd.Series((rng.random(len(group)) + (group % 2) > 0.75).astype(int))
+    return X, y
+
+
+def _toy_temporal(n: int = 200, seed: int = 0) -> tuple[pd.DataFrame, pd.Series]:
+    rng = np.random.default_rng(seed)
+    X = pd.DataFrame(
+        {
+            "num": rng.normal(size=n),
+            # duplicated timestamps to exercise tie handling
+            "ts": pd.to_datetime("2026-01-01") + pd.to_timedelta(np.sort(rng.integers(0, n // 4, size=n)), unit="D"),
+        }
+    )
+    y = pd.Series(rng.integers(0, 2, size=n))
+    return X, y
+
+
+def test__from_input__dict_and_invalid_keys():
+    vs = ValidationStructure.from_input({"group_on": "gid"})
+    assert vs.group_on == "gid"
+    assert ValidationStructure.from_input(None) is None
+    with pytest.raises(ValueError, match="Invalid `validation_structure` keys"):
+        ValidationStructure.from_input({"group": "gid"})
+    with pytest.raises(NotImplementedError):
+        ValidationStructure.from_input({"group_on": "gid", "time_on": "ts"})
+
+
+def test__fold_ids__group_on__folds_are_group_disjoint():
+    X, y = _toy_grouped()
+    vs = ValidationStructure(group_on="gid")
+    fold_ids = vs.fold_ids(X, y, n_splits=5)
+    assert len(fold_ids) == len(X)
+    assert fold_ids.nunique() == 5
+    # every group lands in exactly one fold
+    assert (X.groupby("gid", observed=True).apply(lambda g: fold_ids.loc[g.index].nunique()) == 1).all()
+
+
+def test__fold_ids__group_on__clamps_to_group_count():
+    X, y = _toy_grouped(n_groups=3)
+    fold_ids = ValidationStructure(group_on="gid").fold_ids(X, y, n_splits=8)
+    assert fold_ids.nunique() == 3
+
+
+def test__fold_ids__time_on__blocks_are_contiguous_and_tie_safe():
+    X, y = _toy_temporal()
+    vs = ValidationStructure(time_on="ts")
+    fold_ids = vs.fold_ids(X, y, n_splits=8)
+    order = np.argsort(X["ts"].to_numpy(), kind="stable")
+    # fold labels are non-decreasing in time order -> contiguous blocks
+    assert (np.diff(fold_ids.to_numpy()[order]) >= 0).all()
+    # identical timestamps never straddle two folds
+    assert (X.groupby("ts").apply(lambda g: fold_ids.loc[g.index].nunique()) == 1).all()
+
+
+def test__holdout__time_on__is_forward():
+    X, y = _toy_temporal()
+    train_idx, val_idx = ValidationStructure(time_on="ts").holdout_split_indices(X, y, holdout_frac=0.2)
+    assert len(train_idx) + len(val_idx) == len(X)
+    assert X["ts"].iloc[train_idx].max() <= X["ts"].iloc[val_idx].min()
+
+
+def test__holdout__group_on__is_group_disjoint():
+    X, y = _toy_grouped()
+    train_idx, val_idx = ValidationStructure(group_on="gid").holdout_split_indices(X, y, holdout_frac=0.2)
+    assert not set(X["gid"].iloc[train_idx]) & set(X["gid"].iloc[val_idx])
+
+
+def test__holdout__stratify_only__defers_to_default():
+    X, y = _toy_grouped()
+    assert ValidationStructure(stratify_on="gid").holdout_split_indices(X, y, holdout_frac=0.2) is None
+
+
+def test__predictor_fit__group_on__bagged_and_holdout():
+    from autogluon.tabular import TabularPredictor
+
+    X, y = _toy_grouped()
+    train_data = X.copy()
+    train_data["label"] = y
+
+    # bagged path: fold-ids ride the groups channel
+    predictor = TabularPredictor(label="label", verbosity=0).fit(
+        train_data,
+        hyperparameters={"DUMMY": {}},
+        num_bag_folds=4,
+        validation_structure={"group_on": "gid"},
+    )
+    assert predictor.model_best is not None
+    trainer_groups = predictor._trainer._groups
+    assert trainer_groups is not None
+    assert trainer_groups.nunique() == 4
+    # groups never straddle folds
+    joined = pd.DataFrame({"gid": X["gid"].to_numpy(), "fold": trainer_groups.to_numpy()})
+    assert (joined.groupby("gid", observed=True)["fold"].nunique() == 1).all()
+
+    # holdout path: structure-aware split, no crash
+    predictor = TabularPredictor(label="label", verbosity=0).fit(
+        train_data,
+        hyperparameters={"DUMMY": {}},
+        validation_structure={"group_on": "gid"},
+    )
+    assert predictor.model_best is not None
+
+
+def test__predictor_fit__groups_and_structure__raises():
+    from autogluon.tabular import TabularPredictor
+
+    X, y = _toy_grouped()
+    train_data = X.copy()
+    train_data["label"] = y
+    with pytest.raises(ValueError, match="not both"):
+        TabularPredictor(label="label", groups="gid", verbosity=0).fit(
+            train_data,
+            hyperparameters={"DUMMY": {}},
+            num_bag_folds=4,
+            validation_structure={"group_on": "gid"},
+        )

--- a/tabular/tests/unittests/test_validation_structure.py
+++ b/tabular/tests/unittests/test_validation_structure.py
@@ -277,3 +277,117 @@ def test__predictor_fit__no_structure_leaves_default_splitting_untouched():
     assert bagged_model.params.get("custom_splits") is None
     assert predictor._trainer._groups is None
     assert len(predictor.info()["model_info"]["Dummy_BAG_L1"]["children_info"]) == 10
+
+
+def _grouped_toy_data(n: int = 90, n_groups: int = 15, seed: int = 0) -> pd.DataFrame:
+    """Small grouped classification frame: 15 groups of 6 rows, both classes per group."""
+    rng = np.random.default_rng(seed)
+    return pd.DataFrame(
+        {
+            "f1": rng.normal(size=n),
+            "gid": np.repeat(np.arange(n_groups), n // n_groups),
+            "label": np.tile([0, 1], n // 2),
+        }
+    )
+
+
+def _captured_splits(monkeypatch) -> list[dict]:
+    """Record every `custom_splits` resolution, so tests can assert on what was actually used."""
+    from autogluon.core.utils.validation_structure import ValidationStructure
+
+    captured: list[dict] = []
+    original = ValidationStructure.custom_splits
+
+    def spy(self, X, y, num_folds=None, num_repeats=None, random_state=0):
+        splits, folds, repeats = original(
+            self, X, y, num_folds=num_folds, num_repeats=num_repeats, random_state=random_state
+        )
+        captured.append({"n_rows": len(X), "splits": splits, "random_state": random_state})
+        return splits, folds, repeats
+
+    monkeypatch.setattr(ValidationStructure, "custom_splits", spy)
+    return captured
+
+
+def test__predictor_fit__use_bag_holdout__splits_index_the_bagged_rows(monkeypatch):
+    """With `use_bag_holdout` the trainer holds rows back, so the splits must index what remains.
+
+    Resolving splits over the full frame and holding rows back afterwards leaves indices
+    pointing past the end of the reduced frame, which fails the fit outright.
+    """
+    from autogluon.tabular import TabularPredictor
+
+    df = _grouped_toy_data()
+    captured = _captured_splits(monkeypatch)
+
+    predictor = TabularPredictor(label="label", verbosity=0).fit(
+        df,
+        hyperparameters={"DUMMY": {}},
+        num_bag_folds=3,
+        num_bag_sets=1,
+        validation_structure={"group_on": "gid"},
+        use_bag_holdout=True,
+        fit_weighted_ensemble=False,
+        raise_on_model_failure=True,
+    )
+
+    splits = predictor._trainer.load_model("Dummy_BAG_L1").params.get("custom_splits")
+    assert splits is not None
+    # the resolution that produced the bagged splits saw fewer rows than the input frame
+    bagged = captured[-1]
+    assert bagged["n_rows"] < len(df), "no rows were held back for the bag-holdout"
+    max_index = max(max(train_idx.max(), val_idx.max()) for train_idx, val_idx in splits)
+    assert max_index < bagged["n_rows"], "split indices address rows that are not in the bagged frame"
+
+
+@pytest.mark.parametrize("validation_procedure", ["cv", "holdout"])
+def test__predictor_fit__dynamic_stacking__honors_the_structure(validation_procedure, monkeypatch):
+    """DyStack audits for stacked overfitting, so its own sub-fit splits must not leak either."""
+    from autogluon.core.utils.validation_structure import ValidationStructure
+    from autogluon.tabular import TabularPredictor
+
+    df = _grouped_toy_data(n=60, n_groups=10)
+    groups = df["gid"].to_numpy()
+
+    holdouts: list[tuple[np.ndarray, np.ndarray]] = []
+    original_holdout = ValidationStructure.holdout_split_indices
+
+    def holdout_spy(self, X, y, holdout_frac, random_state=0):
+        split = original_holdout(self, X, y, holdout_frac=holdout_frac, random_state=random_state)
+        if split is not None:
+            holdouts.append(split)
+        return split
+
+    monkeypatch.setattr(ValidationStructure, "holdout_split_indices", holdout_spy)
+    captured = _captured_splits(monkeypatch)
+
+    TabularPredictor(label="label", verbosity=0).fit(
+        df,
+        hyperparameters={"DUMMY": {}},
+        num_bag_folds=2,
+        num_bag_sets=1,
+        num_stack_levels=1,  # DyStack is a no-op unless stacking would be used
+        validation_structure={"group_on": "gid"},
+        dynamic_stacking=True,
+        ds_args={
+            "validation_procedure": validation_procedure,
+            "n_folds": 2,
+            "n_repeats": 1,
+            "enable_ray_logging": False,
+            "memory_safe_fits": False,
+            "clean_up_fits": True,
+        },
+        fit_weighted_ensemble=False,
+    )
+
+    # DyStack resolves its sub-fit split with its own seed (42); every split it uses,
+    # and every split the sub-fits bag over, must be group-disjoint.
+    if validation_procedure == "cv":
+        ds_resolutions = [c for c in captured if c["random_state"] == 42]
+        assert ds_resolutions, "DyStack CV did not use the declared structure"
+        checked = [split for c in ds_resolutions for split in c["splits"]]
+    else:
+        assert holdouts, "DyStack holdout did not use the declared structure"
+        checked = holdouts
+    for train_idx, val_idx in checked:
+        assert not (set(groups[train_idx]) & set(groups[val_idx]))

--- a/tabular/tests/unittests/test_validation_structure.py
+++ b/tabular/tests/unittests/test_validation_structure.py
@@ -132,8 +132,8 @@ def test__predictor_fit__groups_and_structure__raises():
         )
 
 
-def test__validation_structure__repeats_and_auto_counts():
-    """Repeated grouped bagging (impossible via the groups channel) and derived counts."""
+def test__validation_structure__repeats_and_clamping():
+    """Repeated grouped bagging, which the groups channel cannot express."""
     from autogluon.core.utils.validation_structure import ValidationStructure
 
     rng = np.random.default_rng(0)
@@ -142,9 +142,6 @@ def test__validation_structure__repeats_and_auto_counts():
     y = pd.Series(rng.integers(0, 2, n))
 
     vs = ValidationStructure(group_on="gid")
-    # 20 groups <= tiny-data threshold -> tiny regime, derived without user input
-    assert vs.resolve_num_splits(X) == (5, 5)
-
     splits, folds, repeats = vs.custom_splits(X, y, num_folds=5, num_repeats=5)
     assert (folds, repeats) == (5, 5)
     assert len(splits) == 25

--- a/tabular/tests/unittests/test_validation_structure.py
+++ b/tabular/tests/unittests/test_validation_structure.py
@@ -95,20 +95,18 @@ def test__predictor_fit__group_on__bagged_and_holdout():
     train_data = X.copy()
     train_data["label"] = y
 
-    # bagged path: fold-ids ride the groups channel
+    # bagged path: explicit structure-aware splits, one child model per split
     predictor = TabularPredictor(label="label", verbosity=0).fit(
         train_data,
         hyperparameters={"DUMMY": {}},
         num_bag_folds=4,
+        num_bag_sets=1,
         validation_structure={"group_on": "gid"},
+        fit_weighted_ensemble=False,
     )
     assert predictor.model_best is not None
-    trainer_groups = predictor._trainer._groups
-    assert trainer_groups is not None
-    assert trainer_groups.nunique() == 4
-    # groups never straddle folds
-    joined = pd.DataFrame({"gid": X["gid"].to_numpy(), "fold": trainer_groups.to_numpy()})
-    assert (joined.groupby("gid", observed=True)["fold"].nunique() == 1).all()
+    children = predictor.info()["model_info"]["Dummy_BAG_L1"]["children_info"]
+    assert len(children) == 4
 
     # holdout path: structure-aware split, no crash
     predictor = TabularPredictor(label="label", verbosity=0).fit(
@@ -132,3 +130,65 @@ def test__predictor_fit__groups_and_structure__raises():
             num_bag_folds=4,
             validation_structure={"group_on": "gid"},
         )
+
+
+def test__validation_structure__repeats_and_auto_counts():
+    """Repeated grouped bagging (impossible via the groups channel) and derived counts."""
+    from autogluon.core.utils.validation_structure import ValidationStructure
+
+    rng = np.random.default_rng(0)
+    n = 120
+    X = pd.DataFrame({"f1": rng.normal(size=n), "gid": np.repeat(np.arange(20), 6)})
+    y = pd.Series(rng.integers(0, 2, n))
+
+    vs = ValidationStructure(group_on="gid")
+    # 20 groups <= tiny-data threshold -> tiny regime, derived without user input
+    assert vs.resolve_num_splits(X) == (5, 5)
+
+    splits, folds, repeats = vs.custom_splits(X, y, num_folds=5, num_repeats=5)
+    assert (folds, repeats) == (5, 5)
+    assert len(splits) == 25
+    groups = X["gid"].to_numpy()
+    for train_idx, val_idx in splits:
+        assert len(train_idx) and len(val_idx)
+        assert not (set(groups[train_idx]) & set(groups[val_idx]))  # group-disjoint
+
+    # fewer groups than folds clamps folds and forces a single repeat
+    X_small = pd.DataFrame({"f1": rng.normal(size=9), "gid": np.repeat(np.arange(3), 3)})
+    y_small = pd.Series(rng.integers(0, 2, 9))
+    _, folds_small, repeats_small = ValidationStructure(group_on="gid").custom_splits(
+        X_small, y_small, num_folds=8, num_repeats=5
+    )
+    assert folds_small == 3 and repeats_small == 1
+
+
+def test__validation_structure__group_time_on():
+    """`group_time_on` splits are simultaneously group-disjoint and forward in time."""
+    from autogluon.core.utils.validation_structure import ValidationStructure
+
+    n_groups = 12
+    X = pd.DataFrame({"f1": np.arange(n_groups * 5, dtype=float), "gid": np.repeat(np.arange(n_groups), 5)})
+    y = pd.Series(np.tile([0, 1], n_groups * 5 // 2))
+
+    vs = ValidationStructure(group_time_on="gid")
+    splits, folds, repeats = vs.custom_splits(X, y, num_folds=4, num_repeats=3)
+    assert repeats == 1  # temporal partition is deterministic
+    groups = X["gid"].to_numpy()
+    for train_idx, val_idx in splits:
+        assert not (set(groups[train_idx]) & set(groups[val_idx]))
+    # blocks advance in time: each fold's groups are later than the previous fold's
+    fold_max = [groups[val_idx].max() for _, val_idx in splits]
+    assert fold_max == sorted(fold_max)
+
+    train_idx, val_idx = vs.holdout_split_indices(X, y, holdout_frac=0.25)
+    assert groups[val_idx].min() > groups[train_idx].max()  # forward holdout
+
+
+def test__validation_structure__group_and_time_guidance():
+    """`group_on` + `time_on` points at `group_time_on` instead of inventing semantics."""
+    from autogluon.core.utils.validation_structure import ValidationStructure
+
+    with pytest.raises(NotImplementedError, match="group_time_on"):
+        ValidationStructure(group_on="g", time_on="t")
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        ValidationStructure(group_time_on="g", group_on="g2")

--- a/tabular/tests/unittests/test_validation_structure.py
+++ b/tabular/tests/unittests/test_validation_structure.py
@@ -225,3 +225,55 @@ def test__validation_structure__time_blocks_are_contiguous_and_tie_safe():
     y_few = pd.Series([0, 1, 0, 1])
     _, folds_few, _ = ValidationStructure(time_on="t").custom_splits(X_few, y_few, num_folds=5)
     assert folds_few == 2
+
+
+def test__predictor_fit__structure_splits_reach_the_bagged_model():
+    """The resolved splits must actually be consumed by the bagged model, not just computed.
+
+    Child-model counts alone cannot show this: plain KFold produces the same count, so a
+    dropped `custom_splits` looks identical from the outside. Assert on the splits the model
+    was fit with, and on their group-disjointness.
+    """
+    from autogluon.tabular import TabularPredictor
+
+    rng = np.random.default_rng(0)
+    n = 120
+    df = pd.DataFrame({"f1": rng.normal(size=n), "gid": np.repeat(np.arange(20), 6), "label": rng.integers(0, 2, n)})
+
+    for num_bag_sets in (1, 2):
+        predictor = TabularPredictor(label="label", verbosity=0).fit(
+            df,
+            hyperparameters={"DUMMY": {}},
+            num_bag_folds=5,
+            num_bag_sets=num_bag_sets,
+            validation_structure={"group_on": "gid"},
+            fit_weighted_ensemble=False,
+        )
+        bagged_model = predictor._trainer.load_model("Dummy_BAG_L1")
+        splits = bagged_model.params.get("custom_splits")
+        assert splits is not None, "validation_structure splits never reached the bagged model"
+        assert len(splits) == 5 * num_bag_sets
+
+        groups = df["gid"].to_numpy()
+        for train_idx, val_idx in splits:
+            assert not (set(groups[train_idx]) & set(groups[val_idx]))
+        # each repeat validates every row exactly once
+        first_repeat = np.concatenate([val_idx for _, val_idx in splits[:5]])
+        assert sorted(first_repeat.tolist()) == list(range(n))
+
+
+def test__predictor_fit__no_structure_leaves_default_splitting_untouched():
+    """Without `validation_structure` nothing is injected: the default path is unchanged."""
+    from autogluon.tabular import TabularPredictor
+
+    rng = np.random.default_rng(0)
+    n = 120
+    df = pd.DataFrame({"f1": rng.normal(size=n), "label": rng.integers(0, 2, n)})
+
+    predictor = TabularPredictor(label="label", verbosity=0).fit(
+        df, hyperparameters={"DUMMY": {}}, num_bag_folds=5, num_bag_sets=2, fit_weighted_ensemble=False
+    )
+    bagged_model = predictor._trainer.load_model("Dummy_BAG_L1")
+    assert bagged_model.params.get("custom_splits") is None
+    assert predictor._trainer._groups is None
+    assert len(predictor.info()["model_info"]["Dummy_BAG_L1"]["children_info"]) == 10


### PR DESCRIPTION
## Summary

Adds a `validation_structure` fit kwarg for leakage-free validation on grouped and temporal data:

```python
predictor = TabularPredictor(label="churned").fit(
    train_data,
    validation_structure={
        "group_on": "customer_id",     # str | list[str]: group-disjoint splits
        "time_on": "timestamp",        # datetime/numeric: contiguous time blocks; forward holdout
        "group_time_on": "session_id", # groups ordered in time: disjoint AND forward
        "stratify_on": "region",       # optional stratification
    },
)
```

Users declare only the semantic columns; block boundaries, clamping (to group counts / stratification minority classes), and the resulting splits are derived. Referenced columns remain features.

## Design

**New**: `autogluon.common.utils.validation_structure.ValidationStructure` — the declarative spec plus model-agnostic resolvers: `custom_splits()` (bagged path), `holdout_split_indices()` (non-bagged path), and `fold_ids()` (per-row labels). It sits in `common` beside `cv_splitter`, which consumes the splits it produces; the problem-type constants it needs moved to a new `autogluon.common.constants` (re-exported from `autogluon.core.constants`, so existing imports are unaffected) since `common` does not depend on `core`.

### Bagged path

The learner computes explicit `(train_idx, val_idx)` splits on the raw cleaned frame — before feature transformation can alter the referenced columns — and delivers them to the models through `core_kwargs["ag_args_ensemble"]["custom_splits"]`, which `CVSplitter` already consumes.

Explicit splits rather than the `groups` channel, because that channel forces `LeaveOneGroupOut` with `n_repeats == 1` (`CVSplitter` raises `AssertionError: n_repeats must be 1 when split groups are specified`) and silently overrides the fold count to the group count. Repeated grouped cross-validation now works.

- `group_on`: group-disjoint folds. When every group carries a single stratification value, the *group table* (one row per group) is split with `Repeated(Stratified)KFold` and expanded back to rows, so group sizes do not skew stratification; otherwise `StratifiedGroupKFold` / `GroupKFold` over samples.
- `time_on`: contiguous, tie-preserving blocks of the observed time values (never equal-width spans), each cut placed where the cumulative row count is closest to that block's share.
- `group_time_on`: whole groups blocked in time order, so splits are simultaneously group-disjoint and forward in time. `group_on` + `time_on` together points here rather than raising a bare `NotImplementedError`.

**Clamping**: folds drop to the group count, and to the rarest stratification value, each forcing `num_repeats = 1` since the partition is then deterministic. Temporal partitions are likewise single-repeat. Callers must adopt the returned counts rather than assume their originals held.

### Holdout path

The holdout has no splitting algorithm of its own — it is derived from the bagged construction, so tie handling, cut placement, stratification and the per-group/per-sample pathway each exist in exactly one place and cannot drift:

- **grouped**: one fold of the split the bagged path would build. (`GroupShuffleSplit` cannot stratify, so a task declaring both `group_on` and `stratify_on` previously dropped its stratification silently.)
- **temporal**: the latest block of the same blocking, which is also strictly better at honoring the requested size than cutting at the fraction and walking the boundary back over ties — that walk moves in one direction only, so a large tie block overshoots badly (23,697 rows against a 17,588-row target on the worst benchmark task, versus 16,143 for the nearest block boundary).
- **stratify-only**: returns `None`; AutoGluon's default label-stratified holdout needs no correction.

`holdout_frac` selects the fold/block count and is honored closely when the structure supports it (0.05 -> 0.050, 0.2 -> 0.200 on 200 groups). With coarse grouping the realised size is larger, because whole groups cannot be subdivided — inherent to group-disjoint holdout, and documented.

### Dynamic stacking

Both DyStack validation procedures honor the declared structure, so the stacked-overfitting detector is not blind on the data where structure-aware validation matters most: its cross-validation procedure uses `custom_splits()`, and its holdout procedure resolves `holdout_split_indices()` up front and passes it through the `train_indices`/`val_indices` channel the CV procedure already used (the sub-fit itself is unchanged). The sub-fits' own bagging inherits the structure through `ag_fit_kwargs`, so both the outer split and the inner folds are covered.

Other notes: `stratify_on` may name the label rather than a feature column; `groups` (predictor init) and `validation_structure` are mutually exclusive; without `validation_structure` nothing is injected and the default path is untouched. Fold and repeat *counts* are deliberately not derived from data size — that policy is left to the caller, pending more customizable logic in a follow-up.

## Validation

Compared split-for-split against the grouped/temporal validation protocol TabArena applies to its non-IID benchmark tasks, on real BeyondArena data, with fold/repeat counts and seed matched:

| path | exact match |
|---|---|
| bagged | **39 / 39** |
| holdout | **33 / 39** (all 21 temporal exact) |

The 39 tasks cover every distinct configuration: both `group_labels` modes, stratified and unstratified, binary / multiclass / regression, grouped and temporal, from 906 to 1,000,350 rows.

Reaching bagged parity fixed several things a code read alone would not surface: the per-group and per-sample pathways are different algorithms; `stratify_on` can name the label; `GroupKFold` needs shuffling with the seed; and temporal fold *indices* come from routing block labels through `GroupKFold` rather than emitting blocks chronologically (identical partition set either way, so OOF predictions are unaffected — only fold indices differ).

The 6 remaining holdout differences are all grouped+stratified, where the reference calls a dedicated single-split routine (a seed-42 `train_test_split` over the group table for `per_group`, or a fold count derived from average group size for `per_sample`) instead of taking a fold of the k-fold split. Both constructions are group-disjoint, stratified, and clamp identically where whole groups cannot be subdivided; measured against the `1/num_folds` target neither is more accurate (mean |deviation| 23.3% for both, medians 0.9% vs 0.7%, opposite signs per task), so this is treated as equivalent-in-kind rather than a defect.

**IID behavior is unchanged.** The reference builds no custom splits for IID tasks even when `stratify_on` is set, deferring to AutoGluon's built-in stratified splitting; this PR likewise leaves the default path untouched when no structure is declared.

**Performance.** Building the group table originally scanned the full group column once per group, making construction quadratic in group count. With a single `pd.factorize` plus a boolean group->row mask per fold, construction on the largest grouped task (1,000,350 rows / 82,952 groups) drops from ~676s to 0.2s. Across all 39 tasks construction totals ~10s (median 40ms).

## Testing

`tabular/tests/unittests/test_validation_structure.py` (18 tests, ~17s): group-disjointness of folds, fold clamping to group counts, time-block contiguity + tie safety, forward-holdout ordering, stratify-only deferring to the default split, repeated grouped bagging, `group_time_on` disjoint-and-forward blocks, the mutual-exclusion errors, and end-to-end `TabularPredictor.fit` integrations.

Coverage includes the three paths that previously ignored or broke on the declared structure: `use_bag_holdout` (asserting the split indices address the reduced frame the trainer bags over) and both DyStack validation procedures (asserting their sub-fit splits are group-disjoint).

Several tests assert on the splits a fitted bagged model was *actually* fit with, rather than on child-model counts. That distinction matters: plain KFold produces the same child count for a given `num_bag_folds x num_bag_sets`, so splits that are computed and then dropped look identical from the outside.

## Limitations / follow-ups

- Fold/repeat counts are not derived from data size (deliberately deferred).
- `stratify_on` alone builds explicit stratified splits; deferring to AutoGluon's built-in label stratification when it resolves to the label would match the holdout path, which already defers.
- No benchmark task uses multi-column `group_on` or sets `group_on` with `time_on`, so `group_time_on` is covered by unit tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi


