### PR TITLE
Declare auxiliary-param overrides via _default_auxiliary_params_extra class attribute

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -231,6 +231,9 @@ class AbstractModel(ModelBase, Tunable):
     _supported_problem_types: list[str] | None = (
         None  # problem types the model supports; None = unspecified (never filtered by problem type). Read via `supported_problem_types()`.
     )
+    _default_auxiliary_params_extra: dict | None = (
+        None  # auxiliary-param overrides merged onto the base defaults (base-most class first); see `_get_default_auxiliary_params`.
+    )
 
     model_file_name = "model.pkl"
     model_info_name = "info.pkl"
@@ -561,6 +564,14 @@ class AbstractModel(ModelBase, Tunable):
             predict_1_batch_size=None,  # If not None, calculates `self.predict_1_time` at end of fit call by predicting on this many rows of data.
             temperature_scalar=None,  # Temperature scaling parameter that is set post-fit if calibrate=True during TabularPredictor.fit() on the model with the best validation score and eval_metric="log_loss".
         )
+        # Merge each class's declarative `_default_auxiliary_params_extra` overrides,
+        # base-most class first so subclasses win — the same semantics as the historical
+        # chained `super()._get_default_auxiliary_params()` + `update` method overrides,
+        # which also remain supported.
+        for klass in reversed(type(self).__mro__):
+            extra = klass.__dict__.get("_default_auxiliary_params_extra")
+            if extra:
+                default_auxiliary_params.update(extra)
         return default_auxiliary_params
 
     def _set_default_param_value(self, param_name, param_value, params=None):

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -63,6 +63,10 @@ class BaggedEnsembleModel(AbstractModel):
     _oof_filename = "oof.pkl"
     seed_name = "model_random_seed"
 
+    _default_auxiliary_params_extra = dict(
+        drop_unique=False,  # TODO: Get the value from child instead
+    )
+
     def __init__(
         self,
         model_base: AbstractModel | Type[AbstractModel],
@@ -128,14 +132,6 @@ class BaggedEnsembleModel(AbstractModel):
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
         super()._set_default_params()
-
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        extra_auxiliary_params = dict(
-            drop_unique=False,  # TODO: Get the value from child instead
-        )
-        default_auxiliary_params.update(extra_auxiliary_params)
-        return default_auxiliary_params
 
     def is_valid(self) -> bool:
         return self.is_fit() and (self._n_repeats == self._n_repeats_finished)

--- a/core/src/autogluon/core/models/greedy_ensemble/greedy_weighted_ensemble_model.py
+++ b/core/src/autogluon/core/models/greedy_ensemble/greedy_weighted_ensemble_model.py
@@ -16,6 +16,10 @@ class GreedyWeightedEnsembleModel(AbstractModel):
     ag_name = "WeightedEnsemble"
     _supported_problem_types = ["binary", "multiclass", "regression", "quantile", "softclass"]
 
+    _default_auxiliary_params_extra = dict(
+        drop_unique=False,
+    )
+
     def __init__(self, base_model_names=None, model_base=EnsembleSelection, **kwargs):
         super().__init__(**kwargs)
         self.model_base = model_base
@@ -30,14 +34,6 @@ class GreedyWeightedEnsembleModel(AbstractModel):
         }
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
-
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        extra_auxiliary_params = dict(
-            drop_unique=False,
-        )
-        default_auxiliary_params.update(extra_auxiliary_params)
-        return default_auxiliary_params
 
     # TODO: Consider moving convert_pred_probas_df_to_list into inner model to ensure X remains a dataframe after preprocess is called
     def _preprocess_nonadaptive(self, X, **kwargs):

--- a/tabular/src/autogluon/tabular/models/automm/automm_model.py
+++ b/tabular/src/autogluon/tabular/models/automm/automm_model.py
@@ -33,6 +33,11 @@ class MultiModalPredictorModel(AbstractModel):
     _supported_problem_types = ["binary", "multiclass", "regression"]
     _NN_MODEL_NAME = "automm_model"
 
+    _default_auxiliary_params_extra = dict(
+        valid_raw_types=[R_INT, R_FLOAT, R_CATEGORY, R_OBJECT],
+        ignored_type_group_special=[S_TEXT_NGRAM, S_TEXT_AS_CATEGORY, S_TEXT_SPECIAL],
+    )
+
     def __init__(self, **kwargs):
         """Wrapper of autogluon.multimodal.MultiModalPredictor.
 
@@ -73,15 +78,6 @@ class MultiModalPredictorModel(AbstractModel):
         super().__init__(**kwargs)
         self._label_column_name = None
         self._load_model = None  # Whether to load inner model when loading.
-
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        extra_auxiliary_params = dict(
-            valid_raw_types=[R_INT, R_FLOAT, R_CATEGORY, R_OBJECT],
-            ignored_type_group_special=[S_TEXT_NGRAM, S_TEXT_AS_CATEGORY, S_TEXT_SPECIAL],
-        )
-        default_auxiliary_params.update(extra_auxiliary_params)
-        return default_auxiliary_params
 
     @classmethod
     def _get_default_ag_args(cls) -> dict:

--- a/tabular/src/autogluon/tabular/models/automm/ft_transformer.py
+++ b/tabular/src/autogluon/tabular/models/automm/ft_transformer.py
@@ -17,43 +17,10 @@ class FTTransformerModel(MultiModalPredictorModel):
     ag_key = "FT_TRANSFORMER"
     ag_name = "FTTransformer"
 
-    def __init__(self, **kwargs):
-        """
-        FT-Transformer model.
-
-        The features can be a mix of
-        - categorical column
-        - numerical column
-
-        The labels can be categorical or numerical.
-
-        Parameters
-        ----------
-        path
-            The directory to store the modeling outputs.
-        name
-            Name of subdirectory inside path where model will be saved.
-        problem_type
-            Type of problem that this model will handle.
-            Valid options: ['binary', 'multiclass', 'regression'].
-        eval_metric
-            The evaluation metric.
-        num_classes
-            The number of classes.
-        stopping_metric
-            The stopping metric.
-        model
-            The internal model object.
-        hyperparameters
-            The hyperparameters of the model
-        features
-            Names of the features.
-        feature_metadata
-            The feature metadata.
-
-        .. versionadded:: 0.6.0
-        """
-        super().__init__(**kwargs)
+    _default_auxiliary_params_extra = dict(
+        valid_raw_types=[R_INT, R_FLOAT, R_CATEGORY],
+        ignored_type_group_special=[S_TEXT_NGRAM, S_TEXT_SPECIAL],
+    )
 
     def _fit(self, X, num_gpus="auto", **kwargs):
         if not isinstance(num_gpus, str):
@@ -63,15 +30,6 @@ class FTTransformerModel(MultiModalPredictorModel):
                     f"WARNING: Training {self.name} on CPU (no GPU specified). This could take a long time. Use GPU to speed up training.",
                 )
         super()._fit(X, num_gpus=num_gpus, **kwargs)
-
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        extra_auxiliary_params = dict(
-            valid_raw_types=[R_INT, R_FLOAT, R_CATEGORY],
-            ignored_type_group_special=[S_TEXT_NGRAM, S_TEXT_SPECIAL],
-        )
-        default_auxiliary_params.update(extra_auxiliary_params)
-        return default_auxiliary_params
 
     def _set_default_params(self):
         default_params = {

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -41,6 +41,10 @@ class CatBoostModel(AbstractModel):
     seed_name = "random_seed"
     _supported_problem_types = ["binary", "multiclass", "regression", "quantile", "softclass"]
 
+    _default_auxiliary_params_extra = dict(
+        valid_raw_types=[R_BOOL, R_INT, R_FLOAT, R_CATEGORY],
+    )
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._category_features = None
@@ -390,14 +394,6 @@ class CatBoostModel(AbstractModel):
         if y_pred_proba.shape[1] == 2:
             y_pred_proba = y_pred_proba[:, 1]
         return y_pred_proba
-
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        extra_auxiliary_params = dict(
-            valid_raw_types=[R_BOOL, R_INT, R_FLOAT, R_CATEGORY],
-        )
-        default_auxiliary_params.update(extra_auxiliary_params)
-        return default_auxiliary_params
 
     def _get_early_stopping_rounds(self, num_rows_train, strategy="auto"):
         return get_early_stopping_rounds(num_rows_train=num_rows_train, strategy=strategy)

--- a/tabular/src/autogluon/tabular/models/ebm/ebm_model.py
+++ b/tabular/src/autogluon/tabular/models/ebm/ebm_model.py
@@ -60,6 +60,10 @@ class EBMModel(AbstractModel):
     seed_name = "random_state"
     _supported_problem_types = ["binary", "multiclass", "regression"]
 
+    _default_auxiliary_params_extra = {
+        "valid_raw_types": ["int", "float", "category"],
+    }
+
     def _fit(
         self,
         X: pd.DataFrame,
@@ -122,14 +126,6 @@ class EBMModel(AbstractModel):
 
     def _get_default_searchspace(self):
         return get_default_searchspace(problem_type=self.problem_type, num_classes=self.num_classes)
-
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        extra_auxiliary_params = {
-            "valid_raw_types": ["int", "float", "category"],
-        }
-        default_auxiliary_params.update(extra_auxiliary_params)
-        return default_auxiliary_params
 
     def _more_tags(self) -> dict:
         """EBMs support refit full."""

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -112,6 +112,11 @@ class NNFastAiTabularModel(AbstractModel):
 
     model_internals_file_name = "model-internals.pkl"
 
+    _default_auxiliary_params_extra = dict(
+        valid_raw_types=[R_BOOL, R_INT, R_FLOAT, R_CATEGORY],
+        ignored_type_group_special=[S_TEXT_NGRAM, S_TEXT_AS_CATEGORY],
+    )
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.cat_columns = None
@@ -618,15 +623,6 @@ class NNFastAiTabularModel(AbstractModel):
 
     def _get_default_searchspace(self):
         return get_default_searchspace(self.problem_type, num_classes=None)
-
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        extra_auxiliary_params = dict(
-            valid_raw_types=[R_BOOL, R_INT, R_FLOAT, R_CATEGORY],
-            ignored_type_group_special=[S_TEXT_NGRAM, S_TEXT_AS_CATEGORY],
-        )
-        default_auxiliary_params.update(extra_auxiliary_params)
-        return default_auxiliary_params
 
     def _get_default_resources(self):
         # only_physical_cores=True is faster in training

--- a/tabular/src/autogluon/tabular/models/image_prediction/image_predictor.py
+++ b/tabular/src/autogluon/tabular/models/image_prediction/image_predictor.py
@@ -29,6 +29,13 @@ class ImagePredictorModel(MultiModalPredictorModel):
     ag_name = "ImagePredictor"
     _supported_problem_types = ["binary", "multiclass", "regression"]
 
+    _default_auxiliary_params_extra = dict(
+        get_features_kwargs=dict(
+            valid_raw_types=[R_OBJECT],
+            required_special_types=[S_IMAGE_PATH],
+        ),
+    )
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._dummy_pred_proba = None  # Dummy value to predict if image is NaN
@@ -37,17 +44,6 @@ class ImagePredictorModel(MultiModalPredictorModel):
     @property
     def _has_predict_proba(self):
         return self.problem_type in [BINARY, MULTICLASS, SOFTCLASS]
-
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        extra_auxiliary_params = dict(
-            get_features_kwargs=dict(
-                valid_raw_types=[R_OBJECT],
-                required_special_types=[S_IMAGE_PATH],
-            ),
-        )
-        default_auxiliary_params.update(extra_auxiliary_params)
-        return default_auxiliary_params
 
     @classmethod
     def _get_default_ag_args(cls) -> dict:

--- a/tabular/src/autogluon/tabular/models/imodels/imodels_models.py
+++ b/tabular/src/autogluon/tabular/models/imodels/imodels_models.py
@@ -13,6 +13,12 @@ from autogluon.core.models import AbstractModel
 class _IModelsModel(AbstractModel):
     _supported_problem_types = ["binary", "multiclass", "regression"]
 
+    _default_auxiliary_params_extra = dict(
+        get_features_kwargs=dict(
+            valid_raw_types=["int", "float", "category"],
+        ),
+    )
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._feature_generator = None
@@ -66,16 +72,6 @@ class _IModelsModel(AbstractModel):
         }
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
-
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        extra_auxiliary_params = dict(
-            get_features_kwargs=dict(
-                valid_raw_types=["int", "float", "category"],
-            ),
-        )
-        default_auxiliary_params.update(extra_auxiliary_params)
-        return default_auxiliary_params
 
 
 class RuleFitModel(_IModelsModel):

--- a/tabular/src/autogluon/tabular/models/knn/knn_model.py
+++ b/tabular/src/autogluon/tabular/models/knn/knn_model.py
@@ -30,6 +30,11 @@ class KNNModel(AbstractModel):
     ag_priority = 100
     _supported_problem_types = ["binary", "multiclass", "regression"]
 
+    _default_auxiliary_params_extra = dict(
+        valid_raw_types=[R_INT, R_FLOAT],  # TODO: Eventually use category features
+        ignored_type_group_special=[S_BOOL],
+    )
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._X_unused_index = None  # Keeps track of unused training data indices, necessary for LOO OOF generation
@@ -63,15 +68,6 @@ class KNNModel(AbstractModel):
         }
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
-
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        extra_auxiliary_params = dict(
-            valid_raw_types=[R_INT, R_FLOAT],  # TODO: Eventually use category features
-            ignored_type_group_special=[S_BOOL],
-        )
-        default_auxiliary_params.update(extra_auxiliary_params)
-        return default_auxiliary_params
 
     @classmethod
     def _get_default_ag_args(cls) -> dict:

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -51,6 +51,10 @@ class LGBModel(AbstractModel):
     seed_name_alt = ["seed_value", "random_seed", "random_state"]
     _supported_problem_types = ["binary", "multiclass", "regression", "quantile", "softclass"]
 
+    _default_auxiliary_params_extra = dict(
+        valid_raw_types=[R_BOOL, R_INT, R_FLOAT, R_CATEGORY],
+    )
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
@@ -678,14 +682,6 @@ class LGBModel(AbstractModel):
 
     def _get_early_stopping_rounds(self, num_rows_train, strategy="auto"):
         return get_early_stopping_rounds(num_rows_train=num_rows_train, strategy=strategy)
-
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        extra_auxiliary_params = dict(
-            valid_raw_types=[R_BOOL, R_INT, R_FLOAT, R_CATEGORY],
-        )
-        default_auxiliary_params.update(extra_auxiliary_params)
-        return default_auxiliary_params
 
     @staticmethod
     def _is_gpu_lgbm_installed():

--- a/tabular/src/autogluon/tabular/models/lr/lr_model.py
+++ b/tabular/src/autogluon/tabular/models/lr/lr_model.py
@@ -47,6 +47,11 @@ class LinearModel(AbstractModel):
     seed_name = "random_state"
     _supported_problem_types = ["binary", "multiclass", "regression"]
 
+    _default_auxiliary_params_extra = dict(
+        valid_raw_types=[R_BOOL, R_INT, R_FLOAT, R_CATEGORY],
+        ignored_type_group_special=[S_TEXT_AS_CATEGORY],
+    )
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._pipeline = None
@@ -322,15 +327,6 @@ class LinearModel(AbstractModel):
 
     def _select_bool(self, df, features):
         return dict(bool=features)
-
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        extra_auxiliary_params = dict(
-            valid_raw_types=[R_BOOL, R_INT, R_FLOAT, R_CATEGORY],
-            ignored_type_group_special=[S_TEXT_AS_CATEGORY],
-        )
-        default_auxiliary_params.update(extra_auxiliary_params)
-        return default_auxiliary_params
 
     @classmethod
     def _estimate_memory_usage_static(

--- a/tabular/src/autogluon/tabular/models/mitra/_internal/models/base.py
+++ b/tabular/src/autogluon/tabular/models/mitra/_internal/models/base.py
@@ -5,9 +5,6 @@ import torch.nn as nn
 
 
 class BaseModel(nn.Module, ABC):
-    def __init__(self):
-        super().__init__()
-
     def init_weights(self):
         """Initialize model weights."""
         pass

--- a/tabular/src/autogluon/tabular/models/mitra/mitra_model.py
+++ b/tabular/src/autogluon/tabular/models/mitra/mitra_model.py
@@ -39,6 +39,12 @@ class MitraModel(AbstractTorchModel):
     seed_name = "seed"
     _supported_problem_types = ["binary", "multiclass", "regression"]
 
+    _default_auxiliary_params_extra = {
+        "max_rows": 10000,
+        "max_features": 500,
+        "max_classes": 10,
+    }
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._weights_saved = False
@@ -203,17 +209,6 @@ class MitraModel(AbstractTorchModel):
         }
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
-
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        default_auxiliary_params.update(
-            {
-                "max_rows": 10000,
-                "max_features": 500,
-                "max_classes": 10,
-            }
-        )
-        return default_auxiliary_params
 
     def weights_path(self, path: str | None = None) -> str:
         if path is None:

--- a/tabular/src/autogluon/tabular/models/nori/nori_model.py
+++ b/tabular/src/autogluon/tabular/models/nori/nori_model.py
@@ -51,6 +51,19 @@ class NoriModel(AbstractTorchModel):
     """Default prediction chunk size (``ag.max_batch_size``); also the query-batch
     bound assumed by the GPU memory estimate."""
 
+    _default_auxiliary_params_extra = {
+        # Nori attends queries over the full context with no internal chunking:
+        # measured predict-phase VRAM is ~5 GB at 10k rows x 10 features,
+        # ~21 GB at 10k x 100, and ~58 GB at the 50k-row cap (100 features),
+        # so the cap only fits on high-memory GPUs.
+        "max_rows": 50000,
+        "max_features": 2000,
+        # Chunk prediction: an unchunked 50k-query predict against a 50k-row
+        # context fails with a CUDA kernel-configuration error (after ~76 GB);
+        # 10k-query chunks on the same context run fine.
+        "max_batch_size": _DEFAULT_MAX_BATCH_SIZE,
+    }
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._feature_generator = None
@@ -133,24 +146,6 @@ class NoriModel(AbstractTorchModel):
             "num_cpus": 1,
             "num_gpus": 0.5 if is_gpu_available else 0,
         }
-
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        default_auxiliary_params.update(
-            {
-                # Nori attends queries over the full context with no internal chunking:
-                # measured predict-phase VRAM is ~5 GB at 10k rows x 10 features,
-                # ~21 GB at 10k x 100, and ~58 GB at the 50k-row cap (100 features),
-                # so the cap only fits on high-memory GPUs.
-                "max_rows": 50000,
-                "max_features": 2000,
-                # Chunk prediction: an unchunked 50k-query predict against a 50k-row
-                # context fails with a CUDA kernel-configuration error (after ~76 GB);
-                # 10k-query chunks on the same context run fine.
-                "max_batch_size": self._DEFAULT_MAX_BATCH_SIZE,
-            }
-        )
-        return default_auxiliary_params
 
     @classmethod
     def _get_default_ag_args_ensemble(cls, **kwargs) -> dict:

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -35,6 +35,10 @@ class RFModel(AbstractModel):
     seed_name = "random_state"
     _supported_problem_types = ["binary", "multiclass", "regression", "quantile", "softclass"]
 
+    _default_auxiliary_params_extra = dict(
+        valid_raw_types=[R_BOOL, R_INT, R_FLOAT, R_CATEGORY],
+    )
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._feature_generator = None
@@ -400,14 +404,6 @@ class RFModel(AbstractModel):
     def _get_maximum_resources(self) -> dict[str, int | float]:
         # no GPU support
         return {"num_gpus": 0}
-
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        extra_auxiliary_params = dict(
-            valid_raw_types=[R_BOOL, R_INT, R_FLOAT, R_CATEGORY],
-        )
-        default_auxiliary_params.update(extra_auxiliary_params)
-        return default_auxiliary_params
 
     @classmethod
     def _get_default_ag_args_ensemble(cls, problem_type=None, **kwargs) -> dict:

--- a/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_model.py
+++ b/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_model.py
@@ -60,6 +60,12 @@ class TabDPTModel(AbstractTorchModel):
         "regressor": ("context_size", "n_ensembles"),
     }
 
+    _default_auxiliary_params_extra = {
+        "max_rows": 100000,  # TODO: Test >100k rows
+        "max_features": 2500,  # TODO: Test >2500 features
+        "max_classes": 10,  # TODO: Test >10 classes
+    }
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._feature_generator = None
@@ -223,17 +229,6 @@ class TabDPTModel(AbstractTorchModel):
 
     def _more_tags(self) -> dict:
         return {"can_refit_full": True}
-
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        default_auxiliary_params.update(
-            {
-                "max_rows": 100000,  # TODO: Test >100k rows
-                "max_features": 2500,  # TODO: Test >2500 features
-                "max_classes": 10,  # TODO: Test >10 classes
-            }
-        )
-        return default_auxiliary_params
 
     @classmethod
     def _get_default_ag_args_ensemble(cls, **kwargs) -> dict:

--- a/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
+++ b/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
@@ -51,6 +51,17 @@ class TabICLModel(AbstractTorchModel):
     seed_name = "random_state"
     _supported_problem_types = ["binary", "multiclass", "regression", "quantile"]
 
+    _default_auxiliary_params_extra = {
+        # TODO: Instead of caps, should we subsample for large datasets?
+        "max_rows": 1000000,  # TODO: What should be the cap? 1 million rows works, but unsure if it is good
+        "max_features": 2000,  # TODO: What should be the cap? 10k features works, but unsure if it is good
+        # No prediction chunking: tabicl batches internally (VRAM-adaptive with
+        # OOM-halving), and each external chunk would re-encode the full training
+        # context (kv_cache is off by default) — a 1024-row cap made a 100k-row
+        # predict ~100x slower while saving no VRAM.
+        "max_batch_size": None,
+    }
+
     def get_model_cls(self):
         if self.problem_type in ["binary", "multiclass"]:
             from tabicl import TabICLClassifier
@@ -154,22 +165,6 @@ class TabICLModel(AbstractTorchModel):
         self.model.inference_config_.COL_CONFIG.device = self.model.device_
         self.model.inference_config_.ROW_CONFIG.device = self.model.device_
         self.model.inference_config_.ICL_CONFIG.device = self.model.device_
-
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        default_auxiliary_params.update(
-            {
-                # TODO: Instead of caps, should we subsample for large datasets?
-                "max_rows": 1000000,  # TODO: What should be the cap? 1 million rows works, but unsure if it is good
-                "max_features": 2000,  # TODO: What should be the cap? 10k features works, but unsure if it is good
-                # No prediction chunking: tabicl batches internally (VRAM-adaptive with
-                # OOM-halving), and each external chunk would re-encode the full training
-                # context (kv_cache is off by default) — a 1024-row cap made a 100k-row
-                # predict ~100x slower while saving no VRAM.
-                "max_batch_size": None,
-            }
-        )
-        return default_auxiliary_params
 
     def _get_default_resources(self) -> tuple[int, int]:
         # Use only physical cores for better performance based on benchmarks

--- a/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
+++ b/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
@@ -43,6 +43,10 @@ class TabMModel(AbstractTorchModel):
     """Feature count past which the per-feature memory cost saturates (batches shrink
     and the embedding layers stop dominating), so memory estimates stop scaling."""
 
+    _default_auxiliary_params_extra = {
+        "max_batch_size": 16384,  # avoid excessive VRAM usage
+    }
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._imputer = None
@@ -266,15 +270,6 @@ class TabMModel(AbstractTorchModel):
         mem_total = 5 * mem_ds + 1.2 * mem_forward_backward + 1.2 * mem_params + 1.6e9
 
         return mem_total
-
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        default_auxiliary_params.update(
-            {
-                "max_batch_size": 16384,  # avoid excessive VRAM usage
-            }
-        )
-        return default_auxiliary_params
 
     @classmethod
     def get_tabm_auto_batch_size(cls, n_samples: int) -> int:

--- a/tabular/src/autogluon/tabular/models/tabpfnmix/tabpfnmix_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnmix/tabpfnmix_model.py
@@ -48,6 +48,10 @@ class TabPFNMixModel(AbstractModel):
 
     weights_file_name = "model.pt"
 
+    _default_auxiliary_params_extra = {
+        "max_classes": 10,
+    }
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._feature_generator = None
@@ -328,15 +332,6 @@ class TabPFNMixModel(AbstractModel):
     @property
     def weights_path(self) -> str:
         return os.path.join(self.path, self.weights_file_name)
-
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        default_auxiliary_params.update(
-            {
-                "max_classes": 10,
-            }
-        )
-        return default_auxiliary_params
 
     def _get_maximum_resources(self) -> dict[str, int | float]:
         # torch model trains slower when utilizing virtual cores and this issue scale up when the number of cpu cores increases

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfn3_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfn3_model.py
@@ -35,21 +35,16 @@ class TabPFN3Model(TabPFNModel):
     memory — unlike TabPFN-2.5/2.6 (the base default), which re-process the joint
     train + batch sequence per chunk and benefit from a low floor."""
 
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        default_auxiliary_params.update(
-            {
-                "max_rows": 500_000,
-                "max_features": 2500,
-                "max_classes": 160,
-                # max_batch_size (prediction chunking) is the model's only bound on
-                # test-side VRAM (peak grows linearly in unchunked prediction rows);
-                # "auto" resolves at fit time to min(1M, max(100k, n_train)).
-                "max_batch_size": "auto",
-                "model_telemetry": False,
-            }
-        )
-        return default_auxiliary_params
+    _default_auxiliary_params_extra = {
+        "max_rows": 500_000,
+        "max_features": 2500,
+        "max_classes": 160,
+        # max_batch_size (prediction chunking) is the model's only bound on
+        # test-side VRAM (peak grows linearly in unchunked prediction rows);
+        # "auto" resolves at fit time to min(1M, max(100k, n_train)).
+        "max_batch_size": "auto",
+        "model_telemetry": False,
+    }
 
     @staticmethod
     def extra_checkpoints_for_tuning(problem_type: str) -> list[str]:

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
@@ -68,6 +68,16 @@ class TabPFNModel(AbstractTorchModel):
     is reused across chunks (TabPFN-3) override this with a high floor, since
     for them small chunks multiply predict time while saving little memory."""
 
+    _default_auxiliary_params_extra = {
+        "max_rows": 100_000,
+        "max_features": 2000,
+        "max_classes": 10,
+        # "auto" resolves at fit time to min(1M, max(100k, n_train));
+        # None disables prediction chunking.
+        "max_batch_size": "auto",
+        "model_telemetry": False,
+    }
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._feature_generator = None
@@ -263,21 +273,6 @@ class TabPFNModel(AbstractTorchModel):
 
     def _set_device(self, device: str):
         self.model.to(device)
-
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        default_auxiliary_params.update(
-            {
-                "max_rows": 100_000,
-                "max_features": 2000,
-                "max_classes": 10,
-                # "auto" resolves at fit time to min(1M, max(100k, n_train));
-                # None disables prediction chunking.
-                "max_batch_size": "auto",
-                "model_telemetry": False,
-            }
-        )
-        return default_auxiliary_params
 
     @classmethod
     def _get_default_ag_args_ensemble(cls, **kwargs) -> dict:
@@ -491,17 +486,12 @@ class RealTabPFNv2Model(TabPFNModel):
     default_classification_model: str | None = "tabpfn-v2-classifier-finetuned-zk73skhh.ckpt"
     default_regression_model: str | None = "tabpfn-v2-regressor-v2_default.ckpt"
 
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        default_auxiliary_params.update(
-            {
-                "max_rows": 10_000,
-                "max_features": 500,
-                "max_classes": 10,
-                "max_batch_size": 10000,  # TabPFN seems to cryptically error if predicting on 100,000 samples.
-            }
-        )
-        return default_auxiliary_params
+    _default_auxiliary_params_extra = {
+        "max_rows": 10_000,
+        "max_features": 500,
+        "max_classes": 10,
+        "max_batch_size": 10000,  # TabPFN seems to cryptically error if predicting on 100,000 samples.
+    }
 
     # FIXME: Avoid code dupe. This one has 500 features max, 2.5 has 2000.
     @classmethod

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_6_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_6_model.py
@@ -23,6 +23,13 @@ class TabPFNv26Model(TabPFNModel):
     default_classification_model: str | None = "tabpfn-v2.6-classifier-v2.6_default.ckpt"
     default_regression_model: str | None = "tabpfn-v2.6-regressor-v2.6_default.ckpt"
 
+    _default_auxiliary_params_extra = {
+        "max_rows": 100_000,
+        "max_features": 2500,
+        "max_classes": 10,
+        "model_telemetry": False,
+    }
+
     @classmethod
     def _estimate_memory_usage_static(
         cls,
@@ -87,18 +94,6 @@ class TabPFNv26Model(TabPFNModel):
                 + 0.4e3 * total_rows * max(0, min(n_features, 1000) - 300)
             )
         )
-
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        default_auxiliary_params.update(
-            {
-                "max_rows": 100_000,
-                "max_features": 2500,
-                "max_classes": 10,
-                "model_telemetry": False,
-            }
-        )
-        return default_auxiliary_params
 
     @staticmethod
     def extra_checkpoints_for_tuning(problem_type: str) -> list[str]:

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -60,6 +60,11 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
         np.nan
     )  # string used to represent missing values and unknown categories for categorical features.
 
+    _default_auxiliary_params_extra = dict(
+        valid_raw_types=[R_BOOL, R_INT, R_FLOAT, R_CATEGORY],
+        ignored_type_group_special=[S_TEXT_NGRAM, S_TEXT_AS_CATEGORY],
+    )
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.feature_arraycol_map = None
@@ -78,15 +83,6 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
         default_params = get_default_param(problem_type=self.problem_type, framework="pytorch")
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
-
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        extra_auxiliary_params = dict(
-            valid_raw_types=[R_BOOL, R_INT, R_FLOAT, R_CATEGORY],
-            ignored_type_group_special=[S_TEXT_NGRAM, S_TEXT_AS_CATEGORY],
-        )
-        default_auxiliary_params.update(extra_auxiliary_params)
-        return default_auxiliary_params
 
     def _get_default_searchspace(self):
         return get_default_searchspace(problem_type=self.problem_type, framework="pytorch")

--- a/tabular/src/autogluon/tabular/models/text_prediction/text_prediction_v1_model.py
+++ b/tabular/src/autogluon/tabular/models/text_prediction/text_prediction_v1_model.py
@@ -25,11 +25,7 @@ class TextPredictorModel(MultiModalPredictorModel):
     ag_name = "TextPredictor"
     _supported_problem_types = ["binary", "multiclass", "regression"]
 
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        extra_auxiliary_params = dict(
-            valid_raw_types=[R_INT, R_FLOAT, R_CATEGORY, R_OBJECT],
-            ignored_type_group_special=[S_TEXT_NGRAM, S_TEXT_AS_CATEGORY, S_TEXT_SPECIAL, S_IMAGE_PATH],
-        )
-        default_auxiliary_params.update(extra_auxiliary_params)
-        return default_auxiliary_params
+    _default_auxiliary_params_extra = dict(
+        valid_raw_types=[R_INT, R_FLOAT, R_CATEGORY, R_OBJECT],
+        ignored_type_group_special=[S_TEXT_NGRAM, S_TEXT_AS_CATEGORY, S_TEXT_SPECIAL, S_IMAGE_PATH],
+    )

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -36,6 +36,10 @@ class XGBoostModel(AbstractModel):
     seed_name = "seed"
     _supported_problem_types = ["binary", "multiclass", "regression", "softclass"]
 
+    _default_auxiliary_params_extra = dict(
+        valid_raw_types=[R_BOOL, R_INT, R_FLOAT, R_CATEGORY],
+    )
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._ohe: bool = True
@@ -51,14 +55,6 @@ class XGBoostModel(AbstractModel):
 
     def _get_default_searchspace(self):
         return get_default_searchspace(problem_type=self.problem_type, num_classes=self.num_classes)
-
-    def _get_default_auxiliary_params(self) -> dict:
-        default_auxiliary_params = super()._get_default_auxiliary_params()
-        extra_auxiliary_params = dict(
-            valid_raw_types=[R_BOOL, R_INT, R_FLOAT, R_CATEGORY],
-        )
-        default_auxiliary_params.update(extra_auxiliary_params)
-        return default_auxiliary_params
 
     # Use specialized XGBoost metric if available (fast), otherwise use custom func generator
     def get_eval_metric(self):


### PR DESCRIPTION
## Description

Follow-up to #5771, applying the same declare-data-not-methods pattern to `_get_default_auxiliary_params`.

Every `_get_default_auxiliary_params()` override in the codebase was a constant dict wrapped in the identical 6–14 line boilerplate:

```python
def _get_default_auxiliary_params(self) -> dict:
    default_auxiliary_params = super()._get_default_auxiliary_params()
    default_auxiliary_params.update({...})
    return default_auxiliary_params
```

Models now declare the overrides with their other class attributes:

```python
_default_auxiliary_params_extra = {"max_rows": 50000, "max_features": 2000, ...}
```

26 model classes converted (+162/−306 lines). Inline comments inside the dicts are preserved verbatim.

## Semantics

The base `_get_default_auxiliary_params()` builds the base defaults, then merges each class's own `_default_auxiliary_params_extra` (via `__dict__`, so each class contributes exactly once) in reverse MRO order — base-most first, subclass wins. This reproduces the historical chained-`super().update()` behavior exactly, including multi-level chains (TabPFN-3 → TabPFN-2.5, FTTransformer → MultiModalPredictor).

Method overrides remain fully supported for dynamic cases and compose with declarative parents: `super()._get_default_auxiliary_params()` already includes the merged extras.

Also removes two no-op `__init__` pass-throughs (`FTTransformerModel`, mitra's internal `BaseModel`).

## Verification

- Auxiliary params for all 35 registry models plus `BaggedEnsembleModel` and `GreedyWeightedEnsembleModel` are bit-identical to a snapshot captured before the change.
- A legacy method-override subclass of a declarative parent composes correctly; a declarative child correctly overrides its declarative parent's keys.
- Model unit tests exercising the full fit path pass (test_linear, test_dummy, test_lightgbm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi