### PR TITLE
[timeseries] Respect user-provided device for Chronos models

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/chronos/chronos2.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/chronos2.py
@@ -275,7 +275,7 @@ class Chronos2Model(AbstractTimeSeriesModel):
     def load_model_pipeline(self):
         from chronos.chronos2.pipeline import Chronos2Pipeline
 
-        device = (self.get_hyperparameter("device") or "cuda") if self._is_gpu_available() else "cpu"
+        device = self.get_hyperparameter("device") or ("cuda" if self._is_gpu_available() else "cpu")
 
         assert self.model_path is not None
         pipeline = Chronos2Pipeline.from_pretrained(

--- a/timeseries/src/autogluon/timeseries/models/chronos/model.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/model.py
@@ -308,7 +308,7 @@ class ChronosModel(AbstractTimeSeriesModel):
                 "`import torch; torch.cuda.is_available()` returns `True`."
             )
 
-        device = (self.device or "cuda") if gpu_available else "cpu"
+        device = self.device or ("cuda" if gpu_available else "cpu")
 
         assert self.model_path is not None
         pipeline = BaseChronosPipeline.from_pretrained(

--- a/timeseries/tests/unittests/models/chronos/test_chronos2.py
+++ b/timeseries/tests/unittests/models/chronos/test_chronos2.py
@@ -8,7 +8,7 @@ from autogluon.core.utils.exceptions import TimeLimitExceeded
 from autogluon.timeseries.models.chronos import Chronos2Model
 
 from ...common import DATAFRAME_WITH_COVARIATES, DUMMY_TS_DATAFRAME, get_data_frame_with_item_index
-from ..common import CHRONOS2_MODEL_PATH
+from ..common import CHRONOS2_MODEL_PATH, DEVICE_TEST_CASES
 
 
 class TestChronos2Inference:
@@ -121,6 +121,21 @@ class TestChronos2Inference:
 
         mock_from_pretrained.assert_called_once()
         assert mock_from_pretrained.call_args.kwargs.get("revision") == model_revision
+
+    @pytest.mark.parametrize("device_arg, cuda_available, expected_device", DEVICE_TEST_CASES)
+    def test_when_device_provided_then_from_pretrained_is_called_with_device(
+        self, device_arg, cuda_available, expected_device
+    ):
+        model = Chronos2Model(
+            hyperparameters={"model_path": CHRONOS2_MODEL_PATH, "device": device_arg},
+        )
+        with mock.patch("chronos.chronos2.pipeline.Chronos2Pipeline.from_pretrained") as mock_from_pretrained:
+            mock_from_pretrained.return_value = mock.MagicMock()
+            with mock.patch("torch.cuda.is_available", return_value=cuda_available):
+                model.load_model_pipeline()
+
+        mock_from_pretrained.assert_called_once()
+        assert mock_from_pretrained.call_args.kwargs.get("device_map") == expected_device
 
     def test_when_chronos2_scores_oof_and_time_limit_is_exceeded_then_exception_is_raised(self, chronos2_model):
         data = get_data_frame_with_item_index(item_list=list(range(1000)), data_length=50)

--- a/timeseries/tests/unittests/models/chronos/test_model.py
+++ b/timeseries/tests/unittests/models/chronos/test_model.py
@@ -527,7 +527,11 @@ def test_when_device_provided_then_from_pretrained_is_called_with_device(device_
 
     with mock.patch("chronos.BaseChronosPipeline.from_pretrained") as mock_from_pretrained:
         mock_from_pretrained.return_value = mock.MagicMock()
-        with mock.patch("torch.cuda.is_available", return_value=cuda_available):
+        # _has_tf32 queries the real CUDA driver, which is unavailable when cuda_available is mocked to True
+        with (
+            mock.patch("torch.cuda.is_available", return_value=cuda_available),
+            mock.patch.object(ChronosModel, "_has_tf32", return_value=False),
+        ):
             model.fit(train_data=DUMMY_TS_DATAFRAME)
             model.load_model_pipeline()
 

--- a/timeseries/tests/unittests/models/chronos/test_model.py
+++ b/timeseries/tests/unittests/models/chronos/test_model.py
@@ -16,7 +16,7 @@ from ...common import (
     get_data_frame_with_item_index,
     get_data_frame_with_variable_lengths,
 )
-from ..common import CHRONOS_BOLT_MODEL_PATH, CHRONOS_CLASSIC_MODEL_PATH
+from ..common import CHRONOS_BOLT_MODEL_PATH, CHRONOS_CLASSIC_MODEL_PATH, DEVICE_TEST_CASES
 
 DATASETS = [DUMMY_TS_DATAFRAME, DATAFRAME_WITH_STATIC, DATAFRAME_WITH_COVARIATES]
 GPU_AVAILABLE = torch.cuda.is_available()
@@ -517,3 +517,19 @@ def test_when_revision_provided_then_from_pretrained_is_called_with_revision(chr
 
     mock_from_pretrained.assert_called_once()
     assert mock_from_pretrained.call_args.kwargs.get("revision") == model_revision
+
+
+@pytest.mark.parametrize("device_arg, cuda_available, expected_device", DEVICE_TEST_CASES)
+def test_when_device_provided_then_from_pretrained_is_called_with_device(device_arg, cuda_available, expected_device):
+    model = ChronosModel(
+        hyperparameters={"model_path": CHRONOS_BOLT_MODEL_PATH, "device": device_arg},
+    )
+
+    with mock.patch("chronos.BaseChronosPipeline.from_pretrained") as mock_from_pretrained:
+        mock_from_pretrained.return_value = mock.MagicMock()
+        with mock.patch("torch.cuda.is_available", return_value=cuda_available):
+            model.fit(train_data=DUMMY_TS_DATAFRAME)
+            model.load_model_pipeline()
+
+    mock_from_pretrained.assert_called_once()
+    assert mock_from_pretrained.call_args.kwargs.get("device_map") == expected_device

--- a/timeseries/tests/unittests/models/common.py
+++ b/timeseries/tests/unittests/models/common.py
@@ -95,6 +95,23 @@ CHRONOS_BOLT_MODEL_PATH = "autogluon/chronos-bolt-tiny"
 CHRONOS_CLASSIC_MODEL_PATH = "autogluon/chronos-t5-tiny"
 TOTO2_MODEL_PATH = "Datadog/Toto-2.0-4m"
 
+# device_arg, cuda_available, expected_device
+DEVICE_TEST_CASES = [
+    # if device is not provided, CUDA is used when available and CPU otherwise
+    (None, True, "cuda"),
+    (None, False, "cpu"),
+    # an explicitly provided device is always respected, which enables non-CUDA backends
+    ("mps", True, "mps"),
+    ("mps", False, "mps"),
+    ("xpu", True, "xpu"),
+    ("xpu", False, "xpu"),
+    ("cpu", True, "cpu"),
+    ("cpu", False, "cpu"),
+    ("cuda", True, "cuda"),
+    ("cuda", False, "cuda"),
+    ("cuda:1", True, "cuda:1"),
+]
+
 DEFAULT_HYPERPARAMETERS: dict[Type[AbstractTimeSeriesModel], dict] = {
     # Supertypes should come first, so that the most specific hyperparameters are used
     # in case of an overlap


### PR DESCRIPTION
Fixes #5529

`device` provided by the user was overridden with `"cpu"` whenever `torch.cuda.is_available()` returned `False`, so non-CUDA backends like `"mps"` and `"xpu"` could not be used. This restores the pre-v1.5 resolution order in both `ChronosModel` and `Chronos2Model`:

```python
device = self.device or ("cuda" if gpu_available else "cpu")
```

The `device=None` default is unchanged (CUDA if available, else CPU), so CUDA and CPU users are unaffected. Requesting `"cuda"` without CUDA now raises from torch instead of silently falling back to CPU.

Added a parametrized test over `(device, cuda_available, expected_device)` for both models, asserting the `device_map` passed to `from_pretrained`.

Note: `ChronosModel`'s existing GPU guard is CUDA-only, so `chronos-t5-small/base/large` (`num_gpus=1`) still raise without CUDA. Left as-is; the fix applies to Chronos-Bolt, `t5-tiny/mini`, and Chronos-2.