### PR TITLE
AuxiliaryParams typed schema; make params_aux immutable after construction (deprecation, raises in 1.7)

### DIFF
--- a/core/src/autogluon/core/models/__init__.py
+++ b/core/src/autogluon/core/models/__init__.py
@@ -1,3 +1,4 @@
+from .abstract._auxiliary_params import AuxiliaryParams
 from .abstract.abstract_model import AbstractModel, ModelBase, Tunable
 from .dummy.dummy_model import DummyModel
 from .ensemble.bagged_ensemble_model import BaggedEnsembleModel

--- a/core/src/autogluon/core/models/abstract/_auxiliary_params.py
+++ b/core/src/autogluon/core/models/abstract/_auxiliary_params.py
@@ -28,12 +28,12 @@ from packaging import version
 
 from ...version import __version__
 
-#: Field metadata marking params that are consumed by wrapper code but intentionally
-#: absent from the `_get_default_auxiliary_params` defaults dict.
 _WRAPPER_ONLY = {"materialized": False}
+"""Field metadata marking params that are consumed by wrapper code but intentionally
+absent from the `_get_default_auxiliary_params` defaults dict."""
 
-#: AutoGluon version from which mutating `params_aux` raises instead of warning.
 _MUTATION_RAISE_MIN_VERSION = "1.7"
+"""AutoGluon version from which mutating `params_aux` raises instead of warning."""
 _MUTATION_SHOULD_RAISE = version.parse(__version__) >= version.parse(_MUTATION_RAISE_MIN_VERSION)
 
 
@@ -111,69 +111,71 @@ class AuxiliaryParams:
     """Typed view of a model's auxiliary params. See the module docstring."""
 
     # -- materialized defaults: seed `AbstractModel._get_default_auxiliary_params` --
-    # Ratio of memory usage allowed by the model. Values > 1.0 have an increased risk of causing OOM errors.
-    # Used in memory checks during model training to avoid OOM errors.
     max_memory_usage_ratio: float = 1.0
-    # GPU counterpart of max_memory_usage_ratio: ratio of available VRAM the model is allowed to use.
-    # Only checked for models that define a GPU memory estimate (see `_estimate_gpu_memory_usage`).
-    # If None, GPU memory checks are skipped.
+    """Ratio of memory usage allowed by the model. Values > 1.0 have an increased risk of causing OOM
+    errors. Used in memory checks during model training to avoid OOM errors."""
     max_gpu_memory_usage_ratio: float | None = 1.0
-    # Ratio of given time_limit to use during fit(). If time_limit == 10 and max_time_limit_ratio=0.3,
-    # time_limit would be changed to 3.
+    """GPU counterpart of max_memory_usage_ratio: ratio of available VRAM the model is allowed to use.
+    Only checked for models that define a GPU memory estimate (see `_estimate_gpu_memory_usage`).
+    If None, GPU memory checks are skipped."""
     max_time_limit_ratio: float = 1.0
-    # max time_limit value during fit(). If the provided time_limit is greater than this value, it will be
-    # replaced by max_time_limit. Occurs after max_time_limit_ratio is applied.
+    """Ratio of given time_limit to use during fit(). If time_limit == 10 and max_time_limit_ratio=0.3,
+    time_limit would be changed to 3."""
     max_time_limit: float | None = None
-    # min time_limit value during fit(). If the provided time_limit is less than this value, it will be
-    # replaced by min_time_limit. Occurs after max_time_limit is applied.
+    """max time_limit value during fit(). If the provided time_limit is greater than this value, it will
+    be replaced by max_time_limit. Occurs after max_time_limit_ratio is applied."""
     min_time_limit: float = 0
-    # If a feature's raw type is not in this list, it is pruned.
+    """min time_limit value during fit(). If the provided time_limit is less than this value, it will be
+    replaced by min_time_limit. Occurs after max_time_limit is applied."""
     valid_raw_types: list[str] | None = None
-    # If a feature has a special type not in this list, it is pruned.
+    """If a feature's raw type is not in this list, it is pruned."""
     valid_special_types: list[str] | None = None
-    # List, drops any features in `self.feature_metadata.type_group_map_special[type]` for type in
-    # `ignored_type_group_special`. | Currently undocumented in task.
+    """If a feature has a special type not in this list, it is pruned."""
     ignored_type_group_special: list[str] | None = None
-    # List, drops any features in `self.feature_metadata.type_group_map_raw[type]` for type in
-    # `ignored_type_group_raw`. | Currently undocumented in task.
+    """List, drops any features in `self.feature_metadata.type_group_map_special[type]` for type in
+    `ignored_type_group_special`. | Currently undocumented in task."""
     ignored_type_group_raw: list[str] | None = None
-    # Kwargs for `autogluon.tabular.features.feature_metadata.FeatureMetadata.get_features()`.
-    # Overrides valid_raw_types, valid_special_types, ignored_type_group_special and
-    # ignored_type_group_raw. | Currently undocumented in task.
+    """List, drops any features in `self.feature_metadata.type_group_map_raw[type]` for type in
+    `ignored_type_group_raw`. | Currently undocumented in task."""
     get_features_kwargs: dict | None = None
-    # If not None, applies an additional feature filter to the result of get_feature_kwargs.
-    # This should be reserved for users and be None by default. | Currently undocumented in task.
+    """Kwargs for `autogluon.tabular.features.feature_metadata.FeatureMetadata.get_features()`.
+    Overrides valid_raw_types, valid_special_types, ignored_type_group_special and
+    ignored_type_group_raw. | Currently undocumented in task."""
     get_features_kwargs_extra: dict | None = None
-    # If not None, calculates `self.predict_1_time` at end of fit call by predicting on this many rows of data.
+    """If not None, applies an additional feature filter to the result of get_feature_kwargs.
+    This should be reserved for users and be None by default. | Currently undocumented in task."""
     predict_1_batch_size: int | None = None
-    # Temperature scaling parameter that is set post-fit if calibrate=True during TabularPredictor.fit()
-    # on the model with the best validation score and eval_metric="log_loss".
+    """If not None, calculates `self.predict_1_time` at end of fit call by predicting on this many rows
+    of data."""
     temperature_scalar: float | None = None
+    """Temperature scaling parameter that is set post-fit if calibrate=True during TabularPredictor.fit()
+    on the model with the best validation score and eval_metric="log_loss"."""
 
     # -- wrapper-only params: consumed by wrapper code, absent from the defaults dict --
     # (fit-time constraints; see `_ag_params_common` / `_validate_fit_args`)
-    # If specified, raises an AssertionError at fit time if len(X) < min_rows.
     min_rows: int | None = field(default=None, metadata=_WRAPPER_ONLY)
-    # If specified, raises an AssertionError at fit time if len(X) > max_rows.
+    """If specified, raises an AssertionError at fit time if len(X) < min_rows."""
     max_rows: int | None = field(default=None, metadata=_WRAPPER_ONLY)
-    # If specified, raises an AssertionError at fit time if len(X.columns) > max_features.
+    """If specified, raises an AssertionError at fit time if len(X) > max_rows."""
     max_features: int | None = field(default=None, metadata=_WRAPPER_ONLY)
-    # If specified, raises an AssertionError at fit time if self.num_classes > max_classes.
+    """If specified, raises an AssertionError at fit time if len(X.columns) > max_features."""
     max_classes: int | None = field(default=None, metadata=_WRAPPER_ONLY)
-    # If specified, raises an AssertionError at fit time if self.problem_type not in problem_types.
+    """If specified, raises an AssertionError at fit time if self.num_classes > max_classes."""
     problem_types: list[str] | None = field(default=None, metadata=_WRAPPER_ONLY)
-    # If True, ignores the values of `min_rows`, `max_rows`, `max_features`, `max_classes` and `problem_types`.
+    """If specified, raises an AssertionError at fit time if self.problem_type not in problem_types."""
     ignore_constraints: bool = field(default=False, metadata=_WRAPPER_ONLY)
-    # If specified, predictions on more than `max_batch_size` rows are computed in chunks of at most
-    # `max_batch_size` rows each (see `_predict_proba_batch`), bounding prediction-time memory usage.
-    # Models may declare the sentinel "auto" and resolve it to an int during `_fit`.
+    """If True, ignores the values of `min_rows`, `max_rows`, `max_features`, `max_classes` and
+    `problem_types`."""
     max_batch_size: int | str | None = field(default=None, metadata=_WRAPPER_ONLY)
-    # Whether to drop features that have only 1 unique value.
+    """If specified, predictions on more than `max_batch_size` rows are computed in chunks of at most
+    `max_batch_size` rows each (see `_predict_proba_batch`), bounding prediction-time memory usage.
+    Models may declare the sentinel "auto" and resolve it to an int during `_fit`."""
     drop_unique: bool = field(default=True, metadata=_WRAPPER_ONLY)
+    """Whether to drop features that have only 1 unique value."""
 
-    #: Keys of `params_aux` that are not fields above: model-private params (registered via
-    #: the model's `_ag_params()`, e.g. TabPFN's `model_telemetry`) and any user-supplied extras.
     extra: dict[str, Any] = field(default_factory=dict, metadata=_WRAPPER_ONLY)
+    """Keys of `params_aux` that are not fields above: model-private params (registered via
+    the model's `_ag_params()`, e.g. TabPFN's `model_telemetry`) and any user-supplied extras."""
 
     @classmethod
     def base_defaults(cls) -> dict[str, Any]:

--- a/core/src/autogluon/core/models/abstract/_auxiliary_params.py
+++ b/core/src/autogluon/core/models/abstract/_auxiliary_params.py
@@ -1,0 +1,116 @@
+"""Typed schema for model auxiliary params (``params_aux``).
+
+:class:`AuxiliaryParams` is the single source of truth for the auxiliary-param key space:
+
+- Its *materialized* fields seed ``AbstractModel._get_default_auxiliary_params`` (via
+  :meth:`AuxiliaryParams.base_defaults`), replacing the historical literal dict.
+- Its *wrapper-only* fields are the params consumed by wrapper code without being present
+  in the defaults dict (the constraint params of ``_ag_params_common()`` and friends);
+  they carry the same fallback defaults the consuming ``params_aux.get(...)`` calls used.
+- :meth:`AuxiliaryParams.known_keys` drives the ``FitHelper.verify_model`` validation of
+  ``_default_auxiliary_params_extra`` declarations.
+
+Models keep declaring overrides as plain (naturally partial) dicts via
+``_default_auxiliary_params_extra``; user overrides keep flowing in as ``ag_args_fit``
+dicts. This dataclass is the *merged runtime view*: ``AbstractModel.aux_params`` builds it
+from ``params_aux``, giving wrapper code typed, typo-proof attribute access. Keys that are
+not fields (model-private params registered via ``_ag_params()``) land in ``extra``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass, field
+from typing import Any
+
+#: Field metadata marking params that are consumed by wrapper code but intentionally
+#: absent from the `_get_default_auxiliary_params` defaults dict.
+_WRAPPER_ONLY = {"materialized": False}
+
+
+@dataclass
+class AuxiliaryParams:
+    """Typed view of a model's auxiliary params. See the module docstring."""
+
+    # -- materialized defaults: seed `AbstractModel._get_default_auxiliary_params` --
+    # Ratio of memory usage allowed by the model. Values > 1.0 have an increased risk of causing OOM errors.
+    # Used in memory checks during model training to avoid OOM errors.
+    max_memory_usage_ratio: float = 1.0
+    # GPU counterpart of max_memory_usage_ratio: ratio of available VRAM the model is allowed to use.
+    # Only checked for models that define a GPU memory estimate (see `_estimate_gpu_memory_usage`).
+    # If None, GPU memory checks are skipped.
+    max_gpu_memory_usage_ratio: float | None = 1.0
+    # Ratio of given time_limit to use during fit(). If time_limit == 10 and max_time_limit_ratio=0.3,
+    # time_limit would be changed to 3.
+    max_time_limit_ratio: float = 1.0
+    # max time_limit value during fit(). If the provided time_limit is greater than this value, it will be
+    # replaced by max_time_limit. Occurs after max_time_limit_ratio is applied.
+    max_time_limit: float | None = None
+    # min time_limit value during fit(). If the provided time_limit is less than this value, it will be
+    # replaced by min_time_limit. Occurs after max_time_limit is applied.
+    min_time_limit: float = 0
+    # If a feature's raw type is not in this list, it is pruned.
+    valid_raw_types: list[str] | None = None
+    # If a feature has a special type not in this list, it is pruned.
+    valid_special_types: list[str] | None = None
+    # List, drops any features in `self.feature_metadata.type_group_map_special[type]` for type in
+    # `ignored_type_group_special`. | Currently undocumented in task.
+    ignored_type_group_special: list[str] | None = None
+    # List, drops any features in `self.feature_metadata.type_group_map_raw[type]` for type in
+    # `ignored_type_group_raw`. | Currently undocumented in task.
+    ignored_type_group_raw: list[str] | None = None
+    # Kwargs for `autogluon.tabular.features.feature_metadata.FeatureMetadata.get_features()`.
+    # Overrides valid_raw_types, valid_special_types, ignored_type_group_special and
+    # ignored_type_group_raw. | Currently undocumented in task.
+    get_features_kwargs: dict | None = None
+    # If not None, applies an additional feature filter to the result of get_feature_kwargs.
+    # This should be reserved for users and be None by default. | Currently undocumented in task.
+    get_features_kwargs_extra: dict | None = None
+    # If not None, calculates `self.predict_1_time` at end of fit call by predicting on this many rows of data.
+    predict_1_batch_size: int | None = None
+    # Temperature scaling parameter that is set post-fit if calibrate=True during TabularPredictor.fit()
+    # on the model with the best validation score and eval_metric="log_loss".
+    temperature_scalar: float | None = None
+
+    # -- wrapper-only params: consumed by wrapper code, absent from the defaults dict --
+    # (fit-time constraints; see `_ag_params_common` / `_validate_fit_args`)
+    # If specified, raises an AssertionError at fit time if len(X) < min_rows.
+    min_rows: int | None = field(default=None, metadata=_WRAPPER_ONLY)
+    # If specified, raises an AssertionError at fit time if len(X) > max_rows.
+    max_rows: int | None = field(default=None, metadata=_WRAPPER_ONLY)
+    # If specified, raises an AssertionError at fit time if len(X.columns) > max_features.
+    max_features: int | None = field(default=None, metadata=_WRAPPER_ONLY)
+    # If specified, raises an AssertionError at fit time if self.num_classes > max_classes.
+    max_classes: int | None = field(default=None, metadata=_WRAPPER_ONLY)
+    # If specified, raises an AssertionError at fit time if self.problem_type not in problem_types.
+    problem_types: list[str] | None = field(default=None, metadata=_WRAPPER_ONLY)
+    # If True, ignores the values of `min_rows`, `max_rows`, `max_features`, `max_classes` and `problem_types`.
+    ignore_constraints: bool = field(default=False, metadata=_WRAPPER_ONLY)
+    # If specified, predictions on more than `max_batch_size` rows are computed in chunks of at most
+    # `max_batch_size` rows each (see `_predict_proba_batch`), bounding prediction-time memory usage.
+    # Models may declare the sentinel "auto" and resolve it to an int during `_fit`.
+    max_batch_size: int | str | None = field(default=None, metadata=_WRAPPER_ONLY)
+    # Whether to drop features that have only 1 unique value.
+    drop_unique: bool = field(default=True, metadata=_WRAPPER_ONLY)
+
+    #: Keys of `params_aux` that are not fields above: model-private params (registered via
+    #: the model's `_ag_params()`, e.g. TabPFN's `model_telemetry`) and any user-supplied extras.
+    extra: dict[str, Any] = field(default_factory=dict, metadata=_WRAPPER_ONLY)
+
+    @classmethod
+    def base_defaults(cls) -> dict[str, Any]:
+        """The `_get_default_auxiliary_params` base defaults dict (materialized fields only)."""
+        return {f.name: f.default for f in dataclasses.fields(cls) if f.metadata.get("materialized", True)}
+
+    @classmethod
+    def known_keys(cls) -> set[str]:
+        """All schema field names (materialized and wrapper-only), excluding the `extra` catch-all."""
+        return {f.name for f in dataclasses.fields(cls) if f.name != "extra"}
+
+    @classmethod
+    def from_dict(cls, params_aux: dict[str, Any]) -> AuxiliaryParams:
+        """Build the typed view from a `params_aux` dict; non-field keys land in `extra`."""
+        known = cls.known_keys()
+        kwargs = {k: v for k, v in params_aux.items() if k in known}
+        extra = {k: v for k, v in params_aux.items() if k not in known}
+        return cls(**kwargs, extra=extra)

--- a/core/src/autogluon/core/models/abstract/_auxiliary_params.py
+++ b/core/src/autogluon/core/models/abstract/_auxiliary_params.py
@@ -20,12 +20,90 @@ not fields (model-private params registered via ``_ag_params()``) land in ``extr
 from __future__ import annotations
 
 import dataclasses
+import warnings
 from dataclasses import dataclass, field
 from typing import Any
+
+from packaging import version
+
+from ...version import __version__
 
 #: Field metadata marking params that are consumed by wrapper code but intentionally
 #: absent from the `_get_default_auxiliary_params` defaults dict.
 _WRAPPER_ONLY = {"materialized": False}
+
+#: AutoGluon version from which mutating `params_aux` raises instead of warning.
+_MUTATION_RAISE_MIN_VERSION = "1.7"
+_MUTATION_SHOULD_RAISE = version.parse(__version__) >= version.parse(_MUTATION_RAISE_MIN_VERSION)
+
+
+class ParamsAuxDict(dict):
+    """`params_aux` container: a dict that deprecates post-construction mutation.
+
+    Auxiliary params are resolved configuration and must not be mutated after
+    `AbstractModel._init_params_aux`. Values computed at runtime belong on the model
+    instance instead — see `AbstractModel.temperature_scalar` (calibration state) and
+    `AbstractModel._get_max_batch_size` (sentinel resolution) for the pattern; user
+    configuration flows in via `ag_args_fit`, model defaults via
+    `_default_auxiliary_params_extra`.
+
+    Mutation currently emits a DeprecationWarning and raises a TypeError starting in
+    AutoGluon 1.7 (matching the eventual read-only mapping behavior). `copy()` returns a
+    plain (mutable) dict, so serialization-style copy-and-edit code is unaffected.
+    """
+
+    _MUTATION_MSG = (
+        "Mutating a model's `params_aux` after construction is deprecated and will raise an "
+        f"exception starting in AutoGluon {_MUTATION_RAISE_MIN_VERSION}. `params_aux` is resolved "
+        "configuration: store runtime values as instance state instead (see "
+        "`AbstractModel.temperature_scalar` / `AbstractModel._get_max_batch_size` for the pattern), "
+        "or supply configuration via `ag_args_fit` / `_default_auxiliary_params_extra`."
+    )
+
+    @classmethod
+    def _mutation_deprecated(cls):
+        if _MUTATION_SHOULD_RAISE:
+            raise TypeError(cls._MUTATION_MSG)
+        warnings.warn(cls._MUTATION_MSG, category=DeprecationWarning, stacklevel=3)
+
+    def __reduce__(self):
+        # Reconstruct through the constructor: pickle's default protocol for dict
+        # subclasses repopulates item-by-item via `__setitem__`, which would trip the
+        # deprecation on every load/deepcopy.
+        return (self.__class__, (dict(self),))
+
+    def __setitem__(self, key, value):
+        self._mutation_deprecated()
+        super().__setitem__(key, value)
+
+    def __delitem__(self, key):
+        self._mutation_deprecated()
+        super().__delitem__(key)
+
+    def __ior__(self, other):
+        self._mutation_deprecated()
+        return super().__ior__(other)
+
+    def update(self, *args, **kwargs):
+        self._mutation_deprecated()
+        super().update(*args, **kwargs)
+
+    def setdefault(self, key, default=None):
+        if key not in self:  # only an actual insertion is a mutation
+            self._mutation_deprecated()
+        return super().setdefault(key, default)
+
+    def pop(self, *args, **kwargs):
+        self._mutation_deprecated()
+        return super().pop(*args, **kwargs)
+
+    def popitem(self):
+        self._mutation_deprecated()
+        return super().popitem()
+
+    def clear(self):
+        self._mutation_deprecated()
+        super().clear()
 
 
 @dataclass

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -553,10 +553,10 @@ class AbstractModel(ModelBase, Tunable):
 
     @property
     def aux_params(self) -> AuxiliaryParams:
-        """Typed view of `params_aux`, built fresh on each access (models may mutate
-        `params_aux` during fit, e.g. resolving a `max_batch_size="auto"` sentinel).
-        Keys that are not schema fields (model-private params registered via
-        `_ag_params()`) are available under `.extra`.
+        """Typed view of `params_aux`, built fresh on each access (`params_aux` can be
+        mutated after init, e.g. the trainer sets `temperature_scalar` post-fit during
+        calibration). Keys that are not schema fields (model-private params registered
+        via `_ag_params()`) are available under `.extra`.
         """
         return AuxiliaryParams.from_dict(self.params_aux)
 
@@ -1626,7 +1626,7 @@ class AbstractModel(ModelBase, Tunable):
         """
         time_start = time.time() if record_time else None
 
-        max_batch_size: int | None = self.aux_params.max_batch_size
+        max_batch_size: int | None = self._get_max_batch_size()
         if max_batch_size is not None and max_batch_size < len(X):
             y_pred_proba = self._predict_proba_batch(X=X, max_batch_size=max_batch_size, normalize=normalize, **kwargs)
         else:
@@ -1640,6 +1640,13 @@ class AbstractModel(ModelBase, Tunable):
             self.predict_time = time.time() - time_start
             self.record_predict_info(X=X)
         return y_pred_proba
+
+    def _get_max_batch_size(self) -> int | None:
+        """The prediction chunk size used by `predict_proba` (`ag.max_batch_size`);
+        None disables chunking. Models whose declared value is a sentinel (e.g.
+        TabPFN's "auto") override this to return the value resolved during `_fit`.
+        """
+        return self.aux_params.max_batch_size
 
     def _predict_proba_batch(
         self,

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -276,6 +276,10 @@ class AbstractModel(ModelBase, Tunable):
 
         # whether to calibrate predictions via conformal methods
         self.conformalize: bool | None = None
+        # temperature-scaling parameter learned post-fit by the trainer during calibration
+        # (see `temperature_scalar`); runtime state, distinct from the user-configured
+        # `ag.temperature_scalar` it falls back to.
+        self._temperature_scalar: float | None = None
         self.label_cleaner: LabelCleaner | None = None
 
         if eval_metric is not None:
@@ -553,10 +557,12 @@ class AbstractModel(ModelBase, Tunable):
 
     @property
     def aux_params(self) -> AuxiliaryParams:
-        """Typed view of `params_aux`, built fresh on each access (`params_aux` can be
-        mutated after init, e.g. the trainer sets `temperature_scalar` post-fit during
-        calibration). Keys that are not schema fields (model-private params registered
-        via `_ag_params()`) are available under `.extra`.
+        """Typed view of `params_aux`, built fresh on each access. Nothing in AutoGluon
+        mutates `params_aux` after construction (runtime state like the calibration
+        temperature lives on the instance instead), but the dict is not enforced
+        immutable, so the view is not cached. Keys that are not schema fields
+        (model-private params registered via `_ag_params()`) are available under
+        `.extra`.
         """
         return AuxiliaryParams.from_dict(self.params_aux)
 
@@ -1572,10 +1578,25 @@ class AbstractModel(ModelBase, Tunable):
                         return hyperparameters[seed_name], seed_name
         return "N/A", None
 
+    @property
+    def temperature_scalar(self) -> float | None:
+        """Temperature-scaling parameter applied to `predict_proba` (None = no scaling).
+
+        Learned post-fit: the trainer assigns it during calibration
+        (`calibrate=True`); falls back to the user-configured `ag.temperature_scalar`.
+        """
+        if self._temperature_scalar is not None:
+            return self._temperature_scalar
+        return self.aux_params.temperature_scalar
+
+    @temperature_scalar.setter
+    def temperature_scalar(self, value: float | None) -> None:
+        self._temperature_scalar = value
+
     def _apply_temperature_scaling(self, y_pred_proba: np.ndarray) -> np.ndarray:
         return apply_temperature_scaling(
             y_pred_proba=y_pred_proba,
-            temperature_scalar=self.params_aux.get("temperature_scalar"),
+            temperature_scalar=self.temperature_scalar,
             problem_type=self.problem_type,
         )
 
@@ -1632,7 +1653,7 @@ class AbstractModel(ModelBase, Tunable):
         else:
             y_pred_proba = self._predict_proba_internal(X=X, normalize=normalize, **kwargs)
 
-        if self.params_aux.get("temperature_scalar", None) is not None:
+        if self.temperature_scalar is not None:
             y_pred_proba = self._apply_temperature_scaling(y_pred_proba)
         elif self.conformalize is not None:
             y_pred_proba = self._apply_conformalization(y_pred_proba)

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -60,7 +60,7 @@ from ...utils.exceptions import NotEnoughCudaMemoryError, NotEnoughMemoryError, 
 from ...utils.loaders import load_json, load_pkl
 from ...utils.savers import save_json, save_pkl
 from ...utils.time import sample_df_for_time_func, time_func
-from ._auxiliary_params import AuxiliaryParams
+from ._auxiliary_params import AuxiliaryParams, ParamsAuxDict
 from ._tags import _DEFAULT_CLASS_TAGS, _DEFAULT_TAGS
 from .model_trial import model_trial, skip_hpo
 
@@ -421,7 +421,8 @@ class AbstractModel(ModelBase, Tunable):
         These parameters are generally not model specific and can have a wide variety of effects.
         For documentation on some of the available options and their defaults, refer to `self._get_default_auxiliary_params`.
         """
-        self.params_aux = self._get_params_aux()
+        # ParamsAuxDict deprecates post-construction mutation (raises from AutoGluon 1.7).
+        self.params_aux = ParamsAuxDict(self._get_params_aux())
         self._validate_params_aux()
 
     def _get_params_aux(self) -> dict:

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -60,6 +60,7 @@ from ...utils.exceptions import NotEnoughCudaMemoryError, NotEnoughMemoryError, 
 from ...utils.loaders import load_json, load_pkl
 from ...utils.savers import save_json, save_pkl
 from ...utils.time import sample_df_for_time_func, time_func
+from ._auxiliary_params import AuxiliaryParams
 from ._tags import _DEFAULT_CLASS_TAGS, _DEFAULT_TAGS
 from .model_trial import model_trial, skip_hpo
 
@@ -536,34 +537,10 @@ class AbstractModel(ModelBase, Tunable):
         """
         Dictionary of auxiliary parameters that dictate various model-agnostic logic, such as:
             Which column dtypes are filtered out of the input data, or how much memory the model is allowed to use.
+
+        The base defaults and per-key documentation live on the `AuxiliaryParams` schema.
         """
-        default_auxiliary_params = dict(
-            max_memory_usage_ratio=1.0,  # Ratio of memory usage allowed by the model. Values > 1.0 have an increased risk of causing OOM errors. Used in memory checks during model training to avoid OOM errors.
-            max_gpu_memory_usage_ratio=1.0,  # GPU counterpart of max_memory_usage_ratio: ratio of available VRAM the model is allowed to use. Only checked for models that define a GPU memory estimate (see `_estimate_gpu_memory_usage`). If None, GPU memory checks are skipped.
-            # TODO: Add more params
-            # max_memory_usage=None,
-            # max_disk_usage=None,
-            max_time_limit_ratio=1.0,  # ratio of given time_limit to use during fit(). If time_limit == 10 and max_time_limit_ratio=0.3, time_limit would be changed to 3.
-            max_time_limit=None,  # max time_limit value during fit(). If the provided time_limit is greater than this value, it will be replaced by max_time_limit. Occurs after max_time_limit_ratio is applied.
-            min_time_limit=0,  # min time_limit value during fit(). If the provided time_limit is less than this value, it will be replaced by min_time_limit. Occurs after max_time_limit is applied.
-            # drop_unique=True,  # Whether to drop features that have only 1 unique value
-            # num_cpus=None,
-            # num_gpus=None,
-            # ignore_hpo=False,
-            # max_early_stopping_rounds=None,
-            # TODO: add option for only top-k ngrams
-            valid_raw_types=None,  # If a feature's raw type is not in this list, it is pruned.
-            valid_special_types=None,  # If a feature has a special type not in this list, it is pruned.
-            ignored_type_group_special=None,  # List, drops any features in `self.feature_metadata.type_group_map_special[type]` for type in `ignored_type_group_special`. | Currently undocumented in task.
-            ignored_type_group_raw=None,  # List, drops any features in `self.feature_metadata.type_group_map_raw[type]` for type in `ignored_type_group_raw`. | Currently undocumented in task.
-            # Kwargs for `autogluon.tabular.features.feature_metadata.FeatureMetadata.get_features()`.
-            #  Overrides valid_raw_types, valid_special_types, ignored_type_group_special and ignored_type_group_raw. | Currently undocumented in task.
-            get_features_kwargs=None,
-            # TODO: v0.1 Document get_features_kwargs_extra in task.fit
-            get_features_kwargs_extra=None,  # If not None, applies an additional feature filter to the result of get_feature_kwargs. This should be reserved for users and be None by default. | Currently undocumented in task.
-            predict_1_batch_size=None,  # If not None, calculates `self.predict_1_time` at end of fit call by predicting on this many rows of data.
-            temperature_scalar=None,  # Temperature scaling parameter that is set post-fit if calibrate=True during TabularPredictor.fit() on the model with the best validation score and eval_metric="log_loss".
-        )
+        default_auxiliary_params = AuxiliaryParams.base_defaults()
         # Merge each class's declarative `_default_auxiliary_params_extra` overrides,
         # base-most class first so subclasses win — the same semantics as the historical
         # chained `super()._get_default_auxiliary_params()` + `update` method overrides,
@@ -573,6 +550,15 @@ class AbstractModel(ModelBase, Tunable):
             if extra:
                 default_auxiliary_params.update(extra)
         return default_auxiliary_params
+
+    @property
+    def aux_params(self) -> AuxiliaryParams:
+        """Typed view of `params_aux`, built fresh on each access (models may mutate
+        `params_aux` during fit, e.g. resolving a `max_batch_size="auto"` sentinel).
+        Keys that are not schema fields (model-private params registered via
+        `_ag_params()`) are available under `.extra`.
+        """
+        return AuxiliaryParams.from_dict(self.params_aux)
 
     def _set_default_param_value(self, param_name, param_value, params=None):
         if params is None:
@@ -731,7 +717,7 @@ class AbstractModel(ModelBase, Tunable):
             raise NoValidFeatures(f"No valid features exist to fit {self.name}")
         # TODO: If unique_counts == 2 (including NaN), then treat as boolean
         #  FIXME: v1.3: Need to do this on a per-fold basis
-        if self.params_aux.get("drop_unique", True):
+        if self.aux_params.drop_unique:
             # TODO: Could this be optimized to be faster? This might be a bit slow for large data.
             unique_counts = X[self.features].nunique(axis=0, dropna=False)
             columns_to_drop = list(unique_counts[unique_counts < 2].index)
@@ -1378,16 +1364,16 @@ class AbstractModel(ModelBase, Tunable):
             ag.ignore_constraints
         """
         if self.is_initialized():
-            ag_params = self._get_ag_params()
+            aux_params = self.aux_params
         else:
-            ag_params = self._get_ag_params(params_aux=self._get_params_aux())
+            aux_params = AuxiliaryParams.from_dict(self._get_params_aux())
 
-        problem_types: list[str] | None = ag_params.get("problem_types", None)
-        max_classes: int | None = ag_params.get("max_classes", None)
-        min_rows: int | None = ag_params.get("min_rows", None)
-        max_rows: int | None = ag_params.get("max_rows", None)
-        max_features: int | None = ag_params.get("max_features", None)
-        ignore_constraints: bool = ag_params.get("ignore_constraints", False)
+        problem_types: list[str] | None = aux_params.problem_types
+        max_classes: int | None = aux_params.max_classes
+        min_rows: int | None = aux_params.min_rows
+        max_rows: int | None = aux_params.max_rows
+        max_features: int | None = aux_params.max_features
+        ignore_constraints: bool = aux_params.ignore_constraints
 
         if ignore_constraints:
             # skip all validation checks
@@ -1640,7 +1626,7 @@ class AbstractModel(ModelBase, Tunable):
         """
         time_start = time.time() if record_time else None
 
-        max_batch_size: int | None = self.params_aux.get("max_batch_size", None)
+        max_batch_size: int | None = self.aux_params.max_batch_size
         if max_batch_size is not None and max_batch_size < len(X):
             y_pred_proba = self._predict_proba_batch(X=X, max_batch_size=max_batch_size, normalize=normalize, **kwargs)
         else:

--- a/core/tests/unittests/models/abstract_model/test_params_aux_mutation.py
+++ b/core/tests/unittests/models/abstract_model/test_params_aux_mutation.py
@@ -1,0 +1,79 @@
+"""Post-construction `params_aux` mutation is deprecated (raises from AutoGluon 1.7)."""
+
+import pickle
+import warnings
+
+import pytest
+
+from autogluon.core.models import AbstractModel
+from autogluon.core.models.abstract import _auxiliary_params
+from autogluon.core.models.abstract._auxiliary_params import ParamsAuxDict
+
+
+def _initialized_model() -> AbstractModel:
+    model = AbstractModel(name="", path="", problem_type="binary", eval_metric="log_loss")
+    model.initialize()
+    return model
+
+
+def test_params_aux_is_deprecation_dict():
+    model = _initialized_model()
+    assert isinstance(model.params_aux, ParamsAuxDict)
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda d: d.__setitem__("max_rows", 1),
+        lambda d: d.__delitem__("max_memory_usage_ratio"),
+        lambda d: d.update({"max_rows": 1}),
+        lambda d: d.pop("max_memory_usage_ratio"),
+        lambda d: d.popitem(),
+        lambda d: d.clear(),
+        lambda d: d.setdefault("max_rows", 1),  # missing key: an insertion
+        lambda d: d.__ior__({"max_rows": 1}),
+    ],
+)
+def test_params_aux_mutation_warns(mutate):
+    model = _initialized_model()
+    with pytest.warns(DeprecationWarning, match="starting in AutoGluon 1.7"):
+        mutate(model.params_aux)
+
+
+def test_params_aux_reads_do_not_warn():
+    model = _initialized_model()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert model.params_aux["max_memory_usage_ratio"] == 1.0
+        assert model.params_aux.get("max_rows") is None
+        # setdefault on a present key is a read, not a mutation
+        assert model.params_aux.setdefault("max_memory_usage_ratio", 2.0) == 1.0
+        assert "max_rows" not in model.params_aux
+        dict(model.params_aux)
+        len(model.params_aux)
+
+
+def test_params_aux_copy_is_plain_mutable_dict():
+    # copy-and-edit code (e.g. `get_params_aux_info`) must stay warning-free
+    model = _initialized_model()
+    copied = model.params_aux.copy()
+    assert type(copied) is dict
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        copied["max_rows"] = 1
+
+
+def test_params_aux_survives_pickle():
+    model = _initialized_model()
+    loaded = pickle.loads(pickle.dumps(model))
+    assert isinstance(loaded.params_aux, ParamsAuxDict)
+    assert loaded.params_aux == model.params_aux
+    with pytest.warns(DeprecationWarning):
+        loaded.params_aux["max_rows"] = 1
+
+
+def test_params_aux_mutation_raises_from_1_7(monkeypatch):
+    model = _initialized_model()
+    monkeypatch.setattr(_auxiliary_params, "_MUTATION_SHOULD_RAISE", True)
+    with pytest.raises(TypeError, match="starting in AutoGluon 1.7"):
+        model.params_aux["max_rows"] = 1

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
@@ -83,6 +83,8 @@ class TabPFNModel(AbstractTorchModel):
         self._feature_generator = None
         self._cat_features = None
         self._cat_indices = None
+        # `ag.max_batch_size="auto"` resolved against the training size during `_fit`.
+        self._max_batch_size_resolved: int | None = None
 
     def _default_model_map(self) -> dict[str, str | None]:
         fallback = {
@@ -133,9 +135,10 @@ class TabPFNModel(AbstractTorchModel):
         # "auto" prediction chunking resolves against the training size: chunks
         # re-attend the full training context, so chunks smaller than the training set
         # multiply predict time at large n_train while saving little memory. Bounded
-        # to [max_batch_size_min, 1M]. None disables chunking entirely.
-        if self.params_aux.get("max_batch_size") == "auto":
-            self.params_aux["max_batch_size"] = min(1_000_000, max(self.max_batch_size_min, len(X)))
+        # to [max_batch_size_min, 1M]. None disables chunking entirely. The resolved
+        # value is fit state (read via `_get_max_batch_size`), not a params_aux mutation.
+        if self.aux_params.max_batch_size == "auto":
+            self._max_batch_size_resolved = min(1_000_000, max(self.max_batch_size_min, len(X)))
 
         from tabpfn import TabPFNClassifier, TabPFNRegressor
         from torch.cuda import is_available
@@ -272,6 +275,12 @@ class TabPFNModel(AbstractTorchModel):
         # model_telemetry: whether the tabpfn library's telemetry is left enabled
         # during fit/predict (disabled by default).
         return {"model_telemetry"}
+
+    def _get_max_batch_size(self) -> int | None:
+        max_batch_size = self.aux_params.max_batch_size
+        if max_batch_size == "auto":
+            return self._max_batch_size_resolved
+        return max_batch_size
 
     def get_device(self) -> str:
         return self.model.devices_[0].type

--- a/tabular/src/autogluon/tabular/testing/fit_helper.py
+++ b/tabular/src/autogluon/tabular/testing/fit_helper.py
@@ -16,7 +16,7 @@ import pandas.testing as pdt
 from autogluon.common.utils.path_converter import PathConverter
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION
 from autogluon.core.metrics import METRICS
-from autogluon.core.models import AbstractModel, BaggedEnsembleModel
+from autogluon.core.models import AbstractModel, AuxiliaryParams, BaggedEnsembleModel
 from autogluon.core.stacked_overfitting.utils import check_stacked_overfitting_from_leaderboard
 from autogluon.core.testing.global_context_snapshot import GlobalContextSnapshot
 from autogluon.core.utils import download, generate_train_test_split_combined, infer_problem_type, unzip
@@ -417,12 +417,12 @@ class FitHelper:
     def _verify_auxiliary_param_keys(model_cls: type[AbstractModel]) -> None:
         """Fail if the model declares `_default_auxiliary_params_extra` keys that nothing consumes.
 
-        Known keys are the base auxiliary-param defaults plus the registered ag-params
+        Known keys are the `AuxiliaryParams` schema fields plus the registered ag-params
         (`_ag_params_common()` and the model's `_ag_params()`). An unknown key is either a typo
         or a model-private param the wrapper reads without registering it — register such keys
         in the model's `_ag_params()`.
         """
-        known_keys = set(AbstractModel._get_default_auxiliary_params(object.__new__(AbstractModel)))
+        known_keys = AuxiliaryParams.known_keys()
         known_keys |= model_cls._ag_params_common()
         # `_ag_params` implementations are constant per class, so calling on an
         # uninitialized instance is safe.

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -4912,7 +4912,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
 
                 if score_with_temp > score_without_temp:
                     logger.log(15, f"Temperature term found is: {temp_scalar}")
-                    model.params_aux["temperature_scalar"] = temp_scalar
+                    model.temperature_scalar = temp_scalar
                     model.save()
                 else:
                     logger.log(15, "Temperature did not improve performance, skipping calibration.")


### PR DESCRIPTION
## Description

Follow-up to #5773 and the next step toward @LennartPurucker's dataclass suggestion. Four commits:

### 1. `AuxiliaryParams` dataclass schema

The single source of truth for the auxiliary-param key space:
- Its *materialized* fields generate the `_get_default_auxiliary_params` base defaults (replacing the 30-line literal dict; the per-key documentation moved to the schema fields).
- Its *wrapper-only* fields cover the constraint/wrapper params (`max_rows`, `max_batch_size`, `drop_unique`, ...) with the same fallback defaults their consumers used.
- `known_keys()` drives the `verify_model` declaration check from #5773.
- New `AbstractModel.aux_params` property: the typed runtime view, built from `params_aux`; non-schema keys (model-private params registered via `_ag_params()`) land in `.extra`. Base consumers converted as demonstration (`_validate_fit_args`, `drop_unique`, prediction chunking).

Declarations are unchanged: models keep partial `_default_auxiliary_params_extra` dicts, users keep `ag_args_fit` dicts — the dataclass is the *merged view*, which sidesteps the partial-declaration problem a per-class dataclass would have.

### 2–3. Remove the two in-repo `params_aux` mutations

Both were runtime state stored in resolved configuration:
- TabPFN's `max_batch_size="auto"` resolution → instance state, read through a new `_get_max_batch_size()` hook on `AbstractModel` (the documented pattern for sentinel-resolving models).
- The calibration temperature the trainer wrote into the fitted model's `params_aux` → `temperature_scalar` property backed by instance state (mirroring how conformalization already works), falling back to the user-configured `ag.temperature_scalar`.

Behavior unchanged in both: values persist through pickling, refit templates re-resolve as before, explicit user settings are honored.

### 4. Deprecate post-construction mutation — **raises starting in AutoGluon 1.7**

With the above, nothing in AutoGluon mutates `params_aux` after construction, so the invariant is now enforced for external code: `params_aux` is a `ParamsAuxDict` whose mutating operations emit a `DeprecationWarning` naming the replacement patterns. The gate is version-based (same convention as the `Deprecated` decorator): **once the installed version reaches 1.7, mutation raises a `TypeError`** — matching the behavior of the read-only mapping `params_aux` will eventually become, at which point `aux_params` can be cached and frozen.

Notes:
- `copy()` returns a plain mutable dict, so copy-and-edit code (e.g. `get_params_aux_info`) is unaffected.
- `__reduce__` rebuilds through the constructor — pickle's default dict-subclass protocol repopulates via `__setitem__` and would otherwise trip the deprecation on every model load.
- `setdefault` on a present key is a read and does not warn.

## Verification

- Merged auxiliary params for all registry models plus the ensemble models are bit-identical to a snapshot taken before any of this work.
- 13 new unit tests (`test_params_aux_mutation.py`): every mutating op warns, reads don't, copy stays plain, pickle roundtrips warning-free, the 1.7 gate raises `TypeError`.
- Calibrate + model suites pass, and run clean under `-W error::DeprecationWarning` (remaining errors there are third-party pyparsing deprecations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi