### PR TITLE
[timeseries] Add MQL (mean quantile loss) metric to timeseries

### DIFF
--- a/docs/tutorials/timeseries/forecasting-metrics.md
+++ b/docs/tutorials/timeseries/forecasting-metrics.md
@@ -43,6 +43,7 @@ Currently, AutoGluon supports following evaluation metrics:
 .. autosummary::
    :nosignatures:
 
+   MQL
    SQL
    WQL
    MAE
@@ -64,7 +65,7 @@ If you are not sure which evaluation metric to pick, here are three questions th
 
 **1. Are you interested in a point forecast or a probabilistic forecast?**
 
-If your goal is to generate an accurate **probabilistic** forecast, you should use `WQL` or `SQL` metrics.
+If your goal is to generate an accurate **probabilistic** forecast, you should use `WQL`, `MQL` or `SQL` metrics.
 These metrics are based on the [quantile loss](https://en.wikipedia.org/wiki/Quantile_regression) and measure the accuracy of the quantile forecasts.
 By default, AutoGluon predicts quantile levels `[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]`.
 To predict a different set of quantiles, you can use `quantile_levels` argument:
@@ -77,7 +78,7 @@ Note that if you select the `eval_metric` to a point forecast metric when creati
 
 **2. Do you care more about accurately predicting time series with large values?**
 
-If the answer is "yes" (for example, if it's important to more accurately predict sales of popular products), you should use **scale-dependent** metrics like `WQL`, `MAE`, `RMSE`, or `WAPE`.
+If the answer is "yes" (for example, if it's important to more accurately predict sales of popular products), you should use **scale-dependent** metrics like `WQL`, `MQL`, `MAE`, `RMSE`, or `WAPE`.
 These metrics are also well-suited for dealing with sparse (intermittent) time series that have lots of zeros.
 
 If the answer is "no" (you care equally about all time series in the dataset), consider **scaled** metrics like `SQL`, `MASE` and `RMSSE`. Alternatively, **percentage-based** metrics `MAPE` and `SMAPE` can also be used to equalize the scale across time series. However, these percentage-based metrics have some [well-documented limitations](https://robjhyndman.com/publications/another-look-at-measures-of-forecast-accuracy/), so we don't recommend using them in practice.
@@ -101,6 +102,10 @@ If your goal is to predict the **mean** (expected value), you should use `MSE`, 
      - Probabilistic?
      - Scale-dependent?
      - Predicts median or mean?
+   * - :class:`~autogluon.timeseries.metrics.MQL`
+     - ✅
+     - ✅
+     -
    * - :class:`~autogluon.timeseries.metrics.SQL`
      - ✅
      -
@@ -210,6 +215,10 @@ $$
 $$
 
 
+
+```{eval-rst}
+.. autoclass:: MQL
+```
 
 ```{eval-rst}
 .. autoclass:: SQL

--- a/timeseries/src/autogluon/timeseries/metrics/__init__.py
+++ b/timeseries/src/autogluon/timeseries/metrics/__init__.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from .abstract import TimeSeriesScorer
 from .point import MAE, MAPE, MASE, MSE, RMSE, RMSLE, RMSSE, SMAPE, WAPE, WCD
-from .quantile import SQL, WQL
+from .quantile import MQL, SQL, WQL
 
 __all__ = [
     "TimeSeriesScorer",
@@ -17,6 +17,7 @@ __all__ = [
     "MASE",
     "SMAPE",
     "MSE",
+    "MQL",
     "RMSE",
     "RMSLE",
     "RMSSE",
@@ -40,6 +41,7 @@ AVAILABLE_METRICS: dict[str, Type[TimeSeriesScorer]] = {
     "WAPE": WAPE,
     "SQL": SQL,
     "WQL": WQL,
+    "MQL": MQL,
     "MSE": MSE,
     "MAE": MAE,
 }
@@ -57,6 +59,7 @@ METRIC_ALIASES: dict[str, str] = {
     "weighted_absolute_percentage_error": "WAPE",
     "weighted_quantile_loss": "WQL",
     "scaled_quantile_loss": "SQL",
+    "mean_quantile_loss": "MQL",
 }
 
 # For backward compatibility

--- a/timeseries/src/autogluon/timeseries/metrics/quantile.py
+++ b/timeseries/src/autogluon/timeseries/metrics/quantile.py
@@ -9,6 +9,52 @@ from .abstract import TimeSeriesScorer
 from .utils import in_sample_abs_seasonal_error
 
 
+class MQL(TimeSeriesScorer):
+    r"""Mean quantile loss.
+
+    Also known as mean pinball loss.
+
+    Defined as the quantile loss averaged over all time series, time steps in the forecast horizon, and quantile levels.
+
+    .. math::
+
+        \operatorname{MQL} = \frac{1}{N} \frac{1}{H} \sum_{i=1}^{N} \sum_{t=T+1}^{T+H} \frac{1}{|\mathcal{Q}|} \sum_{q \in \mathcal{Q}} \rho_q(y_{i,t}, f^q_{i,t})
+
+    where :math:`\mathcal{Q}` is the set of quantile levels.
+
+    Properties:
+
+    - scale-dependent (time series with large absolute value contribute more to the loss)
+    - equivalent to MAE if ``quantile_levels = [0.5]``
+
+    References
+    ----------
+    - `Forecasting: Principles and Practice <https://otexts.com/fpp3/distaccuracy.html#quantile-scores>`_
+    """
+
+    needs_quantile = True
+
+    def compute_metric(
+        self,
+        data_future: TimeSeriesDataFrame,
+        predictions: TimeSeriesDataFrame,
+        target: str = "target",
+        **kwargs,
+    ) -> float:
+        y_true, q_pred, quantile_levels = self._get_quantile_forecast_score_inputs(data_future, predictions, target)
+        y_true = y_true.to_numpy()[:, None]  # shape [N, 1]
+        q_pred = q_pred.to_numpy()  # shape [N, len(quantile_levels)]
+
+        errors = (
+            np.abs((q_pred - y_true) * ((y_true <= q_pred) - quantile_levels))
+            .mean(axis=1)
+            .reshape([-1, self.prediction_length])
+        )
+        if self.horizon_weight is not None:
+            errors *= self.horizon_weight
+        return 2 * self._safemean(errors)
+
+
 class WQL(TimeSeriesScorer):
     r"""Weighted quantile loss.
 

--- a/timeseries/tests/unittests/test_metrics.py
+++ b/timeseries/tests/unittests/test_metrics.py
@@ -11,6 +11,7 @@ from gluonts.ev.metrics import (
     RMSE,
     SMAPE,
     AverageMeanScaledQuantileLoss,
+    MeanSumQuantileLoss,
     MeanWeightedSumQuantileLoss,
 )
 from gluonts.ev.metrics import Metric as GluonTSMetric
@@ -33,19 +34,23 @@ from .common import DUMMY_TS_DATAFRAME, get_data_frame_with_item_index, get_pred
 pytestmark = pytest.mark.filterwarnings("ignore")
 
 
-def get_ag_and_gts_metrics() -> list[tuple[str, GluonTSMetric]]:
-    # Each entry is a tuple (ag_metric_name, gts_metric_object)
+def get_ag_and_gts_metrics() -> list[tuple[str, GluonTSMetric, float]]:
+    # Each entry is a tuple (ag_metric_name, gts_metric_object, gts_scale). The GluonTS value is multiplied by
+    # `gts_scale` before being compared to the AutoGluon value (e.g. AutoGluon's MQL averages the quantile loss over
+    # quantile levels, while GluonTS's MeanSumQuantileLoss sums it, so we divide the GluonTS value by len(quantiles)).
     default_quantile_levels = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+    num_quantiles = len(default_quantile_levels)
     # Metric that have different names in AutoGluon and GluonTS
     ag_and_gts_metrics = [
-        ("WQL", MeanWeightedSumQuantileLoss(default_quantile_levels)),
-        ("SQL", AverageMeanScaledQuantileLoss(default_quantile_levels)),
-        ("WAPE", ND("mean")),
+        ("MQL", MeanSumQuantileLoss(default_quantile_levels), 1 / num_quantiles),
+        ("WQL", MeanWeightedSumQuantileLoss(default_quantile_levels), 1.0),
+        ("SQL", AverageMeanScaledQuantileLoss(default_quantile_levels), 1.0),
+        ("WAPE", ND("mean"), 1.0),
     ]
     # Metric that have same names in AutoGluon and GluonTS
     for point_metric_cls in [MAPE, SMAPE, MSE, RMSE, MASE, MAE]:
         name = str(point_metric_cls.__name__)
-        ag_and_gts_metrics.append((name, point_metric_cls("mean")))
+        ag_and_gts_metrics.append((name, point_metric_cls("mean"), 1.0))
     return ag_and_gts_metrics
 
 
@@ -104,7 +109,7 @@ def to_gluonts_test_set(data, prediction_length):
     return test_template.generate_instances(prediction_length, windows=1)
 
 
-def check_gluonts_parity(ag_metric_name, gts_metric, data, model, zero_forecast=False, equal_nan=False):
+def check_gluonts_parity(ag_metric_name, gts_metric, gts_scale, data, model, zero_forecast=False, equal_nan=False):
     data_train, data_test = data.train_test_split(model.prediction_length)
     forecast_df = model.predict(data_train)
     forecast_df["mean"] = forecast_df["0.5"]
@@ -120,55 +125,62 @@ def check_gluonts_parity(ag_metric_name, gts_metric, data, model, zero_forecast=
 
     gts_forecast = to_gluonts_forecast(forecast_df, freq=data_train.freq)
     gts_test_set = to_gluonts_test_set(data_test, model.prediction_length)
-    gts_value = evaluate_forecasts(
-        gts_forecast, test_data=gts_test_set, seasonality=ag_metric.seasonal_period, metrics=[gts_metric]
-    ).values.item()
+    gts_value = (
+        evaluate_forecasts(
+            gts_forecast, test_data=gts_test_set, seasonality=ag_metric.seasonal_period, metrics=[gts_metric]
+        ).values.item()
+        * gts_scale
+    )
     assert np.isclose(gts_value, ag_value, atol=1e-5, equal_nan=equal_nan)
 
 
-@pytest.mark.parametrize("ag_metric_name, gts_metric", AG_AND_GTS_METRICS)
-def test_when_metric_evaluated_then_output_equal_to_gluonts(ag_metric_name, gts_metric, deepar_trained):
+@pytest.mark.parametrize("ag_metric_name, gts_metric, gts_scale", AG_AND_GTS_METRICS)
+def test_when_metric_evaluated_then_output_equal_to_gluonts(ag_metric_name, gts_metric, gts_scale, deepar_trained):
     check_gluonts_parity(
         ag_metric_name,
         gts_metric,
+        gts_scale,
         data=DUMMY_TS_DATAFRAME,
         model=deepar_trained,
     )
 
 
-@pytest.mark.parametrize("ag_metric_name, gts_metric", AG_AND_GTS_METRICS)
+@pytest.mark.parametrize("ag_metric_name, gts_metric, gts_scale", AG_AND_GTS_METRICS)
 def test_given_all_zero_data_when_metric_evaluated_then_output_equal_to_gluonts(
-    ag_metric_name, gts_metric, deepar_trained_zero_data
+    ag_metric_name, gts_metric, gts_scale, deepar_trained_zero_data
 ):
     check_gluonts_parity(
         ag_metric_name,
         gts_metric,
+        gts_scale,
         data=DUMMY_TS_DATAFRAME.copy() * 0,
         model=deepar_trained_zero_data,
         equal_nan=True,
     )
 
 
-@pytest.mark.parametrize("ag_metric_name, gts_metric", AG_AND_GTS_METRICS)
+@pytest.mark.parametrize("ag_metric_name, gts_metric, gts_scale", AG_AND_GTS_METRICS)
 def test_given_zero_forecasts_when_metric_evaluated_then_output_equal_to_gluonts(
-    ag_metric_name, gts_metric, deepar_trained
+    ag_metric_name, gts_metric, gts_scale, deepar_trained
 ):
     check_gluonts_parity(
         ag_metric_name,
         gts_metric,
+        gts_scale,
         data=DUMMY_TS_DATAFRAME,
         model=deepar_trained,
         zero_forecast=True,
     )
 
 
-@pytest.mark.parametrize("ag_metric_name, gts_metric", AG_AND_GTS_METRICS)
+@pytest.mark.parametrize("ag_metric_name, gts_metric, gts_scale", AG_AND_GTS_METRICS)
 def test_given_missing_target_values_when_metric_evaluated_then_output_equal_to_gluonts(
-    ag_metric_name, gts_metric, deepar_trained
+    ag_metric_name, gts_metric, gts_scale, deepar_trained
 ):
     check_gluonts_parity(
         ag_metric_name,
         gts_metric,
+        gts_scale,
         data=DUMMY_TS_DATAFRAME,
         model=deepar_trained,
     )

--- a/timeseries/tests/unittests/test_metrics.py
+++ b/timeseries/tests/unittests/test_metrics.py
@@ -11,7 +11,6 @@ from gluonts.ev.metrics import (
     RMSE,
     SMAPE,
     AverageMeanScaledQuantileLoss,
-    MeanSumQuantileLoss,
     MeanWeightedSumQuantileLoss,
 )
 from gluonts.ev.metrics import Metric as GluonTSMetric
@@ -34,23 +33,19 @@ from .common import DUMMY_TS_DATAFRAME, get_data_frame_with_item_index, get_pred
 pytestmark = pytest.mark.filterwarnings("ignore")
 
 
-def get_ag_and_gts_metrics() -> list[tuple[str, GluonTSMetric, float]]:
-    # Each entry is a tuple (ag_metric_name, gts_metric_object, gts_scale). The GluonTS value is multiplied by
-    # `gts_scale` before being compared to the AutoGluon value (e.g. AutoGluon's MQL averages the quantile loss over
-    # quantile levels, while GluonTS's MeanSumQuantileLoss sums it, so we divide the GluonTS value by len(quantiles)).
+def get_ag_and_gts_metrics() -> list[tuple[str, GluonTSMetric]]:
+    # Each entry is a tuple (ag_metric_name, gts_metric_object)
     default_quantile_levels = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
-    num_quantiles = len(default_quantile_levels)
     # Metric that have different names in AutoGluon and GluonTS
     ag_and_gts_metrics = [
-        ("MQL", MeanSumQuantileLoss(default_quantile_levels), 1 / num_quantiles),
-        ("WQL", MeanWeightedSumQuantileLoss(default_quantile_levels), 1.0),
-        ("SQL", AverageMeanScaledQuantileLoss(default_quantile_levels), 1.0),
-        ("WAPE", ND("mean"), 1.0),
+        ("WQL", MeanWeightedSumQuantileLoss(default_quantile_levels)),
+        ("SQL", AverageMeanScaledQuantileLoss(default_quantile_levels)),
+        ("WAPE", ND("mean")),
     ]
     # Metric that have same names in AutoGluon and GluonTS
     for point_metric_cls in [MAPE, SMAPE, MSE, RMSE, MASE, MAE]:
         name = str(point_metric_cls.__name__)
-        ag_and_gts_metrics.append((name, point_metric_cls("mean"), 1.0))
+        ag_and_gts_metrics.append((name, point_metric_cls("mean")))
     return ag_and_gts_metrics
 
 
@@ -109,7 +104,7 @@ def to_gluonts_test_set(data, prediction_length):
     return test_template.generate_instances(prediction_length, windows=1)
 
 
-def check_gluonts_parity(ag_metric_name, gts_metric, gts_scale, data, model, zero_forecast=False, equal_nan=False):
+def check_gluonts_parity(ag_metric_name, gts_metric, data, model, zero_forecast=False, equal_nan=False):
     data_train, data_test = data.train_test_split(model.prediction_length)
     forecast_df = model.predict(data_train)
     forecast_df["mean"] = forecast_df["0.5"]
@@ -125,62 +120,55 @@ def check_gluonts_parity(ag_metric_name, gts_metric, gts_scale, data, model, zer
 
     gts_forecast = to_gluonts_forecast(forecast_df, freq=data_train.freq)
     gts_test_set = to_gluonts_test_set(data_test, model.prediction_length)
-    gts_value = (
-        evaluate_forecasts(
-            gts_forecast, test_data=gts_test_set, seasonality=ag_metric.seasonal_period, metrics=[gts_metric]
-        ).values.item()
-        * gts_scale
-    )
+    gts_value = evaluate_forecasts(
+        gts_forecast, test_data=gts_test_set, seasonality=ag_metric.seasonal_period, metrics=[gts_metric]
+    ).values.item()
     assert np.isclose(gts_value, ag_value, atol=1e-5, equal_nan=equal_nan)
 
 
-@pytest.mark.parametrize("ag_metric_name, gts_metric, gts_scale", AG_AND_GTS_METRICS)
-def test_when_metric_evaluated_then_output_equal_to_gluonts(ag_metric_name, gts_metric, gts_scale, deepar_trained):
+@pytest.mark.parametrize("ag_metric_name, gts_metric", AG_AND_GTS_METRICS)
+def test_when_metric_evaluated_then_output_equal_to_gluonts(ag_metric_name, gts_metric, deepar_trained):
     check_gluonts_parity(
         ag_metric_name,
         gts_metric,
-        gts_scale,
         data=DUMMY_TS_DATAFRAME,
         model=deepar_trained,
     )
 
 
-@pytest.mark.parametrize("ag_metric_name, gts_metric, gts_scale", AG_AND_GTS_METRICS)
+@pytest.mark.parametrize("ag_metric_name, gts_metric", AG_AND_GTS_METRICS)
 def test_given_all_zero_data_when_metric_evaluated_then_output_equal_to_gluonts(
-    ag_metric_name, gts_metric, gts_scale, deepar_trained_zero_data
+    ag_metric_name, gts_metric, deepar_trained_zero_data
 ):
     check_gluonts_parity(
         ag_metric_name,
         gts_metric,
-        gts_scale,
         data=DUMMY_TS_DATAFRAME.copy() * 0,
         model=deepar_trained_zero_data,
         equal_nan=True,
     )
 
 
-@pytest.mark.parametrize("ag_metric_name, gts_metric, gts_scale", AG_AND_GTS_METRICS)
+@pytest.mark.parametrize("ag_metric_name, gts_metric", AG_AND_GTS_METRICS)
 def test_given_zero_forecasts_when_metric_evaluated_then_output_equal_to_gluonts(
-    ag_metric_name, gts_metric, gts_scale, deepar_trained
+    ag_metric_name, gts_metric, deepar_trained
 ):
     check_gluonts_parity(
         ag_metric_name,
         gts_metric,
-        gts_scale,
         data=DUMMY_TS_DATAFRAME,
         model=deepar_trained,
         zero_forecast=True,
     )
 
 
-@pytest.mark.parametrize("ag_metric_name, gts_metric, gts_scale", AG_AND_GTS_METRICS)
+@pytest.mark.parametrize("ag_metric_name, gts_metric", AG_AND_GTS_METRICS)
 def test_given_missing_target_values_when_metric_evaluated_then_output_equal_to_gluonts(
-    ag_metric_name, gts_metric, gts_scale, deepar_trained
+    ag_metric_name, gts_metric, deepar_trained
 ):
     check_gluonts_parity(
         ag_metric_name,
         gts_metric,
-        gts_scale,
         data=DUMMY_TS_DATAFRAME,
         model=deepar_trained,
     )
@@ -193,6 +181,23 @@ def test_given_missing_target_values_when_metric_evaluated_then_metric_is_not_na
     predictions = get_prediction_for_df(train, prediction_length)
     score = metric_cls(prediction_length=prediction_length)(data=test, predictions=predictions)
     assert not pd.isna(score)
+
+
+def test_when_no_missing_values_then_mql_equals_wql_times_mean_abs_target():
+    # MQL and WQL share the same per-entry quantile loss; MQL averages it while WQL divides by the sum of |y_true|.
+    # Therefore MQL == WQL * mean(|y_true|) as long as the target contains no missing values.
+    prediction_length = 4
+    data = get_data_frame_with_item_index(["A", "B", "C"], data_length=12, columns=["target"])
+    train, test = data.train_test_split(prediction_length)
+    predictions = get_prediction_for_df(train, prediction_length)
+
+    mql = check_get_evaluation_metric("MQL", prediction_length=prediction_length)
+    wql = check_get_evaluation_metric("WQL", prediction_length=prediction_length)
+    mean_abs_target = test.slice_by_timestep(-prediction_length, None)["target"].abs().mean()
+
+    mql_value = mql.sign * mql(test, predictions)
+    wql_value = wql.sign * wql(test, predictions)
+    assert np.isclose(mql_value, wql_value * mean_abs_target)
 
 
 @pytest.mark.parametrize("metric_cls", AVAILABLE_METRICS.values())


### PR DESCRIPTION
*Description of changes:*

Adds a new probabilistic metric **MQL (mean quantile loss)** to `autogluon.timeseries`, alongside `WQL` and `SQL`. MQL is the quantile loss averaged over all time series, horizon steps, and quantile levels; it is scale-dependent and equals `MAE` when `quantile_levels = [0.5]`.

Includes registration + `mean_quantile_loss` alias, tutorial docs, and a GluonTS parity test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.