### PR TITLE
Validate _default_auxiliary_params_extra keys in verify_model

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -3556,6 +3556,11 @@ class AbstractModel(ModelBase, Tunable):
             If specified, raises an AssertionError at fit time if self.problem_type not in problem_types
         ignore_constraints: bool
             If True, ignores the values of `min_rows`, `max_rows`, `max_features`, `max_classes` and `problem_types`.
+        max_batch_size: int
+            If specified, predictions on more than `max_batch_size` rows are computed in chunks of at most
+            `max_batch_size` rows each (see `_predict_proba_batch`), bounding prediction-time memory usage.
+        drop_unique: bool
+            Whether to drop features that have only 1 unique value (default True).
 
         """
         return {
@@ -3565,6 +3570,8 @@ class AbstractModel(ModelBase, Tunable):
             "max_classes",
             "problem_types",
             "ignore_constraints",
+            "max_batch_size",
+            "drop_unique",
             "model_specific_feature_generator_kwargs",
             "prep_params",
             "prep_params.passthrough_types",

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
@@ -268,6 +268,11 @@ class TabPFNModel(AbstractTorchModel):
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
 
+    def _ag_params(self) -> set[str]:
+        # model_telemetry: whether the tabpfn library's telemetry is left enabled
+        # during fit/predict (disabled by default).
+        return {"model_telemetry"}
+
     def get_device(self) -> str:
         return self.model.devices_[0].type
 

--- a/tabular/src/autogluon/tabular/testing/fit_helper.py
+++ b/tabular/src/autogluon/tabular/testing/fit_helper.py
@@ -414,6 +414,32 @@ class FitHelper:
             return TabularPredictor(**init_args).fit(train_data, **fit_args)
 
     @staticmethod
+    def _verify_auxiliary_param_keys(model_cls: type[AbstractModel]) -> None:
+        """Fail if the model declares `_default_auxiliary_params_extra` keys that nothing consumes.
+
+        Known keys are the base auxiliary-param defaults plus the registered ag-params
+        (`_ag_params_common()` and the model's `_ag_params()`). An unknown key is either a typo
+        or a model-private param the wrapper reads without registering it — register such keys
+        in the model's `_ag_params()`.
+        """
+        known_keys = set(AbstractModel._get_default_auxiliary_params(object.__new__(AbstractModel)))
+        known_keys |= model_cls._ag_params_common()
+        # `_ag_params` implementations are constant per class, so calling on an
+        # uninitialized instance is safe.
+        known_keys |= model_cls._ag_params(object.__new__(model_cls))
+        declared_keys = set()
+        for klass in model_cls.__mro__:
+            declared_keys |= set(klass.__dict__.get("_default_auxiliary_params_extra") or {})
+        unknown_keys = declared_keys - known_keys
+        if unknown_keys:
+            raise AssertionError(
+                f"Model {model_cls.__name__} declares unknown auxiliary param key(s) in "
+                f"`_default_auxiliary_params_extra`: {sorted(unknown_keys)}"
+                f"\nEither fix the typo (known keys: {sorted(known_keys)}),"
+                f"\nor, if the model's wrapper code consumes the key, register it in the model's `_ag_params()`."
+            )
+
+    @staticmethod
     def verify_model(
         model_cls: Type[AbstractModel],
         model_hyperparameters: dict[str, Any],
@@ -466,6 +492,7 @@ class FitHelper:
     _supported_problem_types = ["binary", "multiclass", "regression", "quantile"]
         """
             )
+        FitHelper._verify_auxiliary_param_keys(model_cls=model_cls)
         supported_problem_types = model_cls.supported_problem_types()
         if supported_problem_types is None:
             raise AssertionError(


### PR DESCRIPTION
## Description

Follow-up to #5772, implementing the first step toward @LennartPurucker's dataclass suggestion: closing the typo hole in the auxiliary-param key space.

A typo'd key in `_default_auxiliary_params_extra` (e.g. `"max_rowz"`) is silently ignored at runtime. `FitHelper.verify_model` now validates that every declared key is actually consumed by something:

- **Known keys** = base auxiliary-param defaults ∪ `_ag_params_common()` ∪ the model's `_ag_params()`.
- An unknown key fails with the sorted unknown/known key lists and the fix: correct the typo, or register a wrapper-consumed private key in the model's `_ag_params()`.

This makes `_ag_params()` the single registration point for model-private auxiliary params, which is the schema a future `AuxiliaryParams` dataclass can be generated from — declarations stay ergonomic partial dicts, the merged runtime object can become typed later without touching model code again.

## Registrations the check surfaced

Three keys were consumed but registered nowhere:

- `max_batch_size` → `_ag_params_common()`: consumed by `AbstractModel` itself (chunked prediction via `_predict_proba_batch`), available to every model.
- `drop_unique` → `_ag_params_common()`: also consumed by `AbstractModel` (unique-value feature dropping).
- `model_telemetry` → `TabPFNModel._ag_params()`: its only consumer.

Both `_ag_params_common()` additions are documented in its docstring. No behavior change: consumers read these via `params_aux.get(...)` and continue to; registration only makes them visible to `_get_ag_params()` and the validator.

## Verification

- All registry models plus `BaggedEnsembleModel` / `GreedyWeightedEnsembleModel` pass the new check.
- The guard raises on a typo'd key and on an unregistered model-private key, and passes once that key is registered in `_ag_params()`.
- Model unit tests pass (test_linear, test_dummy, test_lightgbm — all routed through `verify_model`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi