### PR TITLE
[timeseries] Add method for exporting fine-tuned models

### DIFF
--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -1,6 +1,7 @@
 import logging
 import reprlib
 import time
+from pathlib import Path
 from typing import Any, Literal, Type
 
 import pandas as pd
@@ -328,6 +329,9 @@ class TimeSeriesLearner(AbstractLearner):
         unpersisted_models = self.load_trainer().unpersist()
         self.trainer = None  # type: ignore
         return unpersisted_models
+
+    def export_model(self, path: str | Path, model: str | None = None) -> str:
+        return self.load_trainer().export_model(path=path, model=model)
 
     def refit_full(self, model: str = "all") -> dict[str, str]:
         return self.load_trainer().refit_full(model=model)

--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -330,7 +330,7 @@ class TimeSeriesLearner(AbstractLearner):
         self.trainer = None  # type: ignore
         return unpersisted_models
 
-    def export_model(self, path: str | Path, model: str | None = None) -> str:
+    def export_model(self, path: str | Path, model: str) -> str:
         return self.load_trainer().export_model(path=path, model=model)
 
     def refit_full(self, model: str = "all") -> dict[str, str]:

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -464,7 +464,7 @@ class AbstractTimeSeriesModel(TimeSeriesModelBase, TimeSeriesTunable, metaclass=
     def supports_export(self) -> bool:
         """Whether this model can be exported with `export_model`.
 
-        A model can only be exported if its type implements `export_model` and it does not rely on
+        A model can only be exported if its type implements `export_model` and it does not use any
         AutoGluon-side data transforms, which are not included in the exported artifact.
         """
         return self.__class__._supports_export and not self._get_transforms_blocking_export()
@@ -472,23 +472,18 @@ class AbstractTimeSeriesModel(TimeSeriesModelBase, TimeSeriesTunable, metaclass=
     def _get_transforms_blocking_export(self) -> list[str]:
         """Names of the AutoGluon-side data transforms that prevent this model from being exported.
 
-        Transforms are only instantiated during `fit`, so the hyperparameters are also checked to get the
-        correct answer for a model that has not been fit yet.
+        The exported artifact only contains the wrapped pretrained model. Any target scaler, covariate scaler or
+        covariate regressor is applied by AutoGluon around that model, so an export would silently produce
+        different forecasts than `predictor.predict()`.
         """
-        hyperparameters = self.get_hyperparameters()
         return [
             name
             for name in ["target_scaler", "covariate_scaler", "covariate_regressor"]
-            if getattr(self, name, None) is not None or hyperparameters.get(name) is not None
+            if getattr(self, name, None) is not None
         ]
 
     def _assert_no_transforms_for_export(self) -> None:
-        """Ensure that the model does not rely on AutoGluon-side data transforms before exporting it.
-
-        The exported artifact only contains the wrapped pretrained model. Any target scaler, covariate scaler or
-        covariate regressor is applied by AutoGluon around that model, so an export would silently produce different
-        forecasts than `predictor.predict()`.
-        """
+        """Raise if the model relies on AutoGluon-side data transforms that cannot be exported."""
         transforms = self._get_transforms_blocking_export()
         if transforms:
             raise ValueError(

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -31,17 +31,6 @@ from .tunable import TimeSeriesTunable
 logger = logging.getLogger(__name__)
 
 
-def get_models_supporting_export() -> list[str]:
-    """Names of the model types that support `export_model`."""
-    return sorted(
-        {
-            record.model_class.__name__.removesuffix("Model")
-            for record in ModelRegistry.REGISTRY.values()
-            if record.model_class._supports_export
-        }
-    )
-
-
 class TimeSeriesModelBase(ModelBase, ABC):
     """Abstract base class for all `Model` objects in autogluon.timeseries, including both
     forecasting models and forecast combination/ensemble models.
@@ -84,8 +73,7 @@ class TimeSeriesModelBase(ModelBase, ABC):
     _supports_known_covariates: bool = False
     _supports_past_covariates: bool = False
     _supports_static_features: bool = False
-    # Whether the model implements `export_model`. Meta-models that delegate to a base model must keep this False,
-    # since their support depends on the base model and they should not be advertised as a user-facing model type.
+    # Whether the model implements `export_model`. Meta-models that delegate to a base model keep this False.
     _supports_export: bool = False
 
     def __init__(
@@ -251,6 +239,11 @@ class TimeSeriesModelBase(ModelBase, ABC):
         return self.__class__._supports_past_covariates
 
     @property
+    def supports_export(self) -> bool:
+        """Whether this model can be exported with `export_model`."""
+        return self.__class__._supports_export
+
+    @property
     def supports_static_features(self) -> bool:
         return (
             self.get_hyperparameters().get("covariate_regressor") is not None
@@ -328,10 +321,7 @@ class TimeSeriesModelBase(ModelBase, ABC):
         Only implemented by models that wrap a pretrained model with a well-defined checkpoint format. See
         `TimeSeriesPredictor.export_model` for details.
         """
-        raise NotImplementedError(
-            f"{type(self).__name__.removesuffix('Model')} does not support export_model. "
-            f"Models that support this operation: {', '.join(get_models_supporting_export())}."
-        )
+        raise NotImplementedError(f"{type(self).__name__.removesuffix('Model')} does not support export_model.")
 
     def persist(self) -> Self:
         """Ask the model to persist its assets in memory, i.e., to predict with low latency. In practice
@@ -470,6 +460,28 @@ class AbstractTimeSeriesModel(TimeSeriesModelBase, TimeSeriesTunable, metaclass=
         """List of hyperparameters allowed by the model."""
         return ["target_scaler", "covariate_regressor", "covariate_scaler"]
 
+    @property
+    def supports_export(self) -> bool:
+        """Whether this model can be exported with `export_model`.
+
+        A model can only be exported if its type implements `export_model` and it does not rely on
+        AutoGluon-side data transforms, which are not included in the exported artifact.
+        """
+        return self.__class__._supports_export and not self._get_transforms_blocking_export()
+
+    def _get_transforms_blocking_export(self) -> list[str]:
+        """Names of the AutoGluon-side data transforms that prevent this model from being exported.
+
+        Transforms are only instantiated during `fit`, so the hyperparameters are also checked to get the
+        correct answer for a model that has not been fit yet.
+        """
+        hyperparameters = self.get_hyperparameters()
+        return [
+            name
+            for name in ["target_scaler", "covariate_scaler", "covariate_regressor"]
+            if getattr(self, name, None) is not None or hyperparameters.get(name) is not None
+        ]
+
     def _assert_no_transforms_for_export(self) -> None:
         """Ensure that the model does not rely on AutoGluon-side data transforms before exporting it.
 
@@ -477,11 +489,7 @@ class AbstractTimeSeriesModel(TimeSeriesModelBase, TimeSeriesTunable, metaclass=
         covariate regressor is applied by AutoGluon around that model, so an export would silently produce different
         forecasts than `predictor.predict()`.
         """
-        transforms = [
-            name
-            for name in ["target_scaler", "covariate_scaler", "covariate_regressor"]
-            if getattr(self, name, None) is not None
-        ]
+        transforms = self._get_transforms_blocking_export()
         if transforms:
             raise ValueError(
                 f"{type(self).__name__.removesuffix('Model')} cannot be exported because it uses the following "

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -4,6 +4,7 @@ import os
 import re
 import time
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any, Sequence
 
 import pandas as pd
@@ -28,6 +29,17 @@ from autogluon.timeseries.utils.forecast import make_future_data_frame
 from .tunable import TimeSeriesTunable
 
 logger = logging.getLogger(__name__)
+
+
+def get_models_supporting_export() -> list[str]:
+    """Names of the model types that support `export_model`."""
+    return sorted(
+        {
+            record.model_class.__name__.removesuffix("Model")
+            for record in ModelRegistry.REGISTRY.values()
+            if record.model_class._supports_export
+        }
+    )
 
 
 class TimeSeriesModelBase(ModelBase, ABC):
@@ -72,6 +84,9 @@ class TimeSeriesModelBase(ModelBase, ABC):
     _supports_known_covariates: bool = False
     _supports_past_covariates: bool = False
     _supports_static_features: bool = False
+    # Whether the model implements `export_model`. Meta-models that delegate to a base model must keep this False,
+    # since their support depends on the base model and they should not be advertised as a user-facing model type.
+    _supports_export: bool = False
 
     def __init__(
         self,
@@ -306,6 +321,18 @@ class TimeSeriesModelBase(ModelBase, ABC):
     def _get_model_base(self) -> Self:
         return self
 
+    def export_model(self, path: str | Path) -> str:
+        """Export this model in a format that can be loaded by the upstream library that implements it,
+        without any AutoGluon dependency.
+
+        Only implemented by models that wrap a pretrained model with a well-defined checkpoint format. See
+        `TimeSeriesPredictor.export_model` for details.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__.removesuffix('Model')} does not support export_model. "
+            f"Models that support this operation: {', '.join(get_models_supporting_export())}."
+        )
+
     def persist(self) -> Self:
         """Ask the model to persist its assets in memory, i.e., to predict with low latency. In practice
         this is used for pretrained models that have to lazy-load model parameters to device memory at
@@ -442,6 +469,27 @@ class AbstractTimeSeriesModel(TimeSeriesModelBase, TimeSeriesTunable, metaclass=
     def allowed_hyperparameters(self) -> list[str]:
         """List of hyperparameters allowed by the model."""
         return ["target_scaler", "covariate_regressor", "covariate_scaler"]
+
+    def _assert_no_transforms_for_export(self) -> None:
+        """Ensure that the model does not rely on AutoGluon-side data transforms before exporting it.
+
+        The exported artifact only contains the wrapped pretrained model. Any target scaler, covariate scaler or
+        covariate regressor is applied by AutoGluon around that model, so an export would silently produce different
+        forecasts than `predictor.predict()`.
+        """
+        transforms = [
+            name
+            for name in ["target_scaler", "covariate_scaler", "covariate_regressor"]
+            if getattr(self, name, None) is not None
+        ]
+        if transforms:
+            raise ValueError(
+                f"{type(self).__name__.removesuffix('Model')} cannot be exported because it uses the following "
+                f"AutoGluon-side data transforms: {', '.join(transforms)}. These transforms are applied outside of "
+                f"the exported model, so the exported model would produce different forecasts than "
+                f"`predictor.predict()`. To export this model, train it without "
+                f"{' / '.join(repr(name) for name in transforms)} in its hyperparameters."
+            )
 
     def fit(
         self,

--- a/timeseries/src/autogluon/timeseries/models/chronos/chronos2.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/chronos2.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -88,6 +89,7 @@ class Chronos2Model(AbstractTimeSeriesModel):
 
     _supports_known_covariates = True
     _supports_past_covariates = True
+    _supports_export = True
 
     def __init__(
         self,
@@ -289,6 +291,33 @@ class Chronos2Model(AbstractTimeSeriesModel):
     def persist(self) -> Self:
         self.load_model_pipeline()
         return self
+
+    def export_model(self, path: str | Path) -> str:
+        """Export the model as a Hugging Face checkpoint that can be loaded with
+        ``chronos.chronos2.Chronos2Pipeline.from_pretrained``.
+
+        If the model was fine-tuned with LoRA, the adapter weights are merged into the base model, so that the
+        exported checkpoint is self-contained.
+
+        See `TimeSeriesPredictor.export_model` for details.
+        """
+        self._assert_no_transforms_for_export()
+
+        if self._model_pipeline is None:
+            self.load_model_pipeline()
+        assert self._model_pipeline is not None
+
+        path = Path(path)
+        # `Chronos2Pipeline.from_pretrained` merges LoRA adapters into the base model when loading, so the
+        # pipeline held in memory always contains a plain Chronos2Model that can be saved as a base checkpoint.
+        self._model_pipeline.save_pretrained(path)
+        logger.info(
+            f"Exported {self.name} to {path}\n"
+            f"\tsource model_path: {self.model_path}\n"
+            f"\tcontext_length: {self._model_pipeline.model.chronos_config.context_length}\n"
+            f"\tprediction_length: {self.prediction_length}"
+        )
+        return str(path)
 
     def _update_transformers_loggers(self, log_level: int):
         for logger_name in logging.root.manager.loggerDict:

--- a/timeseries/src/autogluon/timeseries/models/chronos/chronos2.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/chronos2.py
@@ -311,12 +311,6 @@ class Chronos2Model(AbstractTimeSeriesModel):
         # `Chronos2Pipeline.from_pretrained` merges LoRA adapters into the base model when loading, so the
         # pipeline held in memory always contains a plain Chronos2Model that can be saved as a base checkpoint.
         self._model_pipeline.save_pretrained(path)
-        logger.info(
-            f"Exported {self.name} to {path}\n"
-            f"\tsource model_path: {self.model_path}\n"
-            f"\tcontext_length: {self._model_pipeline.model.chronos_config.context_length}\n"
-            f"\tprediction_length: {self.prediction_length}"
-        )
         return str(path)
 
     def _update_transformers_loggers(self, log_level: int):

--- a/timeseries/src/autogluon/timeseries/models/chronos/chronos2.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/chronos2.py
@@ -301,16 +301,15 @@ class Chronos2Model(AbstractTimeSeriesModel):
 
         See `TimeSeriesPredictor.export_model` for details.
         """
+        from chronos.chronos2.pipeline import Chronos2Pipeline
+
         self._assert_no_transforms_for_export()
 
-        if self._model_pipeline is None:
-            self.load_model_pipeline()
-        assert self._model_pipeline is not None
-
         path = Path(path)
-        # `Chronos2Pipeline.from_pretrained` merges LoRA adapters into the base model when loading, so the
-        # pipeline held in memory always contains a plain Chronos2Model that can be saved as a base checkpoint.
-        self._model_pipeline.save_pretrained(path)
+        # after fine-tuning, `model_path` points at a checkpoint that only contains the LoRA adapter, and the
+        # pipeline in memory holds a `PeftModel`. Reloading merges the adapter into the base model, so that the
+        # exported checkpoint contains the full weights and is self-contained.
+        Chronos2Pipeline.from_pretrained(self.model_path).save_pretrained(path)
         return str(path)
 
     def _update_transformers_loggers(self, log_level: int):

--- a/timeseries/src/autogluon/timeseries/models/chronos/model.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/model.py
@@ -185,6 +185,7 @@ class ChronosModel(AbstractTimeSeriesModel):
     """
 
     ag_priority = 55
+    _supports_export = True
     default_num_samples: int = 20  # default number of samples for prediction
     default_model_path = "autogluon/chronos-bolt-small"
     default_max_time_limit_ratio = 0.8
@@ -324,6 +325,23 @@ class ChronosModel(AbstractTimeSeriesModel):
         # TODO: Check the model has been fit before persist
         self.load_model_pipeline()
         return self
+
+    def export_model(self, path: str | Path) -> str:
+        """Export the model as a Hugging Face checkpoint that can be loaded with
+        ``chronos.BaseChronosPipeline.from_pretrained``.
+
+        See `TimeSeriesPredictor.export_model` for details.
+        """
+        self._assert_no_transforms_for_export()
+
+        path = Path(path)
+        self.model_pipeline.inner_model.save_pretrained(path)
+        logger.info(
+            f"Exported {self.name} to {path}\n"
+            f"\tsource model_path: {self.model_path}\n"
+            f"\tquantile_levels: {self.quantile_levels}"
+        )
+        return str(path)
 
     def _has_tf32(self):
         import torch.cuda

--- a/timeseries/src/autogluon/timeseries/models/chronos/model.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/model.py
@@ -336,11 +336,6 @@ class ChronosModel(AbstractTimeSeriesModel):
 
         path = Path(path)
         self.model_pipeline.inner_model.save_pretrained(path)
-        logger.info(
-            f"Exported {self.name} to {path}\n"
-            f"\tsource model_path: {self.model_path}\n"
-            f"\tquantile_levels: {self.quantile_levels}"
-        )
         return str(path)
 
     def _has_tf32(self):

--- a/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
+++ b/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
@@ -78,7 +78,7 @@ class MultiWindowBacktestingModel(AbstractTimeSeriesModel):
     @property
     def supports_export(self) -> bool:
         # exporting delegates to the model fit on the most recent window, so its transforms are what matter
-        return (self.most_recent_model or self.model_base).supports_export
+        return self.most_recent_model is not None and self.most_recent_model.supports_export
 
     def _get_model_base(self):
         return self.model_base

--- a/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
+++ b/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
@@ -4,6 +4,7 @@ import logging
 import math
 import os
 import time
+from pathlib import Path
 from typing import Any, Type
 
 import numpy as np
@@ -265,6 +266,11 @@ class MultiWindowBacktestingModel(AbstractTimeSeriesModel):
             raise ValueError(f"{self.name} must be fit before persisting")
         self.most_recent_model.persist()
         return self
+
+    def export_model(self, path: str | Path) -> str:
+        if self.most_recent_model is None:
+            raise ValueError(f"{self.name} must be fit before exporting")
+        return self.most_recent_model.export_model(path)
 
     @classmethod
     def load(

--- a/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
+++ b/timeseries/src/autogluon/timeseries/models/multi_window/multi_window_model.py
@@ -75,6 +75,11 @@ class MultiWindowBacktestingModel(AbstractTimeSeriesModel):
     def supports_past_covariates(self) -> bool:
         return self.model_base.supports_past_covariates
 
+    @property
+    def supports_export(self) -> bool:
+        # exporting delegates to the model fit on the most recent window, so its transforms are what matter
+        return (self.most_recent_model or self.model_base).supports_export
+
     def _get_model_base(self):
         return self.model_base
 

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -1617,6 +1617,61 @@ class TimeSeriesPredictor:
         """
         return self._learner.unpersist_trainer()
 
+    def export_model(self, path: str | Path, model: str | None = None) -> str:
+        """Export a trained model to a standalone checkpoint that can be loaded without AutoGluon.
+
+        This is useful if you fine-tuned a pretrained model with AutoGluon and want to use the resulting model
+        outside of AutoGluon, e.g., for deployment or for sharing it with others.
+
+        The exported checkpoint is written in the format defined by the library that implements the model. For
+        example, ``Chronos`` and ``Chronos2`` models are exported as Hugging Face checkpoints:
+
+        .. code-block:: python
+
+            predictor.export_model("./my_chronos2_model", model="Chronos2")
+
+            # the exported checkpoint can be loaded without AutoGluon
+            from chronos import BaseChronosPipeline
+
+            pipeline = BaseChronosPipeline.from_pretrained("./my_chronos2_model")
+
+        The exported checkpoint can also be used inside AutoGluon by passing it as ``model_path``:
+
+        .. code-block:: python
+
+            predictor.fit(train_data, hyperparameters={"Chronos2": {"model_path": "./my_chronos2_model"}})
+
+        .. note::
+            The exported checkpoint only contains the model itself. Data transformations that AutoGluon applies
+            around the model, such as ``target_scaler`` or ``covariate_regressor``, are not included. Models that
+            use such transformations cannot be exported, since the exported model would produce different
+            forecasts than :meth:`~autogluon.timeseries.TimeSeriesPredictor.predict`.
+
+        Parameters
+        ----------
+        path : str | Path
+            Directory where the exported model will be saved.
+        model : str, optional
+            Name of the model to export. Available models can be listed with
+            :meth:`~autogluon.timeseries.TimeSeriesPredictor.model_names`. Defaults to the best model according
+            to the validation score.
+
+        Returns
+        -------
+        path : str
+            Directory containing the exported model.
+
+        Raises
+        ------
+        NotImplementedError
+            If the selected model does not support exporting. Only some pretrained models can be exported;
+            the error message lists the model types that support this operation.
+        ValueError
+            If the selected model uses a ``target_scaler``, ``covariate_scaler`` or ``covariate_regressor``.
+        """
+        self._assert_is_fit("export_model")
+        return self._learner.export_model(path=path, model=model)
+
     def leaderboard(
         self,
         data: TimeSeriesDataFrame | pd.DataFrame | Path | str | None = None,

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -1617,7 +1617,7 @@ class TimeSeriesPredictor:
         """
         return self._learner.unpersist_trainer()
 
-    def export_model(self, path: str | Path, model: str | None = None) -> str:
+    def export_model(self, path: str | Path, model: str) -> str:
         """Export a trained model to a standalone checkpoint that can be loaded without AutoGluon.
 
         This is useful if you fine-tuned a pretrained model with AutoGluon and want to use the resulting model
@@ -1651,10 +1651,9 @@ class TimeSeriesPredictor:
         ----------
         path : str | Path
             Directory where the exported model will be saved.
-        model : str, optional
+        model : str
             Name of the model to export. Available models can be listed with
-            :meth:`~autogluon.timeseries.TimeSeriesPredictor.model_names`. Defaults to the best model according
-            to the validation score.
+            :meth:`~autogluon.timeseries.TimeSeriesPredictor.model_names`.
 
         Returns
         -------

--- a/timeseries/src/autogluon/timeseries/trainer/trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/trainer.py
@@ -729,9 +729,22 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
 
         return model_names
 
-    def export_model(self, path: str | Path, model: str | None = None) -> str:
-        model_name = self._get_model_for_prediction(model, verbose=False)
-        return self.load_model(model_name).export_model(path)
+    def export_model(self, path: str | Path, model: str) -> str:
+        if model not in self.get_model_names():
+            raise KeyError(f"Model '{model}' not found. Available models: {self.get_model_names()}")
+        try:
+            exported_path = self.load_model(model).export_model(path)
+        except (NotImplementedError, ValueError) as e:
+            raise type(e)(
+                f"Cannot export model '{model}'. {e} "
+                f"Trained models that support export: {self.get_models_supporting_export()}."
+            ) from e
+        logger.info(f"Exported model '{model}' to {exported_path}")
+        return exported_path
+
+    def get_models_supporting_export(self) -> list[str]:
+        """Names of the trained models that can be exported with `export_model`."""
+        return [name for name in self.get_model_names() if self.load_model(name).supports_export]
 
     def unpersist(self, model_names: Literal["all"] | list[str] = "all") -> list[str]:
         if model_names == "all":

--- a/timeseries/src/autogluon/timeseries/trainer/trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/trainer.py
@@ -729,6 +729,10 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
 
         return model_names
 
+    def export_model(self, path: str | Path, model: str | None = None) -> str:
+        model_name = self._get_model_for_prediction(model, verbose=False)
+        return self.load_model(model_name).export_model(path)
+
     def unpersist(self, model_names: Literal["all"] | list[str] = "all") -> list[str]:
         if model_names == "all":
             model_names = list(self.models.keys())

--- a/timeseries/tests/unittests/models/chronos/test_export.py
+++ b/timeseries/tests/unittests/models/chronos/test_export.py
@@ -115,6 +115,41 @@ def test_when_model_uses_no_transforms_then_supports_export_is_true(model_class,
     assert model.supports_export
 
 
+def test_when_chronos_bolt_fine_tuned_with_custom_quantile_levels_then_export_keeps_them(tmp_path):
+    # fine-tuning Chronos-Bolt on custom quantile_levels replaces its output layer, so the exported
+    # checkpoint must record the new quantiles instead of the ones of the original checkpoint
+    quantile_levels = [0.15, 0.5, 0.85]
+    model = ChronosModel(
+        path=str(tmp_path / "model"),
+        prediction_length=PREDICTION_LENGTH,
+        quantile_levels=quantile_levels,
+        hyperparameters={
+            "model_path": CHRONOS_BOLT_MODEL_PATH,
+            "device": "cpu",
+            "fine_tune": True,
+            "fine_tune_steps": 2,
+            "fine_tune_batch_size": 4,
+        },
+    )
+    model.fit(DUMMY_TS_DATAFRAME)
+    expected = predict_with_seed(model)
+
+    export_path = model.export_model(tmp_path / "export")
+
+    assert load_exported_pipeline(export_path).quantiles == quantile_levels
+
+    exported_model = ChronosModel(
+        path=str(tmp_path / "reimported"),
+        prediction_length=PREDICTION_LENGTH,
+        quantile_levels=quantile_levels,
+        hyperparameters={"model_path": export_path, "device": "cpu"},
+    )
+    exported_model.fit(DUMMY_TS_DATAFRAME)
+    predictions = predict_with_seed(exported_model)
+
+    assert np.allclose(expected.values, predictions.values, rtol=1e-4)
+
+
 class TestExportFineTunedChronos2:
     @pytest.fixture(scope="class")
     def fine_tuned_predictor(self, tmp_path_factory):

--- a/timeseries/tests/unittests/models/chronos/test_export.py
+++ b/timeseries/tests/unittests/models/chronos/test_export.py
@@ -146,8 +146,22 @@ def test_when_model_uses_transforms_then_export_raises(transform, value, df_with
     model.fit(data)
     assert getattr(model, transform) is not None, f"{transform} was not initialized, the test is not meaningful"
 
+    assert not model.supports_export
+
     with pytest.raises(ValueError, match=f"cannot be exported.*{transform}"):
         model.export_model(tmp_path / "export")
+
+
+@pytest.mark.parametrize("model_class, model_path", ALL_MODELS)
+def test_when_model_uses_no_transforms_then_supports_export_is_true(model_class, model_path, tmp_path):
+    model = model_class(
+        path=str(tmp_path / "model"),
+        prediction_length=PREDICTION_LENGTH,
+        hyperparameters={"model_path": model_path, "device": "cpu"},
+    )
+    model.fit(DUMMY_TS_DATAFRAME)
+
+    assert model.supports_export
 
 
 class TestExportFineTunedChronos2:
@@ -174,7 +188,7 @@ class TestExportFineTunedChronos2:
         return predictor
 
     def test_when_fine_tuned_model_exported_then_lora_adapter_is_merged(self, fine_tuned_predictor, tmp_path):
-        export_path = fine_tuned_predictor.export_model(tmp_path / "export")
+        export_path = fine_tuned_predictor.export_model(tmp_path / "export", model="Chronos2")
 
         # a merged checkpoint contains full model weights instead of adapter weights
         assert os.path.isfile(os.path.join(export_path, "model.safetensors"))
@@ -184,7 +198,7 @@ class TestExportFineTunedChronos2:
     def test_when_fine_tuned_model_exported_then_predictions_are_unchanged(self, fine_tuned_predictor, tmp_path):
         expected = fine_tuned_predictor.predict(DUMMY_TS_DATAFRAME)
 
-        export_path = fine_tuned_predictor.export_model(tmp_path / "export")
+        export_path = fine_tuned_predictor.export_model(tmp_path / "export", model="Chronos2")
 
         reimported_predictor = TimeSeriesPredictor(
             prediction_length=PREDICTION_LENGTH, path=str(tmp_path / "reimported"), verbosity=0
@@ -201,6 +215,6 @@ class TestExportFineTunedChronos2:
     def test_when_predictor_loaded_from_disk_then_model_can_be_exported(self, fine_tuned_predictor, tmp_path):
         loaded_predictor = TimeSeriesPredictor.load(fine_tuned_predictor.path)
 
-        export_path = loaded_predictor.export_model(tmp_path / "export")
+        export_path = loaded_predictor.export_model(tmp_path / "export", model="Chronos2")
 
         assert load_exported_pipeline(export_path) is not None

--- a/timeseries/tests/unittests/models/chronos/test_export.py
+++ b/timeseries/tests/unittests/models/chronos/test_export.py
@@ -1,0 +1,206 @@
+"""Tests for exporting Chronos models as standalone checkpoints via `export_model`."""
+
+import os
+
+import numpy as np
+import pytest
+
+from autogluon.timeseries import TimeSeriesPredictor
+from autogluon.timeseries.models import Chronos2Model, ChronosModel
+
+from ...common import DUMMY_TS_DATAFRAME
+from ..common import CHRONOS2_MODEL_PATH, CHRONOS_BOLT_MODEL_PATH, CHRONOS_CLASSIC_MODEL_PATH
+
+PREDICTION_LENGTH = 3
+
+
+def load_exported_pipeline(path):
+    from chronos import BaseChronosPipeline
+
+    return BaseChronosPipeline.from_pretrained(path, device_map="cpu")
+
+
+def get_inner_model(model):
+    """The underlying `transformers` model wrapped by an AutoGluon Chronos model."""
+    if isinstance(model, Chronos2Model):
+        model.load_model_pipeline()
+        return model._model_pipeline.inner_model
+    return model.model_pipeline.inner_model
+
+
+# The original Chronos models generate forecasts by sampling, so their predictions are not reproducible across
+# `predict` calls. For these models we compare the exported weights instead of the predictions.
+DETERMINISTIC_MODELS = [
+    (ChronosModel, CHRONOS_BOLT_MODEL_PATH),
+    (Chronos2Model, CHRONOS2_MODEL_PATH),
+]
+ALL_MODELS = DETERMINISTIC_MODELS + [(ChronosModel, CHRONOS_CLASSIC_MODEL_PATH)]
+
+
+@pytest.mark.parametrize("model_class, model_path", DETERMINISTIC_MODELS)
+def test_when_zero_shot_model_exported_then_predictions_are_unchanged(model_class, model_path, tmp_path):
+    model = model_class(
+        path=str(tmp_path / "model"),
+        prediction_length=PREDICTION_LENGTH,
+        hyperparameters={"model_path": model_path, "device": "cpu"},
+    )
+    model.fit(DUMMY_TS_DATAFRAME)
+    expected = model.predict(DUMMY_TS_DATAFRAME)
+
+    export_path = model.export_model(tmp_path / "export")
+
+    exported_model = model_class(
+        path=str(tmp_path / "reimported"),
+        prediction_length=PREDICTION_LENGTH,
+        hyperparameters={"model_path": export_path, "device": "cpu"},
+    )
+    exported_model.fit(DUMMY_TS_DATAFRAME)
+    predictions = exported_model.predict(DUMMY_TS_DATAFRAME)
+
+    assert np.allclose(expected.values, predictions.values, rtol=1e-4)
+
+
+@pytest.mark.parametrize("model_class, model_path", ALL_MODELS)
+def test_when_zero_shot_model_exported_then_weights_are_unchanged(model_class, model_path, tmp_path):
+    model = model_class(
+        path=str(tmp_path / "model"),
+        prediction_length=PREDICTION_LENGTH,
+        hyperparameters={"model_path": model_path, "device": "cpu"},
+    )
+    model.fit(DUMMY_TS_DATAFRAME)
+    expected_state_dict = get_inner_model(model).state_dict()
+
+    export_path = model.export_model(tmp_path / "export")
+
+    exported_state_dict = load_exported_pipeline(export_path).inner_model.state_dict()
+
+    assert exported_state_dict.keys() == expected_state_dict.keys()
+    for key, expected_weight in expected_state_dict.items():
+        assert (exported_state_dict[key] == expected_weight).all(), f"Weight mismatch for {key}"
+
+
+@pytest.mark.parametrize(
+    "model_class, model_path",
+    [
+        (ChronosModel, CHRONOS_BOLT_MODEL_PATH),
+        (Chronos2Model, CHRONOS2_MODEL_PATH),
+    ],
+)
+def test_when_model_exported_then_checkpoint_can_be_loaded_by_chronos(model_class, model_path, tmp_path):
+    model = model_class(
+        path=str(tmp_path / "model"),
+        prediction_length=PREDICTION_LENGTH,
+        hyperparameters={"model_path": model_path, "device": "cpu"},
+    )
+    model.fit(DUMMY_TS_DATAFRAME)
+
+    export_path = model.export_model(tmp_path / "export")
+
+    assert os.path.isfile(os.path.join(export_path, "config.json"))
+    assert os.path.isfile(os.path.join(export_path, "model.safetensors"))
+    assert load_exported_pipeline(export_path) is not None
+
+
+@pytest.mark.parametrize(
+    "model_class, model_path",
+    [
+        (ChronosModel, CHRONOS_BOLT_MODEL_PATH),
+        (Chronos2Model, CHRONOS2_MODEL_PATH),
+    ],
+)
+def test_when_model_exported_then_export_contains_no_symlinks(model_class, model_path, tmp_path):
+    model = model_class(
+        path=str(tmp_path / "model"),
+        prediction_length=PREDICTION_LENGTH,
+        hyperparameters={"model_path": model_path, "device": "cpu"},
+    )
+    model.fit(DUMMY_TS_DATAFRAME)
+
+    export_path = model.export_model(tmp_path / "export")
+
+    symlinks = [
+        os.path.join(root, name)
+        for root, dirs, files in os.walk(export_path)
+        for name in dirs + files
+        if os.path.islink(os.path.join(root, name))
+    ]
+    assert symlinks == []
+
+
+@pytest.mark.parametrize(
+    "transform, value",
+    [
+        ("target_scaler", "standard"),
+        ("covariate_scaler", "global"),
+        ("covariate_regressor", "LR"),
+    ],
+)
+def test_when_model_uses_transforms_then_export_raises(transform, value, df_with_covariates, tmp_path):
+    data, covariate_metadata = df_with_covariates
+    model = ChronosModel(
+        path=str(tmp_path / "model"),
+        prediction_length=PREDICTION_LENGTH,
+        covariate_metadata=covariate_metadata,
+        hyperparameters={"model_path": CHRONOS_BOLT_MODEL_PATH, "device": "cpu", transform: value},
+    )
+    model.fit(data)
+    assert getattr(model, transform) is not None, f"{transform} was not initialized, the test is not meaningful"
+
+    with pytest.raises(ValueError, match=f"cannot be exported.*{transform}"):
+        model.export_model(tmp_path / "export")
+
+
+class TestExportFineTunedChronos2:
+    @pytest.fixture(scope="class")
+    def fine_tuned_predictor(self, tmp_path_factory):
+        predictor = TimeSeriesPredictor(
+            prediction_length=PREDICTION_LENGTH,
+            path=str(tmp_path_factory.mktemp("fine_tuned_predictor")),
+            verbosity=0,
+        )
+        predictor.fit(
+            DUMMY_TS_DATAFRAME,
+            hyperparameters={
+                "Chronos2": {
+                    "model_path": CHRONOS2_MODEL_PATH,
+                    "device": "cpu",
+                    "fine_tune": True,
+                    "fine_tune_steps": 2,
+                    "fine_tune_batch_size": 4,
+                }
+            },
+            skip_model_selection=True,
+        )
+        return predictor
+
+    def test_when_fine_tuned_model_exported_then_lora_adapter_is_merged(self, fine_tuned_predictor, tmp_path):
+        export_path = fine_tuned_predictor.export_model(tmp_path / "export")
+
+        # a merged checkpoint contains full model weights instead of adapter weights
+        assert os.path.isfile(os.path.join(export_path, "model.safetensors"))
+        assert not os.path.exists(os.path.join(export_path, "adapter_config.json"))
+        assert load_exported_pipeline(export_path) is not None
+
+    def test_when_fine_tuned_model_exported_then_predictions_are_unchanged(self, fine_tuned_predictor, tmp_path):
+        expected = fine_tuned_predictor.predict(DUMMY_TS_DATAFRAME)
+
+        export_path = fine_tuned_predictor.export_model(tmp_path / "export")
+
+        reimported_predictor = TimeSeriesPredictor(
+            prediction_length=PREDICTION_LENGTH, path=str(tmp_path / "reimported"), verbosity=0
+        )
+        reimported_predictor.fit(
+            DUMMY_TS_DATAFRAME,
+            hyperparameters={"Chronos2": {"model_path": export_path, "device": "cpu"}},
+            skip_model_selection=True,
+        )
+        predictions = reimported_predictor.predict(DUMMY_TS_DATAFRAME)
+
+        assert np.allclose(expected.values, predictions.values, rtol=1e-4)
+
+    def test_when_predictor_loaded_from_disk_then_model_can_be_exported(self, fine_tuned_predictor, tmp_path):
+        loaded_predictor = TimeSeriesPredictor.load(fine_tuned_predictor.path)
+
+        export_path = loaded_predictor.export_model(tmp_path / "export")
+
+        assert load_exported_pipeline(export_path) is not None

--- a/timeseries/tests/unittests/models/chronos/test_export.py
+++ b/timeseries/tests/unittests/models/chronos/test_export.py
@@ -5,6 +5,7 @@ import os
 import numpy as np
 import pytest
 
+from autogluon.common.utils.utils import seed_everything
 from autogluon.timeseries import TimeSeriesPredictor
 from autogluon.timeseries.models import Chronos2Model, ChronosModel
 
@@ -20,79 +21,45 @@ def load_exported_pipeline(path):
     return BaseChronosPipeline.from_pretrained(path, device_map="cpu")
 
 
-def get_inner_model(model):
-    """The underlying `transformers` model wrapped by an AutoGluon Chronos model."""
-    if isinstance(model, Chronos2Model):
-        model.load_model_pipeline()
-        return model._model_pipeline.inner_model
-    return model.model_pipeline.inner_model
-
-
-# The original Chronos models generate forecasts by sampling, so their predictions are not reproducible across
-# `predict` calls. For these models we compare the exported weights instead of the predictions.
-DETERMINISTIC_MODELS = [
-    (ChronosModel, CHRONOS_BOLT_MODEL_PATH),
-    (Chronos2Model, CHRONOS2_MODEL_PATH),
-]
-ALL_MODELS = DETERMINISTIC_MODELS + [(ChronosModel, CHRONOS_CLASSIC_MODEL_PATH)]
-
-
-@pytest.mark.parametrize("model_class, model_path", DETERMINISTIC_MODELS)
-def test_when_zero_shot_model_exported_then_predictions_are_unchanged(model_class, model_path, tmp_path):
+def fit_model(model_class, model_path, path):
     model = model_class(
-        path=str(tmp_path / "model"),
+        path=str(path),
         prediction_length=PREDICTION_LENGTH,
         hyperparameters={"model_path": model_path, "device": "cpu"},
     )
     model.fit(DUMMY_TS_DATAFRAME)
-    expected = model.predict(DUMMY_TS_DATAFRAME)
+    return model
+
+
+def predict_with_seed(model):
+    """Predict with a fixed seed, since the original Chronos models generate forecasts by sampling."""
+    seed_everything(42)
+    return model.predict(DUMMY_TS_DATAFRAME)
+
+
+ALL_MODELS = [
+    (ChronosModel, CHRONOS_BOLT_MODEL_PATH),
+    (ChronosModel, CHRONOS_CLASSIC_MODEL_PATH),
+    (Chronos2Model, CHRONOS2_MODEL_PATH),
+]
+
+
+@pytest.mark.parametrize("model_class, model_path", ALL_MODELS)
+def test_when_zero_shot_model_exported_then_predictions_are_unchanged(model_class, model_path, tmp_path):
+    model = fit_model(model_class, model_path, tmp_path / "model")
+    expected = predict_with_seed(model)
 
     export_path = model.export_model(tmp_path / "export")
 
-    exported_model = model_class(
-        path=str(tmp_path / "reimported"),
-        prediction_length=PREDICTION_LENGTH,
-        hyperparameters={"model_path": export_path, "device": "cpu"},
-    )
-    exported_model.fit(DUMMY_TS_DATAFRAME)
-    predictions = exported_model.predict(DUMMY_TS_DATAFRAME)
+    exported_model = fit_model(model_class, export_path, tmp_path / "reimported")
+    predictions = predict_with_seed(exported_model)
 
     assert np.allclose(expected.values, predictions.values, rtol=1e-4)
 
 
 @pytest.mark.parametrize("model_class, model_path", ALL_MODELS)
-def test_when_zero_shot_model_exported_then_weights_are_unchanged(model_class, model_path, tmp_path):
-    model = model_class(
-        path=str(tmp_path / "model"),
-        prediction_length=PREDICTION_LENGTH,
-        hyperparameters={"model_path": model_path, "device": "cpu"},
-    )
-    model.fit(DUMMY_TS_DATAFRAME)
-    expected_state_dict = get_inner_model(model).state_dict()
-
-    export_path = model.export_model(tmp_path / "export")
-
-    exported_state_dict = load_exported_pipeline(export_path).inner_model.state_dict()
-
-    assert exported_state_dict.keys() == expected_state_dict.keys()
-    for key, expected_weight in expected_state_dict.items():
-        assert (exported_state_dict[key] == expected_weight).all(), f"Weight mismatch for {key}"
-
-
-@pytest.mark.parametrize(
-    "model_class, model_path",
-    [
-        (ChronosModel, CHRONOS_BOLT_MODEL_PATH),
-        (Chronos2Model, CHRONOS2_MODEL_PATH),
-    ],
-)
 def test_when_model_exported_then_checkpoint_can_be_loaded_by_chronos(model_class, model_path, tmp_path):
-    model = model_class(
-        path=str(tmp_path / "model"),
-        prediction_length=PREDICTION_LENGTH,
-        hyperparameters={"model_path": model_path, "device": "cpu"},
-    )
-    model.fit(DUMMY_TS_DATAFRAME)
+    model = fit_model(model_class, model_path, tmp_path / "model")
 
     export_path = model.export_model(tmp_path / "export")
 
@@ -101,20 +68,9 @@ def test_when_model_exported_then_checkpoint_can_be_loaded_by_chronos(model_clas
     assert load_exported_pipeline(export_path) is not None
 
 
-@pytest.mark.parametrize(
-    "model_class, model_path",
-    [
-        (ChronosModel, CHRONOS_BOLT_MODEL_PATH),
-        (Chronos2Model, CHRONOS2_MODEL_PATH),
-    ],
-)
+@pytest.mark.parametrize("model_class, model_path", ALL_MODELS)
 def test_when_model_exported_then_export_contains_no_symlinks(model_class, model_path, tmp_path):
-    model = model_class(
-        path=str(tmp_path / "model"),
-        prediction_length=PREDICTION_LENGTH,
-        hyperparameters={"model_path": model_path, "device": "cpu"},
-    )
-    model.fit(DUMMY_TS_DATAFRAME)
+    model = fit_model(model_class, model_path, tmp_path / "model")
 
     export_path = model.export_model(tmp_path / "export")
 
@@ -154,12 +110,7 @@ def test_when_model_uses_transforms_then_export_raises(transform, value, df_with
 
 @pytest.mark.parametrize("model_class, model_path", ALL_MODELS)
 def test_when_model_uses_no_transforms_then_supports_export_is_true(model_class, model_path, tmp_path):
-    model = model_class(
-        path=str(tmp_path / "model"),
-        prediction_length=PREDICTION_LENGTH,
-        hyperparameters={"model_path": model_path, "device": "cpu"},
-    )
-    model.fit(DUMMY_TS_DATAFRAME)
+    model = fit_model(model_class, model_path, tmp_path / "model")
 
     assert model.supports_export
 

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -2003,13 +2003,15 @@ class TestExportModel:
     def test_when_export_model_called_before_fit_then_exception_is_raised(self, temp_model_path):
         predictor = TimeSeriesPredictor(path=temp_model_path)
         with pytest.raises(AssertionError, match="Predictor is not fit"):
-            predictor.export_model(Path(temp_model_path) / "export")
+            predictor.export_model(Path(temp_model_path) / "export", model="Naive")
 
     def test_when_model_does_not_support_export_then_exception_lists_supported_models(self, temp_model_path):
         predictor = TimeSeriesPredictor(path=temp_model_path)
         predictor.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}})
 
-        with pytest.raises(NotImplementedError, match="Naive does not support export_model"):
+        with pytest.raises(
+            NotImplementedError, match="Naive does not support export_model.*Trained models that support export"
+        ):
             predictor.export_model(Path(temp_model_path) / "export", model="Naive")
 
     def test_when_unknown_model_name_provided_then_exception_is_raised(self, temp_model_path):
@@ -2019,14 +2021,14 @@ class TestExportModel:
         with pytest.raises(KeyError, match="not found"):
             predictor.export_model(Path(temp_model_path) / "export", model="NonExistentModel")
 
-    def test_when_model_not_provided_then_best_model_is_exported(self, temp_model_path):
+    def test_when_model_provided_then_that_model_is_exported(self, temp_model_path):
         predictor = TimeSeriesPredictor(path=temp_model_path)
         predictor.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}})
 
         with mock.patch(
             "autogluon.timeseries.models.local.naive.NaiveModel.export_model", return_value="dummy_path"
         ) as mock_export:
-            predictor.export_model(Path(temp_model_path) / "export")
+            predictor.export_model(Path(temp_model_path) / "export", model="Naive")
 
         assert mock_export.call_count == 1
 

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -1999,6 +1999,38 @@ def test_when_method_called_before_fit_then_exception_is_raised(temp_model_path,
         getattr(predictor, method)(*args)
 
 
+class TestExportModel:
+    def test_when_export_model_called_before_fit_then_exception_is_raised(self, temp_model_path):
+        predictor = TimeSeriesPredictor(path=temp_model_path)
+        with pytest.raises(AssertionError, match="Predictor is not fit"):
+            predictor.export_model(Path(temp_model_path) / "export")
+
+    def test_when_model_does_not_support_export_then_exception_lists_supported_models(self, temp_model_path):
+        predictor = TimeSeriesPredictor(path=temp_model_path)
+        predictor.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}})
+
+        with pytest.raises(NotImplementedError, match="Naive does not support export_model"):
+            predictor.export_model(Path(temp_model_path) / "export", model="Naive")
+
+    def test_when_unknown_model_name_provided_then_exception_is_raised(self, temp_model_path):
+        predictor = TimeSeriesPredictor(path=temp_model_path)
+        predictor.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}})
+
+        with pytest.raises(KeyError, match="not found"):
+            predictor.export_model(Path(temp_model_path) / "export", model="NonExistentModel")
+
+    def test_when_model_not_provided_then_best_model_is_exported(self, temp_model_path):
+        predictor = TimeSeriesPredictor(path=temp_model_path)
+        predictor.fit(DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}})
+
+        with mock.patch(
+            "autogluon.timeseries.models.local.naive.NaiveModel.export_model", return_value="dummy_path"
+        ) as mock_export:
+            predictor.export_model(Path(temp_model_path) / "export")
+
+        assert mock_export.call_count == 1
+
+
 class TestMultilayerValidationAndNormalization:
     def test_given_int_num_val_windows_when_normalized_then_converted_to_tuple(self, temp_model_path):
         predictor = TimeSeriesPredictor(path=temp_model_path)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds `TimeSeriesPredictor.export_model(path, model)` to export a trained model as a standalone Hugging Face checkpoint that can be loaded directly with `chronos`, independent of AutoGluon.

- Supported for Chronos, Chronos-Bolt and Chronos-2 (including fine-tuned models). For fine-tuned Chronos-2, the LoRA adapter is merged into the base weights so the exported checkpoint is self-contained.
- `model` is a required argument; export raises with an actionable list of exportable models otherwise.
- Refuses to export a model that relies on AutoGluon-side data transforms (target/covariate scaler, covariate regressor), since these are applied outside the exported artifact and would silently change forecasts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
