### PR TITLE
GPU memory estimation plumbing + calibrated CPU/GPU memory estimates for foundation models

### DIFF
--- a/common/src/autogluon/common/utils/resource_utils.py
+++ b/common/src/autogluon/common/utils/resource_utils.py
@@ -85,6 +85,26 @@ class ResourceManager:
         return num_gpus
 
     @staticmethod
+    def get_available_vram(device: int = 0) -> float | None:
+        """Available GPU memory (VRAM) of `device` in bytes, or None when it cannot be determined.
+
+        Uses `torch.cuda.mem_get_info` when torch with CUDA is available, falling back to
+        `nvidia-smi`. The GPU counterpart of `get_available_virtual_mem`.
+        """
+        try:
+            import torch
+
+            if torch.cuda.is_available() and device < torch.cuda.device_count():
+                free, _total = torch.cuda.mem_get_info(device)
+                return float(free)
+        except Exception:
+            pass
+        memory_free_values = ResourceManager.get_gpu_free_memory()  # MiB per device
+        if device < len(memory_free_values):
+            return float(memory_free_values[device]) * 1024**2
+        return None
+
+    @staticmethod
     def get_gpu_free_memory():
         """Grep gpu free memory from nvidia-smi tool.
         This function can fail due to many reasons(driver, nvidia-smi tool, envs, etc) so please simply use

--- a/common/src/autogluon/common/utils/resource_utils.py
+++ b/common/src/autogluon/common/utils/resource_utils.py
@@ -88,15 +88,38 @@ class ResourceManager:
     def get_available_vram(device: int = 0) -> float | None:
         """Available GPU memory (VRAM) of `device` in bytes, or None when it cannot be determined.
 
-        Uses `torch.cuda.mem_get_info` when torch with CUDA is available, falling back to
-        `nvidia-smi`. The GPU counterpart of `get_available_virtual_mem`.
+        The GPU counterpart of `get_available_virtual_mem`. Three effects make this more
+        than a `torch.cuda.mem_get_info` call:
+
+        1. `mem_get_info` reports memory free on the *device*, which excludes memory
+           PyTorch's caching allocator already holds. That memory is reusable by this
+           process without a new device allocation, so it is added back
+           (`memory_reserved - memory_allocated`); ignoring it under-reports what a fit
+           can actually use and needlessly skips models.
+        2. `torch.cuda.set_per_process_memory_fraction` caps this process below the
+           device total. The cap is not visible to `mem_get_info`, so it is applied here —
+           a process allocating past its fraction OOMs even with the device free.
+        3. Without torch/CUDA, `nvidia-smi` gives device-level free memory only (no
+           allocator or fraction information available).
         """
         try:
             import torch
 
             if torch.cuda.is_available() and device < torch.cuda.device_count():
-                free, _total = torch.cuda.mem_get_info(device)
-                return float(free)
+                device_free, device_total = torch.cuda.mem_get_info(device)
+                cached_unused = torch.cuda.memory_reserved(device) - torch.cuda.memory_allocated(device)
+                available = float(device_free + cached_unused)
+
+                # Respect a per-process cap when one is set (used to partition a GPU
+                # across processes). The getter exists from torch 2.9; older versions
+                # expose no way to read it back, so the cap is simply not applied.
+                get_fraction = getattr(torch.cuda, "get_per_process_memory_fraction", None)
+                if get_fraction is not None:
+                    fraction = float(get_fraction(device))
+                    if fraction < 1.0:
+                        process_headroom = fraction * device_total - torch.cuda.memory_allocated(device)
+                        available = min(available, max(process_headroom, 0.0))
+                return min(available, float(device_total))
         except Exception:
             pass
         memory_free_values = ResourceManager.get_gpu_free_memory()  # MiB per device

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -56,7 +56,7 @@ from ...utils import (
     infer_problem_type,
     normalize_pred_probas,
 )
-from ...utils.exceptions import NotEnoughMemoryError, NoValidFeatures, TimeLimitExceeded
+from ...utils.exceptions import NotEnoughCudaMemoryError, NotEnoughMemoryError, NoValidFeatures, TimeLimitExceeded
 from ...utils.loaders import load_json, load_pkl
 from ...utils.savers import save_json, save_pkl
 from ...utils.time import sample_df_for_time_func, time_func
@@ -516,6 +516,7 @@ class AbstractModel(ModelBase, Tunable):
         """
         default_auxiliary_params = dict(
             max_memory_usage_ratio=1.0,  # Ratio of memory usage allowed by the model. Values > 1.0 have an increased risk of causing OOM errors. Used in memory checks during model training to avoid OOM errors.
+            max_gpu_memory_usage_ratio=1.0,  # GPU counterpart of max_memory_usage_ratio: ratio of available VRAM the model is allowed to use. Only checked for models that define a GPU memory estimate (see `_estimate_gpu_memory_usage`). If None, GPU memory checks are skipped.
             # TODO: Add more params
             # max_memory_usage=None,
             # max_disk_usage=None,
@@ -1267,6 +1268,7 @@ class AbstractModel(ModelBase, Tunable):
         self._register_fit_metadata(**kwargs)
         self.validate_fit_resources(**kwargs)
         approx_mem_size_req, available_mem = self._validate_fit_memory_usage(**kwargs)
+        self._validate_fit_gpu_memory_usage(**kwargs)
         if "time_limit" in kwargs and kwargs["time_limit"] is not None:
             time_start_fit = time.time()
             kwargs["time_limit"] -= time_start_fit - time_start
@@ -2706,6 +2708,84 @@ class AbstractModel(ModelBase, Tunable):
         """
         return self.estimate_memory_usage(**kwargs)
 
+    def estimate_gpu_memory_usage(self, X: pd.DataFrame, **kwargs) -> int | None:
+        """
+        Estimates the peak GPU memory (VRAM) usage of the model while training.
+
+        The GPU counterpart of `estimate_memory_usage`. Returns None when the model
+        defines no GPU memory estimate (the default) — VRAM checks are then skipped.
+
+        Parameters
+        ----------
+        X: pd.DataFrame
+            The training data features
+
+        Returns
+        -------
+        int | None: estimated peak VRAM usage in bytes during training, or None if the model defines no estimate
+        """
+        assert self.is_initialized(), "Only estimate GPU memory usage after the model is initialized."
+        gpu_memory_usage_estimate = self._estimate_gpu_memory_usage(X=X, **kwargs)
+        self._gpu_memory_usage_estimate = gpu_memory_usage_estimate
+        return gpu_memory_usage_estimate
+
+    def _estimate_gpu_memory_usage(self, X: pd.DataFrame, **kwargs) -> int | None:
+        """
+        Estimates the peak GPU memory (VRAM) usage in bytes during model fitting.
+
+        Default: None (no estimate; VRAM checks are skipped). Models that fit on GPU
+        should override this to enable VRAM safety checks and, eventually, safe
+        parallel scheduling of GPU models.
+        """
+        return None
+
+    @classmethod
+    def can_estimate_gpu_memory_usage_static(cls) -> bool:
+        """
+        True if `estimate_gpu_memory_usage_static` is implemented for this model.
+        If False, calling `estimate_gpu_memory_usage_static` will raise a NotImplementedError.
+        """
+        return cls._get_class_tags().get("can_estimate_gpu_memory_usage_static", False)
+
+    @classmethod
+    def estimate_gpu_memory_usage_static(
+        cls,
+        *,
+        X: pd.DataFrame,
+        y: pd.Series = None,
+        hyperparameters: dict = None,
+        problem_type: str = "infer",
+        num_classes: int | None | str = "infer",
+        **kwargs,
+    ) -> int:
+        """
+        Estimates the peak GPU memory (VRAM) usage of the model while training, without
+        having to initialize the model. The GPU counterpart of `estimate_memory_usage_static`.
+        """
+        if problem_type == "infer":
+            problem_type = cls._infer_problem_type(y=y)
+        if isinstance(num_classes, str) and num_classes == "infer":
+            num_classes = cls._infer_num_classes(y=y, problem_type=problem_type)
+        if hyperparameters is None:
+            hyperparameters = {}
+        hyperparameters = cls._get_model_params_static(
+            hyperparameters=hyperparameters, convert_search_spaces_to_default=True
+        )
+        return cls._estimate_gpu_memory_usage_static(
+            X=X, y=y, hyperparameters=hyperparameters, problem_type=problem_type, num_classes=num_classes, **kwargs
+        )
+
+    @classmethod
+    def _estimate_gpu_memory_usage_static(
+        cls,
+        *,
+        X: pd.DataFrame,
+        hyperparameters: dict = None,
+        num_classes: int = 1,
+        **kwargs,
+    ) -> int:
+        raise NotImplementedError
+
     def estimate_memory_usage_static_child(
         self,
         *,
@@ -2927,6 +3007,66 @@ class AbstractModel(ModelBase, Tunable):
                     f"You may consider using a machine with more memory as a safer alternative."
                 )
             logger.warning(f"\tWarning: Potentially not enough memory to safely train model. {log_user_guideline}")
+
+        return approx_mem_size_req, available_mem
+
+    def _validate_fit_gpu_memory_usage(
+        self,
+        mem_error_threshold: float = 0.9,
+        mem_warning_threshold: float = 0.75,
+        approx_mem_size_req: int | None = None,
+        available_mem: int | None = None,
+        num_gpus: int | float | str | None = None,
+        **kwargs,
+    ) -> tuple[int | None, int | None]:
+        """
+        Asserts that enough GPU memory (VRAM) is available to fit the model.
+
+        The GPU counterpart of `_validate_fit_memory_usage`. The check only runs when the
+        model is assigned at least one GPU AND defines a GPU memory estimate
+        (`estimate_gpu_memory_usage` returns non-None); otherwise it is skipped. Thresholds
+        depend on the `params_aux` hyperparameter `max_gpu_memory_usage_ratio` (default 1.0;
+        None skips all VRAM checks). Raises NotEnoughCudaMemoryError when the estimate
+        exceeds the error threshold (handled by the trainer as a graceful model skip).
+
+        Returns
+        -------
+        approx_mem_size_req: int | None
+            The estimated VRAM requirement of the model in bytes (None = not calculated / no estimate).
+        available_mem: int | None
+            The available VRAM in bytes (None = not calculated / not detectable).
+        """
+        max_memory_usage_ratio = self.params_aux["max_gpu_memory_usage_ratio"]
+        if max_memory_usage_ratio is None:
+            return approx_mem_size_req, available_mem  # Skip VRAM check
+        if not num_gpus or (isinstance(num_gpus, str)):
+            return approx_mem_size_req, available_mem  # Not fitting on GPU
+
+        if approx_mem_size_req is None:
+            approx_mem_size_req = self.estimate_gpu_memory_usage(**kwargs)
+        if approx_mem_size_req is None:
+            return None, available_mem  # Model defines no GPU memory estimate
+
+        if available_mem is None:
+            available_mem = ResourceManager.get_available_vram()
+        if available_mem is None:
+            logger.debug("\tAvailable VRAM could not be determined, skipping GPU memory check.")
+            return approx_mem_size_req, None
+
+        expected_memory_usage_ratio = approx_mem_size_req / available_mem
+        max_memory_usage_error_ratio = mem_error_threshold * max_memory_usage_ratio
+        max_memory_usage_warning_ratio = mem_warning_threshold * max_memory_usage_ratio
+
+        log_user_guideline = (
+            f"Estimated to require {approx_mem_size_req / (1024**3):.3f} GB "
+            f"out of {available_mem / (1024**3):.3f} GB available GPU memory ({expected_memory_usage_ratio * 100:.3f}%)... "
+            f"({max_memory_usage_error_ratio * 100:.3f}% of avail GPU memory is the max safe size)"
+        )
+        if expected_memory_usage_ratio > max_memory_usage_error_ratio:
+            logger.warning(f"\tWarning: Not enough GPU memory to safely train model. {log_user_guideline}")
+            raise NotEnoughCudaMemoryError
+        elif expected_memory_usage_ratio > max_memory_usage_warning_ratio:
+            logger.warning(f"\tWarning: Potentially not enough GPU memory to safely train model. {log_user_guideline}")
 
         return approx_mem_size_req, available_mem
 

--- a/tabular/src/autogluon/tabular/models/abstract/abstract_torch_model.py
+++ b/tabular/src/autogluon/tabular/models/abstract/abstract_torch_model.py
@@ -13,10 +13,53 @@ class AbstractTorchModel(AbstractModel):
     .. versionadded:: 1.5.0
     """
 
+    gpu_strongly_recommended: bool = False
+    """Whether fitting this model on CPU is slow enough to warn about.
+
+    Set by in-context-learning models, whose prediction cost is dominated by
+    attending over the training context: on CPU they measure 12-63x slower end to
+    end than on GPU (versus ~1.5-3x for models trained with SGD), which makes a
+    silent CPU fallback look like a hang rather than a configuration problem.
+    See :meth:`_log_cpu_fallback_warning`.
+    """
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.device = None
         self.device_train = None
+
+    def _log_cpu_fallback_warning(self, num_gpus: int | float) -> None:
+        """Warn once per fit when a ``gpu_strongly_recommended`` model fits on CPU
+        without the user having asked for it.
+
+        Silent when the user set ``num_gpus`` themselves (e.g. ``num_gpus=0`` in
+        ``ag_args_fit``), since then the CPU fit is the requested behavior.
+        """
+        if not self.gpu_strongly_recommended or num_gpus:
+            return
+        if self._user_params_aux.get("num_gpus") is not None:
+            return  # explicit user choice, not a fallback
+
+        try:
+            import torch
+
+            gpu_present = torch.cuda.is_available()
+        except Exception:
+            gpu_present = False
+
+        reason = (
+            "no GPU was allocated to it, though this machine has one - check `num_gpus` "
+            "in `ag_args_fit` and the resources available to the fit"
+            if gpu_present
+            else "no CUDA GPU is available on this machine"
+        )
+        logger.log(
+            30,
+            f"\tWARNING: {self.name} is fitting on CPU because {reason}. This model attends over the "
+            f"training context for every prediction, so a CPU fit is typically an order of magnitude "
+            f"slower than on GPU (measured 12-63x end to end) and may appear to hang. "
+            f"Pass `num_gpus=0` explicitly to silence this warning.",
+        )
 
     def suggest_device_infer(self, verbose: bool = False) -> str:
         import torch

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -181,7 +181,13 @@ class LGBModel(AbstractModel):
             n_estimators_min * mem_size_per_estimator
         )  # memory estimate after fitting up to 5000 estimators
 
-        approx_mem_size_req = data_mem_usage_bytes + histogram_mem_usage_bytes + mem_size_estimators
+        # Fixed overhead of a LightGBM fit (library init, threading buffers): measured
+        # ~25-40 MB regardless of data size; without it small fits are underestimated 3-10x.
+        fixed_overhead_bytes = 50e6
+
+        approx_mem_size_req = (
+            fixed_overhead_bytes + data_mem_usage_bytes + histogram_mem_usage_bytes + mem_size_estimators
+        )
         return int(approx_mem_size_req)
 
     def _fit(
@@ -234,7 +240,7 @@ class LGBModel(AbstractModel):
                 params["device"] = "gpu"
                 logger.log(
                     20,
-                    f"\tWarning: Training LightGBM with GPU. This may negatively impact model quality compared to CPU training.",
+                    "\tWarning: Training LightGBM with GPU. This may negatively impact model quality compared to CPU training.",
                 )
         logger.log(15, f"\tFitting {num_boost_round} rounds... Hyperparameters: {params}")
 
@@ -417,14 +423,14 @@ class LGBModel(AbstractModel):
                         if time_left < 0.5 * time_limit:
                             retrain = False
                     if retrain:
-                        logger.log(15, f"Retraining LGB model to optimal iterations ('dart' mode).")
+                        logger.log(15, "Retraining LGB model to optimal iterations ('dart' mode).")
                         train_params.pop("callbacks", None)
                         train_params.pop("valid_sets", None)
                         train_params.pop("valid_names", None)
                         train_params["num_boost_round"] = self.model.best_iteration
                         self.model = train_lgb_model(**train_params)
                     else:
-                        logger.log(15, f"Not enough time to retrain LGB model ('dart' mode)...")
+                        logger.log(15, "Not enough time to retrain LGB model ('dart' mode)...")
 
         if generate_curves:
 
@@ -708,7 +714,7 @@ class LGBModel(AbstractModel):
             }
             gbm = lightgbm.train(params, num_boost_round=10, train_set=train_data)
             return True
-        except Exception as e:
+        except Exception:
             return False
 
     @staticmethod
@@ -729,7 +735,7 @@ class LGBModel(AbstractModel):
             }
             gbm = lightgbm.train(params, num_boost_round=10, train_set=train_data)
             return True
-        except Exception as e:
+        except Exception:
             return False
 
     def get_minimum_resources(self, is_gpu_available=False):

--- a/tabular/src/autogluon/tabular/models/mitra/mitra_model.py
+++ b/tabular/src/autogluon/tabular/models/mitra/mitra_model.py
@@ -31,6 +31,7 @@ class MitraModel(AbstractTorchModel):
     .. versionadded:: 1.4.0
     """
 
+    gpu_strongly_recommended: bool = True  # in-context inference is 12-63x slower on CPU
     ag_key = "MITRA"
     ag_name = "Mitra"
     weights_file_name = "model.pt"
@@ -144,6 +145,7 @@ class MitraModel(AbstractTorchModel):
             logger.log(30, f"\tCustom hf_model specified: {hf_model}")
             hyp["hf_model"] = hf_model
 
+        self._log_cpu_fallback_warning(num_gpus=num_gpus)
         if hyp.get("device", None) is None:
             if num_gpus == 0:
                 hyp["device"] = "cpu"

--- a/tabular/src/autogluon/tabular/models/nori/nori_model.py
+++ b/tabular/src/autogluon/tabular/models/nori/nori_model.py
@@ -45,6 +45,10 @@ class NoriModel(AbstractTorchModel):
     ag_name = "Nori"
     ag_priority = 40
 
+    _DEFAULT_MAX_BATCH_SIZE: int = 10000
+    """Default prediction chunk size (``ag.max_batch_size``); also the query-batch
+    bound assumed by the GPU memory estimate."""
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._feature_generator = None
@@ -144,7 +148,7 @@ class NoriModel(AbstractTorchModel):
                 # Chunk prediction: an unchunked 50k-query predict against a 50k-row
                 # context fails with a CUDA kernel-configuration error (after ~76 GB);
                 # 10k-query chunks on the same context run fine.
-                "max_batch_size": 10000,
+                "max_batch_size": self._DEFAULT_MAX_BATCH_SIZE,
             }
         )
         return default_auxiliary_params
@@ -169,6 +173,7 @@ class NoriModel(AbstractTorchModel):
         # load) and add static memory estimation.
         tags = super()._class_tags()
         tags["can_estimate_memory_usage_static"] = True
+        tags["can_estimate_gpu_memory_usage_static"] = True
         return tags
 
     def _more_tags(self) -> dict:
@@ -202,3 +207,40 @@ class NoriModel(AbstractTorchModel):
         baseline_mem_est = 3e9
         dataset_mem_est = 5 * get_approximate_df_mem_usage(X).sum()
         return int(baseline_mem_est + dataset_mem_est)
+
+    @classmethod
+    def _estimate_gpu_memory_usage_static(
+        cls,
+        *,
+        X: pd.DataFrame,
+        hyperparameters: dict | None = None,
+        **kwargs,
+    ) -> int:
+        """Peak VRAM (reserved + CUDA context) across fit and prediction.
+
+        Nori holds the whole labeled context on the device and attends over it for
+        every query, so memory is driven by context *cells* (rows x features) rather
+        than by rows alone: ~32 KB/cell up to ~1M cells, then ~8 KB/cell. The query
+        batch adds ~0.5 MB/row, bounded by ``ag.max_batch_size`` chunking; as this
+        bounds *fit* memory, where predictions are on held-out folds of the training
+        data, the batch is also bounded by ``n_train``.
+
+        This is substantial for a small model: measured peaks reach 95 GB on a
+        24k-row x 387-feature task, so the estimate matters for scheduling.
+        Calibrated on 30 real regression tasks (100 to 45k rows, 5 to 1024
+        features): 1.0-2.2x of measured, no underestimates.
+        """
+        n_train, n_features = X.shape
+        max_batch_size = (hyperparameters or {}).get("ag.max_batch_size")
+        if not isinstance(max_batch_size, int):
+            max_batch_size = cls._DEFAULT_MAX_BATCH_SIZE
+        n_test = min(max_batch_size, n_train)
+
+        n_cells = n_train * n_features
+        cell_saturation = 1e6
+        return int(
+            1.0e9  # CUDA context + model weights floor
+            + 32e3 * min(n_cells, cell_saturation)
+            + 8e3 * max(n_cells - cell_saturation, 0)
+            + 0.5e6 * n_test
+        )

--- a/tabular/src/autogluon/tabular/models/nori/nori_model.py
+++ b/tabular/src/autogluon/tabular/models/nori/nori_model.py
@@ -41,6 +41,7 @@ class NoriModel(AbstractTorchModel):
     .. versionadded:: 1.6.0
     """
 
+    gpu_strongly_recommended: bool = True  # in-context inference is 12-63x slower on CPU
     ag_key = "NORI"
     ag_name = "Nori"
     ag_priority = 40
@@ -72,6 +73,7 @@ class NoriModel(AbstractTorchModel):
 
         from torch.cuda import is_available
 
+        self._log_cpu_fallback_warning(num_gpus=num_gpus)
         device = "cuda" if num_gpus != 0 else "cpu"
         if (device == "cuda") and (not is_available()):
             raise AssertionError(

--- a/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
+++ b/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
@@ -369,8 +369,30 @@ class RealMLPModel(AbstractTorchModel):
         return mem_estimate
 
     @classmethod
+    def _estimate_gpu_memory_usage_static(
+        cls,
+        *,
+        X,
+        hyperparameters: dict | None = None,
+        **kwargs,
+    ) -> int:
+        """Peak VRAM (reserved + CUDA context) across fit and prediction.
+
+        RealMLP is lightweight on GPU: a ~1.4 GB base (context + runtime) plus small
+        per-row (~660 B) and per-cell (~11 B) terms. Calibrated on numeric-only
+        synthetic fit+predict measurements (1k-1M rows, 10-1000 features, 1.1-2x
+        conservative); categorical one-hot expansion increases the effective feature
+        count. Epoch count adds time, not peak memory (SGD steady state).
+        """
+        n_train, n_features = X.shape
+        return int(1.4e9 + 660 * n_train + 0.3e6 * n_features + 11 * n_train * n_features)
+
+    @classmethod
     def _class_tags(cls) -> dict:
-        return {"can_estimate_memory_usage_static": True}
+        return {
+            "can_estimate_memory_usage_static": True,
+            "can_estimate_gpu_memory_usage_static": True,
+        }
 
     def _more_tags(self) -> dict:
         # TODO: Need to add train params support, track best epoch

--- a/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
+++ b/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
@@ -379,14 +379,22 @@ class RealMLPModel(AbstractTorchModel):
         """Peak VRAM (reserved + CUDA context) across fit and prediction.
 
         RealMLP is lightweight on GPU: a ~1.65 GB base (context + runtime) plus small
-        per-row (~660 B) and per-cell (~11 B) terms. Calibrated on numeric-only
-        synthetic fit+predict measurements (1k-1M rows, 10-1000 features) and all 51
-        TabArena tasks (1.0-2.4x conservative, no underestimates); categorical
-        one-hot expansion increases the effective feature count. Epoch count adds
-        time, not peak memory (SGD steady state).
+        per-row (~660 B) and per-cell (~11 B) terms over the *effective* feature
+        count after pytabkit's categorical encoding — low-cardinality categoricals
+        are one-hot expanded (one column per level up to
+        ``max_one_hot_cat_size=9``), higher-cardinality ones become fixed-width
+        embeddings (``embedding_size=8``). Calibrated on numeric-only synthetic
+        fit+predict measurements (1k-1M rows, 10-1000 features) and all 51 TabArena
+        plus 69 BeyondArena tasks (1.0-5.8x conservative, no underestimates).
+        Epoch count adds time, not peak memory (SGD steady state).
         """
-        n_train, n_features = X.shape
-        return int(1.65e9 + 660 * n_train + 0.3e6 * n_features + 11 * n_train * n_features)
+        n_train = len(X)
+        n_features_eff = len(X.select_dtypes(include=["number"]).columns)
+        for col in X.select_dtypes(include=["category", "object"]).columns:
+            cardinality = X[col].nunique()
+            # pytabkit RealMLP defaults: one-hot up to max_one_hot_cat_size, else embedding_size
+            n_features_eff += cardinality if cardinality <= 9 else 8
+        return int(1.65e9 + 660 * n_train + 0.3e6 * n_features_eff + 11 * n_train * n_features_eff)
 
     @classmethod
     def _class_tags(cls) -> dict:

--- a/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
+++ b/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
@@ -316,10 +316,16 @@ class RealMLPModel(AbstractTorchModel):
         hyperparameters: dict = None,
         **kwargs,
     ) -> int:
-        """
-        Heuristic memory estimate that correlates strongly with RealMLP's more sophisticated method
+        """Peak CPU RSS: a process baseline plus the model's per-feature cost and
+        several copies of the dataset.
 
-        More comprehensive memory estimate logic:
+        Calibrated against measured peak RSS on 136 real tasks (100 to 1M rows):
+        1.05-3.4x of measured, no underestimates. GPU fits are the calibration
+        target; a CPU-only fit of the same task uses *less* host RAM (no CUDA
+        context, no pinned transfer buffers), so the estimate stays conservative
+        there.
+
+        The shape of the estimate follows RealMLP's own, more comprehensive logic:
 
         ```python
         from typing import Any
@@ -361,8 +367,13 @@ class RealMLPModel(AbstractTorchModel):
         columns_mem_est_hidden_2 = columns_mem_est * hidden_2_weight * plr_hidden_2 / 16 * width_factor
         columns_mem_est = columns_mem_est_hidden_1 + columns_mem_est_hidden_2
 
-        dataset_size_mem_est = 5 * get_approximate_df_mem_usage(X).sum()  # roughly 5x DataFrame memory size
-        baseline_overhead_mem_est = 3e8  # 300 MB generic overhead
+        dataset_size_mem_est = 11 * get_approximate_df_mem_usage(X).sum()  # roughly 11x DataFrame memory size
+        # Process baseline: torch plus AutoGluon overhead, and the CUDA context when
+        # fitting on GPU (measured ~0.47 GB of host RAM on its own). The previous
+        # 300 MB constant was below the floor a real fit starts from, so small
+        # datasets - where the baseline is nearly all of the footprint - were
+        # underestimated ~7x.
+        baseline_overhead_mem_est = 2.2e9
 
         mem_estimate = dataset_size_mem_est + columns_mem_est + baseline_overhead_mem_est
 

--- a/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
+++ b/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
@@ -378,16 +378,17 @@ class RealMLPModel(AbstractTorchModel):
     ) -> int:
         """Peak VRAM (reserved + CUDA context) across fit and prediction.
 
-        RealMLP is lightweight on GPU: a ~1.65 GB base (context + runtime) plus small
-        per-row (~660 B) and per-cell (~28 B) terms over the *effective* feature
-        count after pytabkit's categorical encoding — low-cardinality categoricals
-        are one-hot expanded (one column per level up to
-        ``max_one_hot_cat_size=9``), higher-cardinality ones become fixed-width
-        embeddings (``embedding_size=8``). Calibrated on numeric-only synthetic
-        fit+predict measurements (1k-1M rows, 10-1000 features) and all 51 TabArena
-        plus 85 BeyondArena tasks spanning 100 to 1M rows (1.0-5.8x conservative,
-        no underestimates). Epoch count adds time, not peak memory (SGD steady
-        state).
+        RealMLP is lightweight on GPU: a ~1.65 GB base (context + runtime) dominates
+        on nearly every real task (measured peaks are 0.65-2 GB on 125 of 136 of
+        them), plus small per-row (~660 B), per-feature (~50 KB) and per-cell
+        (~28 B) terms over the *effective* feature count after pytabkit's
+        categorical encoding — low-cardinality categoricals are one-hot expanded
+        (one column per level up to ``max_one_hot_cat_size=9``), higher-cardinality
+        ones become fixed-width embeddings (``embedding_size=8``). Calibrated on
+        numeric-only synthetic fit+predict measurements (1k-1M rows, 10-1000
+        features) and all 51 TabArena plus 85 BeyondArena tasks spanning 100 to 1M
+        rows (1.0-2.5x, no underestimates). Epoch count adds time, not peak memory
+        (SGD steady state).
         """
         n_train = len(X)
         n_features_eff = len(X.select_dtypes(include=["number"]).columns)
@@ -395,7 +396,7 @@ class RealMLPModel(AbstractTorchModel):
             cardinality = X[col].nunique()
             # pytabkit RealMLP defaults: one-hot up to max_one_hot_cat_size, else embedding_size
             n_features_eff += cardinality if cardinality <= 9 else 8
-        return int(1.65e9 + 660 * n_train + 0.3e6 * n_features_eff + 28 * n_train * n_features_eff)
+        return int(1.65e9 + 660 * n_train + 0.05e6 * n_features_eff + 28 * n_train * n_features_eff)
 
     @classmethod
     def _class_tags(cls) -> dict:

--- a/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
+++ b/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
@@ -379,14 +379,15 @@ class RealMLPModel(AbstractTorchModel):
         """Peak VRAM (reserved + CUDA context) across fit and prediction.
 
         RealMLP is lightweight on GPU: a ~1.65 GB base (context + runtime) plus small
-        per-row (~660 B) and per-cell (~11 B) terms over the *effective* feature
+        per-row (~660 B) and per-cell (~28 B) terms over the *effective* feature
         count after pytabkit's categorical encoding — low-cardinality categoricals
         are one-hot expanded (one column per level up to
         ``max_one_hot_cat_size=9``), higher-cardinality ones become fixed-width
         embeddings (``embedding_size=8``). Calibrated on numeric-only synthetic
         fit+predict measurements (1k-1M rows, 10-1000 features) and all 51 TabArena
-        plus 69 BeyondArena tasks (1.0-5.8x conservative, no underestimates).
-        Epoch count adds time, not peak memory (SGD steady state).
+        plus 85 BeyondArena tasks spanning 100 to 1M rows (1.0-5.8x conservative,
+        no underestimates). Epoch count adds time, not peak memory (SGD steady
+        state).
         """
         n_train = len(X)
         n_features_eff = len(X.select_dtypes(include=["number"]).columns)
@@ -394,7 +395,7 @@ class RealMLPModel(AbstractTorchModel):
             cardinality = X[col].nunique()
             # pytabkit RealMLP defaults: one-hot up to max_one_hot_cat_size, else embedding_size
             n_features_eff += cardinality if cardinality <= 9 else 8
-        return int(1.65e9 + 660 * n_train + 0.3e6 * n_features_eff + 11 * n_train * n_features_eff)
+        return int(1.65e9 + 660 * n_train + 0.3e6 * n_features_eff + 28 * n_train * n_features_eff)
 
     @classmethod
     def _class_tags(cls) -> dict:

--- a/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
+++ b/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
@@ -378,14 +378,15 @@ class RealMLPModel(AbstractTorchModel):
     ) -> int:
         """Peak VRAM (reserved + CUDA context) across fit and prediction.
 
-        RealMLP is lightweight on GPU: a ~1.4 GB base (context + runtime) plus small
+        RealMLP is lightweight on GPU: a ~1.65 GB base (context + runtime) plus small
         per-row (~660 B) and per-cell (~11 B) terms. Calibrated on numeric-only
-        synthetic fit+predict measurements (1k-1M rows, 10-1000 features, 1.1-2x
-        conservative); categorical one-hot expansion increases the effective feature
-        count. Epoch count adds time, not peak memory (SGD steady state).
+        synthetic fit+predict measurements (1k-1M rows, 10-1000 features) and all 51
+        TabArena tasks (1.0-2.4x conservative, no underestimates); categorical
+        one-hot expansion increases the effective feature count. Epoch count adds
+        time, not peak memory (SGD steady state).
         """
         n_train, n_features = X.shape
-        return int(1.4e9 + 660 * n_train + 0.3e6 * n_features + 11 * n_train * n_features)
+        return int(1.65e9 + 660 * n_train + 0.3e6 * n_features + 11 * n_train * n_features)
 
     @classmethod
     def _class_tags(cls) -> dict:

--- a/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_model.py
+++ b/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_model.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
 # TODO: unit test
 # TODO: memory estimate
 class TabDPTModel(AbstractTorchModel):
+    gpu_strongly_recommended: bool = True  # in-context inference is 12-63x slower on CPU
     ag_key = "TABDPT"
     ag_name = "TabDPT"
     seed_name = "seed"
@@ -74,6 +75,7 @@ class TabDPTModel(AbstractTorchModel):
     ):
         from torch.cuda import is_available
 
+        self._log_cpu_fallback_warning(num_gpus=num_gpus)
         device = "cuda" if num_gpus != 0 else "cpu"
         if (device == "cuda") and (not is_available()):
             raise AssertionError(

--- a/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_turbo_model.py
+++ b/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_turbo_model.py
@@ -46,15 +46,16 @@ class TabDPTTurboModel(TabDPTModel):
     ) -> int:
         """Peak VRAM (reserved + CUDA context) across fit and prediction.
 
-        TabDPT-Turbo's peak is feature-independent (fixed-width encoding of a
-        subsampled context) and scales only with rows (~25 KB per train + prediction
-        row). The prediction-row count is unknown at fit time; assume at least 100k.
-        Calibrated on synthetic fit+predict measurements (1k-100k rows, 10-1000
-        features, up to 200k prediction rows).
+        TabDPT-Turbo's peak is a ~1.15 GB floor (CUDA context + weights) plus a
+        feature-independent row term (fixed-width encoding of a subsampled context,
+        ~25 KB per train + prediction row). The prediction-row count is unknown at
+        fit time; assume at least 100k. Calibrated on synthetic fit+predict
+        measurements (1k-100k rows, 10-1000 features, up to 200k prediction rows)
+        plus all 51 TabArena tasks (the floor dominates small datasets).
         """
         n_train = len(X)
         n_test = max(100_000, n_train)
-        return int(0.5e9 + 25e3 * (n_train + n_test))
+        return int(1.15e9 + 25e3 * (n_train + n_test))
 
     @classmethod
     def _class_tags(cls):

--- a/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_turbo_model.py
+++ b/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_turbo_model.py
@@ -35,3 +35,27 @@ class TabDPTTurboModel(TabDPTModel):
         "classifier": ("context_size", "n_ensembles", "batch_size", "permute_classes", "temperature"),
         "regressor": ("context_size", "n_ensembles", "batch_size"),
     }
+
+    @classmethod
+    def _estimate_gpu_memory_usage_static(
+        cls,
+        *,
+        X,
+        hyperparameters: dict | None = None,
+        **kwargs,
+    ) -> int:
+        """Peak VRAM (reserved + CUDA context) across fit and prediction.
+
+        TabDPT-Turbo's peak is feature-independent (fixed-width encoding of a
+        subsampled context) and scales only with rows (~25 KB per train + prediction
+        row). The prediction-row count is unknown at fit time; assume at least 100k.
+        Calibrated on synthetic fit+predict measurements (1k-100k rows, 10-1000
+        features, up to 200k prediction rows).
+        """
+        n_train = len(X)
+        n_test = max(100_000, n_train)
+        return int(0.5e9 + 25e3 * (n_train + n_test))
+
+    @classmethod
+    def _class_tags(cls):
+        return {**super()._class_tags(), "can_estimate_gpu_memory_usage_static": True}

--- a/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_turbo_model.py
+++ b/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_turbo_model.py
@@ -46,16 +46,21 @@ class TabDPTTurboModel(TabDPTModel):
     ) -> int:
         """Peak VRAM (reserved + CUDA context) across fit and prediction.
 
-        TabDPT-Turbo's peak is a ~1.15 GB floor (CUDA context + weights) plus a
-        feature-independent row term (fixed-width encoding of a subsampled context,
-        ~25 KB per train + prediction row). The prediction-row count is unknown at
-        fit time; assume at least 100k. Calibrated on synthetic fit+predict
-        measurements (1k-100k rows, 10-1000 features, up to 200k prediction rows)
-        plus all 51 TabArena tasks (the floor dominates small datasets).
+        TabDPT-Turbo's peak is a ~1.3 GB floor (CUDA context + weights), which
+        dominates small datasets, plus a feature-independent row term (fixed-width
+        encoding of a subsampled context, ~25 KB per train + prediction row).
+
+        This bounds *fit* memory, where predictions are on held-out folds of the
+        training data, so the prediction-row count is taken as ``n_train``.
+        (Inference on a test set far larger than the training data can exceed this;
+        that is inference-time memory, which AutoGluon's fit-time checks do not
+        cover.) Calibrated on synthetic fit+predict measurements (1k-100k rows,
+        10-1000 features, up to 200k prediction rows) plus all 136 real TabArena and
+        BeyondArena tasks (100 to 1M rows): 1.0-1.9x of measured, no underestimates.
         """
         n_train = len(X)
-        n_test = max(100_000, n_train)
-        return int(1.15e9 + 25e3 * (n_train + n_test))
+        n_test = n_train
+        return int(1.3e9 + 25e3 * (n_train + n_test))
 
     @classmethod
     def _class_tags(cls):

--- a/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
+++ b/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
@@ -159,7 +159,11 @@ class TabICLModel(AbstractTorchModel):
                 # TODO: Instead of caps, should we subsample for large datasets?
                 "max_rows": 1000000,  # TODO: What should be the cap? 1 million rows works, but unsure if it is good
                 "max_features": 2000,  # TODO: What should be the cap? 10k features works, but unsure if it is good
-                "max_batch_size": 1024,  # avoid excessive VRAM usage
+                # No prediction chunking: tabicl batches internally (VRAM-adaptive with
+                # OOM-halving), and each external chunk would re-encode the full training
+                # context (kv_cache is off by default) — a 1024-row cap made a 100k-row
+                # predict ~100x slower while saving no VRAM.
+                "max_batch_size": None,
             }
         )
         return default_auxiliary_params
@@ -237,8 +241,37 @@ class TabICLModel(AbstractTorchModel):
         return default_ag_args_ensemble
 
     @classmethod
+    def _estimate_gpu_memory_usage_static(
+        cls,
+        *,
+        X: pd.DataFrame,
+        hyperparameters: dict = None,
+        **kwargs,
+    ) -> int:
+        """Minimum VRAM required across fit and prediction — NOT expected usage.
+
+        tabicl plans its internal batches from free device memory, so its usage is
+        opportunistic: the same task that reserves ~30 GB on an idle large GPU
+        completes in under 1.5 GB of free VRAM at ~2x the runtime. Estimating usage
+        instead of requirement would needlessly skip the model on busy/small devices.
+        Requirement floors measured on synthetic fit+predict tasks: ~1 GB at 2M total
+        cells (train + prediction rows x features), ~5 GB at 20M. The prediction-row
+        count is unknown at fit time; assume at least 100k.
+
+        Caveat: the plan is made from free memory at fit/predict start — VRAM claimed
+        by other processes afterwards can still cause a hard OOM.
+        """
+        n_train, n_features = X.shape
+        n_test = max(100_000, n_train)
+        total_cells = (n_train + n_test) * n_features
+        return int(0.7e9 + 250 * total_cells)
+
+    @classmethod
     def _class_tags(cls) -> dict:
-        return {"can_estimate_memory_usage_static": True}
+        return {
+            "can_estimate_memory_usage_static": True,
+            "can_estimate_gpu_memory_usage_static": True,
+        }
 
     def _more_tags(self) -> dict:
         return {"can_refit_full": True}

--- a/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
+++ b/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
@@ -40,6 +40,7 @@ class TabICLModel(AbstractTorchModel):
     .. versionadded:: 1.4.0
     """
 
+    gpu_strongly_recommended: bool = True  # in-context inference is 12-63x slower on CPU
     ag_key = "TABICL"
     ag_name = "TabICL"
 
@@ -111,6 +112,7 @@ class TabICLModel(AbstractTorchModel):
 
         from torch.cuda import is_available
 
+        self._log_cpu_fallback_warning(num_gpus=num_gpus)
         device = "cuda" if num_gpus != 0 else "cpu"
         if (device == "cuda") and (not is_available()):
             # FIXME: warn instead and switch to CPU.

--- a/tabular/src/autogluon/tabular/models/tabm/_tabm_internal.py
+++ b/tabular/src/autogluon/tabular/models/tabm/_tabm_internal.py
@@ -248,10 +248,18 @@ class TabMImplementation:
         cat_cardinalities = self.ord_enc_.get_cardinalities()
         self.n_classes_ = n_classes
 
-        # filter out numerical columns with only a single value
-        #  -> AG also does this already but preprocessing might create constant columns again
+        # Filter out numerical columns that are near-constant on the training split
+        #  -> AG also does this already but preprocessing might create constant columns again.
+        # The tolerance (vs exact equality) matters: float32 mean-imputation of a constant
+        # column yields a second value one ulp off the constant, which would otherwise survive
+        # as a "two-valued" column and build a single ~1e-8-wide piecewise-linear-embedding bin
+        # whose unclamped encoding explodes on out-of-range values at predict time (measured
+        # predictions of ~3e5 against ~2e-2 for in-range rows). The pipeline's outputs are
+        # bounded (quantile-transformed |z| <= 5.2, indicators 0/1), so an absolute tolerance is
+        # safe: legitimate columns have a range >= ~1e-3.
         x_cont_train = ds_parts["train"]["x_cont"]
-        self.num_col_mask_ = ~torch.all(x_cont_train == x_cont_train[0:1, :], dim=0)
+        col_range = x_cont_train.max(dim=0).values - x_cont_train.min(dim=0).values
+        self.num_col_mask_ = col_range > 1e-6
         for part in part_names:
             ds_parts[part]["x_cont"] = ds_parts[part]["x_cont"][:, self.num_col_mask_]
             # tensor infos are not correct anymore, but might not be used either

--- a/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
+++ b/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
@@ -301,14 +301,18 @@ class TabMModel(AbstractTorchModel):
         feature) plus a per-cell (row x feature) activation term (~82 B). Numerical
         columns with missing values count as an extra feature each (the wrapper adds
         an indicator column per such column), and each categorical level adds
-        ~500 KB of embedding parameters + optimizer state. Calibrated on synthetic
-        fit+predict measurements (1k-1M rows, 10-1000 features), cross-checked on
-        real TabArena datasets (high-cardinality categoricals, missing-heavy data).
-        Epoch count adds time, not peak memory (SGD steady state).
+        ~500 KB of embedding parameters + optimizer state. The per-feature cost
+        saturates past a few thousand features (batches shrink and the embedding
+        layers stop being the bottleneck), so the feature count is capped for
+        estimation. Calibrated on synthetic fit+predict measurements (1k-1M rows,
+        10-1000 features) and all 51 TabArena plus 69 BeyondArena tasks (1.0-7.2x,
+        no underestimates; high-cardinality categoricals, missing-heavy data, and
+        gene-expression frames up to 22k features). Epoch count adds time, not peak
+        memory (SGD steady state).
         """
         n_train, n_features = X.shape
         numeric = X.select_dtypes(include=["number"])
-        n_features_eff = n_features + int(numeric.isna().any().sum())
+        n_features_eff = min(n_features + int(numeric.isna().any().sum()), 2000)
         sum_cat_levels = int(
             sum(X[col].nunique() for col in X.select_dtypes(include=["category", "object"]).columns)
         )

--- a/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
+++ b/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
@@ -314,24 +314,20 @@ class TabMModel(AbstractTorchModel):
     ) -> int:
         """Peak VRAM (reserved + CUDA context) across fit and prediction.
 
-        TabM's peak is feature-driven (k-ensemble embedding layers: ~10.5 MB per
-        feature) plus a per-cell (row x feature) term whose coefficient grows with
-        the training batch size: activations for a whole batch are held at once, and
-        the auto batch size steps up with the row count (see
-        :meth:`get_tabm_auto_batch_size`), so the same cell costs more on a large
-        dataset. Numerical columns with missing values count as an extra feature
-        each (the wrapper adds an indicator column per such column), and each
-        categorical level adds ~500 KB of embedding parameters + optimizer state.
-        The per-feature cost saturates past a few thousand features, so the feature
-        count is capped for estimation. Calibrated on synthetic fit+predict
-        measurements (1k-1M rows, 10-1000 features) and all 51 TabArena plus 85
-        BeyondArena tasks spanning 100 to 1M rows (1.0-7.3x, no underestimates;
-        high-cardinality categoricals, missing-heavy data, and gene-expression
-        frames up to 22k features). Epoch count adds time, not peak memory (SGD
-        steady state).
+        TabM's peak has three drivers: k-ensemble embedding layers (~10.5 MB per
+        feature), each categorical level (~1 MB of embedding parameters + optimizer
+        state), and a per-cell (row x feature) term that saturates — ~140 B/cell up
+        to ~100M cells, then ~40 B/cell, since past that point batches cover a
+        shrinking fraction of the data and activations stop scaling with it.
+        Numerical columns with missing values count as an extra feature each (the
+        wrapper adds an indicator column per such column), and the feature count is
+        capped for estimation (the per-feature cost stops growing past a few
+        thousand). Calibrated on synthetic fit+predict measurements (1k-1M rows,
+        10-1000 features) and all 51 TabArena plus 85 BeyondArena tasks spanning 100
+        to 1M rows (1.0-7.3x, no underestimates; high-cardinality categoricals,
+        missing-heavy data, and gene-expression frames up to 22k features). Epoch
+        count adds time, not peak memory (SGD steady state).
         """
-        if hyperparameters is None:
-            hyperparameters = {}
         n_train, n_features = X.shape
         numeric = X.select_dtypes(include=["number"])
         n_features_eff = min(
@@ -340,14 +336,14 @@ class TabMModel(AbstractTorchModel):
         sum_cat_levels = int(
             sum(X[col].nunique() for col in X.select_dtypes(include=["category", "object"]).columns)
         )
-        batch_size = hyperparameters.get("batch_size", "auto")
-        if isinstance(batch_size, str) and batch_size == "auto":
-            batch_size = cls.get_tabm_auto_batch_size(n_samples=n_train)
+        n_cells = n_train * n_features_eff
+        cell_saturation = 100e6
         return int(
             1.2e9
             + 10.5e6 * n_features_eff
-            + (140 + 0.05 * batch_size) * n_train * n_features_eff
-            + 500e3 * sum_cat_levels
+            + 140 * min(n_cells, cell_saturation)
+            + 40 * max(n_cells - cell_saturation, 0)
+            + 1.0e6 * sum_cat_levels
         )
 
     @classmethod

--- a/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
+++ b/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
@@ -330,12 +330,8 @@ class TabMModel(AbstractTorchModel):
         """
         n_train, n_features = X.shape
         numeric = X.select_dtypes(include=["number"])
-        n_features_eff = min(
-            n_features + int(numeric.isna().any().sum()), cls._MAX_FEATURES_FOR_MEMORY_ESTIMATE
-        )
-        sum_cat_levels = int(
-            sum(X[col].nunique() for col in X.select_dtypes(include=["category", "object"]).columns)
-        )
+        n_features_eff = min(n_features + int(numeric.isna().any().sum()), cls._MAX_FEATURES_FOR_MEMORY_ESTIMATE)
+        sum_cat_levels = int(sum(X[col].nunique() for col in X.select_dtypes(include=["category", "object"]).columns))
         n_cells = n_train * n_features_eff
         cell_saturation = 100e6
         return int(

--- a/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
+++ b/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
@@ -315,18 +315,23 @@ class TabMModel(AbstractTorchModel):
         """Peak VRAM (reserved + CUDA context) across fit and prediction.
 
         TabM's peak is feature-driven (k-ensemble embedding layers: ~10.5 MB per
-        feature) plus a per-cell (row x feature) activation term (~82 B). Numerical
-        columns with missing values count as an extra feature each (the wrapper adds
-        an indicator column per such column), and each categorical level adds
-        ~500 KB of embedding parameters + optimizer state. The per-feature cost
-        saturates past a few thousand features (batches shrink and the embedding
-        layers stop being the bottleneck), so the feature count is capped for
-        estimation. Calibrated on synthetic fit+predict measurements (1k-1M rows,
-        10-1000 features) and all 51 TabArena plus 69 BeyondArena tasks (1.0-7.2x,
-        no underestimates; high-cardinality categoricals, missing-heavy data, and
-        gene-expression frames up to 22k features). Epoch count adds time, not peak
-        memory (SGD steady state).
+        feature) plus a per-cell (row x feature) term whose coefficient grows with
+        the training batch size: activations for a whole batch are held at once, and
+        the auto batch size steps up with the row count (see
+        :meth:`get_tabm_auto_batch_size`), so the same cell costs more on a large
+        dataset. Numerical columns with missing values count as an extra feature
+        each (the wrapper adds an indicator column per such column), and each
+        categorical level adds ~500 KB of embedding parameters + optimizer state.
+        The per-feature cost saturates past a few thousand features, so the feature
+        count is capped for estimation. Calibrated on synthetic fit+predict
+        measurements (1k-1M rows, 10-1000 features) and all 51 TabArena plus 85
+        BeyondArena tasks spanning 100 to 1M rows (1.0-7.3x, no underestimates;
+        high-cardinality categoricals, missing-heavy data, and gene-expression
+        frames up to 22k features). Epoch count adds time, not peak memory (SGD
+        steady state).
         """
+        if hyperparameters is None:
+            hyperparameters = {}
         n_train, n_features = X.shape
         numeric = X.select_dtypes(include=["number"])
         n_features_eff = min(
@@ -335,10 +340,13 @@ class TabMModel(AbstractTorchModel):
         sum_cat_levels = int(
             sum(X[col].nunique() for col in X.select_dtypes(include=["category", "object"]).columns)
         )
+        batch_size = hyperparameters.get("batch_size", "auto")
+        if isinstance(batch_size, str) and batch_size == "auto":
+            batch_size = cls.get_tabm_auto_batch_size(n_samples=n_train)
         return int(
             1.2e9
             + 10.5e6 * n_features_eff
-            + 82 * n_train * n_features_eff
+            + (140 + 0.05 * batch_size) * n_train * n_features_eff
             + 500e3 * sum_cat_levels
         )
 

--- a/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
+++ b/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
@@ -288,9 +288,42 @@ class TabMModel(AbstractTorchModel):
         return 1024
 
     @classmethod
+    def _estimate_gpu_memory_usage_static(
+        cls,
+        *,
+        X,
+        hyperparameters: dict | None = None,
+        **kwargs,
+    ) -> int:
+        """Peak VRAM (reserved + CUDA context) across fit and prediction.
+
+        TabM's peak is feature-driven (k-ensemble embedding layers: ~10.5 MB per
+        feature) plus a per-cell (row x feature) activation term (~82 B). Numerical
+        columns with missing values count as an extra feature each (the wrapper adds
+        an indicator column per such column), and each categorical level adds
+        ~500 KB of embedding parameters + optimizer state. Calibrated on synthetic
+        fit+predict measurements (1k-1M rows, 10-1000 features), cross-checked on
+        real TabArena datasets (high-cardinality categoricals, missing-heavy data).
+        Epoch count adds time, not peak memory (SGD steady state).
+        """
+        n_train, n_features = X.shape
+        numeric = X.select_dtypes(include=["number"])
+        n_features_eff = n_features + int(numeric.isna().any().sum())
+        sum_cat_levels = int(
+            sum(X[col].nunique() for col in X.select_dtypes(include=["category", "object"]).columns)
+        )
+        return int(
+            1.2e9
+            + 10.5e6 * n_features_eff
+            + 82 * n_train * n_features_eff
+            + 500e3 * sum_cat_levels
+        )
+
+    @classmethod
     def _class_tags(cls):
         return {
             "can_estimate_memory_usage_static": True,
+            "can_estimate_gpu_memory_usage_static": True,
             "reset_torch_threads": True,
         }
 

--- a/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
+++ b/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
@@ -38,6 +38,10 @@ class TabMModel(AbstractTorchModel):
     ag_priority = 85
     seed_name = "random_state"
 
+    _MAX_FEATURES_FOR_MEMORY_ESTIMATE: int = 2000
+    """Feature count past which the per-feature memory cost saturates (batches shrink
+    and the embedding layers stop dominating), so memory estimates stop scaling."""
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._imputer = None
@@ -180,8 +184,17 @@ class TabMModel(AbstractTorchModel):
         num_classes: int | None = 1,
         **kwargs,
     ) -> int:
-        """
-        Heuristic memory estimate that correlates strongly with RealMLP
+        """Peak CPU RSS: the model's parameter + forward/backward footprint (which
+        lives in RAM for a CPU fit) on top of a torch-process baseline.
+
+        The parameter and activation terms scale with the feature count, which is
+        capped for estimation the same way as in the GPU estimate: past a few
+        thousand features the per-feature cost saturates rather than growing
+        linearly (uncapped, a 22k-feature frame estimates >300 GB for a model that
+        fits in 30). Validated on all 51 TabArena plus 69 BeyondArena tasks
+        (1.1-17x of measured GPU-fit RSS, no underestimates); the upper end is
+        wide data, where a CPU fit would genuinely hold the activations this
+        estimate covers while a GPU fit keeps them in VRAM.
         """
         if num_classes is None:
             num_classes = 1
@@ -200,17 +213,19 @@ class TabMModel(AbstractTorchModel):
 
         n_numerical = len(X.select_dtypes(include=["number"]).columns)
 
-        # TODO: This estimates very high memory usage,
-        #  we probably need to adjust batch size automatically to compensate
-        mem_estimate_bytes = cls._estimate_tabm_ram(
+        n_features_eff = n_numerical + sum(cat_sizes)
+        if n_features_eff > cls._MAX_FEATURES_FOR_MEMORY_ESTIMATE:
+            scale = cls._MAX_FEATURES_FOR_MEMORY_ESTIMATE / n_features_eff
+            n_numerical = int(n_numerical * scale)
+            cat_sizes = [int(size * scale) for size in cat_sizes]
+
+        return cls._estimate_tabm_ram(
             hyperparameters=hyperparameters,
             n_numerical=n_numerical,
             cat_sizes=cat_sizes,
             n_classes=num_classes,
             n_samples=len(X),
         )
-
-        return mem_estimate_bytes
 
     @classmethod
     def _estimate_tabm_ram(
@@ -258,8 +273,10 @@ class TabMModel(AbstractTorchModel):
 
         mem_ds = n_samples * (4 * n_numerical + 8 * len(cat_sizes))
 
-        # some safety constants and offsets (the 5 is probably excessive)
-        mem_total = 5 * mem_ds + 1.2 * mem_forward_backward + 1.2 * mem_params + 0.3 * (1024**3)
+        # some safety constants and offsets (the 5 is probably excessive); the
+        # baseline is the measured torch-process floor (~1.6 GB), which dominates
+        # on small datasets.
+        mem_total = 5 * mem_ds + 1.2 * mem_forward_backward + 1.2 * mem_params + 1.6e9
 
         return mem_total
 
@@ -312,7 +329,9 @@ class TabMModel(AbstractTorchModel):
         """
         n_train, n_features = X.shape
         numeric = X.select_dtypes(include=["number"])
-        n_features_eff = min(n_features + int(numeric.isna().any().sum()), 2000)
+        n_features_eff = min(
+            n_features + int(numeric.isna().any().sum()), cls._MAX_FEATURES_FOR_MEMORY_ESTIMATE
+        )
         sum_cat_levels = int(
             sum(X[col].nunique() for col in X.select_dtypes(include=["category", "object"]).columns)
         )

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfn3_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfn3_model.py
@@ -91,13 +91,14 @@ class TabPFN3Model(TabPFNModel):
 
         TabPFN-3's peak is asymmetric in train vs prediction rows: train rows persist
         as attention context (~40 KB/row reserved) while prediction rows are transient
-        (~26 KB/row) and bounded by ``ag.max_batch_size`` chunking. Features saturate
-        quickly (~2.4 GB above 100, peaking near 300 before internal subsampling
-        caps the cost). Flat in ``n_estimators``. Regression's
+        (~26 KB/row) and bounded by ``ag.max_batch_size`` chunking. Features cost
+        ~18 MB each (x1.5 for regression), saturating at ~230 where internal
+        subsampling caps the cost. Flat in ``n_estimators``. Regression's
         distributional (full-support) output adds ~2.9 GB of buffers plus a ~4x
         heavier per-prediction-row cost. Calibrated on synthetic measurements up to
-        500k train rows / 800k prediction rows / 2000 features, cross-checked on
-        real TabArena datasets.
+        500k train rows / 800k prediction rows / 2000 features plus all 51 TabArena
+        tasks (1.0-3.4x of measured at the actual prediction size, no
+        underestimates).
         """
         n_train, n_features = X.shape
         n_test = cls._n_test_for_memory_estimate(n_train=n_train, hyperparameters=hyperparameters)
@@ -107,7 +108,7 @@ class TabPFN3Model(TabPFNModel):
             + 40e3 * n_train
             + (110e3 if is_regression else 26e3) * n_test
             + 2.9e9 * is_regression
-            + 2.4e9 * (n_features > 100)
+            + 18e6 * min(n_features, 230) * (1.5 if is_regression else 1.0)
         )
 
     @classmethod

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfn3_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfn3_model.py
@@ -29,6 +29,12 @@ class TabPFN3Model(TabPFNModel):
     default_classification_model: str | None = "tabpfn-v3-classifier-v3_default.ckpt"
     default_regression_model: str | None = "tabpfn-v3-regressor-v3_default.ckpt"
 
+    max_batch_size_min: int = 100_000
+    """TabPFN-3 reuses the training context (KV cache) across prediction chunks, so
+    chunks smaller than the training set multiply predict time while saving little
+    memory — unlike TabPFN-2.5/2.6 (the base default), which re-process the joint
+    train + batch sequence per chunk and benefit from a low floor."""
+
     def _get_default_auxiliary_params(self) -> dict:
         default_auxiliary_params = super()._get_default_auxiliary_params()
         default_auxiliary_params.update(
@@ -59,15 +65,17 @@ class TabPFN3Model(TabPFNModel):
         **kwargs,
     ) -> int:
         """Peak CPU RSS: ~2.5 GB process baseline plus ~7.5 float64 copies of the
-        train + prediction-batch data made by TabPFN-3's preprocessing.
+        train + prediction-batch data made by TabPFN-3's preprocessing. Features
+        count up to the model's internal 500-feature subsampling cap.
 
         Calibrated on synthetic fit+predict measurements (1k-800k rows, 10-2000
-        features); accurate within 0.9-1.5x including 500k-row x 500-feature cells.
+        features); accurate within 0.9-1.5x including 500k-row x 500-feature cells,
+        cross-checked on real TabArena datasets (up to 1774 features).
         """
         n_train, n_features = X.shape
         n_test = cls._n_test_for_memory_estimate(n_train=n_train, hyperparameters=hyperparameters)
         baseline_mem_est = 2.5e9
-        preprocessing_mem_est = 7.5 * 8 * (n_train + n_test) * n_features
+        preprocessing_mem_est = 7.5 * 8 * (n_train + n_test) * min(n_features, 500)
         return int(baseline_mem_est + preprocessing_mem_est)
 
     @classmethod
@@ -76,6 +84,7 @@ class TabPFN3Model(TabPFNModel):
         *,
         X: pd.DataFrame,
         hyperparameters: dict | None = None,
+        problem_type: str | None = None,
         **kwargs,
     ) -> int:
         """Peak VRAM (reserved + CUDA context) across fit and prediction.
@@ -83,16 +92,22 @@ class TabPFN3Model(TabPFNModel):
         TabPFN-3's peak is asymmetric in train vs prediction rows: train rows persist
         as attention context (~40 KB/row reserved) while prediction rows are transient
         (~26 KB/row) and bounded by ``ag.max_batch_size`` chunking. Features saturate
-        quickly (~1.5 GB above 100). Flat in ``n_estimators``. Calibrated on synthetic
-        measurements up to 500k train rows / 800k prediction rows / 2000 features.
+        quickly (~2.4 GB above 100, peaking near 300 before internal subsampling
+        caps the cost). Flat in ``n_estimators``. Regression's
+        distributional (full-support) output adds ~2.9 GB of buffers plus a ~4x
+        heavier per-prediction-row cost. Calibrated on synthetic measurements up to
+        500k train rows / 800k prediction rows / 2000 features, cross-checked on
+        real TabArena datasets.
         """
         n_train, n_features = X.shape
         n_test = cls._n_test_for_memory_estimate(n_train=n_train, hyperparameters=hyperparameters)
+        is_regression = problem_type == "regression"
         return int(
             1.1e9  # CUDA context + model weights floor
             + 40e3 * n_train
-            + 26e3 * n_test
-            + 1.5e9 * (n_features > 100)
+            + (110e3 if is_regression else 26e3) * n_test
+            + 2.9e9 * is_regression
+            + 2.4e9 * (n_features > 100)
         )
 
     @classmethod

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfn3_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfn3_model.py
@@ -4,8 +4,6 @@ from typing import ClassVar
 
 import pandas as pd
 
-from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
-
 from .tabpfnv2_5_model import TabPFNModel
 
 
@@ -38,8 +36,10 @@ class TabPFN3Model(TabPFNModel):
                 "max_rows": 500_000,
                 "max_features": 2500,
                 "max_classes": 160,
-                # TabPFN-3 batches inference internally once past this many samples.
-                "max_batch_size": 150_000,
+                # max_batch_size (prediction chunking) is the model's only bound on
+                # test-side VRAM (peak grows linearly in unchunked prediction rows);
+                # "auto" resolves at fit time to min(1M, max(100k, n_train)).
+                "max_batch_size": "auto",
                 "model_telemetry": False,
             }
         )
@@ -58,11 +58,43 @@ class TabPFN3Model(TabPFNModel):
         hyperparameters: dict | None = None,
         **kwargs,
     ) -> int:
-        """Assume a 10 GB baseline (model + activations) plus the dataset memory footprint.
+        """Peak CPU RSS: ~2.5 GB process baseline plus ~7.5 float64 copies of the
+        train + prediction-batch data made by TabPFN-3's preprocessing.
 
-        The v2 layer/embedding heuristic used by the older TabPFN models does not
-        transfer to the v3 architecture.
+        Calibrated on synthetic fit+predict measurements (1k-800k rows, 10-2000
+        features); accurate within 0.9-1.5x including 500k-row x 500-feature cells.
         """
-        baseline_mem_est = 10 * 1e9  # 10 GB minimum for TabPFN-3 model + activations
-        dataset_mem_est = 5 * get_approximate_df_mem_usage(X).sum()
-        return int(baseline_mem_est + dataset_mem_est)
+        n_train, n_features = X.shape
+        n_test = cls._n_test_for_memory_estimate(n_train=n_train, hyperparameters=hyperparameters)
+        baseline_mem_est = 2.5e9
+        preprocessing_mem_est = 7.5 * 8 * (n_train + n_test) * n_features
+        return int(baseline_mem_est + preprocessing_mem_est)
+
+    @classmethod
+    def _estimate_gpu_memory_usage_static(
+        cls,
+        *,
+        X: pd.DataFrame,
+        hyperparameters: dict | None = None,
+        **kwargs,
+    ) -> int:
+        """Peak VRAM (reserved + CUDA context) across fit and prediction.
+
+        TabPFN-3's peak is asymmetric in train vs prediction rows: train rows persist
+        as attention context (~40 KB/row reserved) while prediction rows are transient
+        (~26 KB/row) and bounded by ``ag.max_batch_size`` chunking. Features saturate
+        quickly (~1.5 GB above 100). Flat in ``n_estimators``. Calibrated on synthetic
+        measurements up to 500k train rows / 800k prediction rows / 2000 features.
+        """
+        n_train, n_features = X.shape
+        n_test = cls._n_test_for_memory_estimate(n_train=n_train, hyperparameters=hyperparameters)
+        return int(
+            1.1e9  # CUDA context + model weights floor
+            + 40e3 * n_train
+            + 26e3 * n_test
+            + 1.5e9 * (n_features > 100)
+        )
+
+    @classmethod
+    def _class_tags(cls):
+        return {**super()._class_tags(), "can_estimate_gpu_memory_usage_static": True}

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfn3_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfn3_model.py
@@ -64,18 +64,18 @@ class TabPFN3Model(TabPFNModel):
         hyperparameters: dict | None = None,
         **kwargs,
     ) -> int:
-        """Peak CPU RSS: ~2.5 GB process baseline plus ~7.5 float64 copies of the
+        """Peak CPU RSS: ~2.8 GB process baseline plus ~10 float64 copies of the
         train + prediction-batch data made by TabPFN-3's preprocessing. Features
         count up to the model's internal 500-feature subsampling cap.
 
         Calibrated on synthetic fit+predict measurements (1k-800k rows, 10-2000
-        features); accurate within 0.9-1.5x including 500k-row x 500-feature cells,
-        cross-checked on real TabArena datasets (up to 1774 features).
+        features) and all 136 real TabArena and BeyondArena tasks (100 to 1M rows):
+        1.03-2.5x of measured, no underestimates.
         """
         n_train, n_features = X.shape
         n_test = cls._n_test_for_memory_estimate(n_train=n_train, hyperparameters=hyperparameters)
-        baseline_mem_est = 2.5e9
-        preprocessing_mem_est = 7.5 * 8 * (n_train + n_test) * min(n_features, 500)
+        baseline_mem_est = 2.8e9
+        preprocessing_mem_est = 10 * 8 * (n_train + n_test) * min(n_features, 500)
         return int(baseline_mem_est + preprocessing_mem_est)
 
     @classmethod
@@ -91,23 +91,32 @@ class TabPFN3Model(TabPFNModel):
 
         TabPFN-3's peak is asymmetric in train vs prediction rows: train rows persist
         as attention context (~40 KB/row reserved) while prediction rows are transient
-        (~26 KB/row) and bounded by ``ag.max_batch_size`` chunking. Features cost
-        ~18 MB each (x1.5 for regression), saturating at ~230 where internal
-        subsampling caps the cost. Flat in ``n_estimators``. Regression's
-        distributional (full-support) output adds ~2.9 GB of buffers plus a ~4x
-        heavier per-prediction-row cost. Calibrated on synthetic measurements up to
-        500k train rows / 800k prediction rows / 2000 features plus all 51 TabArena
-        tasks (1.0-3.4x of measured at the actual prediction size, no
-        underestimates).
+        (~26 KB/row) and bounded by the fit-time prediction batch (see
+        :meth:`_n_test_for_memory_estimate`). Features cost ~18 MB each (x1.5 for
+        regression), saturating at ~230 where internal subsampling caps the cost.
+        Flat in ``n_estimators``.
+
+        Regression's distributional (full-support) output costs more per prediction
+        row (~110 KB, saturating to ~40 KB past 100k rows) plus buffers that grow
+        with the training size to a ~2.9 GB ceiling. Calibrated on synthetic
+        measurements up to 500k train rows / 800k prediction rows / 2000 features
+        plus all 136 real TabArena and BeyondArena tasks (100 to 1M rows):
+        1.0-4.3x of measured, no underestimates.
         """
         n_train, n_features = X.shape
         n_test = cls._n_test_for_memory_estimate(n_train=n_train, hyperparameters=hyperparameters)
         is_regression = problem_type == "regression"
+        if is_regression:
+            prediction_mem_est = 110e3 * min(n_test, 100_000) + 40e3 * max(n_test - 100_000, 0)
+            output_buffer_mem_est = min(2.9e9, 1e6 * n_train)
+        else:
+            prediction_mem_est = 26e3 * n_test
+            output_buffer_mem_est = 0
         return int(
             1.1e9  # CUDA context + model weights floor
             + 40e3 * n_train
-            + (110e3 if is_regression else 26e3) * n_test
-            + 2.9e9 * is_regression
+            + prediction_mem_est
+            + output_buffer_mem_est
             + 18e6 * min(n_features, 230) * (1.5 if is_regression else 1.0)
         )
 

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
@@ -54,6 +54,17 @@ class TabPFNModel(AbstractTorchModel):
     default_classification_model: str | None = "NOTSET"
     default_regression_model: str | None = "NOTSET"
     default_model_map: dict | None = None
+    max_batch_size_min: int = 1_000
+    """Lower bound of the ``"auto"`` ``ag.max_batch_size`` (prediction chunking)
+    resolution; also the prediction-batch floor assumed by memory estimates.
+
+    TabPFN-2.5/2.6 re-process the joint train + prediction-batch sequence per
+    chunk, so peak VRAM scales with the batch size and chunks sized near the
+    training set already amortize the context cost. A low floor keeps small
+    datasets from paying 100k-row prediction-batch memory (and from being
+    skipped by memory estimates assuming it). Versions whose training context
+    is reused across chunks (TabPFN-3) override this with a high floor, since
+    for them small chunks multiply predict time while saving little memory."""
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -110,9 +121,9 @@ class TabPFNModel(AbstractTorchModel):
         # "auto" prediction chunking resolves against the training size: chunks
         # re-attend the full training context, so chunks smaller than the training set
         # multiply predict time at large n_train while saving little memory. Bounded
-        # to [100k, 1M]. None disables chunking entirely.
+        # to [max_batch_size_min, 1M]. None disables chunking entirely.
         if self.params_aux.get("max_batch_size") == "auto":
-            self.params_aux["max_batch_size"] = min(1_000_000, max(100_000, len(X)))
+            self.params_aux["max_batch_size"] = min(1_000_000, max(self.max_batch_size_min, len(X)))
 
         from tabpfn import TabPFNClassifier, TabPFNRegressor
         from torch.cuda import is_available
@@ -288,13 +299,13 @@ class TabPFNModel(AbstractTorchModel):
         """Proxy for the prediction batch size in memory estimates.
 
         The model's ``ag.max_batch_size`` when explicitly set; otherwise the auto
-        default's lower bound, ``max(100_000, n_train)``.
+        default's lower bound, ``max(max_batch_size_min, n_train)``.
         """
         max_batch_size = (hyperparameters or {}).get("ag.max_batch_size", "auto")
         if max_batch_size is None or max_batch_size == "auto":
             # "auto" resolves to at least this at fit time; explicit None (chunking
             # disabled) has no bound, so fall back to the same conservative proxy.
-            return max(100_000, n_train)
+            return max(cls.max_batch_size_min, n_train)
         return int(max_batch_size)
 
     def _estimate_memory_usage(self, X: pd.DataFrame, **kwargs) -> int:

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
@@ -107,6 +107,13 @@ class TabPFNModel(AbstractTorchModel):
         if not self.params_aux.get("model_telemetry", False):
             self.disable_tabpfn_telemetry()
 
+        # "auto" prediction chunking resolves against the training size: chunks
+        # re-attend the full training context, so chunks smaller than the training set
+        # multiply predict time at large n_train while saving little memory. Bounded
+        # to [100k, 1M]. None disables chunking entirely.
+        if self.params_aux.get("max_batch_size") == "auto":
+            self.params_aux["max_batch_size"] = min(1_000_000, max(100_000, len(X)))
+
         from tabpfn import TabPFNClassifier, TabPFNRegressor
         from torch.cuda import is_available
 
@@ -254,6 +261,9 @@ class TabPFNModel(AbstractTorchModel):
                 "max_rows": 100_000,
                 "max_features": 2000,
                 "max_classes": 10,
+                # "auto" resolves at fit time to min(1M, max(100k, n_train));
+                # None disables prediction chunking.
+                "max_batch_size": "auto",
                 "model_telemetry": False,
             }
         )
@@ -272,6 +282,20 @@ class TabPFNModel(AbstractTorchModel):
         }
         default_ag_args_ensemble.update(extra_ag_args_ensemble)
         return default_ag_args_ensemble
+
+    @classmethod
+    def _n_test_for_memory_estimate(cls, *, n_train: int, hyperparameters: dict | None) -> int:
+        """Proxy for the prediction batch size in memory estimates.
+
+        The model's ``ag.max_batch_size`` when explicitly set; otherwise the auto
+        default's lower bound, ``max(100_000, n_train)``.
+        """
+        max_batch_size = (hyperparameters or {}).get("ag.max_batch_size", "auto")
+        if max_batch_size is None or max_batch_size == "auto":
+            # "auto" resolves to at least this at fit time; explicit None (chunking
+            # disabled) has no bound, so fall back to the same conservative proxy.
+            return max(100_000, n_train)
+        return int(max_batch_size)
 
     def _estimate_memory_usage(self, X: pd.DataFrame, **kwargs) -> int:
         hyperparameters = self._get_model_params()

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
@@ -34,6 +34,7 @@ class TabPFNModel(AbstractTorchModel):
     .. versionadded:: 1.5.0
     """
 
+    gpu_strongly_recommended: bool = True  # in-context inference is 12-63x slower on CPU
     ag_key = "NOTSET"
     ag_name = "NOTSET"
     ag_priority = 40
@@ -132,6 +133,7 @@ class TabPFNModel(AbstractTorchModel):
 
         model_base = TabPFNClassifier if is_classification else TabPFNRegressor
 
+        self._log_cpu_fallback_warning(num_gpus=num_gpus)
         device = self._get_tabpfn_device(num_gpus=num_gpus)
         if (device != "cpu") and (not is_available()):
             raise AssertionError(

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
@@ -298,15 +298,19 @@ class TabPFNModel(AbstractTorchModel):
     def _n_test_for_memory_estimate(cls, *, n_train: int, hyperparameters: dict | None) -> int:
         """Proxy for the prediction batch size in memory estimates.
 
-        The model's ``ag.max_batch_size`` when explicitly set; otherwise the auto
-        default's lower bound, ``max(max_batch_size_min, n_train)``.
+        These estimates bound *fit* memory, and the predictions made during a fit are
+        on held-out folds of the training data, so the batch is bounded by the
+        training size as well as by ``ag.max_batch_size`` chunking — hence the
+        minimum of the two. (Predicting on a test set far larger than the training
+        data can exceed this; that is inference-time memory, which AutoGluon's
+        fit-time memory checks do not cover.)
         """
         max_batch_size = (hyperparameters or {}).get("ag.max_batch_size", "auto")
         if max_batch_size is None or max_batch_size == "auto":
-            # "auto" resolves to at least this at fit time; explicit None (chunking
-            # disabled) has no bound, so fall back to the same conservative proxy.
-            return max(cls.max_batch_size_min, n_train)
-        return int(max_batch_size)
+            # "auto" resolves to at least max_batch_size_min at fit time; explicit
+            # None (chunking disabled) has no bound, so use the same proxy.
+            max_batch_size = max(cls.max_batch_size_min, n_train)
+        return min(int(max_batch_size), n_train)
 
     def _estimate_memory_usage(self, X: pd.DataFrame, **kwargs) -> int:
         hyperparameters = self._get_model_params()

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_6_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_6_model.py
@@ -57,27 +57,34 @@ class TabPFNv26Model(TabPFNModel):
         """Peak VRAM (reserved + CUDA context) across fit and prediction.
 
         TabPFN-2.6 materializes the joint train + prediction-batch sequence, so peak
-        VRAM is symmetric in total rows, with a two-segment per-cell (row x feature)
-        slope: steep to ~300 features, shallow to the hard cap at ~1000, plus a
-        ~25 KB/row per-row cost independent of feature count (dominant on narrow
-        data). Peak is set by the most expensive ensemble-member preprocessing
-        config, reached by ``n_estimators >= 8`` (coefficients below assume
-        default-sized ensembles; n_estimators=1 peaks ~1.8x lower). Regression's
-        distributional output costs ~2.5x the classification slopes. Calibrated on
-        synthetic measurements (1k-100k train rows, up to 100k prediction rows,
-        10-2000 features), cross-checked on real TabArena datasets.
+        VRAM is symmetric in total rows. The per-cell (row x feature) cost is
+        piecewise: ~3.8 KB/cell while tabpfn runs full activations, dropping ~5x
+        once its memory-saving mode kicks in above a total-cell threshold (see
+        ``tabpfn.architectures.base.memory.should_save_peak_mem``: ~6M cells on an
+        80 GB device, scaled by free VRAM; 5M is used below as a conservative knee).
+        Features count to ~300, with a shallow slope to the hard cap at ~1000. Rows
+        also carry a feature-independent cost (~25 KB, ~40 KB for regression's
+        distributional output), and regression costs ~2.5x overall. Peak assumes
+        default-sized ensembles (``n_estimators=1`` peaks ~1.8x lower). Calibrated
+        on all 51 TabArena tasks (1.02-2.8x of measured at actual prediction sizes,
+        no underestimates) plus synthetic sweeps (1k-100k train rows, up to 100k
+        prediction rows, 10-2000 features).
         """
         n_train, n_features = X.shape
         n_test = cls._n_test_for_memory_estimate(n_train=n_train, hyperparameters=hyperparameters)
         total_rows = n_train + n_test
-        regression_multiplier = 2.5 if problem_type == "regression" else 1.0
+        is_regression = problem_type == "regression"
+        regression_multiplier = 2.5 if is_regression else 1.0
+        cells = total_rows * min(n_features, 300)
+        memory_saving_knee = 5e6
         return int(
             0.85e9  # CUDA context + model weights floor
             + regression_multiplier
             * (
-                25e3 * total_rows
-                + 3.4e3 * total_rows * min(n_features, 300)
-                + 0.65e3 * total_rows * max(0, min(n_features, 1000) - 300)
+                (40e3 if is_regression else 25e3) * total_rows
+                + 3.8e3 * min(cells, memory_saving_knee)
+                + 0.8e3 * max(cells - memory_saving_knee, 0)
+                + 0.4e3 * total_rows * max(0, min(n_features, 1000) - 300)
             )
         )
 

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_6_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_6_model.py
@@ -31,16 +31,18 @@ class TabPFNv26Model(TabPFNModel):
         hyperparameters: dict | None = None,
         **kwargs,
     ) -> int:
-        """Peak CPU RSS: ~1.7 GB process baseline plus ~3.6 float64 copies of the
+        """Peak CPU RSS: ~1.9 GB process baseline plus ~5 float64 copies of the
         train + prediction-batch data made by TabPFN-2.6's preprocessing.
 
         Calibrated on synthetic fit+predict measurements (1k-100k rows, 10-2000
-        features); accurate within 0.9-1.2x.
+        features) plus real TabArena datasets (categorical-heavy data needs a
+        higher copy count than numeric-only synthetic data); accurate within
+        0.9-1.2x on both.
         """
         n_train, n_features = X.shape
         n_test = cls._n_test_for_memory_estimate(n_train=n_train, hyperparameters=hyperparameters)
-        baseline_mem_est = 1.7e9
-        preprocessing_mem_est = 3.6 * 8 * (n_train + n_test) * n_features
+        baseline_mem_est = 1.9e9
+        preprocessing_mem_est = 5.0 * 8 * (n_train + n_test) * n_features
         return int(baseline_mem_est + preprocessing_mem_est)
 
     @classmethod
@@ -49,25 +51,34 @@ class TabPFNv26Model(TabPFNModel):
         *,
         X: pd.DataFrame,
         hyperparameters: dict | None = None,
+        problem_type: str | None = None,
         **kwargs,
     ) -> int:
         """Peak VRAM (reserved + CUDA context) across fit and prediction.
 
         TabPFN-2.6 materializes the joint train + prediction-batch sequence, so peak
         VRAM is symmetric in total rows, with a two-segment per-cell (row x feature)
-        slope: steep to ~300 features, shallow to the hard cap at ~1000. Peak is set
-        by the most expensive ensemble-member preprocessing config, reached by
-        ``n_estimators >= 8`` (coefficients below assume default-sized ensembles;
-        n_estimators=1 peaks ~1.8x lower). Calibrated on synthetic measurements
-        (1k-100k train rows, up to 100k prediction rows, 10-2000 features).
+        slope: steep to ~300 features, shallow to the hard cap at ~1000, plus a
+        ~25 KB/row per-row cost independent of feature count (dominant on narrow
+        data). Peak is set by the most expensive ensemble-member preprocessing
+        config, reached by ``n_estimators >= 8`` (coefficients below assume
+        default-sized ensembles; n_estimators=1 peaks ~1.8x lower). Regression's
+        distributional output costs ~2.5x the classification slopes. Calibrated on
+        synthetic measurements (1k-100k train rows, up to 100k prediction rows,
+        10-2000 features), cross-checked on real TabArena datasets.
         """
         n_train, n_features = X.shape
         n_test = cls._n_test_for_memory_estimate(n_train=n_train, hyperparameters=hyperparameters)
         total_rows = n_train + n_test
+        regression_multiplier = 2.5 if problem_type == "regression" else 1.0
         return int(
             0.76e9  # CUDA context + model weights floor
-            + 2.8e3 * total_rows * min(n_features, 300)
-            + 0.65e3 * total_rows * max(0, min(n_features, 1000) - 300)
+            + regression_multiplier
+            * (
+                25e3 * total_rows
+                + 3.4e3 * total_rows * min(n_features, 300)
+                + 0.65e3 * total_rows * max(0, min(n_features, 1000) - 300)
+            )
         )
 
     @classmethod
@@ -90,35 +101,3 @@ class TabPFNv26Model(TabPFNModel):
     def extra_checkpoints_for_tuning(problem_type: str) -> list[str]:
         """The list of checkpoints to use for hyperparameter tuning."""
         raise NotImplementedError("We did not benchmark more checkpoints or tuning.")
-
-    @classmethod
-    def _estimate_memory_usage_static(
-        cls,
-        *,
-        X: pd.DataFrame,
-        hyperparameters: dict | None = None,
-        **kwargs,
-    ) -> int:
-        """Heuristic memory estimate based on TabPFN's memory estimate logic in:
-        https://github.com/PriorLabs/TabPFN/blob/57a2efd3ebdb3886245e4d097cefa73a5261a969/src/tabpfn/model/memory.py#L147.
-
-        This is based on GPU memory usage, but hopefully with overheads it also approximates CPU memory usage.
-        """
-        # TODO: update, this is not correct anymore, consider using internal TabPFN functions directly.
-        features_per_group = 3  # Based on TabPFNv2 default (unused)
-        n_layers = 12  # Based on TabPFNv2 default
-        embedding_size = 192  # Based on TabPFNv2 default
-        dtype_byte_size = 2  # Based on TabPFNv2 default
-
-        model_mem = 14489108  # Based on TabPFNv2 default
-
-        n_samples, n_features = X.shape[0], min(X.shape[1], 500)
-        n_feature_groups = n_features / features_per_group + 1  # TODO: Unsure how to calculate this
-
-        X_mem = n_samples * n_feature_groups * dtype_byte_size
-        activation_mem = n_samples * n_feature_groups * embedding_size * n_layers * dtype_byte_size
-
-        baseline_overhead_mem_est = 1e9  # 1 GB generic overhead
-
-        # Add some buffer to each term + 1 GB overhead to be safe
-        return int(model_mem + 4 * X_mem + activation_mem + baseline_overhead_mem_est)

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_6_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_6_model.py
@@ -23,6 +23,57 @@ class TabPFNv26Model(TabPFNModel):
     default_classification_model: str | None = "tabpfn-v2.6-classifier-v2.6_default.ckpt"
     default_regression_model: str | None = "tabpfn-v2.6-regressor-v2.6_default.ckpt"
 
+    @classmethod
+    def _estimate_memory_usage_static(
+        cls,
+        *,
+        X: pd.DataFrame,
+        hyperparameters: dict | None = None,
+        **kwargs,
+    ) -> int:
+        """Peak CPU RSS: ~1.7 GB process baseline plus ~3.6 float64 copies of the
+        train + prediction-batch data made by TabPFN-2.6's preprocessing.
+
+        Calibrated on synthetic fit+predict measurements (1k-100k rows, 10-2000
+        features); accurate within 0.9-1.2x.
+        """
+        n_train, n_features = X.shape
+        n_test = cls._n_test_for_memory_estimate(n_train=n_train, hyperparameters=hyperparameters)
+        baseline_mem_est = 1.7e9
+        preprocessing_mem_est = 3.6 * 8 * (n_train + n_test) * n_features
+        return int(baseline_mem_est + preprocessing_mem_est)
+
+    @classmethod
+    def _estimate_gpu_memory_usage_static(
+        cls,
+        *,
+        X: pd.DataFrame,
+        hyperparameters: dict | None = None,
+        **kwargs,
+    ) -> int:
+        """Peak VRAM (reserved + CUDA context) across fit and prediction.
+
+        TabPFN-2.6 materializes the joint train + prediction-batch sequence, so peak
+        VRAM is symmetric in total rows, with a two-segment per-cell (row x feature)
+        slope: steep to ~300 features, shallow to the hard cap at ~1000. Peak is set
+        by the most expensive ensemble-member preprocessing config, reached by
+        ``n_estimators >= 8`` (coefficients below assume default-sized ensembles;
+        n_estimators=1 peaks ~1.8x lower). Calibrated on synthetic measurements
+        (1k-100k train rows, up to 100k prediction rows, 10-2000 features).
+        """
+        n_train, n_features = X.shape
+        n_test = cls._n_test_for_memory_estimate(n_train=n_train, hyperparameters=hyperparameters)
+        total_rows = n_train + n_test
+        return int(
+            0.76e9  # CUDA context + model weights floor
+            + 2.8e3 * total_rows * min(n_features, 300)
+            + 0.65e3 * total_rows * max(0, min(n_features, 1000) - 300)
+        )
+
+    @classmethod
+    def _class_tags(cls):
+        return {**super()._class_tags(), "can_estimate_gpu_memory_usage_static": True}
+
     def _get_default_auxiliary_params(self) -> dict:
         default_auxiliary_params = super()._get_default_auxiliary_params()
         default_auxiliary_params.update(

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_6_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_6_model.py
@@ -31,18 +31,18 @@ class TabPFNv26Model(TabPFNModel):
         hyperparameters: dict | None = None,
         **kwargs,
     ) -> int:
-        """Peak CPU RSS: ~1.9 GB process baseline plus ~5 float64 copies of the
+        """Peak CPU RSS: a ~2.25 GB process baseline plus ~8.5 float64 copies of the
         train + prediction-batch data made by TabPFN-2.6's preprocessing.
 
-        Calibrated on synthetic fit+predict measurements (1k-100k rows, 10-2000
-        features) plus real TabArena datasets (categorical-heavy data needs a
-        higher copy count than numeric-only synthetic data); accurate within
-        0.9-1.2x on both.
+        Calibrated on measured fit+predict RSS across all 51 TabArena tasks
+        (1.0-1.33x of measured, no underestimates; categorical-heavy real data
+        needs a higher copy count than numeric-only synthetic data) plus synthetic
+        sweeps (1k-100k rows, 10-2000 features).
         """
         n_train, n_features = X.shape
         n_test = cls._n_test_for_memory_estimate(n_train=n_train, hyperparameters=hyperparameters)
-        baseline_mem_est = 1.9e9
-        preprocessing_mem_est = 5.0 * 8 * (n_train + n_test) * n_features
+        baseline_mem_est = 2.25e9
+        preprocessing_mem_est = 8.5 * 8 * (n_train + n_test) * n_features
         return int(baseline_mem_est + preprocessing_mem_est)
 
     @classmethod
@@ -72,7 +72,7 @@ class TabPFNv26Model(TabPFNModel):
         total_rows = n_train + n_test
         regression_multiplier = 2.5 if problem_type == "regression" else 1.0
         return int(
-            0.76e9  # CUDA context + model weights floor
+            0.85e9  # CUDA context + model weights floor
             + regression_multiplier
             * (
                 25e3 * total_rows

--- a/tabular/tests/unittests/test_gpu_memory_estimate.py
+++ b/tabular/tests/unittests/test_gpu_memory_estimate.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from autogluon.common.utils.resource_utils import ResourceManager
+from autogluon.core.utils.exceptions import NotEnoughCudaMemoryError
+from autogluon.core.models.dummy.dummy_model import DummyModel
+
+GB = 1024**3
+
+
+class GpuDummyModel(DummyModel):
+    """DummyModel that declares a fixed GPU memory estimate."""
+
+    gpu_mem_estimate: int = 10 * GB
+
+    def _estimate_gpu_memory_usage(self, X: pd.DataFrame, **kwargs) -> int:
+        return self.gpu_mem_estimate
+
+
+def _init_model(model_cls):
+    X = pd.DataFrame({"a": np.arange(10.0), "b": np.arange(10.0)})
+    y = pd.Series([0, 1] * 5)
+    model = model_cls(path="", name=model_cls.__name__, problem_type="binary", eval_metric="accuracy")
+    model.initialize(X=X, y=y)
+    return model, X, y
+
+
+def test__estimate_gpu_memory_usage__default_is_none():
+    model, X, y = _init_model(DummyModel)
+    assert model.estimate_gpu_memory_usage(X=X, y=y) is None
+    # no estimate -> check is skipped even with a GPU assigned
+    approx, _ = model._validate_fit_gpu_memory_usage(X=X, y=y, num_gpus=1, available_mem=1)
+    assert approx is None
+
+
+def test__validate_fit_gpu_memory_usage__raises_when_estimate_exceeds_vram():
+    model, X, y = _init_model(GpuDummyModel)
+    assert model.estimate_gpu_memory_usage(X=X, y=y) == 10 * GB
+    with pytest.raises(NotEnoughCudaMemoryError):
+        model._validate_fit_gpu_memory_usage(X=X, y=y, num_gpus=1, available_mem=8 * GB)
+
+
+def test__validate_fit_gpu_memory_usage__passes_when_estimate_fits():
+    model, X, y = _init_model(GpuDummyModel)
+    approx, avail = model._validate_fit_gpu_memory_usage(X=X, y=y, num_gpus=1, available_mem=100 * GB)
+    assert approx == 10 * GB
+    assert avail == 100 * GB
+
+
+def test__validate_fit_gpu_memory_usage__skipped_without_gpu():
+    model, X, y = _init_model(GpuDummyModel)
+    # num_gpus=0 -> not fitting on GPU -> no check, no raise
+    model._validate_fit_gpu_memory_usage(X=X, y=y, num_gpus=0, available_mem=1)
+
+
+def test__validate_fit_gpu_memory_usage__skipped_when_ratio_none():
+    model, X, y = _init_model(GpuDummyModel)
+    model.params_aux["max_gpu_memory_usage_ratio"] = None
+    model._validate_fit_gpu_memory_usage(X=X, y=y, num_gpus=1, available_mem=1)
+
+
+def test__estimate_gpu_memory_usage_static__not_implemented_by_default():
+    assert DummyModel.can_estimate_gpu_memory_usage_static() is False
+    X = pd.DataFrame({"a": [1.0, 2.0]})
+    with pytest.raises(NotImplementedError):
+        DummyModel.estimate_gpu_memory_usage_static(X=X, y=pd.Series([0, 1]))
+
+
+def test__get_available_vram__returns_bytes_or_none():
+    vram = ResourceManager.get_available_vram()
+    assert vram is None or (isinstance(vram, float) and vram > 0)

--- a/tabular/tests/unittests/test_gpu_memory_estimate.py
+++ b/tabular/tests/unittests/test_gpu_memory_estimate.py
@@ -5,8 +5,8 @@ import pandas as pd
 import pytest
 
 from autogluon.common.utils.resource_utils import ResourceManager
-from autogluon.core.utils.exceptions import NotEnoughCudaMemoryError
 from autogluon.core.models.dummy.dummy_model import DummyModel
+from autogluon.core.utils.exceptions import NotEnoughCudaMemoryError
 
 GB = 1024**3
 


### PR DESCRIPTION
## Summary

Gives models a first-class way to declare **GPU memory (VRAM) estimates**, mirroring the existing CPU memory machinery, and ships **measurement-calibrated CPU/GPU estimates** for every GPU model in `tabular` (TabPFN-3, TabPFN-2.6, TabICL, TabDPT-Turbo, TabM, RealMLP, Nori) plus a fix to LightGBM's CPU estimate. Groundwork for safely parallelizing GPU models without VRAM OOMs.

Estimates are calibrated against **776 measured fits on 136 real tasks** (51 TabArena + 85 BeyondArena, 100 to 1M rows, fold 0, AutoGluon-preprocessed) on top of synthetic sweeps. Peak VRAM is the NVML per-process peak over fit + predict, measured in an isolated subprocess.

<img width="2465" height="1632" alt="membench_estimate_accuracy_2" src="https://github.com/user-attachments/assets/22bd8a84-64c4-43d8-a1dc-629c749800aa" />

**Estimate vs measured across all 136 real tasks** (ratio = estimate ÷ measured peak; >1 is conservative, the safe direction):

| model | tasks | min | median | max | below parity |
|---|---|---|---|---|---|
| TabDPT-Turbo | 129 | 1.01 | 1.12 | 1.85 | none |
| TabPFN-2.6 | 113 | 1.00 | 1.25 | 3.79 | none |
| Nori-30M | 30 | 1.03 | 1.24 | 2.20 | none |
| TabPFN-3 | 132 | 1.02 | 1.31 | 4.28 | none |
| TabM | 136 | 1.00 | 1.61 | 7.25 | none |
| RealMLP | 136 | 1.04 | 2.30 | 2.46 | none |

No model underestimates on any task. TabICL is excluded from the table: its estimate is deliberately a *minimum requirement*, not expected usage (see below).

## GPU memory plumbing

CPU-parity API on `AbstractModel`:
- `_estimate_gpu_memory_usage` / `estimate_gpu_memory_usage_static` (+ `can_estimate_gpu_memory_usage_static` class tag). Default: no estimate, checks skipped — existing models unaffected.
- `_validate_fit_gpu_memory_usage`: fit-time check against available VRAM via the new `ResourceManager.get_available_vram()` (`torch.cuda.mem_get_info` with `nvidia-smi` fallback), governed by `ag.max_gpu_memory_usage_ratio` (default 1.0; None disables). Raises `NotEnoughCudaMemoryError` (already handled by the trainer as a graceful skip). Only runs when the model is assigned a GPU **and** defines an estimate.

## Calibrated GPU estimates

`R` = train + prediction rows, `f` = features, `cells` = rows x features.

| model | VRAM estimate |
|---|---|
| **TabPFN-3** | `1.1GB + 40KB·n_train + p + b + 18MB·min(f,230)·[1.5 if reg]`, where `p` = `26KB·n_test` (classification) or `110KB·min(n_test,100k) + 40KB·(n_test−100k)₊` (regression), `b` = `min(2.9GB, 1MB·n_train)` for regression else 0 |
| **TabPFN-2.6** | `0.85GB + m·(r + 3.8KB·min(cells,5M) + 0.8KB·(cells−5M)₊ + 0.4KB·R·(min(f,1000)−300)₊)`, `cells = R·min(f,300)`, `r` = `25KB·R` (`40KB·R` regression), `m` = 2.5 for regression |
| **TabDPT-Turbo** | `1.3GB + 25KB·(n_train + n_test)` — feature-independent |
| **TabM** | `1.2GB + 10.5MB·f_eff + 140B·min(cells,100M) + 40B·(cells−100M)₊ + 1MB·Σcat_levels`, `f_eff = min(f + #numeric-cols-with-NaN, 2000)` |
| **RealMLP** | `1.65GB + 660B·n_train + 50KB·f_eff + 28B·n_train·f_eff`, `f_eff` = post-encoding width (pytabkit one-hots cardinality ≤ `max_one_hot_cat_size`, else `embedding_size` columns) |
| **Nori** | `1GB + 32KB·min(cells,1M) + 8KB·(cells−1M)₊ + 0.5MB·n_test` |
| **TabICL** | `0.7GB + 250B·total_cells` — **minimum requirement, not usage** |

Non-obvious behaviors the measurements forced into the formulas:

- **TabPFN-2.6's per-cell cost is piecewise** because tabpfn itself switches to a memory-saving execution mode above a total-cell threshold (`tabpfn.architectures.base.memory.should_save_peak_mem`, ~6M cells on an 80GB device, scaled by free VRAM), cutting per-cell cost ~5×. Modeling that knee is what makes same-row-count tasks with different widths fit the same formula.
- **TabM's and Nori's per-cell costs saturate.** Linear-in-cells extrapolated to 359GB (TabM) on a 1M×1903 task measuring 79GB; past the knee, batches cover a shrinking fraction of the data and activations stop scaling with it.
- **TabM and RealMLP need post-encoding width, not raw column count** — categorical expansion and NaN-indicator columns change effective width by up to 30×, and the two models expand differently (a 131-row × 12.6k-feature frame uses ~12GB in TabM but ~0.9GB in RealMLP).
- **Nori is memory-heavy for a small model**: measured peaks reach 95GB on an ordinary 24k-row × 387-feature task (79GB on 12.8k × 739), well inside its own 50k-row cap. It previously had no GPU estimate at all.
- **TabICL plans batches from free VRAM**: it uses ~30GB idle but completes in <1.5GB free at ~2× runtime, so its estimate is the requirement floor — estimating usage would needlessly skip it on busy devices.

## Calibrated CPU estimates

| model | estimate |
|---|---|
| TabPFN-3 | `2.8GB + 10 float64 copies of (train + prediction batch) × min(f,500)` (replaces a flat 10GB guess) |
| TabPFN-2.6 | `2.25GB + 8.5 copies × R·f` |
| TabM | existing structural formula, with the feature count capped like the GPU estimate and the baseline raised 0.3 → 1.6GB (measured torch-process floor). Was 0.44–148× of measured (a 22k-feature frame estimated 318GB for a model that fits in 30); now 1.1–17×, no underestimates |
| LightGBM | +50MB fixed-overhead intercept: small fits were underestimated 3–11× by the size-proportional formula; worst case now ≤2.9× |

## Behavior changes

- **Prediction-row proxy is now the fit-time batch.** These estimates bound *fit* memory, where predictions are on held-out folds of the training data, so the proxy is `min(ag.max_batch_size, n_train)` rather than `max(100k, n_train)`. This was the single largest accuracy win (TabPFN-3 median 2.96× → 1.36×, TabDPT-Turbo 2.89× → 1.12×). Inference on a test set far larger than the training data is not covered — that is inference-time memory, which AutoGluon's fit-time checks never bounded.
- **TabPFN family `max_batch_size` default is `"auto"`** → resolved at fit time to `min(1M, max(max_batch_size_min, n_train))`. The floor is a per-class attribute: **1k for TabPFN-2.5/2.6**, which re-process the joint train+batch sequence per chunk (a 10k-train/50k-test regression fit peaks at 12.9GB instead of 40.6GB), and **100k for TabPFN-3**, whose KV-cached context makes small chunks a predict-time loss for little memory. Explicit `None` genuinely disables chunking.
- **TabICL's `max_batch_size=1024` is removed** (`None`): each 1024-row chunk re-encoded the full training context, making a 100k-row prediction ~50× slower (1462s → 28s measured) while saving no VRAM — tabicl batches internally, sizing to free device memory with OOM-halving.
- **Nori gains `ag.max_batch_size=10000`** (as a class constant shared with its estimate): an unchunked 50k-query predict against a 50k-row context fails with a CUDA kernel-configuration error after ~76GB; 10k-row chunks on the same context run in ~58GB.

## Testing

`tabular/tests/unittests/test_gpu_memory_estimate.py` (7 tests): estimate defaults / None-skip, VRAM check raise/pass/skip paths, ratio-None disable, static `NotImplementedError`, VRAM detection. Existing model constraint tests and `test_nori.py` pass. Lint matches the pinned pre-commit ruff (v0.16.0): `ruff check --select I` and `ruff format` clean.

### Known limitations

- **RealMLP's 2.30× median is floor-bound, not fixable by coefficients**: it measures 0.65–2GB on 125 of 136 tasks, and the 1.65GB base cannot drop without underestimating the tasks that do sit near 1.5GB.
- **TabM's 7.25× tail** is small-row/wide-feature tasks (~114–380 rows × ~1000 features), where the per-feature term is needed at 2000+ features but overshoots around 1000.
- **Nori's calibration is regression-only** (all it supports) and bounded by its 50k-row cap; its tightest task measured 94.8GB on a 96GB device, so if that peak was clipped by available VRAM the true requirement there may be higher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi
