### PR TITLE
Make params immutable after construction (deprecation, raises in 1.7)

### DIFF
--- a/core/src/autogluon/core/models/abstract/_auxiliary_params.py
+++ b/core/src/autogluon/core/models/abstract/_auxiliary_params.py
@@ -20,36 +20,24 @@ not fields (model-private params registered via ``_ag_params()``) land in ``extr
 from __future__ import annotations
 
 import dataclasses
-import warnings
 from dataclasses import dataclass, field
 from typing import Any
 
-from packaging import version
-
-from ...version import __version__
+from ._mutation_deprecated_dict import _MUTATION_RAISE_MIN_VERSION, MutationDeprecatedDict
 
 _WRAPPER_ONLY = {"materialized": False}
 """Field metadata marking params that are consumed by wrapper code but intentionally
 absent from the `_get_default_auxiliary_params` defaults dict."""
 
-_MUTATION_RAISE_MIN_VERSION = "1.7"
-"""AutoGluon version from which mutating `params_aux` raises instead of warning."""
-_MUTATION_SHOULD_RAISE = version.parse(__version__) >= version.parse(_MUTATION_RAISE_MIN_VERSION)
 
+class ParamsAuxDict(MutationDeprecatedDict):
+    """`params_aux` container; deprecates post-construction mutation.
 
-class ParamsAuxDict(dict):
-    """`params_aux` container: a dict that deprecates post-construction mutation.
-
-    Auxiliary params are resolved configuration and must not be mutated after
-    `AbstractModel._init_params_aux`. Values computed at runtime belong on the model
-    instance instead — see `AbstractModel.temperature_scalar` (calibration state) and
+    Values computed at runtime belong on the model instance instead — see
+    `AbstractModel.temperature_scalar` (calibration state) and
     `AbstractModel._get_max_batch_size` (sentinel resolution) for the pattern; user
     configuration flows in via `ag_args_fit`, model defaults via
     `_default_auxiliary_params_extra`.
-
-    Mutation currently emits a DeprecationWarning and raises a TypeError starting in
-    AutoGluon 1.7 (matching the eventual read-only mapping behavior). `copy()` returns a
-    plain (mutable) dict, so serialization-style copy-and-edit code is unaffected.
     """
 
     _MUTATION_MSG = (
@@ -59,51 +47,6 @@ class ParamsAuxDict(dict):
         "`AbstractModel.temperature_scalar` / `AbstractModel._get_max_batch_size` for the pattern), "
         "or supply configuration via `ag_args_fit` / `_default_auxiliary_params_extra`."
     )
-
-    @classmethod
-    def _mutation_deprecated(cls):
-        if _MUTATION_SHOULD_RAISE:
-            raise TypeError(cls._MUTATION_MSG)
-        warnings.warn(cls._MUTATION_MSG, category=DeprecationWarning, stacklevel=3)
-
-    def __reduce__(self):
-        # Reconstruct through the constructor: pickle's default protocol for dict
-        # subclasses repopulates item-by-item via `__setitem__`, which would trip the
-        # deprecation on every load/deepcopy.
-        return (self.__class__, (dict(self),))
-
-    def __setitem__(self, key, value):
-        self._mutation_deprecated()
-        super().__setitem__(key, value)
-
-    def __delitem__(self, key):
-        self._mutation_deprecated()
-        super().__delitem__(key)
-
-    def __ior__(self, other):
-        self._mutation_deprecated()
-        return super().__ior__(other)
-
-    def update(self, *args, **kwargs):
-        self._mutation_deprecated()
-        super().update(*args, **kwargs)
-
-    def setdefault(self, key, default=None):
-        if key not in self:  # only an actual insertion is a mutation
-            self._mutation_deprecated()
-        return super().setdefault(key, default)
-
-    def pop(self, *args, **kwargs):
-        self._mutation_deprecated()
-        return super().pop(*args, **kwargs)
-
-    def popitem(self):
-        self._mutation_deprecated()
-        return super().popitem()
-
-    def clear(self):
-        self._mutation_deprecated()
-        super().clear()
 
 
 @dataclass

--- a/core/src/autogluon/core/models/abstract/_mutation_deprecated_dict.py
+++ b/core/src/autogluon/core/models/abstract/_mutation_deprecated_dict.py
@@ -1,0 +1,91 @@
+"""Dict containers that deprecate post-construction mutation.
+
+A model's resolved configuration (`params`, `params_aux`) must not be mutated after
+construction: values computed at runtime belong on the model instance (or in
+`params_trained` for fit-resolved hyperparameters), and user configuration flows in
+through the constructor. :class:`MutationDeprecatedDict` enforces this as a deprecation:
+mutating operations emit a DeprecationWarning now and raise a TypeError starting in
+AutoGluon ``1.7`` (matching the eventual read-only mapping behavior). ``copy()`` returns
+a plain (mutable) dict, so copy-and-edit code is unaffected.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+from packaging import version
+
+from ...version import __version__
+
+_MUTATION_RAISE_MIN_VERSION = "1.7"
+"""AutoGluon version from which mutating these containers raises instead of warning."""
+
+_MUTATION_SHOULD_RAISE = version.parse(__version__) >= version.parse(_MUTATION_RAISE_MIN_VERSION)
+
+
+class MutationDeprecatedDict(dict):
+    """dict whose mutating operations are deprecated; see the module docstring.
+
+    Subclasses set `_MUTATION_MSG` to a message naming the container and the
+    replacement patterns.
+    """
+
+    _MUTATION_MSG: str = "Mutating this container after construction is deprecated."
+
+    @classmethod
+    def _mutation_deprecated(cls):
+        if _MUTATION_SHOULD_RAISE:
+            raise TypeError(cls._MUTATION_MSG)
+        warnings.warn(cls._MUTATION_MSG, category=DeprecationWarning, stacklevel=3)
+
+    def __reduce__(self):
+        # Reconstruct through the constructor: pickle's default protocol for dict
+        # subclasses repopulates item-by-item via `__setitem__`, which would trip the
+        # deprecation on every load/deepcopy.
+        return (self.__class__, (dict(self),))
+
+    def __setitem__(self, key, value):
+        self._mutation_deprecated()
+        super().__setitem__(key, value)
+
+    def __delitem__(self, key):
+        self._mutation_deprecated()
+        super().__delitem__(key)
+
+    def __ior__(self, other):
+        self._mutation_deprecated()
+        return super().__ior__(other)
+
+    def update(self, *args, **kwargs):
+        self._mutation_deprecated()
+        super().update(*args, **kwargs)
+
+    def setdefault(self, key, default=None):
+        if key not in self:  # only an actual insertion is a mutation
+            self._mutation_deprecated()
+        return super().setdefault(key, default)
+
+    def pop(self, *args, **kwargs):
+        self._mutation_deprecated()
+        return super().pop(*args, **kwargs)
+
+    def popitem(self):
+        self._mutation_deprecated()
+        return super().popitem()
+
+    def clear(self):
+        self._mutation_deprecated()
+        super().clear()
+
+
+class ParamsDict(MutationDeprecatedDict):
+    """`params` (model hyperparameters) container; deprecates post-construction mutation."""
+
+    _MUTATION_MSG = (
+        "Mutating a model's `params` after construction is deprecated and will raise an "
+        f"exception starting in AutoGluon {_MUTATION_RAISE_MIN_VERSION}. `params` is the model's "
+        "resolved hyperparameter configuration: work on the copy returned by `_get_model_params()`, "
+        "record hyperparameter values resolved during fit in `params_trained`, and store other "
+        "runtime values as instance state. User configuration flows in via the `hyperparameters` "
+        "constructor argument."
+    )

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -61,6 +61,7 @@ from ...utils.loaders import load_json, load_pkl
 from ...utils.savers import save_json, save_pkl
 from ...utils.time import sample_df_for_time_func, time_func
 from ._auxiliary_params import AuxiliaryParams, ParamsAuxDict
+from ._mutation_deprecated_dict import ParamsDict
 from ._tags import _DEFAULT_CLASS_TAGS, _DEFAULT_TAGS
 from .model_trial import model_trial, skip_hpo
 
@@ -900,7 +901,10 @@ class AbstractModel(ModelBase, Tunable):
 
         self._init_params()
 
-        self.params = self.init_random_seed(random_seed=kwargs.get("random_seed", "auto"), hyperparameters=self.params)
+        # ParamsDict deprecates post-construction mutation (raises from AutoGluon 1.7).
+        self.params = ParamsDict(
+            self.init_random_seed(random_seed=kwargs.get("random_seed", "auto"), hyperparameters=self.params)
+        )
 
         if X is not None:
             self._preprocess_set_features(X=X, feature_metadata=feature_metadata)

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -107,6 +107,9 @@ class BaggedEnsembleModel(AbstractModel):
         self._child_oof = False  # Whether the OOF preds were taken from a single child model (Assumes child can produce OOF preds without bagging).
         self._cv_splitters = []  # Keeps track of the CV splitter used for each bagged repeat.
         self._params_aux_child = None  # aux params of child model
+        # Whether fit forced fold-saving on despite `save_bag_folds=False` (children that
+        # cannot refit_full must keep a fold model to copy); see `save_bag_folds`.
+        self._save_bag_folds_forced = False
 
         self._predict_n_size_lst = None  # A list of the predict row count for each child, useful to calculate the expected inference throughput of the bag.
 
@@ -136,8 +139,17 @@ class BaggedEnsembleModel(AbstractModel):
     def is_valid(self) -> bool:
         return self.is_fit() and (self._n_repeats == self._n_repeats_finished)
 
+    @property
+    def save_bag_folds(self) -> bool:
+        """Effective fold-saving setting: the configured `save_bag_folds` hyperparameter,
+        unless fit forced fold-saving on (see `_save_bag_folds_forced`).
+        """
+        if self._save_bag_folds_forced:
+            return True
+        return self.params.get("save_bag_folds", True)
+
     def can_infer(self) -> bool:
-        return self.is_fit() and self.params.get("save_bag_folds", True)
+        return self.is_fit() and self.save_bag_folds
 
     def is_stratified(self) -> bool:
         """
@@ -369,12 +381,12 @@ class BaggedEnsembleModel(AbstractModel):
             #  Therefore we must override save_bag_folds for these unsupported models so that the refit versions have a fold model to copy.
             #  This could be implemented better by only keeping the first fold model artifact and avoid saving the other fold model artifacts (lower disk usage)
             #  However, this is complex to code accounting for the fitting strategies and would be prone to difficult to diagnose bugs.
-            self.params["save_bag_folds"] = True
+            self._save_bag_folds_forced = True
             if k_fold != 1:
                 # Only log in the situation where functionality is currently suboptimal
                 logger.log(20, "\tForcing `save_bag_folds=True` because child model does not support `refit_full`.")
 
-        save_bag_folds = self.params.get("save_bag_folds", True)
+        save_bag_folds = self.save_bag_folds
         if k_fold == 1:
             self._fit_single(
                 X=X,
@@ -758,7 +770,7 @@ class BaggedEnsembleModel(AbstractModel):
             self._oof_pred_model_repeats = np.ones(shape=len(X), dtype=np.uint8)
         model_base.record_predict_info(X=X)
         model_base.reduce_memory_size(remove_fit=True, remove_info=False, requires_save=True)
-        if not self.params.get("save_bag_folds", True):
+        if not self.save_bag_folds:
             model_base.model = None
         if self.low_memory:
             self.save_child(model_base)
@@ -1264,7 +1276,7 @@ class BaggedEnsembleModel(AbstractModel):
         Creates a new refit_full variant of the model, but instead of training it simply copies `self` while keeping only the first fold model.
         This method is for compatibility with models that have not implemented refit_full support as a fallback.
         """
-        if not self.params.get("save_bag_folds", True):
+        if not self.save_bag_folds:
             raise AssertionError("Cannot perform copy-based refit_full when save_bag_folds is False!")
         __models = self.models
         self.models = []

--- a/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
+++ b/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
@@ -297,7 +297,7 @@ class FoldFittingStrategy(AbstractFoldFittingStrategy):
         y_pred_proba = fold_model.predict_proba(X_val_fold, record_time=True)
         fold_model.val_score = fold_model.score_with_y_pred_proba(y=y_val_fold, y_pred_proba=y_pred_proba)
         fold_model.reduce_memory_size(remove_fit=True, remove_info=False, requires_save=True)
-        if not self.bagged_ensemble_model.params.get("save_bag_folds", True):
+        if not self.bagged_ensemble_model.save_bag_folds:
             fold_model.model = None
         return fold_model, y_pred_proba
 

--- a/core/tests/unittests/models/abstract_model/test_params_aux_mutation.py
+++ b/core/tests/unittests/models/abstract_model/test_params_aux_mutation.py
@@ -6,7 +6,7 @@ import warnings
 import pytest
 
 from autogluon.core.models import AbstractModel
-from autogluon.core.models.abstract import _auxiliary_params
+from autogluon.core.models.abstract import _mutation_deprecated_dict
 from autogluon.core.models.abstract._auxiliary_params import ParamsAuxDict
 
 
@@ -74,6 +74,6 @@ def test_params_aux_survives_pickle():
 
 def test_params_aux_mutation_raises_from_1_7(monkeypatch):
     model = _initialized_model()
-    monkeypatch.setattr(_auxiliary_params, "_MUTATION_SHOULD_RAISE", True)
+    monkeypatch.setattr(_mutation_deprecated_dict, "_MUTATION_SHOULD_RAISE", True)
     with pytest.raises(TypeError, match="starting in AutoGluon 1.7"):
         model.params_aux["max_rows"] = 1

--- a/core/tests/unittests/models/abstract_model/test_params_mutation.py
+++ b/core/tests/unittests/models/abstract_model/test_params_mutation.py
@@ -1,0 +1,64 @@
+"""Post-construction `params` mutation is deprecated (raises from AutoGluon 1.7)."""
+
+import pickle
+import warnings
+
+import pytest
+
+from autogluon.core.models import AbstractModel
+from autogluon.core.models.abstract import _mutation_deprecated_dict
+from autogluon.core.models.abstract._mutation_deprecated_dict import ParamsDict
+
+
+def _initialized_model() -> AbstractModel:
+    model = AbstractModel(
+        name="",
+        path="",
+        problem_type="binary",
+        eval_metric="log_loss",
+        hyperparameters={"some_param": 1},
+    )
+    model.initialize()
+    return model
+
+
+def test_params_is_deprecation_dict():
+    model = _initialized_model()
+    assert isinstance(model.params, ParamsDict)
+    assert model.params["some_param"] == 1
+
+
+def test_params_mutation_warns():
+    model = _initialized_model()
+    with pytest.warns(DeprecationWarning, match="`params` after construction is deprecated"):
+        model.params["some_param"] = 2
+    with pytest.warns(DeprecationWarning, match="starting in AutoGluon 1.7"):
+        model.params.pop("some_param")
+
+
+def test_params_reads_and_copies_do_not_warn():
+    model = _initialized_model()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert model.params["some_param"] == 1
+        assert model.params.get("missing") is None
+        copied = model.params.copy()
+        assert type(copied) is dict
+        copied["some_param"] = 2  # copies stay plain and mutable
+        # `_get_model_params` (the documented pattern) works on a mutable copy
+        model_params = model._get_model_params()
+        model_params["some_param"] = 3
+
+
+def test_params_survives_pickle():
+    model = _initialized_model()
+    loaded = pickle.loads(pickle.dumps(model))
+    assert isinstance(loaded.params, ParamsDict)
+    assert loaded.params == model.params
+
+
+def test_params_mutation_raises_from_1_7(monkeypatch):
+    model = _initialized_model()
+    monkeypatch.setattr(_mutation_deprecated_dict, "_MUTATION_SHOULD_RAISE", True)
+    with pytest.raises(TypeError, match="starting in AutoGluon 1.7"):
+        model.params["some_param"] = 2

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -5221,7 +5221,7 @@ def _detached_refit_single_full(
                 f"\n\tThis is likely due to an out-of-memory error or other memory related issue. "
                 f"\n\tPlease create a GitHub issue if this was triggered from a non-memory related problem.",
             )
-            if not model.params.get("save_bag_folds", True):
+            if not model.save_bag_folds:
                 raise AssertionError(
                     f"Cannot avoid training failure during refit for '{model_name}' by falling back to "
                     f"copying the first fold because it does not exist! (save_bag_folds=False)"


### PR DESCRIPTION
## Description

Follow-up to #5775, applying the same treatment to `params` (the model hyperparameters). Two commits:

### 1. Relocate the one real mutator

`BaggedEnsembleModel` forced `save_bag_folds=True` for children without `refit_full` support by writing into `self.params` mid-fit — the only post-construction mutation of model hyperparameters in the codebase. The forcing is now the `_save_bag_folds_forced` instance flag, and readers of the *effective* setting (fold pruning, the fold-fitting strategy's model stripping, `can_infer`, copy-based refit's assertion, and the trainer's refit-failure fallback) go through the new `save_bag_folds` property, which prefers the forced state over the configured hyperparameter. The configured value in `params` is never overwritten.

### 2. Deprecate post-construction mutation — raises starting in AutoGluon 1.7

The mutation-deprecating dict machinery from #5775 is generalized into `MutationDeprecatedDict` (version gate, mutating dunders, the `__reduce__` fix that keeps pickle/deepcopy from tripping the deprecation; `ParamsAuxDict` now only supplies its message), and `params` becomes a `ParamsDict` wrapping the final assignment at the end of `initialize()`. Its message points at the `params`-specific remedies:

- work on the copy returned by `_get_model_params()` (the documented model-author pattern — untouched),
- record hyperparameter values resolved during fit in `params_trained`,
- store other runtime values as instance state.

As with `params_aux`, mutation warns today and raises a `TypeError` once the installed version reaches **1.7**.

Design note: `params` may hold search spaces pre-HPO — no conflict, since HPO resolves into freshly constructed instances rather than mutating in place.

## Verification

- 6 new unit tests (`test_params_mutation.py`) plus the `params_aux` suite (18 total): mutating ops warn, reads/copies don't, `_get_model_params()` copies stay plain and mutable, pickle roundtrips, the 1.7 gate raises.
- dummy / lightgbm / linear / calibrate suites pass (bagged, refit, and calibration flows exercise the `save_bag_folds` property) and emit **zero** of these warnings under `-W error::DeprecationWarning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi