### PR TITLE
Share the _fit device-resolution block on AbstractTorchModel

### DIFF
--- a/tabular/src/autogluon/tabular/models/abstract/abstract_torch_model.py
+++ b/tabular/src/autogluon/tabular/models/abstract/abstract_torch_model.py
@@ -28,6 +28,27 @@ class AbstractTorchModel(AbstractModel):
         self.device = None
         self.device_train = None
 
+    def _resolve_fit_device(self, num_gpus: int | float, gpu_device: str = "cuda") -> str:
+        """Resolve the torch device for `_fit` from the allocated `num_gpus`.
+
+        Logs the CPU-fallback warning (see `_log_cpu_fallback_warning`) and raises when a
+        GPU was allocated but CUDA is unavailable. `gpu_device` is the device string
+        returned for GPU fits (pass e.g. "cuda:0" for models that assume a single
+        visible GPU).
+        """
+        self._log_cpu_fallback_warning(num_gpus=num_gpus)
+        if num_gpus == 0:
+            return "cpu"
+        from torch.cuda import is_available
+
+        if not is_available():
+            # TODO: Consider warning and falling back to CPU instead of raising.
+            raise AssertionError(
+                "Fit specified to use GPU, but CUDA is not available on this machine. "
+                "Please switch to CPU usage instead.",
+            )
+        return gpu_device
+
     def _log_cpu_fallback_warning(self, num_gpus: int | float) -> None:
         """Warn once per fit when a ``gpu_strongly_recommended`` model fits on CPU
         without the user having asked for it.

--- a/tabular/src/autogluon/tabular/models/nori/nori_model.py
+++ b/tabular/src/autogluon/tabular/models/nori/nori_model.py
@@ -87,15 +87,7 @@ class NoriModel(AbstractTorchModel):
             )
             raise err
 
-        from torch.cuda import is_available
-
-        self._log_cpu_fallback_warning(num_gpus=num_gpus)
-        device = "cuda" if num_gpus != 0 else "cpu"
-        if (device == "cuda") and (not is_available()):
-            raise AssertionError(
-                "Fit specified to use GPU, but CUDA is not available on this machine. "
-                "Please switch to CPU usage instead.",
-            )
+        device = self._resolve_fit_device(num_gpus=num_gpus)
 
         hyp = self._get_model_params()
         hyp.pop("device", None)  # device is set explicitly from the allocated resources

--- a/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
+++ b/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
@@ -125,12 +125,7 @@ class RealMLPModel(AbstractTorchModel):
             _lightning_log_level = logging.INFO
 
         # FIXME: code assume we only see one GPU in the fit process.
-        device = "cpu" if num_gpus == 0 else "cuda:0"
-        if (device == "cuda:0") and (not torch.cuda.is_available()):
-            raise AssertionError(
-                "Fit specified to use GPU, but CUDA is not available on this machine. "
-                "Please switch to CPU usage instead.",
-            )
+        device = self._resolve_fit_device(num_gpus=num_gpus, gpu_device="cuda:0")
 
         hyp = self._get_model_params()
 

--- a/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_model.py
+++ b/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_model.py
@@ -83,15 +83,7 @@ class TabDPTModel(AbstractTorchModel):
         num_gpus: int = 0,
         **kwargs,
     ):
-        from torch.cuda import is_available
-
-        self._log_cpu_fallback_warning(num_gpus=num_gpus)
-        device = "cuda" if num_gpus != 0 else "cpu"
-        if (device == "cuda") and (not is_available()):
-            raise AssertionError(
-                "Fit specified to use GPU, but CUDA is not available on this machine. "
-                "Please switch to CPU usage instead.",
-            )
+        device = self._resolve_fit_device(num_gpus=num_gpus)
         from tabdpt import TabDPTClassifier, TabDPTRegressor
 
         model_cls = TabDPTClassifier if self.problem_type in [BINARY, MULTICLASS] else TabDPTRegressor

--- a/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
+++ b/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
@@ -128,16 +128,7 @@ class TabICLModel(AbstractTorchModel):
             )
             raise err
 
-        from torch.cuda import is_available
-
-        self._log_cpu_fallback_warning(num_gpus=num_gpus)
-        device = "cuda" if num_gpus != 0 else "cpu"
-        if (device == "cuda") and (not is_available()):
-            # FIXME: warn instead and switch to CPU.
-            raise AssertionError(
-                "Fit specified to use GPU, but CUDA is not available on this machine. "
-                "Please switch to CPU usage instead.",
-            )
+        device = self._resolve_fit_device(num_gpus=num_gpus)
 
         model_cls = self.get_model_cls()
         hyp = self._get_model_params()

--- a/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
+++ b/tabular/src/autogluon/tabular/models/tabm/tabm_model.py
@@ -72,8 +72,6 @@ class TabMModel(AbstractTorchModel):
 
         try:
             # imports various dependencies such as torch
-            from torch.cuda import is_available
-
             from ._tabm_internal import TabMImplementation
         except ImportError as err:
             logger.log(
@@ -83,13 +81,7 @@ class TabMModel(AbstractTorchModel):
             )
             raise err
 
-        device = "cpu" if num_gpus == 0 else "cuda"
-        if (device == "cuda") and (not is_available()):
-            # FIXME: warn instead and switch to CPU.
-            raise AssertionError(
-                "Fit specified to use GPU, but CUDA is not available on this machine. "
-                "Please switch to CPU usage instead.",
-            )
+        device = self._resolve_fit_device(num_gpus=num_gpus)
 
         if X_val is None:
             from autogluon.core.utils import generate_train_test_split

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
@@ -137,19 +137,13 @@ class TabPFNModel(AbstractTorchModel):
             self._max_batch_size_resolved = min(1_000_000, max(self.max_batch_size_min, len(X)))
 
         from tabpfn import TabPFNClassifier, TabPFNRegressor
-        from torch.cuda import is_available
 
         is_classification = self.problem_type in ["binary", "multiclass"]
 
         model_base = TabPFNClassifier if is_classification else TabPFNRegressor
 
-        self._log_cpu_fallback_warning(num_gpus=num_gpus)
+        self._resolve_fit_device(num_gpus=num_gpus)  # CPU-fallback warning + CUDA availability check
         device = self._get_tabpfn_device(num_gpus=num_gpus)
-        if (device != "cpu") and (not is_available()):
-            raise AssertionError(
-                "Fit specified to use GPU, but CUDA is not available on this machine. "
-                "Please switch to CPU usage instead.",
-            )
 
         if verbosity >= 2:
             # logs "Built with PriorLabs-TabPFN"


### PR DESCRIPTION
## Description

Companion to #5778 (this commit was pushed to that branch after it merged, so it never landed — reopened here on a clean branch).

Six torch models — TabM, TabICL, Nori, TabDPT, RealMLP, TabPFN — carried the same `_fit` block: derive `"cuda"`/`"cpu"` from the allocated `num_gpus` and raise when a GPU was allocated but CUDA is unavailable. Now:

```python
device = self._resolve_fit_device(num_gpus=num_gpus)                       # TabM/TabICL/Nori/TabDPT
device = self._resolve_fit_device(num_gpus=num_gpus, gpu_device="cuda:0")  # RealMLP (single-visible-GPU assumption)
```

- The helper also logs the `gpu_strongly_recommended` CPU-fallback warning — a no-op for models without the flag (TabM/RealMLP, which previously skipped the warning call), and free coverage if they're ever flagged.
- TabPFN calls the helper for the warning + availability check and keeps `_get_tabpfn_device` for its multi-GPU device list.
- Mitra is untouched: its device flows through hyperparameters with separate suggestion logic.
- TabM's `# FIXME: warn instead and switch to CPU` moves into the helper as a general TODO — it applies to every model equally.

## Verification

- Helper returns cpu / cuda / cuda:0 for `num_gpus` 0 / 1 / fractional exactly as the original conditionals did (verified on a CUDA machine, including the `!= 0` vs `== 0` inversions).
- TabM and RealMLP fit tests pass end to end; orphaned `from torch.cuda import is_available` imports removed (remaining try-block F401s are pre-existing availability probes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi