### PR TITLE
Disable prediction caching by default in TimeSeriesPredictor

### DIFF
--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -29,7 +29,7 @@ class TimeSeriesLearner(AbstractLearner):
         trainer_type: Type[TimeSeriesTrainer] = TimeSeriesTrainer,
         eval_metric: str | TimeSeriesScorer | None = None,
         prediction_length: int = 1,
-        cache_predictions: bool = True,
+        cache_predictions: bool = False,
         ensemble_model_type: Type | None = None,
         **kwargs,
     ):

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -4,6 +4,7 @@ import math
 import os
 import pprint
 import time
+import warnings
 from pathlib import Path
 from typing import Any, Literal, Type, cast, overload
 
@@ -128,12 +129,14 @@ class TimeSeriesPredictor:
         File path to save the logs.
         If auto, logs will be saved under ``predictor_path/logs/predictor_log.txt``.
         Will be ignored if ``log_to_file`` is set to False
-    cache_predictions : bool, default = True
+    cache_predictions : bool, default = False
         If True, the predictor will cache and reuse the predictions made by individual models whenever
         :meth:`~autogluon.timeseries.TimeSeriesPredictor.predict`, :meth:`~autogluon.timeseries.TimeSeriesPredictor.leaderboard`,
-        or :meth:`~autogluon.timeseries.TimeSeriesPredictor.evaluate` methods are called. This allows to significantly
-        speed up these methods. If False, caching will be disabled. You can set this argument to False to reduce disk
-        usage at the cost of longer prediction times.
+        or :meth:`~autogluon.timeseries.TimeSeriesPredictor.evaluate` methods are called. This speeds up repeated calls
+        on the same data at the cost of extra disk usage.
+
+        .. deprecated:: 1.6.0
+            Prediction caching is deprecated and will be removed in a future release.
     label : str, optional
         Alias for :attr:`target`.
     """
@@ -157,7 +160,7 @@ class TimeSeriesPredictor:
         log_to_file: bool = True,
         log_file_path: str | Path = "auto",
         quantile_levels: list[float] | None = None,
-        cache_predictions: bool = True,
+        cache_predictions: bool = False,
         label: str | None = None,
         **kwargs,
     ):
@@ -171,6 +174,13 @@ class TimeSeriesPredictor:
             )
         self._setup_log_to_file(log_to_file=log_to_file, log_file_path=log_file_path)
 
+        if cache_predictions:
+            warnings.warn(
+                "`cache_predictions=True` is deprecated and will be removed in a future release. "
+                "Prediction caching will be removed entirely; predictions will always be computed from scratch.",
+                category=FutureWarning,
+                stacklevel=2,
+            )
         self.cache_predictions = cache_predictions
         if target is not None and label is not None:
             raise ValueError("Both `label` and `target` are specified. Please specify at most one of these arguments.")
@@ -1002,7 +1012,10 @@ class TimeSeriesPredictor:
             results for most models (except those trained on GPU because of the non-determinism of GPU operations).
         use_cache : bool, default = True
             If True, will attempt to use the cached predictions. If False, cached predictions will be ignored.
-            This argument is ignored if ``cache_predictions`` was set to False when creating the ``TimeSeriesPredictor``.
+            Has no effect unless ``cache_predictions=True`` was passed to the ``TimeSeriesPredictor`` constructor.
+
+            .. deprecated:: 1.6.0
+                Prediction caching is deprecated and will be removed in a future release.
 
 
         Examples
@@ -1123,7 +1136,10 @@ class TimeSeriesPredictor:
             ``prediction_length``.
         use_cache : bool, default = True
             If True, will attempt to use cached predictions. If False, cached predictions will be ignored.
-            This argument is ignored if ``cache_predictions`` was set to False when creating the ``TimeSeriesPredictor``.
+            Has no effect unless ``cache_predictions=True`` was passed to the ``TimeSeriesPredictor`` constructor.
+
+            .. deprecated:: 1.6.0
+                Prediction caching is deprecated and will be removed in a future release.
 
         Returns
         -------
@@ -1294,7 +1310,10 @@ class TimeSeriesPredictor:
             If True, the scores will be printed.
         use_cache : bool, default = True
             If True, will attempt to use the cached predictions. If False, cached predictions will be ignored.
-            This argument is ignored if ``cache_predictions`` was set to False when creating the ``TimeSeriesPredictor``.
+            Has no effect unless ``cache_predictions=True`` was passed to the ``TimeSeriesPredictor`` constructor.
+
+            .. deprecated:: 1.6.0
+                Prediction caching is deprecated and will be removed in a future release.
 
         Returns
         -------
@@ -1661,7 +1680,10 @@ class TimeSeriesPredictor:
             If True, the leaderboard DataFrame will be printed.
         use_cache : bool, default = True
             If True, will attempt to use the cached predictions. If False, cached predictions will be ignored.
-            This argument is ignored if ``cache_predictions`` was set to False when creating the ``TimeSeriesPredictor``.
+            Has no effect unless ``cache_predictions=True`` was passed to the ``TimeSeriesPredictor`` constructor.
+
+            .. deprecated:: 1.6.0
+                Prediction caching is deprecated and will be removed in a future release.
 
         Returns
         -------

--- a/timeseries/src/autogluon/timeseries/trainer/trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/trainer.py
@@ -55,8 +55,8 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
         num_val_windows: tuple[int, ...] = (1,),
         val_step_size: int | None = None,
         refit_every_n_windows: int | None = 1,
-        # TODO: Set cache_predictions=False by default once all models in default presets have a reasonable inference speed
-        cache_predictions: bool = True,
+        # TODO: Deprecated in v1.6.0, remove cache_predictions and use_cache in a future release
+        cache_predictions: bool = False,
         **kwargs,
     ):
         super().__init__(

--- a/timeseries/tests/unittests/trainer/test_trainer.py
+++ b/timeseries/tests/unittests/trainer/test_trainer.py
@@ -5,6 +5,7 @@ import itertools
 import shutil
 import sys
 import tempfile
+import warnings
 from pathlib import Path
 from unittest import mock
 
@@ -20,6 +21,7 @@ from autogluon.timeseries.models import DeepARModel, ETSModel
 from autogluon.timeseries.models.ensemble import GreedyEnsemble, SimpleAverageEnsemble
 from autogluon.timeseries.models.ensemble.abstract import AbstractTimeSeriesEnsembleModel
 from autogluon.timeseries.models.multi_window.multi_window_model import MultiWindowBacktestingModel
+from autogluon.timeseries.predictor import TimeSeriesPredictor
 from autogluon.timeseries.trainer import TimeSeriesTrainer
 from autogluon.timeseries.trainer.prediction_cache import FileBasedPredictionCache, NoOpPredictionCache
 
@@ -529,7 +531,7 @@ def test_when_get_model_pred_dict_called_then_pred_time_dict_contains_all_requir
 
 
 def test_given_cache_predictions_is_true_when_calling_get_model_pred_dict_then_predictions_are_cached(temp_model_path):
-    trainer = TimeSeriesTrainer(path=temp_model_path)
+    trainer = TimeSeriesTrainer(path=temp_model_path, cache_predictions=True)
     trainer.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}, "SeasonalNaive": {}})
 
     assert isinstance(trainer.prediction_cache, FileBasedPredictionCache)
@@ -545,7 +547,7 @@ def test_given_cache_predictions_is_true_when_calling_get_model_pred_dict_then_p
 def test_given_cache_predictions_is_true_when_predicting_multiple_times_then_cached_predictions_are_updated(
     temp_model_path,
 ):
-    trainer = TimeSeriesTrainer(path=temp_model_path)
+    trainer = TimeSeriesTrainer(path=temp_model_path, cache_predictions=True)
     trainer.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}, "SeasonalNaive": {}})
 
     trainer.predict(DUMMY_TS_DATAFRAME, model="Naive")
@@ -560,7 +562,7 @@ def test_given_cache_predictions_is_true_when_predicting_multiple_times_then_cac
 def test_given_cache_predictions_is_true_when_predicting_multiple_times_then_cached_predictions_are_used(
     temp_model_path,
 ):
-    trainer = TimeSeriesTrainer(path=temp_model_path)
+    trainer = TimeSeriesTrainer(path=temp_model_path, cache_predictions=True)
     trainer.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}})
     mock_predictions = pd.DataFrame(columns=["mean"] + [str(q) for q in trainer.quantile_levels])
     with mock.patch("autogluon.timeseries.models.local.naive.NaiveModel.predict") as naive_predict:
@@ -571,6 +573,26 @@ def test_given_cache_predictions_is_true_when_predicting_multiple_times_then_cac
         predictions = trainer.predict(DUMMY_TS_DATAFRAME, model="Naive")
         naive_predict.assert_not_called()
         assert predictions.equals(mock_predictions)
+
+
+def test_when_cache_predictions_not_provided_then_caching_is_disabled_by_default(temp_model_path):
+    trainer = TimeSeriesTrainer(path=temp_model_path)
+    assert isinstance(trainer.prediction_cache, NoOpPredictionCache)
+
+
+def test_given_cache_predictions_is_true_when_creating_predictor_then_future_warning_is_raised(temp_model_path):
+    with pytest.warns(FutureWarning, match="cache_predictions"):
+        TimeSeriesPredictor(path=temp_model_path, cache_predictions=True)
+
+
+@pytest.mark.parametrize("cache_predictions", [False, None])
+def test_given_cache_predictions_is_not_enabled_when_creating_predictor_then_no_warning_is_raised(
+    temp_model_path, cache_predictions
+):
+    kwargs = {} if cache_predictions is None else {"cache_predictions": cache_predictions}
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        TimeSeriesPredictor(path=temp_model_path, **kwargs)
 
 
 def test_given_cache_predictions_is_false_when_calling_get_model_pred_dict_then_predictions_are_not_cached(
@@ -588,7 +610,7 @@ def test_given_cache_predictions_is_false_when_calling_get_model_pred_dict_then_
 @pytest.mark.parametrize("method_name", ["leaderboard", "predict", "evaluate"])
 @pytest.mark.parametrize("use_cache", [True, False])
 def test_when_use_cache_is_set_to_false_then_cached_predictions_are_ignored(temp_model_path, use_cache, method_name):
-    trainer = TimeSeriesTrainer(path=temp_model_path)
+    trainer = TimeSeriesTrainer(path=temp_model_path, cache_predictions=True)
     trainer.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}})
     trainer.predict(DUMMY_TS_DATAFRAME)
 
@@ -604,7 +626,7 @@ def test_when_use_cache_is_set_to_false_then_cached_predictions_are_ignored(temp
 def test_given_cached_predictions_cannot_be_loaded_when_predict_call_then_new_predictions_are_generated(
     temp_model_path,
 ):
-    trainer = TimeSeriesTrainer(path=temp_model_path)
+    trainer = TimeSeriesTrainer(path=temp_model_path, cache_predictions=True)
     trainer.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}})
     trainer.predict(DUMMY_TS_DATAFRAME, model="Naive")
 


### PR DESCRIPTION
## Description of changes

Most forecasting models now have acceptable inference speed, so caching predictions to disk is no longer worth the added complexity it introduces. This PR sets `cache_predictions=False` by default and marks prediction caching as deprecated.

- Flip `cache_predictions` to `False` in `TimeSeriesPredictor`, `TimeSeriesLearner` and `TimeSeriesTrainer` (the value chains through all three, so all must change together).
- Raise a `FutureWarning` when `cache_predictions=True` is passed explicitly. `FutureWarning` rather than `DeprecationWarning` because the latter is silenced by default outside `__main__`, so library users would never see it. The warning only fires on explicit opt-in, so nobody is affected by the default flip alone.
- Update docstrings for `cache_predictions` and the four `use_cache` arguments. The old note ("ignored if `cache_predictions` was set to False") now describes the default path, so it is reworded.

`use_cache` on `predict` / `backtest_predictions` / `evaluate` / `leaderboard` keeps its current default. It already means "use the cache *if* caching is enabled", so it is now a silent no-op via `NoOpPredictionCache`; flipping it would only break users who deliberately set `cache_predictions=True`. Both arguments, along with `trainer/prediction_cache.py`, are intended for removal in a future release.

### Behavior change

`leaderboard()` or `evaluate()` followed by `predict()` on the same data now re-runs inference instead of reusing cached predictions. Within a single call nothing changes: `get_model_pred_dict` still shares base model predictions through the in-memory dict, so ensembles are unaffected. `feature_importance` already passed `use_cache=False`.

## Testing

- Five existing tests that assert `FileBasedPredictionCache` now pass `cache_predictions=True` explicitly.
- Added tests covering the new default (`NoOpPredictionCache`), the `FutureWarning` on opt-in, and the absence of a warning when the argument is omitted or `False`.

Ran `pytest timeseries/tests/unittests/trainer/test_trainer.py -k "cache or warning"` and `timeseries/tests/unittests/trainer/test_prediction_cache.py` locally (20 passed). Broader suites left to CI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.