### PR TITLE
Share the categorical label-encoding preprocess step across models

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -296,6 +296,8 @@ class AbstractModel(ModelBase, Tunable):
         # (see `temperature_scalar`); runtime state, distinct from the user-configured
         # `ag.temperature_scalar` it falls back to.
         self._temperature_scalar: float | None = None
+        # stateful categorical label encoder fitted by `_label_encode_categoricals`
+        self._label_encoder = None
         self.label_cleaner: LabelCleaner | None = None
 
         if eval_metric is not None:
@@ -697,6 +699,25 @@ class AbstractModel(ModelBase, Tunable):
         If preprocessing code could produce different output depending on the child model that processes the input data, then it must live here.
         When in doubt, put preprocessing code here instead of in `_preprocess_nonadaptive`.
         """
+        return X
+
+    def _label_encode_categoricals(self, X: pd.DataFrame, is_train: bool = False) -> pd.DataFrame:
+        """Convert categorical features to label-encoded integers, preserving missing values.
+
+        Common `_preprocess` step for models that require fully numeric input. The stateful
+        encoder is stored on `self._label_encoder`: it is fitted on the first call, or
+        refitted when `is_train=True` (pass it for models whose `_preprocess` distinguishes
+        fit-time calls). Columns without categorical content are untouched; the categorical
+        feature names are available afterwards via `self._label_encoder.features_in`.
+        """
+        from autogluon.features.generators import LabelEncoderFeatureGenerator
+
+        if is_train or self._label_encoder is None:
+            self._label_encoder = LabelEncoderFeatureGenerator(verbosity=0)
+            self._label_encoder.fit(X=X)
+        if self._label_encoder.features_in:
+            X = X.copy()
+            X[self._label_encoder.features_in] = self._label_encoder.transform(X=X)
         return X
 
     # TODO: Remove kwargs?

--- a/tabular/src/autogluon/tabular/models/imodels/imodels_models.py
+++ b/tabular/src/autogluon/tabular/models/imodels/imodels_models.py
@@ -21,7 +21,6 @@ class _IModelsModel(AbstractModel):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._feature_generator = None
         self._ohe = None
         self._ohe_columns = None
         self._categorical_featnames = None

--- a/tabular/src/autogluon/tabular/models/mitra/mitra_model.py
+++ b/tabular/src/autogluon/tabular/models/mitra/mitra_model.py
@@ -9,7 +9,6 @@ import pandas as pd
 from typing_extensions import Self
 
 from autogluon.common.utils.resource_utils import ResourceManager
-from autogluon.features.generators import LabelEncoderFeatureGenerator
 from autogluon.tabular import __version__
 from autogluon.tabular.models.abstract.abstract_torch_model import AbstractTorchModel
 
@@ -53,7 +52,6 @@ class MitraModel(AbstractTorchModel):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._weights_saved = False
-        self._feature_generator = None
 
     @staticmethod
     def _get_default_device():
@@ -103,17 +101,7 @@ class MitraModel(AbstractTorchModel):
 
     def _preprocess(self, X: pd.DataFrame, is_train: bool = False, **kwargs) -> pd.DataFrame:
         X = super()._preprocess(X, **kwargs)
-
-        if is_train:
-            # X will be the training data.
-            self._feature_generator = LabelEncoderFeatureGenerator(verbosity=0)
-            self._feature_generator.fit(X=X)
-
-        # This converts categorical features to numeric via stateful label encoding.
-        if self._feature_generator.features_in:
-            X = X.copy()
-            X[self._feature_generator.features_in] = self._feature_generator.transform(X=X)
-
+        X = self._label_encode_categoricals(X, is_train=is_train)
         return X
 
     def _fit(

--- a/tabular/src/autogluon/tabular/models/nori/nori_model.py
+++ b/tabular/src/autogluon/tabular/models/nori/nori_model.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
-from autogluon.features.generators import LabelEncoderFeatureGenerator
 from autogluon.tabular.models.abstract.abstract_torch_model import AbstractTorchModel
 
 if TYPE_CHECKING:
@@ -71,10 +70,6 @@ class NoriModel(AbstractTorchModel):
     default_resources_physical_cores_only = True
     default_num_gpus = 1
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self._feature_generator = None
-
     def _fit(
         self,
         X: pd.DataFrame,
@@ -119,12 +114,7 @@ class NoriModel(AbstractTorchModel):
         """Nori requires a fully numeric array as input; cast to float32 (the dtype
         Nori coerces to internally) with NaN preserved (handled natively)."""
         X = super()._preprocess(X, **kwargs)
-        if self._feature_generator is None:
-            self._feature_generator = LabelEncoderFeatureGenerator(verbosity=0)
-            self._feature_generator.fit(X=X)
-        if self._feature_generator.features_in:
-            X = X.copy()
-            X[self._feature_generator.features_in] = self._feature_generator.transform(X=X)
+        X = self._label_encode_categoricals(X)
         return np.asarray(X.to_numpy(), dtype=np.float32)
 
     def get_device(self) -> str:

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -17,7 +17,6 @@ from autogluon.core.constants import MULTICLASS, QUANTILE, REGRESSION, SOFTCLASS
 from autogluon.core.models import AbstractModel
 from autogluon.core.utils.exceptions import NotEnoughMemoryError, TimeLimitExceeded
 from autogluon.core.utils.utils import normalize_pred_probas
-from autogluon.features.generators import LabelEncoderFeatureGenerator
 
 from .compilers.native import RFNativeCompiler
 from .compilers.onnx import RFOnnxCompiler
@@ -42,7 +41,6 @@ class RFModel(AbstractModel):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._feature_generator = None
         self._daal = False  # Whether daal4py backend is being used
         self._num_features_post_process = None
 
@@ -83,12 +81,7 @@ class RFModel(AbstractModel):
     # TODO: X.fillna -inf? Add extra is_missing column?
     def _preprocess(self, X, **kwargs):
         X = super()._preprocess(X, **kwargs)
-        if self._feature_generator is None:
-            self._feature_generator = LabelEncoderFeatureGenerator(verbosity=0)
-            self._feature_generator.fit(X=X)
-        if self._feature_generator.features_in:
-            X = X.copy()
-            X[self._feature_generator.features_in] = self._feature_generator.transform(X=X)
+        X = self._label_encode_categoricals(X)
         X = X.fillna(0).to_numpy(dtype=np.float32)
         return X
 

--- a/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_model.py
+++ b/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_model.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, ClassVar
 
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION
-from autogluon.features.generators import LabelEncoderFeatureGenerator
 from autogluon.tabular.models.abstract.abstract_torch_model import AbstractTorchModel
 
 if TYPE_CHECKING:
@@ -73,7 +72,6 @@ class TabDPTModel(AbstractTorchModel):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._feature_generator = None
         self._predict_hps = None
         self._use_flash_og = None
 
@@ -210,12 +208,7 @@ class TabDPTModel(AbstractTorchModel):
     def _preprocess(self, X: pd.DataFrame, **kwargs) -> pd.DataFrame:
         """TabDPT requires numpy array as input."""
         X = super()._preprocess(X, **kwargs)
-        if self._feature_generator is None:
-            self._feature_generator = LabelEncoderFeatureGenerator(verbosity=0)
-            self._feature_generator.fit(X=X)
-        if self._feature_generator.features_in:
-            X = X.copy()
-            X[self._feature_generator.features_in] = self._feature_generator.transform(X=X)
+        X = self._label_encode_categoricals(X)
         return X.to_numpy()
 
     def _more_tags(self) -> dict:

--- a/tabular/src/autogluon/tabular/models/tabpfnmix/tabpfnmix_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnmix/tabpfnmix_model.py
@@ -15,7 +15,6 @@ from autogluon.core.constants import BINARY, MULTICLASS, QUANTILE, REGRESSION
 from autogluon.core.models import AbstractModel
 from autogluon.core.utils import generate_train_test_split
 from autogluon.core.utils.exceptions import TimeLimitExceeded
-from autogluon.features.generators import LabelEncoderFeatureGenerator
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +54,6 @@ class TabPFNMixModel(AbstractModel):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._feature_generator = None
         self._weights_saved = False
 
     def _get_model_type(self):
@@ -292,13 +290,7 @@ class TabPFNMixModel(AbstractModel):
         Keeps missing values, as TabPFN automatically handles missing values internally.
         """
         X = super()._preprocess(X, **kwargs)
-        if self._feature_generator is None:
-            # FIXME: Check if this is needed, never actually tried removing it, copy pasted from TabPFNModel implementation in AG
-            self._feature_generator = LabelEncoderFeatureGenerator(verbosity=0)
-            self._feature_generator.fit(X=X)
-        if self._feature_generator.features_in:
-            X = X.copy()
-            X[self._feature_generator.features_in] = self._feature_generator.transform(X=X)
+        X = self._label_encode_categoricals(X)
         X = X.values.astype(np.float64)
         return X
 

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, ClassVar
 
 import numpy as np
 
-from autogluon.features.generators import LabelEncoderFeatureGenerator
 from autogluon.tabular.models.abstract.abstract_torch_model import AbstractTorchModel
 
 if TYPE_CHECKING:
@@ -87,7 +86,6 @@ class TabPFNModel(AbstractTorchModel):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._feature_generator = None
         self._cat_features = None
         self._cat_indices = None
         # `ag.max_batch_size="auto"` resolved against the training size during `_fit`.
@@ -105,23 +103,14 @@ class TabPFNModel(AbstractTorchModel):
 
     def _preprocess(self, X: pd.DataFrame, is_train=False, **kwargs) -> pd.DataFrame:
         X = super()._preprocess(X, **kwargs)
+        X = self._label_encode_categoricals(X, is_train=is_train)
 
         if is_train:
+            # Detect/set cat features and indices
             self._cat_indices = []
-
-            # X will be the training data.
-            self._feature_generator = LabelEncoderFeatureGenerator(verbosity=0)
-            self._feature_generator.fit(X=X)
-
-        # This converts categorical features to numeric via stateful label encoding.
-        if self._feature_generator.features_in:
-            X = X.copy()
-            X[self._feature_generator.features_in] = self._feature_generator.transform(X=X)
-
-            if is_train:
-                # Detect/set cat features and indices
+            if self._label_encoder.features_in:
                 if self._cat_features is None:
-                    self._cat_features = self._feature_generator.features_in[:]
+                    self._cat_features = self._label_encoder.features_in[:]
                 self._cat_indices = [X.columns.get_loc(col) for col in self._cat_features]
 
         return X


### PR DESCRIPTION
## Description

Six models — RF, Nori, TabDPT, TabPFN, TabPFNMix, Mitra — carried the identical stateful label-encoding block in `_preprocess`. It is now a base-class helper:

```python
X = self._label_encode_categoricals(X)                    # lazy: fit on first call
X = self._label_encode_categoricals(X, is_train=is_train) # refit at fit time (Mitra/TabPFN variant)
```

- The encoder lives on `self._label_encoder` (a specific name replacing the generic per-model `_feature_generator`), initialized by the base constructor; the six per-model `__init__` assignments (and a dead one in iModels) are removed — Nori's `__init__` becomes empty and is deleted.
- Per-model output handling (float32 cast, `fillna(0)`, `.to_numpy()`) stays in each `_preprocess`.
- TabPFN's cat-feature/index bookkeeping is restructured around the helper call with identical results.
- This block was already spreading by copy-paste (TabPFNMix's carried a "copy pasted from TabPFNModel, never tried removing" FIXME).

The companion `_fit` device-resolution helper is #5780.

## Verification

- Helper output frame-identical to the original block on mixed categorical/NaN data; lazy vs `is_train`-refit semantics match both prior variants; input never mutated; numeric-only frames pass through uncopied.
- TabPFN's `_cat_features` / `_cat_indices` identical through the rewritten `_preprocess`.
- RF (full fits with categoricals through the helper) + dummy unit tests pass; the one RF failure (`test_rf_binary_compile_onnx_as_ag_arg`) fails identically without this change (environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi