### PR TITLE
Declare supported problem types via _supported_problem_types class attribute

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -228,6 +228,9 @@ class AbstractModel(ModelBase, Tunable):
         None  # the name of the hyperparameter that controls the model's random seed, or None if no random seed exists.
     )
     seed_name_alt: list[str] = []  # alternative names for the random seed hyperparameter.
+    _supported_problem_types: list[str] | None = (
+        None  # problem types the model supports; None = unspecified (never filtered by problem type). Read via `supported_problem_types()`.
+    )
 
     model_file_name = "model.pkl"
     model_info_name = "info.pkl"
@@ -3406,8 +3409,11 @@ class AbstractModel(ModelBase, Tunable):
         Returns the list of supported problem types.
         If None is returned, then the model has not specified the supported problem types, and it is unknown which problem types are valid.
             In this case, all problem types are considered supported and the model will never be filtered out based on problem type.
+
+        Subclasses declare their supported problem types via the `_supported_problem_types` class attribute;
+        overriding this classmethod also remains supported.
         """
-        return None
+        return cls._supported_problem_types
 
     def _get_default_stopping_metric(self) -> Scorer:
         """

--- a/core/src/autogluon/core/models/dummy/dummy_model.py
+++ b/core/src/autogluon/core/models/dummy/dummy_model.py
@@ -44,6 +44,4 @@ class DummyModel(AbstractModel):
             self.model = model_cls()
         self.model.fit(X=X, y=y)
 
-    @classmethod
-    def supported_problem_types(cls) -> list[str] | None:
-        return ["binary", "multiclass", "regression", "quantile"]
+    _supported_problem_types = ["binary", "multiclass", "regression", "quantile"]

--- a/core/src/autogluon/core/models/dummy/dummy_model.py
+++ b/core/src/autogluon/core/models/dummy/dummy_model.py
@@ -15,6 +15,7 @@ class DummyModel(AbstractModel):
 
     ag_key = "DUMMY"
     ag_name = "Dummy"
+    _supported_problem_types = ["binary", "multiclass", "regression", "quantile"]
 
     def _get_model_type(self):
         from sklearn.dummy import DummyClassifier, DummyRegressor
@@ -43,5 +44,3 @@ class DummyModel(AbstractModel):
         else:
             self.model = model_cls()
         self.model.fit(X=X, y=y)
-
-    _supported_problem_types = ["binary", "multiclass", "regression", "quantile"]

--- a/core/src/autogluon/core/models/greedy_ensemble/greedy_weighted_ensemble_model.py
+++ b/core/src/autogluon/core/models/greedy_ensemble/greedy_weighted_ensemble_model.py
@@ -141,9 +141,7 @@ class GreedyWeightedEnsembleModel(AbstractModel):
         default_ag_args.update(extra_ag_args)
         return default_ag_args
 
-    @classmethod
-    def supported_problem_types(cls) -> list[str] | None:
-        return ["binary", "multiclass", "regression", "quantile", "softclass"]
+    _supported_problem_types = ["binary", "multiclass", "regression", "quantile", "softclass"]
 
     def _get_default_stopping_metric(self):
         return self.eval_metric

--- a/core/src/autogluon/core/models/greedy_ensemble/greedy_weighted_ensemble_model.py
+++ b/core/src/autogluon/core/models/greedy_ensemble/greedy_weighted_ensemble_model.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 class GreedyWeightedEnsembleModel(AbstractModel):
     ag_key = "ENS_WEIGHTED"
     ag_name = "WeightedEnsemble"
+    _supported_problem_types = ["binary", "multiclass", "regression", "quantile", "softclass"]
 
     def __init__(self, base_model_names=None, model_base=EnsembleSelection, **kwargs):
         super().__init__(**kwargs)
@@ -140,8 +141,6 @@ class GreedyWeightedEnsembleModel(AbstractModel):
         extra_ag_args = {"valid_base": False}
         default_ag_args.update(extra_ag_args)
         return default_ag_args
-
-    _supported_problem_types = ["binary", "multiclass", "regression", "quantile", "softclass"]
 
     def _get_default_stopping_metric(self):
         return self.eval_metric

--- a/tabular/src/autogluon/tabular/models/automm/automm_model.py
+++ b/tabular/src/autogluon/tabular/models/automm/automm_model.py
@@ -91,9 +91,7 @@ class MultiModalPredictorModel(AbstractModel):
         default_ag_args.update(extra_ag_args)
         return default_ag_args
 
-    @classmethod
-    def supported_problem_types(cls) -> list[str] | None:
-        return ["binary", "multiclass", "regression"]
+    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     # FIXME: Enable parallel bagging once AutoMM supports being run within Ray without hanging
     @classmethod

--- a/tabular/src/autogluon/tabular/models/automm/automm_model.py
+++ b/tabular/src/autogluon/tabular/models/automm/automm_model.py
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 class MultiModalPredictorModel(AbstractModel):
     ag_key = "AG_AUTOMM"
     ag_name = "MultiModalPredictor"
+    _supported_problem_types = ["binary", "multiclass", "regression"]
     _NN_MODEL_NAME = "automm_model"
 
     def __init__(self, **kwargs):
@@ -90,8 +91,6 @@ class MultiModalPredictorModel(AbstractModel):
         }
         default_ag_args.update(extra_ag_args)
         return default_ag_args
-
-    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     # FIXME: Enable parallel bagging once AutoMM supports being run within Ray without hanging
     @classmethod

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -39,6 +39,7 @@ class CatBoostModel(AbstractModel):
     ag_priority = 70
     ag_priority_by_problem_type = MappingProxyType({SOFTCLASS: 60})
     seed_name = "random_seed"
+    _supported_problem_types = ["binary", "multiclass", "regression", "quantile", "softclass"]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -432,8 +433,6 @@ class CatBoostModel(AbstractModel):
         num_cpus = ResourceManager.get_cpu_count(only_physical_cores=True)
         num_gpus = 0
         return num_cpus, num_gpus
-
-    _supported_problem_types = ["binary", "multiclass", "regression", "quantile", "softclass"]
 
     def _more_tags(self):
         # `can_refit_full=True` because iterations is communicated at end of `_fit`

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -433,9 +433,7 @@ class CatBoostModel(AbstractModel):
         num_gpus = 0
         return num_cpus, num_gpus
 
-    @classmethod
-    def supported_problem_types(cls) -> list[str] | None:
-        return ["binary", "multiclass", "regression", "quantile", "softclass"]
+    _supported_problem_types = ["binary", "multiclass", "regression", "quantile", "softclass"]
 
     def _more_tags(self):
         # `can_refit_full=True` because iterations is communicated at end of `_fit`

--- a/tabular/src/autogluon/tabular/models/ebm/ebm_model.py
+++ b/tabular/src/autogluon/tabular/models/ebm/ebm_model.py
@@ -58,6 +58,7 @@ class EBMModel(AbstractModel):
     ag_name = "EBM"
     ag_priority = 35
     seed_name = "random_state"
+    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     def _fit(
         self,
@@ -129,8 +130,6 @@ class EBMModel(AbstractModel):
         }
         default_auxiliary_params.update(extra_auxiliary_params)
         return default_auxiliary_params
-
-    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     def _more_tags(self) -> dict:
         """EBMs support refit full."""

--- a/tabular/src/autogluon/tabular/models/ebm/ebm_model.py
+++ b/tabular/src/autogluon/tabular/models/ebm/ebm_model.py
@@ -130,9 +130,7 @@ class EBMModel(AbstractModel):
         default_auxiliary_params.update(extra_auxiliary_params)
         return default_auxiliary_params
 
-    @classmethod
-    def supported_problem_types(cls) -> list[str] | None:
-        return ["binary", "multiclass", "regression"]
+    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     def _more_tags(self) -> dict:
         """EBMs support refit full."""

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -108,6 +108,7 @@ class NNFastAiTabularModel(AbstractModel):
         }
     )
     seed_name = "random_seed"
+    _supported_problem_types = ["binary", "multiclass", "regression", "quantile"]
 
     model_internals_file_name = "model-internals.pkl"
 
@@ -691,8 +692,6 @@ class NNFastAiTabularModel(AbstractModel):
         if is_gpu_available:
             minimum_resources["num_gpus"] = 0.5
         return minimum_resources
-
-    _supported_problem_types = ["binary", "multiclass", "regression", "quantile"]
 
     @classmethod
     def _class_tags(cls):

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -692,9 +692,7 @@ class NNFastAiTabularModel(AbstractModel):
             minimum_resources["num_gpus"] = 0.5
         return minimum_resources
 
-    @classmethod
-    def supported_problem_types(cls) -> list[str] | None:
-        return ["binary", "multiclass", "regression", "quantile"]
+    _supported_problem_types = ["binary", "multiclass", "regression", "quantile"]
 
     @classmethod
     def _class_tags(cls):

--- a/tabular/src/autogluon/tabular/models/image_prediction/image_predictor.py
+++ b/tabular/src/autogluon/tabular/models/image_prediction/image_predictor.py
@@ -131,6 +131,4 @@ class ImagePredictorModel(MultiModalPredictorModel):
             raise NotImplementedError(f"Computing dummy pred_proba is not implemented for {self.problem_type}.")
         return pred_proba_mean
 
-    @classmethod
-    def supported_problem_types(cls) -> list[str] | None:
-        return ["binary", "multiclass", "regression"]
+    _supported_problem_types = ["binary", "multiclass", "regression"]

--- a/tabular/src/autogluon/tabular/models/image_prediction/image_predictor.py
+++ b/tabular/src/autogluon/tabular/models/image_prediction/image_predictor.py
@@ -27,6 +27,7 @@ class ImagePredictorModel(MultiModalPredictorModel):
 
     ag_key = "AG_IMAGE_NN"
     ag_name = "ImagePredictor"
+    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -130,5 +131,3 @@ class ImagePredictorModel(MultiModalPredictorModel):
         else:
             raise NotImplementedError(f"Computing dummy pred_proba is not implemented for {self.problem_type}.")
         return pred_proba_mean
-
-    _supported_problem_types = ["binary", "multiclass", "regression"]

--- a/tabular/src/autogluon/tabular/models/imodels/imodels_models.py
+++ b/tabular/src/autogluon/tabular/models/imodels/imodels_models.py
@@ -65,9 +65,7 @@ class _IModelsModel(AbstractModel):
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
 
-    @classmethod
-    def supported_problem_types(cls) -> list[str] | None:
-        return ["binary", "multiclass", "regression"]
+    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     def _get_default_auxiliary_params(self) -> dict:
         default_auxiliary_params = super()._get_default_auxiliary_params()

--- a/tabular/src/autogluon/tabular/models/imodels/imodels_models.py
+++ b/tabular/src/autogluon/tabular/models/imodels/imodels_models.py
@@ -11,6 +11,8 @@ from autogluon.core.models import AbstractModel
 
 
 class _IModelsModel(AbstractModel):
+    _supported_problem_types = ["binary", "multiclass", "regression"]
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._feature_generator = None
@@ -64,8 +66,6 @@ class _IModelsModel(AbstractModel):
         }
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
-
-    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     def _get_default_auxiliary_params(self) -> dict:
         default_auxiliary_params = super()._get_default_auxiliary_params()

--- a/tabular/src/autogluon/tabular/models/knn/knn_model.py
+++ b/tabular/src/autogluon/tabular/models/knn/knn_model.py
@@ -28,6 +28,7 @@ class KNNModel(AbstractModel):
     ag_key = "KNN"
     ag_name = "KNeighbors"
     ag_priority = 100
+    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -291,8 +292,6 @@ class KNNModel(AbstractModel):
         num_cpus = ResourceManager.get_cpu_count()
         num_gpus = 0
         return num_cpus, num_gpus
-
-    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     def _more_tags(self):
         return {

--- a/tabular/src/autogluon/tabular/models/knn/knn_model.py
+++ b/tabular/src/autogluon/tabular/models/knn/knn_model.py
@@ -292,9 +292,7 @@ class KNNModel(AbstractModel):
         num_gpus = 0
         return num_cpus, num_gpus
 
-    @classmethod
-    def supported_problem_types(cls) -> list[str] | None:
-        return ["binary", "multiclass", "regression"]
+    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     def _more_tags(self):
         return {

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -742,9 +742,7 @@ class LGBModel(AbstractModel):
         num_gpus = 0
         return num_cpus, num_gpus
 
-    @classmethod
-    def supported_problem_types(cls) -> list[str] | None:
-        return ["binary", "multiclass", "regression", "quantile", "softclass"]
+    _supported_problem_types = ["binary", "multiclass", "regression", "quantile", "softclass"]
 
     def _ag_params(self) -> set:
         return {"early_stop", "generate_curves", "curve_metrics", "use_error_for_curve_metrics"}

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -49,6 +49,7 @@ class LGBModel(AbstractModel):
     ag_priority_by_problem_type = MappingProxyType({SOFTCLASS: 100})
     seed_name = "seed"
     seed_name_alt = ["seed_value", "random_seed", "random_state"]
+    _supported_problem_types = ["binary", "multiclass", "regression", "quantile", "softclass"]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -741,8 +742,6 @@ class LGBModel(AbstractModel):
         num_cpus = ResourceManager.get_cpu_count(only_physical_cores=True)
         num_gpus = 0
         return num_cpus, num_gpus
-
-    _supported_problem_types = ["binary", "multiclass", "regression", "quantile", "softclass"]
 
     def _ag_params(self) -> set:
         return {"early_stop", "generate_curves", "curve_metrics", "use_error_for_curve_metrics"}

--- a/tabular/src/autogluon/tabular/models/lr/lr_model.py
+++ b/tabular/src/autogluon/tabular/models/lr/lr_model.py
@@ -348,9 +348,7 @@ class LinearModel(AbstractModel):
         # no GPU support
         return {"num_gpus": 0}
 
-    @classmethod
-    def supported_problem_types(cls) -> list[str] | None:
-        return ["binary", "multiclass", "regression"]
+    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     def _more_tags(self):
         # `can_refit_full=True` because validation data isn't used during fit.

--- a/tabular/src/autogluon/tabular/models/lr/lr_model.py
+++ b/tabular/src/autogluon/tabular/models/lr/lr_model.py
@@ -45,6 +45,7 @@ class LinearModel(AbstractModel):
     ag_name = "LinearModel"
     ag_priority = 30
     seed_name = "random_state"
+    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -347,8 +348,6 @@ class LinearModel(AbstractModel):
     def _get_maximum_resources(self) -> dict[str, int | float]:
         # no GPU support
         return {"num_gpus": 0}
-
-    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     def _more_tags(self):
         # `can_refit_full=True` because validation data isn't used during fit.

--- a/tabular/src/autogluon/tabular/models/mitra/mitra_model.py
+++ b/tabular/src/autogluon/tabular/models/mitra/mitra_model.py
@@ -37,6 +37,7 @@ class MitraModel(AbstractTorchModel):
     weights_file_name = "model.pt"
     ag_priority = 55
     seed_name = "seed"
+    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -301,8 +302,6 @@ class MitraModel(AbstractTorchModel):
         """
         cls.download_weights(repo_id="autogluon/mitra-classifier")
         cls.download_weights(repo_id="autogluon/mitra-regressor")
-
-    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     @classmethod
     def _get_default_ag_args_ensemble(cls, **kwargs) -> dict:

--- a/tabular/src/autogluon/tabular/models/mitra/mitra_model.py
+++ b/tabular/src/autogluon/tabular/models/mitra/mitra_model.py
@@ -302,9 +302,7 @@ class MitraModel(AbstractTorchModel):
         cls.download_weights(repo_id="autogluon/mitra-classifier")
         cls.download_weights(repo_id="autogluon/mitra-regressor")
 
-    @classmethod
-    def supported_problem_types(cls) -> Optional[List[str]]:
-        return ["binary", "multiclass", "regression"]
+    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     @classmethod
     def _get_default_ag_args_ensemble(cls, **kwargs) -> dict:

--- a/tabular/src/autogluon/tabular/models/nori/nori_model.py
+++ b/tabular/src/autogluon/tabular/models/nori/nori_model.py
@@ -120,9 +120,7 @@ class NoriModel(AbstractTorchModel):
         self.model.device = device
         self.model._predictor = None
 
-    @classmethod
-    def supported_problem_types(cls) -> list[str] | None:
-        return ["regression"]
+    _supported_problem_types = ["regression"]
 
     def _get_default_resources(self) -> tuple[int, int]:
         # Use only physical cores for better performance based on benchmarks

--- a/tabular/src/autogluon/tabular/models/nori/nori_model.py
+++ b/tabular/src/autogluon/tabular/models/nori/nori_model.py
@@ -45,6 +45,7 @@ class NoriModel(AbstractTorchModel):
     ag_key = "NORI"
     ag_name = "Nori"
     ag_priority = 40
+    _supported_problem_types = ["regression"]
 
     _DEFAULT_MAX_BATCH_SIZE: int = 10000
     """Default prediction chunk size (``ag.max_batch_size``); also the query-batch
@@ -119,8 +120,6 @@ class NoriModel(AbstractTorchModel):
         # next predict rebuilds on the new device (e.g. GPU -> CPU on load/save).
         self.model.device = device
         self.model._predictor = None
-
-    _supported_problem_types = ["regression"]
 
     def _get_default_resources(self) -> tuple[int, int]:
         # Use only physical cores for better performance based on benchmarks

--- a/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
+++ b/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
@@ -283,9 +283,7 @@ class RealMLPModel(AbstractTorchModel):
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
 
-    @classmethod
-    def supported_problem_types(cls) -> list[str] | None:
-        return ["binary", "multiclass", "regression"]
+    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     def _get_default_stopping_metric(self):
         return self.eval_metric

--- a/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
+++ b/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
@@ -53,6 +53,7 @@ class RealMLPModel(AbstractTorchModel):
     ag_name = "RealMLP"
     ag_priority = 75
     seed_name = "random_state"
+    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -282,8 +283,6 @@ class RealMLPModel(AbstractTorchModel):
         )
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
-
-    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     def _get_default_stopping_metric(self):
         return self.eval_metric

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -416,9 +416,7 @@ class RFModel(AbstractModel):
             default_ag_args_ensemble.update(extra_ag_args_ensemble)
         return default_ag_args_ensemble
 
-    @classmethod
-    def supported_problem_types(cls) -> list[str] | None:
-        return ["binary", "multiclass", "regression", "quantile", "softclass"]
+    _supported_problem_types = ["binary", "multiclass", "regression", "quantile", "softclass"]
 
     def _more_tags(self):
         # `can_refit_full=True` because final n_estimators is communicated at end of `_fit`:

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -33,6 +33,7 @@ class RFModel(AbstractModel):
     ag_name = "RandomForest"
     ag_priority = 80
     seed_name = "random_state"
+    _supported_problem_types = ["binary", "multiclass", "regression", "quantile", "softclass"]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -415,8 +416,6 @@ class RFModel(AbstractModel):
             extra_ag_args_ensemble = {"use_child_oof": True}
             default_ag_args_ensemble.update(extra_ag_args_ensemble)
         return default_ag_args_ensemble
-
-    _supported_problem_types = ["binary", "multiclass", "regression", "quantile", "softclass"]
 
     def _more_tags(self):
         # `can_refit_full=True` because final n_estimators is communicated at end of `_fit`:

--- a/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_model.py
+++ b/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_model.py
@@ -220,9 +220,7 @@ class TabDPTModel(AbstractTorchModel):
             X[self._feature_generator.features_in] = self._feature_generator.transform(X=X)
         return X.to_numpy()
 
-    @classmethod
-    def supported_problem_types(cls) -> list[str] | None:
-        return ["binary", "multiclass", "regression"]
+    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     def _more_tags(self) -> dict:
         return {"can_refit_full": True}

--- a/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_model.py
+++ b/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_model.py
@@ -39,6 +39,7 @@ class TabDPTModel(AbstractTorchModel):
     ag_name = "TabDPT"
     seed_name = "seed"
     ag_priority = 50
+    _supported_problem_types = ["binary", "multiclass", "regression"]
     default_random_seed = 0
 
     #: Hugging Face repo hosting every TabDPT checkpoint.
@@ -219,8 +220,6 @@ class TabDPTModel(AbstractTorchModel):
             X = X.copy()
             X[self._feature_generator.features_in] = self._feature_generator.transform(X=X)
         return X.to_numpy()
-
-    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     def _more_tags(self) -> dict:
         return {"can_refit_full": True}

--- a/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
+++ b/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
@@ -170,9 +170,7 @@ class TabICLModel(AbstractTorchModel):
         )
         return default_auxiliary_params
 
-    @classmethod
-    def supported_problem_types(cls) -> list[str] | None:
-        return ["binary", "multiclass", "regression", "quantile"]
+    _supported_problem_types = ["binary", "multiclass", "regression", "quantile"]
 
     def _get_default_resources(self) -> tuple[int, int]:
         # Use only physical cores for better performance based on benchmarks

--- a/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
+++ b/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
@@ -49,6 +49,7 @@ class TabICLModel(AbstractTorchModel):
 
     ag_priority = 65
     seed_name = "random_state"
+    _supported_problem_types = ["binary", "multiclass", "regression", "quantile"]
 
     def get_model_cls(self):
         if self.problem_type in ["binary", "multiclass"]:
@@ -169,8 +170,6 @@ class TabICLModel(AbstractTorchModel):
             }
         )
         return default_auxiliary_params
-
-    _supported_problem_types = ["binary", "multiclass", "regression", "quantile"]
 
     def _get_default_resources(self) -> tuple[int, int]:
         # Use only physical cores for better performance based on benchmarks

--- a/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
+++ b/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
@@ -151,9 +151,7 @@ class TabMModel(AbstractTorchModel):
         self.model.device_ = device
         self.model.model_ = self.model.model_.to(device)
 
-    @classmethod
-    def supported_problem_types(cls) -> list[str] | None:
-        return ["binary", "multiclass", "regression"]
+    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     def _get_default_stopping_metric(self):
         return self.eval_metric

--- a/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
+++ b/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
@@ -37,6 +37,7 @@ class TabMModel(AbstractTorchModel):
     ag_name = "TabM"
     ag_priority = 85
     seed_name = "random_state"
+    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     _MAX_FEATURES_FOR_MEMORY_ESTIMATE: int = 2000
     """Feature count past which the per-feature memory cost saturates (batches shrink
@@ -150,8 +151,6 @@ class TabMModel(AbstractTorchModel):
         device = self.to_torch_device(device)
         self.model.device_ = device
         self.model.model_ = self.model.model_.to(device)
-
-    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     def _get_default_stopping_metric(self):
         return self.eval_metric

--- a/tabular/src/autogluon/tabular/models/tabpfnmix/tabpfnmix_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnmix/tabpfnmix_model.py
@@ -328,9 +328,7 @@ class TabPFNMixModel(AbstractModel):
     def weights_path(self) -> str:
         return os.path.join(self.path, self.weights_file_name)
 
-    @classmethod
-    def supported_problem_types(cls) -> list[str] | None:
-        return ["binary", "multiclass", "regression"]
+    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     def _get_default_auxiliary_params(self) -> dict:
         default_auxiliary_params = super()._get_default_auxiliary_params()

--- a/tabular/src/autogluon/tabular/models/tabpfnmix/tabpfnmix_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnmix/tabpfnmix_model.py
@@ -44,6 +44,7 @@ class TabPFNMixModel(AbstractModel):
     ag_name = "TabPFNMix"
     ag_priority = 45
     seed_name = "random_state"
+    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     weights_file_name = "model.pt"
 
@@ -327,8 +328,6 @@ class TabPFNMixModel(AbstractModel):
     @property
     def weights_path(self) -> str:
         return os.path.join(self.path, self.weights_file_name)
-
-    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     def _get_default_auxiliary_params(self) -> dict:
         default_auxiliary_params = super()._get_default_auxiliary_params()

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
@@ -263,9 +263,7 @@ class TabPFNModel(AbstractTorchModel):
     def _set_device(self, device: str):
         self.model.to(device)
 
-    @classmethod
-    def supported_problem_types(cls) -> list[str] | None:
-        return ["binary", "multiclass", "regression", "quantile"]
+    _supported_problem_types = ["binary", "multiclass", "regression", "quantile"]
 
     def _get_default_auxiliary_params(self) -> dict:
         default_auxiliary_params = super()._get_default_auxiliary_params()

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
@@ -39,6 +39,7 @@ class TabPFNModel(AbstractTorchModel):
     ag_name = "NOTSET"
     ag_priority = 40
     seed_name = "random_state"
+    _supported_problem_types = ["binary", "multiclass", "regression", "quantile"]
     fixed_random_state: int | None = None
     """If not None, this fixes the random state to a static value to avoid that the
     validation score is misleading for the refit model."""
@@ -262,8 +263,6 @@ class TabPFNModel(AbstractTorchModel):
 
     def _set_device(self, device: str):
         self.model.to(device)
-
-    _supported_problem_types = ["binary", "multiclass", "regression", "quantile"]
 
     def _get_default_auxiliary_params(self) -> dict:
         default_auxiliary_params = super()._get_default_auxiliary_params()

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -1038,9 +1038,7 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
             model=(self.processor, self.model), path=self.path, input_types=input_types
         )
 
-    @classmethod
-    def supported_problem_types(cls) -> list[str] | None:
-        return ["binary", "multiclass", "regression", "quantile", "softclass"]
+    _supported_problem_types = ["binary", "multiclass", "regression", "quantile", "softclass"]
 
     @classmethod
     def _class_tags(cls):

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -53,6 +53,7 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
     ag_name = "NeuralNetTorch"
     ag_priority = 25
     seed_name = "seed_value"
+    _supported_problem_types = ["binary", "multiclass", "regression", "quantile", "softclass"]
 
     # Constants used throughout this class:
     unique_category_str = (
@@ -1037,8 +1038,6 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
         self.processor = self._compiler.compile(
             model=(self.processor, self.model), path=self.path, input_types=input_types
         )
-
-    _supported_problem_types = ["binary", "multiclass", "regression", "quantile", "softclass"]
 
     @classmethod
     def _class_tags(cls):

--- a/tabular/src/autogluon/tabular/models/text_prediction/text_prediction_v1_model.py
+++ b/tabular/src/autogluon/tabular/models/text_prediction/text_prediction_v1_model.py
@@ -33,6 +33,4 @@ class TextPredictorModel(MultiModalPredictorModel):
         default_auxiliary_params.update(extra_auxiliary_params)
         return default_auxiliary_params
 
-    @classmethod
-    def supported_problem_types(cls) -> list[str] | None:
-        return ["binary", "multiclass", "regression"]
+    _supported_problem_types = ["binary", "multiclass", "regression"]

--- a/tabular/src/autogluon/tabular/models/text_prediction/text_prediction_v1_model.py
+++ b/tabular/src/autogluon/tabular/models/text_prediction/text_prediction_v1_model.py
@@ -23,6 +23,7 @@ class TextPredictorModel(MultiModalPredictorModel):
 
     ag_key = "AG_TEXT_NN"
     ag_name = "TextPredictor"
+    _supported_problem_types = ["binary", "multiclass", "regression"]
 
     def _get_default_auxiliary_params(self) -> dict:
         default_auxiliary_params = super()._get_default_auxiliary_params()
@@ -32,5 +33,3 @@ class TextPredictorModel(MultiModalPredictorModel):
         )
         default_auxiliary_params.update(extra_auxiliary_params)
         return default_auxiliary_params
-
-    _supported_problem_types = ["binary", "multiclass", "regression"]

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -404,9 +404,7 @@ class XGBoostModel(AbstractModel):
             model._xgb_model_type = None
         return model
 
-    @classmethod
-    def supported_problem_types(cls) -> list[str] | None:
-        return ["binary", "multiclass", "regression", "softclass"]
+    _supported_problem_types = ["binary", "multiclass", "regression", "softclass"]
 
     @classmethod
     def _class_tags(cls):

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -34,6 +34,7 @@ class XGBoostModel(AbstractModel):
     ag_name = "XGBoost"
     ag_priority = 40
     seed_name = "seed"
+    _supported_problem_types = ["binary", "multiclass", "regression", "softclass"]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -403,8 +404,6 @@ class XGBoostModel(AbstractModel):
             model.model.load_model(os.path.join(path, "xgb.ubj"))
             model._xgb_model_type = None
         return model
-
-    _supported_problem_types = ["binary", "multiclass", "regression", "softclass"]
 
     @classmethod
     def _class_tags(cls):

--- a/tabular/src/autogluon/tabular/models/xt/xt_model.py
+++ b/tabular/src/autogluon/tabular/models/xt/xt_model.py
@@ -13,6 +13,7 @@ class XTModel(RFModel):
     ag_key = "XT"
     ag_name = "ExtraTrees"
     ag_priority = 60
+    _supported_problem_types = ["binary", "multiclass", "regression", "quantile"]
 
     def _get_model_type(self):
         if self.problem_type == REGRESSION:
@@ -27,5 +28,3 @@ class XTModel(RFModel):
             from sklearn.ensemble import ExtraTreesClassifier
 
             return ExtraTreesClassifier
-
-    _supported_problem_types = ["binary", "multiclass", "regression", "quantile"]

--- a/tabular/src/autogluon/tabular/models/xt/xt_model.py
+++ b/tabular/src/autogluon/tabular/models/xt/xt_model.py
@@ -28,6 +28,4 @@ class XTModel(RFModel):
 
             return ExtraTreesClassifier
 
-    @classmethod
-    def supported_problem_types(cls) -> list[str] | None:
-        return ["binary", "multiclass", "regression", "quantile"]
+    _supported_problem_types = ["binary", "multiclass", "regression", "quantile"]

--- a/tabular/src/autogluon/tabular/testing/fit_helper.py
+++ b/tabular/src/autogluon/tabular/testing/fit_helper.py
@@ -458,10 +458,18 @@ class FitHelper:
         fit_args = dict(
             hyperparameters={model_cls: model_hyperparameters},
         )
+        if model_cls.supported_problem_types.__func__ is not AbstractModel.supported_problem_types.__func__:
+            raise AssertionError(
+                f"Model {model_cls.__name__} overrides `supported_problem_types()`. "
+                f"Declare the `_supported_problem_types` class attribute instead of overriding the classmethod."
+                f"""\nExample code:
+    _supported_problem_types = ["binary", "multiclass", "regression", "quantile"]
+        """
+            )
         supported_problem_types = model_cls.supported_problem_types()
         if supported_problem_types is None:
             raise AssertionError(
-                f"Model must specify `cls.supported_problem_types`"
+                f"Model must specify `cls._supported_problem_types`"
                 f"""\nExample code:
     _supported_problem_types = ["binary", "multiclass", "regression", "quantile"]
         """

--- a/tabular/src/autogluon/tabular/testing/fit_helper.py
+++ b/tabular/src/autogluon/tabular/testing/fit_helper.py
@@ -463,9 +463,7 @@ class FitHelper:
             raise AssertionError(
                 f"Model must specify `cls.supported_problem_types`"
                 f"""\nExample code:
-    @classmethod
-    def supported_problem_types(cls) -> list[str] | None:
-        return ["binary", "multiclass", "regression", "quantile"]
+    _supported_problem_types = ["binary", "multiclass", "regression", "quantile"]
         """
             )
         assert isinstance(supported_problem_types, list)


### PR DESCRIPTION
## Description

Every `supported_problem_types()` override in the codebase was a trivial constant return, while the same classes already declare `ag_key` / `ag_name` / `ag_priority` as plain class attributes. Models now declare their supported problem types as data, alongside that metadata:

```python
_supported_problem_types = ["binary", "multiclass", "regression"]
```

one line instead of three, for 24 model classes (+32/−76 lines overall).

## API is unchanged

`supported_problem_types()` remains the public classmethod all callers use — the base implementation returns `cls._supported_problem_types`. Third-party custom models that override the classmethod keep working untouched (both through direct calls and `_get_default_ag_args()`), which is why this is not a plain attribute conversion: with a mixed ecosystem, attribute-style access on a classmethod-overriding subclass would return a truthy bound method and silently corrupt `ag_args["problem_types"]`.

## Guard for first-party models

`FitHelper.verify_model` now fails when the tested model class overrides the classmethod, with an error message showing the attribute style to use instead — so new in-repo models converge on the attribute while third-party overrides stay supported.

## Verification

- All 35 registry models return identical values via the attribute and the classmethod, and `_get_default_ag_args()` produces a correct `problem_types` list for attribute-style, legacy classmethod-override, and unspecified models.
- Model unit tests exercising `verify_model` pass (test_linear, test_dummy, test_lightgbm).
- The new guard raises on a legacy-style override and on a model with no declaration, each with the intended message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi