### PR TITLE
[tabular] Support loading Mitra from a local checkpoint path

### DIFF
--- a/tabular/src/autogluon/tabular/models/mitra/_internal/models/tab2d.py
+++ b/tabular/src/autogluon/tabular/models/mitra/_internal/models/tab2d.py
@@ -34,6 +34,18 @@ from ..._internal.models.embedding import (
 logger = logging.getLogger(__name__)
 
 
+def _resolve_pretrained_file(path_or_repo_id: str, filename: str) -> str:
+    """Locate `filename` inside a local checkpoint directory, falling back to a HuggingFace repo download."""
+    if os.path.isdir(path_or_repo_id):
+        local_path = os.path.join(path_or_repo_id, filename)
+        if not os.path.isfile(local_path):
+            raise FileNotFoundError(
+                f"Local checkpoint directory '{path_or_repo_id}' is missing the required file '{filename}'."
+            )
+        return local_path
+    return hf_hub_download(repo_id=path_or_repo_id, filename=filename)
+
+
 class Tab2D(BaseModel):
     def __init__(
         self,
@@ -213,7 +225,8 @@ class Tab2D(BaseModel):
 
     @classmethod
     def from_pretrained(cls, path_or_repo_id: str, device: str = "cuda") -> "Tab2D":
-        config_path = hf_hub_download(repo_id=path_or_repo_id, filename="config.json")
+        """Load a pretrained model from a local directory (as saved by `save_pretrained`) or a HuggingFace repo id."""
+        config_path = _resolve_pretrained_file(path_or_repo_id, "config.json")
         with open(config_path, "r") as f:
             config = json.load(f)
 
@@ -228,7 +241,7 @@ class Tab2D(BaseModel):
             device=device,
         )
 
-        weights_path = hf_hub_download(repo_id=path_or_repo_id, filename="model.safetensors")
+        weights_path = _resolve_pretrained_file(path_or_repo_id, "model.safetensors")
         state_dict = load_file(weights_path, device=device)
         model.load_state_dict(state_dict)
 

--- a/tabular/src/autogluon/tabular/models/mitra/mitra_model.py
+++ b/tabular/src/autogluon/tabular/models/mitra/mitra_model.py
@@ -64,6 +64,30 @@ class MitraModel(AbstractTorchModel):
             raise AssertionError(f"Unsupported problem_type: {self.problem_type}")
         return model_cls
 
+    @staticmethod
+    def _resolve_hf_model(problem_type: str, hyp: dict) -> str | None:
+        """Pop the `hf_*` checkpoint aliases from `hyp` and return the one that applies.
+
+        The most specific alias wins: problem-specific > general > generic. Every alias is
+        popped regardless of which one wins, as leaving an unused one behind would leak into
+        the model constructor as an unexpected keyword argument.
+
+        Each alias accepts either a local checkpoint directory or a HuggingFace repo id.
+        """
+        hf_cls_model = hyp.pop("hf_cls_model", None)
+        hf_reg_model = hyp.pop("hf_reg_model", None)
+        hf_general_model = hyp.pop("hf_general_model", None)
+        hf_model = hyp.pop("hf_model", None)
+
+        if problem_type in ["binary", "multiclass"]:
+            hf_problem_model = hf_cls_model
+        elif problem_type == "regression":
+            hf_problem_model = hf_reg_model
+        else:
+            raise AssertionError(f"Unsupported problem_type: {problem_type}")
+
+        return next((m for m in (hf_problem_model, hf_general_model, hf_model) if m is not None), None)
+
     def _preprocess(self, X: pd.DataFrame, is_train: bool = False, **kwargs) -> pd.DataFrame:
         X = super()._preprocess(X, **kwargs)
 
@@ -115,18 +139,7 @@ class MitraModel(AbstractTorchModel):
 
         hyp = self._get_model_params()
 
-        hf_cls_model = hyp.pop("hf_cls_model", None)
-        hf_reg_model = hyp.pop("hf_reg_model", None)
-        if self.problem_type in ["binary", "multiclass"]:
-            hf_model = hf_cls_model
-        elif self.problem_type == "regression":
-            hf_model = hf_reg_model
-        else:
-            raise AssertionError(f"Unsupported problem_type: {self.problem_type}")
-        if hf_model is None:
-            hf_model = hyp.pop("hf_general_model", None)
-        if hf_model is None:
-            hf_model = hyp.pop("hf_model", None)
+        hf_model = self._resolve_hf_model(problem_type=self.problem_type, hyp=hyp)
         if hf_model is not None:
             logger.log(30, f"\tCustom hf_model specified: {hf_model}")
             hyp["hf_model"] = hf_model

--- a/tabular/src/autogluon/tabular/models/mitra/mitra_model.py
+++ b/tabular/src/autogluon/tabular/models/mitra/mitra_model.py
@@ -157,14 +157,17 @@ class MitraModel(AbstractTorchModel):
                 f"We strongly recommend using a GPU instance to fine-tune Mitra.",
             )
 
-        if "state_dict_classification" in hyp:
-            state_dict_classification = hyp.pop("state_dict_classification")
-            if self.problem_type in ["binary", "multiclass"]:
-                hyp["state_dict"] = state_dict_classification
-        if "state_dict_regression" in hyp:
-            state_dict_regression = hyp.pop("state_dict_regression")
-            if self.problem_type in ["regression"]:
-                hyp["state_dict"] = state_dict_regression
+        # `state_dict_classification` / `state_dict_regression` pointed at a raw `.pt` checkpoint.
+        # That loading path was never reachable, so these have always been no-ops. Pop them so an
+        # existing hyperparameter dict keeps working, and point users at the replacement.
+        for deprecated_key in ["state_dict", "state_dict_classification", "state_dict_regression"]:
+            if hyp.pop(deprecated_key, None) is not None:
+                logger.log(
+                    30,
+                    f"\tWarning: `{deprecated_key}` is deprecated and ignored. "
+                    f"To load custom weights, save them with `Tab2D.save_pretrained(<dir>)` and pass "
+                    f"the directory as `hf_model`, which also accepts a HuggingFace repo id.",
+                )
 
         if "verbose" not in hyp:
             hyp["verbose"] = verbosity >= 3

--- a/tabular/src/autogluon/tabular/models/mitra/sklearn_interface.py
+++ b/tabular/src/autogluon/tabular/models/mitra/sklearn_interface.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import contextlib
 import time
-from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -68,7 +67,6 @@ class MitraBase(BaseEstimator):
         fine_tune=DEFAULT_FINE_TUNE,
         fine_tune_steps=DEFAULT_FINE_TUNE_STEPS,
         metric=DEFAULT_CLS_METRIC,
-        state_dict=None,
         hf_model=None,
         patience=PATIENCE,
         lr=LR,
@@ -94,9 +92,6 @@ class MitraBase(BaseEstimator):
             Device to run the model on
         fine_tune_steps: int, default=0
             Number of epochs to train for
-        state_dict : str, optional
-            Path to a raw state dict checkpoint (``.pt``) to load weights from.
-            Takes precedence over ``hf_model`` when set.
         hf_model : str, optional
             Local directory containing ``config.json`` + ``model.safetensors``
             (as written by ``Tab2D.save_pretrained``), or a HuggingFace repo id.
@@ -107,7 +102,6 @@ class MitraBase(BaseEstimator):
         self.fine_tune = fine_tune
         self.fine_tune_steps = fine_tune_steps
         self.metric = metric
-        self.state_dict = state_dict
         self.hf_model = hf_model
         self.patience = patience
         self.lr = lr
@@ -150,7 +144,6 @@ class MitraBase(BaseEstimator):
                 "lr": self.lr,
                 "weight_decay": 0.1,
                 "warmup_steps": self.warmup_steps,
-                "path_to_weights": self.state_dict,
                 "precision": "bfloat16",
                 "random_mirror_regression": self.random_mirror_regression,
                 "random_mirror_x": self.random_mirror_x,
@@ -206,23 +199,9 @@ class MitraBase(BaseEstimator):
 
                 self.train_time = 0
                 for _ in range(self.n_estimators):
-                    if self.state_dict is not None:
-                        # Raw state dict checkpoint: architecture comes from the config, not from a config.json.
-                        model = Tab2D(
-                            dim=cfg.hyperparams["dim"],
-                            dim_output=dim_output,
-                            n_layers=cfg.hyperparams["n_layers"],
-                            n_heads=cfg.hyperparams["n_heads"],
-                            task=task.upper(),
-                            use_pretrained_weights=True,
-                            path_to_weights=Path(self.state_dict),
-                            device=self.device,
-                        )
-                    else:
-                        # `hf_model` is either a local directory holding `config.json` +
-                        # `model.safetensors`, or a HuggingFace repo id.
-                        assert self.hf_model is not None, "One of `hf_model` or `state_dict` must be specified."
-                        model = Tab2D.from_pretrained(self.hf_model, device=self.device)
+                    # `hf_model` is either a local directory holding `config.json` +
+                    # `model.safetensors`, or a HuggingFace repo id.
+                    model = Tab2D.from_pretrained(self.hf_model, device=self.device)
                     trainer = TrainerFinetune(
                         cfg, model, n_classes=n_classes, device=self.device, rng=rng, verbose=self.verbose
                     )
@@ -272,7 +251,6 @@ class MitraClassifier(MitraBase, ClassifierMixin):
         fine_tune=DEFAULT_FINE_TUNE,
         fine_tune_steps=DEFAULT_FINE_TUNE_STEPS,
         metric=DEFAULT_CLS_METRIC,
-        state_dict=None,
         hf_model=DEFAULT_CLS_MODEL,
         patience=PATIENCE,
         lr=LR,
@@ -293,7 +271,6 @@ class MitraClassifier(MitraBase, ClassifierMixin):
             fine_tune,
             fine_tune_steps,
             metric,
-            state_dict,
             hf_model=hf_model,
             patience=patience,
             lr=lr,
@@ -412,7 +389,6 @@ class MitraRegressor(MitraBase, RegressorMixin):
         fine_tune=DEFAULT_FINE_TUNE,
         fine_tune_steps=DEFAULT_FINE_TUNE_STEPS,
         metric=DEFAULT_REG_METRIC,
-        state_dict=None,
         hf_model=DEFAULT_REG_MODEL,
         patience=PATIENCE,
         lr=LR,
@@ -433,7 +409,6 @@ class MitraRegressor(MitraBase, RegressorMixin):
             fine_tune,
             fine_tune_steps,
             metric,
-            state_dict,
             hf_model=hf_model,
             patience=patience,
             lr=lr,

--- a/tabular/src/autogluon/tabular/models/mitra/sklearn_interface.py
+++ b/tabular/src/autogluon/tabular/models/mitra/sklearn_interface.py
@@ -55,7 +55,6 @@ DEFAULT_LAYERS = 12
 DEFAULT_HEADS = 4
 DEFAULT_CLASSES = 10
 DEFAULT_VALIDATION_SPLIT = 0.2
-USE_HF = True  # Use Hugging Face pretrained models if available
 
 
 class MitraBase(BaseEstimator):
@@ -96,7 +95,11 @@ class MitraBase(BaseEstimator):
         fine_tune_steps: int, default=0
             Number of epochs to train for
         state_dict : str, optional
-            Path to the pretrained weights
+            Path to a raw state dict checkpoint (``.pt``) to load weights from.
+            Takes precedence over ``hf_model`` when set.
+        hf_model : str, optional
+            Local directory containing ``config.json`` + ``model.safetensors``
+            (as written by ``Tab2D.save_pretrained``), or a HuggingFace repo id.
         """
         self.model_type = model_type
         self.n_estimators = n_estimators
@@ -203,10 +206,8 @@ class MitraBase(BaseEstimator):
 
                 self.train_time = 0
                 for _ in range(self.n_estimators):
-                    if USE_HF:
-                        assert self.hf_model is not None, "hf_model must not be None."
-                        model = Tab2D.from_pretrained(self.hf_model, device=self.device)
-                    else:
+                    if self.state_dict is not None:
+                        # Raw state dict checkpoint: architecture comes from the config, not from a config.json.
                         model = Tab2D(
                             dim=cfg.hyperparams["dim"],
                             dim_output=dim_output,
@@ -217,6 +218,11 @@ class MitraBase(BaseEstimator):
                             path_to_weights=Path(self.state_dict),
                             device=self.device,
                         )
+                    else:
+                        # `hf_model` is either a local directory holding `config.json` +
+                        # `model.safetensors`, or a HuggingFace repo id.
+                        assert self.hf_model is not None, "One of `hf_model` or `state_dict` must be specified."
+                        model = Tab2D.from_pretrained(self.hf_model, device=self.device)
                     trainer = TrainerFinetune(
                         cfg, model, n_classes=n_classes, device=self.device, rng=rng, verbose=self.verbose
                     )

--- a/tabular/src/autogluon/tabular/models/nori/nori_model.py
+++ b/tabular/src/autogluon/tabular/models/nori/nori_model.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+import numpy as np
+
 from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
 from autogluon.common.utils.resource_utils import ResourceManager
 from autogluon.features.generators import LabelEncoderFeatureGenerator
 from autogluon.tabular.models.abstract.abstract_torch_model import AbstractTorchModel
-
-import numpy as np
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/tabular/tests/unittests/models/test_mitra.py
+++ b/tabular/tests/unittests/models/test_mitra.py
@@ -1,4 +1,3 @@
-import os
 from unittest import mock
 
 import pytest
@@ -83,7 +82,8 @@ def test_mitra_loads_local_checkpoint_dir(tmp_path):
         path_to_weights="",
         device="cpu",
     ).save_pretrained(str(checkpoint_dir))
-    assert sorted(os.listdir(checkpoint_dir)) == ["config.json", "model.safetensors"]
+    assert (checkpoint_dir / "config.json").is_file()
+    assert (checkpoint_dir / "model.safetensors").is_file()
 
     with mock.patch(
         "autogluon.tabular.models.mitra._internal.models.tab2d.hf_hub_download",

--- a/tabular/tests/unittests/models/test_mitra.py
+++ b/tabular/tests/unittests/models/test_mitra.py
@@ -1,3 +1,6 @@
+import os
+from unittest import mock
+
 import pytest
 
 from autogluon.common.utils.resource_utils import ResourceManager
@@ -23,3 +26,78 @@ def test_mitra():
         # Mitra returns different predictions when predicting on an individual sample
         verify_single_prediction_equivalent_to_multi=False,
     )
+
+
+@pytest.mark.parametrize(
+    "problem_type, hyperparameters, expected",
+    [
+        # No alias given -> None, so the model class' own default applies.
+        ("binary", {}, None),
+        ("regression", {}, None),
+        # The most specific alias wins: problem-specific > general > generic.
+        ("binary", {"hf_cls_model": "org/cls", "hf_general_model": "org/gen"}, "org/cls"),
+        ("binary", {"hf_cls_model": "org/cls", "hf_model": "org/generic"}, "org/cls"),
+        ("binary", {"hf_general_model": "org/gen", "hf_model": "org/generic"}, "org/gen"),
+        ("binary", {"hf_model": "org/generic"}, "org/generic"),
+        ("regression", {"hf_reg_model": "org/reg", "hf_cls_model": "org/cls"}, "org/reg"),
+        ("regression", {"hf_general_model": "org/gen"}, "org/gen"),
+        # An alias for the other problem type is ignored.
+        ("binary", {"hf_reg_model": "org/reg"}, None),
+        ("regression", {"hf_cls_model": "org/cls"}, None),
+    ],
+)
+def test_mitra_resolve_hf_model(problem_type, hyperparameters, expected):
+    assert MitraModel._resolve_hf_model(problem_type=problem_type, hyp=dict(hyperparameters)) == expected
+
+
+def test_mitra_resolve_hf_model_pops_every_alias():
+    """Every alias must be popped, else an unused one leaks into the model constructor."""
+    hyp = {
+        "hf_cls_model": "org/cls",
+        "hf_reg_model": "org/reg",
+        "hf_general_model": "org/gen",
+        "hf_model": "org/generic",
+        "n_estimators": 1,
+    }
+    assert MitraModel._resolve_hf_model(problem_type="binary", hyp=hyp) == "org/cls"
+    assert hyp == {"n_estimators": 1}
+
+
+def test_mitra_resolve_hf_model_rejects_unsupported_problem_type():
+    with pytest.raises(AssertionError, match="Unsupported problem_type"):
+        MitraModel._resolve_hf_model(problem_type="quantile", hyp={})
+
+
+def test_mitra_loads_local_checkpoint_dir(tmp_path):
+    """A local directory written by `save_pretrained` is loaded from disk instead of HuggingFace."""
+    from autogluon.tabular.models.mitra._internal.models.tab2d import Tab2D
+
+    checkpoint_dir = tmp_path / "checkpoint"
+    Tab2D(
+        dim=32,
+        dim_output=10,
+        n_layers=1,
+        n_heads=2,
+        task="CLASSIFICATION",
+        use_pretrained_weights=False,
+        path_to_weights="",
+        device="cpu",
+    ).save_pretrained(str(checkpoint_dir))
+    assert sorted(os.listdir(checkpoint_dir)) == ["config.json", "model.safetensors"]
+
+    with mock.patch(
+        "autogluon.tabular.models.mitra._internal.models.tab2d.hf_hub_download",
+        side_effect=AssertionError("must not hit HuggingFace for a local checkpoint"),
+    ):
+        loaded = Tab2D.from_pretrained(str(checkpoint_dir), device="cpu")
+    assert loaded.dim == 32
+    assert loaded.n_layers == 1
+
+
+def test_mitra_local_checkpoint_dir_missing_file(tmp_path):
+    """An incomplete local checkpoint directory reports the missing file instead of a download error."""
+    from autogluon.tabular.models.mitra._internal.models.tab2d import Tab2D
+
+    (tmp_path / "empty").mkdir()
+    with pytest.raises(FileNotFoundError, match="config.json"):
+        Tab2D.from_pretrained(str(tmp_path / "empty"), device="cpu")

--- a/tabular/tests/unittests/models/test_nori.py
+++ b/tabular/tests/unittests/models/test_nori.py
@@ -33,10 +33,24 @@ class _FakeNoriRegressor:
     """
 
     _INIT_KWARGS = {
-        "model_path", "model", "device", "inference_config", "token", "augmentations",
-        "yj_skew_threshold", "quantile_collapse", "bar_temperature", "bar_point_estimator",
-        "discrete_y_snap_max_unique", "discretize", "categorical_levels", "text_columns",
-        "svd_dim", "embedder", "text_max_cardinality", "text_normalize",
+        "model_path",
+        "model",
+        "device",
+        "inference_config",
+        "token",
+        "augmentations",
+        "yj_skew_threshold",
+        "quantile_collapse",
+        "bar_temperature",
+        "bar_point_estimator",
+        "discrete_y_snap_max_unique",
+        "discretize",
+        "categorical_levels",
+        "text_columns",
+        "svd_dim",
+        "embedder",
+        "text_max_cardinality",
+        "text_normalize",
     }
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
## Description

Mitra could only load pretrained weights from HuggingFace, so a local checkpoint path passed via `hf_cls_model` / `hf_reg_model` was always treated as a repo id and failed. These hyperparameters now accept a local directory too.

Three changes:

1. **Local paths** (`_internal/models/tab2d.py`) — `Tab2D.from_pretrained` called `hf_hub_download` unconditionally. It now reads `config.json` / `model.safetensors` from a local directory when given one, else falls back to HuggingFace. The `os.path.isdir` dispatch matches what HuggingFace's own `ModelHubMixin.from_pretrained` does. An incomplete directory raises `FileNotFoundError` naming the missing file, instead of a confusing 404.

2. **Remove the dead `state_dict` path** (`sklearn_interface.py`) — loading a raw `.pt` checkpoint was gated behind a module-level `USE_HF = True` that could not be set, so it has never executed since Mitra was added in #5195. Since (1) covers the use case — `Tab2D.save_pretrained(<dir>)`, then pass the directory — the branch and its `state_dict` parameter are removed rather than revived. `state_dict`, `state_dict_classification` and `state_dict_regression` are still popped in `_fit` so existing hyperparameter dicts keep working, but now log a warning pointing at `hf_model`; they were already no-ops.

3. **Fix `hf_*` alias leak** (`mitra_model.py`) — fallback aliases were only popped when no more specific alias matched, so an unused key stayed in the hyperparameters dict and was splatted into the model constructor. Passing an override plus a fallback crashed the fit:

   ```python
   hyperparameters={MitraModel: {"hf_cls_model": "org/cls", "hf_general_model": "org/gen"}}
   # TypeError: MitraClassifier.__init__() got an unexpected keyword argument 'hf_general_model'
   ```

   Alias resolution is now a small pure helper, `MitraModel._resolve_hf_model`, which pops all four aliases before applying precedence (problem-specific > general > generic).

Usage:

```python
predictor.fit(train_data, hyperparameters={
    MitraModel: {"hf_cls_model": "/path/to/local/ckpt"},   # config.json + model.safetensors
    # or: {"hf_cls_model": "some-org/some-mitra"}          # HuggingFace repo id
})
```

HuggingFace defaults are unchanged. No new hyperparameters.

Also included: a formatting-only lint fix for `nori_model.py` / `test_nori.py` (added in #5705), which currently fail `ruff format` / `ruff check --select I` on every branch. Happy to split this out.
