### PR TITLE
Update semantic_segmentation.py

### DIFF
--- a/multimodal/src/autogluon/multimodal/learners/semantic_segmentation.py
+++ b/multimodal/src/autogluon/multimodal/learners/semantic_segmentation.py
@@ -295,7 +295,7 @@ class SemanticSegmentationLearner(BaseLearner):
         Optionally return a dataframe of prediction results.
         """
         data = self.on_predict_start(data)
-        return self.evaluate_semantic_segmentation(data, metrics, realtime)
+        return self.evaluate_semantic_segmentation(data, metrics, return_pred, realtime)
 
     def predict(
         self,


### PR DESCRIPTION
*Description of changes:*

Fixed a parameter mapping bug where `predictor.evaluate()` was passing positional arguments incorrectly to `evaluate_semantic_segmentation()`. Explicitly pass keyword arguments `(data, metrics, return_pred, realtime)` so that `return_pred` is correctly forwarded, preventing a `ValueError` during tuple unpacking when evaluating semantic segmentation tasks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
