### PR TITLE
[timeseries] Add MAEB and WAPEB bias-penalized metrics to timeseries

### DIFF
--- a/docs/tutorials/timeseries/forecasting-metrics.md
+++ b/docs/tutorials/timeseries/forecasting-metrics.md
@@ -83,6 +83,7 @@ Note that if you select the `eval_metric` to a point forecast metric when creati
 If the answer is "yes" (for example, if it's important to more accurately predict sales of popular products), you should use **scale-dependent** metrics like `WQL`, `MQL`, `MAE`, `RMSE`, or `WAPE`.
 These metrics are also well-suited for dealing with sparse (intermittent) time series that have lots of zeros.
 If you additionally want to penalize forecasts that are systematically biased (consistently over- or under-forecasting demand), consider the bias-penalized metrics `MAEB` or `WAPEB`.
+To *measure* (rather than penalize) the direction and magnitude of the forecast bias, you can evaluate a trained predictor with the `BIAS` metric via `predictor.evaluate(..., metrics="BIAS")`. Since a low `BIAS` value can be achieved by a poor forecast (both over- and under-forecasting are penalized only in absolute terms), `BIAS` cannot be used as an `eval_metric` for model selection.
 
 If the answer is "no" (you care equally about all time series in the dataset), consider **scaled** metrics like `SQL`, `MASE` and `RMSSE`. Alternatively, **percentage-based** metrics `MAPE` and `SMAPE` can also be used to equalize the scale across time series. However, these percentage-based metrics have some [well-documented limitations](https://robjhyndman.com/publications/another-look-at-measures-of-forecast-accuracy/), so we don't recommend using them in practice.
 Note that both scaled and percentage-based metrics are poorly suited for sparse (intermittent) data.
@@ -217,6 +218,10 @@ We use the following notation in mathematical definitions of point forecast metr
 
 ```{eval-rst}
 .. autoclass:: WAPEB
+```
+
+```{eval-rst}
+.. autoclass:: BIAS
 ```
 
 

--- a/docs/tutorials/timeseries/forecasting-metrics.md
+++ b/docs/tutorials/timeseries/forecasting-metrics.md
@@ -92,6 +92,7 @@ Note that both scaled and percentage-based metrics are poorly suited for sparse 
 
 To estimate the **median**, you need to use metrics such as `MAE`, `MASE` or `WAPE`.
 If your goal is to predict the **mean** (expected value), you should use `MSE`, `RMSE` or `RMSSE` metrics.
+When dealing with intermittent or sparse time series, you can use the bias-penalized metrics `MAEB` and `WAPEB`. These balance between a median-seeking accuracy term and a mean-seeking bias penalty, which discourages the chronic under-forecasting that minimizing `MAE` or `WAPE` alone tends to reward.
 
 
 

--- a/docs/tutorials/timeseries/forecasting-metrics.md
+++ b/docs/tutorials/timeseries/forecasting-metrics.md
@@ -47,6 +47,7 @@ Currently, AutoGluon supports following evaluation metrics:
    SQL
    WQL
    MAE
+   MAEB
    MAPE
    MASE
    MSE
@@ -55,6 +56,7 @@ Currently, AutoGluon supports following evaluation metrics:
    RMSSE
    SMAPE
    WAPE
+   WAPEB
 
 ```
 Alternatively, you can [define a custom forecast evaluation metric](#custom-forecast-metrics).
@@ -80,6 +82,7 @@ Note that if you select the `eval_metric` to a point forecast metric when creati
 
 If the answer is "yes" (for example, if it's important to more accurately predict sales of popular products), you should use **scale-dependent** metrics like `WQL`, `MQL`, `MAE`, `RMSE`, or `WAPE`.
 These metrics are also well-suited for dealing with sparse (intermittent) time series that have lots of zeros.
+If you additionally want to penalize forecasts that are systematically biased (consistently over- or under-forecasting demand), consider the bias-penalized metrics `MAEB` or `WAPEB`.
 
 If the answer is "no" (you care equally about all time series in the dataset), consider **scaled** metrics like `SQL`, `MASE` and `RMSSE`. Alternatively, **percentage-based** metrics `MAPE` and `SMAPE` can also be used to equalize the scale across time series. However, these percentage-based metrics have some [well-documented limitations](https://robjhyndman.com/publications/another-look-at-measures-of-forecast-accuracy/), so we don't recommend using them in practice.
 Note that both scaled and percentage-based metrics are poorly suited for sparse (intermittent) data.
@@ -118,6 +121,10 @@ If your goal is to predict the **mean** (expected value), you should use `MSE`, 
      -
      - ✅
      - median
+   * - :class:`~autogluon.timeseries.metrics.MAEB`
+     -
+     - ✅
+     -
    * - :class:`~autogluon.timeseries.metrics.MASE`
      -
      -
@@ -126,6 +133,10 @@ If your goal is to predict the **mean** (expected value), you should use `MSE`, 
      -
      - ✅
      - median
+   * - :class:`~autogluon.timeseries.metrics.WAPEB`
+     -
+     - ✅
+     -
    * - :class:`~autogluon.timeseries.metrics.MSE`
      -
      - ✅
@@ -169,6 +180,10 @@ We use the following notation in mathematical definitions of point forecast metr
 ```
 
 ```{eval-rst}
+.. autoclass:: MAEB
+```
+
+```{eval-rst}
 .. autoclass:: MAPE
 ```
 
@@ -198,6 +213,10 @@ We use the following notation in mathematical definitions of point forecast metr
 
 ```{eval-rst}
 .. autoclass:: WAPE
+```
+
+```{eval-rst}
+.. autoclass:: WAPEB
 ```
 
 

--- a/timeseries/src/autogluon/timeseries/metrics/__init__.py
+++ b/timeseries/src/autogluon/timeseries/metrics/__init__.py
@@ -6,12 +6,13 @@ from typing import Any, Sequence, Type
 import numpy as np
 
 from .abstract import TimeSeriesScorer
-from .point import MAE, MAEB, MAPE, MASE, MSE, RMSE, RMSLE, RMSSE, SMAPE, WAPE, WAPEB, WCD
+from .point import BIAS, MAE, MAEB, MAPE, MASE, MSE, RMSE, RMSLE, RMSSE, SMAPE, WAPE, WAPEB, WCD
 from .quantile import MQL, SQL, WQL
 
 __all__ = [
     "TimeSeriesScorer",
     "check_get_evaluation_metric",
+    "BIAS",
     "MAE",
     "MAEB",
     "MAPE",
@@ -48,6 +49,7 @@ AVAILABLE_METRICS: dict[str, Type[TimeSeriesScorer]] = {
     "MSE": MSE,
     "MAE": MAE,
     "MAEB": MAEB,
+    "BIAS": BIAS,
 }
 
 # Provide lowercase aliases for metrics for consistency with autogluon.tabular
@@ -66,6 +68,7 @@ METRIC_ALIASES: dict[str, str] = {
     "mean_quantile_loss": "MQL",
     "mean_absolute_error_with_bias": "MAEB",
     "weighted_absolute_percentage_error_with_bias": "WAPEB",
+    "forecast_bias": "BIAS",
 }
 
 # For backward compatibility

--- a/timeseries/src/autogluon/timeseries/metrics/__init__.py
+++ b/timeseries/src/autogluon/timeseries/metrics/__init__.py
@@ -6,13 +6,14 @@ from typing import Any, Sequence, Type
 import numpy as np
 
 from .abstract import TimeSeriesScorer
-from .point import MAE, MAPE, MASE, MSE, RMSE, RMSLE, RMSSE, SMAPE, WAPE, WCD
+from .point import MAE, MAEB, MAPE, MASE, MSE, RMSE, RMSLE, RMSSE, SMAPE, WAPE, WAPEB, WCD
 from .quantile import MQL, SQL, WQL
 
 __all__ = [
     "TimeSeriesScorer",
     "check_get_evaluation_metric",
     "MAE",
+    "MAEB",
     "MAPE",
     "MASE",
     "SMAPE",
@@ -23,6 +24,7 @@ __all__ = [
     "RMSSE",
     "SQL",
     "WAPE",
+    "WAPEB",
     "WCD",
     "WQL",
     "AVAILABLE_METRICS",
@@ -39,11 +41,13 @@ AVAILABLE_METRICS: dict[str, Type[TimeSeriesScorer]] = {
     "RMSLE": RMSLE,
     "RMSSE": RMSSE,
     "WAPE": WAPE,
+    "WAPEB": WAPEB,
     "SQL": SQL,
     "WQL": WQL,
     "MQL": MQL,
     "MSE": MSE,
     "MAE": MAE,
+    "MAEB": MAEB,
 }
 
 # Provide lowercase aliases for metrics for consistency with autogluon.tabular
@@ -60,6 +64,8 @@ METRIC_ALIASES: dict[str, str] = {
     "weighted_quantile_loss": "WQL",
     "scaled_quantile_loss": "SQL",
     "mean_quantile_loss": "MQL",
+    "mean_absolute_error_with_bias": "MAEB",
+    "weighted_absolute_percentage_error_with_bias": "WAPEB",
 }
 
 # For backward compatibility

--- a/timeseries/src/autogluon/timeseries/metrics/__init__.py
+++ b/timeseries/src/autogluon/timeseries/metrics/__init__.py
@@ -68,7 +68,6 @@ METRIC_ALIASES: dict[str, str] = {
     "mean_quantile_loss": "MQL",
     "mean_absolute_error_with_bias": "MAEB",
     "weighted_absolute_percentage_error_with_bias": "WAPEB",
-    "forecast_bias": "BIAS",
 }
 
 # For backward compatibility

--- a/timeseries/src/autogluon/timeseries/metrics/abstract.py
+++ b/timeseries/src/autogluon/timeseries/metrics/abstract.py
@@ -46,6 +46,11 @@ class TimeSeriesScorer:
         Name of an equivalent metric used by AutoGluon-Tabular with ``problem_type="regression"``. Used by forecasting
         models that train tabular regression models under the hood. This attribute should only be specified by point
         forecast metrics.
+    evaluate_only : bool, default = False
+        Whether the metric can only be used to evaluate a trained predictor but not for model selection. If True,
+        passing this metric as ``eval_metric`` to :class:`~autogluon.timeseries.TimeSeriesPredictor` raises an error.
+        This should be set for diagnostic metrics whose optimum is not achieved by minimizing or maximizing the metric
+        (e.g., signed forecast bias, where both positive and negative values indicate a worse forecast).
     """
 
     greater_is_better_internal: bool = False
@@ -53,6 +58,7 @@ class TimeSeriesScorer:
     optimized_by_median: bool = False
     needs_quantile: bool = False
     equivalent_tabular_regression_metric: str | None = None
+    evaluate_only: bool = False
 
     def __init__(
         self,

--- a/timeseries/src/autogluon/timeseries/metrics/point.py
+++ b/timeseries/src/autogluon/timeseries/metrics/point.py
@@ -150,6 +150,10 @@ class MAEB(TimeSeriesScorer):
     See :class:`WAPEB` for a scale-free version of this metric that normalizes the error across time series.
     """
 
+    # Target mean (RMSE + no median paste) to avoid underforecasting on intermittent series
+    optimized_by_median = False
+    equivalent_tabular_regression_metric = "root_mean_squared_error"
+
     def compute_metric(
         self,
         data_future: TimeSeriesDataFrame,
@@ -284,6 +288,10 @@ class WAPEB(TimeSeriesScorer):
     ----------
     - `VN1 Forecasting Accuracy Challenge <https://www.datasource.ai/en/home/data-science-competitions-for-startups/vn1-forecasting-accuracy-challenge-phase-1/description>`_
     """
+
+    # Target mean (RMSE + no median paste) to avoid underforecasting on intermittent series
+    optimized_by_median = False
+    equivalent_tabular_regression_metric = "root_mean_squared_error"
 
     def compute_metric(
         self,

--- a/timeseries/src/autogluon/timeseries/metrics/point.py
+++ b/timeseries/src/autogluon/timeseries/metrics/point.py
@@ -128,6 +128,45 @@ class MAE(TimeSeriesScorer):
         return self._safemean(errors)
 
 
+class MAEB(TimeSeriesScorer):
+    r"""Mean absolute error with a bias penalty.
+
+    Adds a penalty for systematically biased (over- or under-) forecasts to :class:`MAE`. Defined as the mean absolute
+    error plus the absolute mean forecast bias.
+
+    .. math::
+
+        \operatorname{MAEB} = \frac{1}{N} \frac{1}{H} \sum_{i=1}^{N} \sum_{t=T+1}^{T+H} |y_{i,t} - f_{i,t}| + \left| \frac{1}{N} \frac{1}{H} \sum_{i=1}^{N} \sum_{t=T+1}^{T+H} (f_{i,t} - y_{i,t}) \right|
+
+    The first term measures forecast accuracy (as in MAE), while the second term penalizes forecast bias (the mean net
+    over- or under-forecast). This discourages models that achieve low error by systematically under-forecasting
+    demand, which is a common failure mode when optimizing MAE on intermittent (sparse) time series.
+
+    Properties:
+
+    - scale-dependent (time series with large absolute value contribute more to the loss)
+    - equivalent to :class:`MAE` when the forecast is unbiased (mean net error is zero)
+
+    See :class:`WAPEB` for a scale-free version of this metric that normalizes the error across time series.
+    """
+
+    def compute_metric(
+        self,
+        data_future: TimeSeriesDataFrame,
+        predictions: TimeSeriesDataFrame,
+        target: str = "target",
+        **kwargs,
+    ) -> float:
+        y_true, y_pred = self._get_point_forecast_score_inputs(data_future, predictions, target=target)
+        y_true, y_pred = y_true.to_numpy(), y_pred.to_numpy()
+        abs_errors = np.abs(y_true - y_pred).reshape([-1, self.prediction_length])
+        biases = (y_pred - y_true).reshape([-1, self.prediction_length])
+        if self.horizon_weight is not None:
+            abs_errors = abs_errors * self.horizon_weight
+            biases = biases * self.horizon_weight
+        return self._safemean(abs_errors) + np.abs(self._safemean(biases))
+
+
 class WAPE(TimeSeriesScorer):
     r"""Weighted absolute percentage error.
 
@@ -167,6 +206,57 @@ class WAPE(TimeSeriesScorer):
             errors *= self.horizon_weight
             y_true = y_true.reshape([-1, self.prediction_length]) * self.horizon_weight
         return np.nansum(errors) / np.nansum(np.abs(y_true))
+
+
+class WAPEB(TimeSeriesScorer):
+    r"""Weighted absolute percentage error with a bias penalty.
+
+    Adds a penalty for systematically biased (over- or under-) forecasts to :class:`WAPE`. Defined as the sum of
+    absolute errors plus the absolute total forecast bias, divided by the sum of absolute time series values in the
+    forecast horizon.
+
+    .. math::
+
+        \operatorname{WAPEB} = \frac{\sum_{i=1}^{N} \sum_{t=T+1}^{T+H}  |y_{i,t} - f_{i,t}| + \left| \sum_{i=1}^{N} \sum_{t=T+1}^{T+H} (f_{i,t} - y_{i,t}) \right|}{\sum_{i=1}^{N} \sum_{t=T+1}^{T+H} |y_{i, t}|}
+
+    The numerator combines forecast accuracy (absolute error, as in WAPE) with forecast bias (the absolute net
+    over- or under-forecast). This discourages models that achieve low error by systematically under-forecasting
+    demand, which is a common failure mode for intermittent (sparse) time series. WAPEB is the scale-free counterpart
+    of :class:`MAEB`, analogous to how WAPE relates to MAE.
+
+    This metric was used to rank submissions in the VN1 Forecasting Accuracy Challenge (for non-negative target values,
+    :math:`\sum |y_{i,t}|` equals the total actual sales used to normalize the score in the competition).
+
+    Properties:
+
+    - scale-dependent (time series with large absolute value contribute more to the loss)
+    - equivalent to :class:`WAPE` when the forecast is unbiased (net error is zero)
+    - well-suited for sparse (intermittent) time series that contain many zeros
+
+    If ``self.horizon_weight`` is provided, the errors, the biases, and the target time series in the denominator will
+    all be re-weighted.
+
+    References
+    ----------
+    - `VN1 Forecasting Accuracy Challenge <https://www.datasource.ai/en/home/data-science-competitions-for-startups/vn1-forecasting-accuracy-challenge-phase-1/description>`_
+    """
+
+    def compute_metric(
+        self,
+        data_future: TimeSeriesDataFrame,
+        predictions: TimeSeriesDataFrame,
+        target: str = "target",
+        **kwargs,
+    ) -> float:
+        y_true, y_pred = self._get_point_forecast_score_inputs(data_future, predictions, target=target)
+        y_true, y_pred = y_true.to_numpy(), y_pred.to_numpy()
+        abs_errors = np.abs(y_true - y_pred).reshape([-1, self.prediction_length])
+        biases = (y_pred - y_true).reshape([-1, self.prediction_length])
+        if self.horizon_weight is not None:
+            abs_errors = abs_errors * self.horizon_weight
+            biases = biases * self.horizon_weight
+            y_true = y_true.reshape([-1, self.prediction_length]) * self.horizon_weight
+        return (np.nansum(abs_errors) + np.abs(np.nansum(biases))) / np.nansum(np.abs(y_true))
 
 
 class SMAPE(TimeSeriesScorer):

--- a/timeseries/src/autogluon/timeseries/metrics/point.py
+++ b/timeseries/src/autogluon/timeseries/metrics/point.py
@@ -167,6 +167,50 @@ class MAEB(TimeSeriesScorer):
         return self._safemean(abs_errors) + np.abs(self._safemean(biases))
 
 
+class BIAS(TimeSeriesScorer):
+    r"""Mean forecast bias (signed).
+
+    Measures the average net over- or under-forecast. Positive values indicate that the forecast systematically
+    *over-predicts* the target, negative values indicate systematic *under-prediction*.
+
+    .. math::
+
+        \operatorname{BIAS} = \frac{1}{N} \frac{1}{H} \sum_{i=1}^{N} \sum_{t=T+1}^{T+H} (f_{i,t} - y_{i,t})
+
+    Forecast bias is a standard diagnostic in demand and retail forecasting, where the *direction* of the error
+    matters: over-forecasting ties up inventory and capital, while under-forecasting causes stockouts.
+
+    .. warning::
+        Unlike other metrics, BIAS is **not** a loss function: its optimum is 0, and *both* positive and negative
+        values indicate a worse forecast. For this reason it can only be used to evaluate a trained predictor via
+        :meth:`~autogluon.timeseries.TimeSeriesPredictor.evaluate` and cannot be passed as ``eval_metric`` for model
+        selection (``evaluate_only=True``). To penalize forecast bias *during* model selection, use :class:`MAEB` or
+        :class:`WAPEB` instead, which combine forecast accuracy with an absolute bias penalty.
+
+    Properties:
+
+    - scale-dependent (time series with large absolute value contribute more to the metric)
+    """
+
+    evaluate_only = True
+    # Reported without a sign flip so that predictor.evaluate() returns the raw signed bias (positive = over-forecast).
+    greater_is_better_internal = True
+
+    def compute_metric(
+        self,
+        data_future: TimeSeriesDataFrame,
+        predictions: TimeSeriesDataFrame,
+        target: str = "target",
+        **kwargs,
+    ) -> float:
+        y_true, y_pred = self._get_point_forecast_score_inputs(data_future, predictions, target=target)
+        y_true, y_pred = y_true.to_numpy(), y_pred.to_numpy()
+        biases = (y_pred - y_true).reshape([-1, self.prediction_length])
+        if self.horizon_weight is not None:
+            biases = biases * self.horizon_weight
+        return self._safemean(biases)
+
+
 class WAPE(TimeSeriesScorer):
     r"""Weighted absolute percentage error.
 

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -216,6 +216,12 @@ class TimeSeriesPredictor:
             seasonal_period=eval_metric_seasonal_period,
             horizon_weight=horizon_weight,
         )
+        if self.eval_metric.evaluate_only:
+            raise ValueError(
+                f"eval_metric='{self.eval_metric.name}' cannot be used for model selection. It can only be used to "
+                f"evaluate a trained predictor via `predictor.evaluate(..., metrics='{self.eval_metric.name}')`. "
+                f"Please choose a different eval_metric."
+            )
         if quantile_levels is None:
             quantile_levels = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
         self.quantile_levels = sorted(quantile_levels)

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -80,6 +80,7 @@ class TimeSeriesPredictor:
         Point forecast metrics (these are always evaluated on the ``"mean"`` column of the predictions):
 
         - ``"MAE"``: mean absolute error
+        - ``"MAEB"``: mean absolute error with a bias penalty
         - ``"MAPE"``: mean absolute percentage error
         - ``"MASE"``: mean absolute scaled error
         - ``"MSE"``: mean squared error
@@ -88,6 +89,7 @@ class TimeSeriesPredictor:
         - ``"RMSSE"``: root mean squared scaled error
         - ``"SMAPE"``: "symmetric" mean absolute percentage error
         - ``"WAPE"``: weighted absolute percentage error
+        - ``"WAPEB"``: weighted absolute percentage error with a bias penalty
 
         For more information about these metrics, see :ref:`Forecasting Time Series - Evaluation Metrics <forecasting_metrics>`.
     eval_metric_seasonal_period : int, optional

--- a/timeseries/tests/unittests/test_metrics.py
+++ b/timeseries/tests/unittests/test_metrics.py
@@ -32,6 +32,10 @@ from .common import DUMMY_TS_DATAFRAME, get_data_frame_with_item_index, get_pred
 
 pytestmark = pytest.mark.filterwarnings("ignore")
 
+# Metrics that can be used for model selection (i.e., behave as a loss/score). Excludes diagnostic metrics such as
+# BIAS whose optimum is not achieved by minimizing/maximizing the value.
+SELECTION_METRICS = {name: cls for name, cls in AVAILABLE_METRICS.items() if not cls.evaluate_only}
+
 
 def get_ag_and_gts_metrics() -> list[tuple[str, GluonTSMetric]]:
     # Each entry is a tuple (ag_metric_name, gts_metric_object)
@@ -224,6 +228,37 @@ def test_when_forecast_is_unbiased_then_bias_penalized_metric_equals_base_metric
     assert bias_penalized.sign * bias_penalized(test, biased) > base.sign * base(test, biased)
 
 
+@pytest.mark.parametrize("offset, expected_sign", [(5.0, 1), (-5.0, -1), (0.0, 0)])
+def test_when_forecast_is_biased_then_bias_metric_has_correct_sign(offset, expected_sign):
+    # BIAS reports the signed mean net error (f - y): positive for over-forecasting, negative for under-forecasting,
+    # and zero for an unbiased forecast. It is reported in greater-is-better format, so no sign flip is applied.
+    prediction_length = 4
+    data = get_data_frame_with_item_index(["A", "B", "C"], data_length=12, columns=["target"])
+    train, test = data.train_test_split(prediction_length)
+    future = test.slice_by_timestep(-prediction_length, None)
+
+    bias = check_get_evaluation_metric("BIAS", prediction_length=prediction_length)
+    assert bias.sign == 1
+
+    predictions = future.rename(columns={"target": "mean"}).copy()
+    predictions["mean"] = future["target"].to_numpy() + offset
+    value = bias(test, predictions)
+    assert np.sign(np.round(value, 8)) == expected_sign
+    if expected_sign != 0:
+        assert np.isclose(value, offset)
+
+
+def test_when_evaluate_only_metric_passed_as_eval_metric_then_predictor_raises():
+    with pytest.raises(ValueError, match="cannot be used for model selection"):
+        TimeSeriesPredictor(eval_metric="BIAS")
+
+
+def test_when_evaluate_only_metric_used_in_evaluate_then_it_is_allowed():
+    # BIAS cannot be an eval_metric, but must still resolve via check_get_evaluation_metric (used by evaluate()).
+    scorer = check_get_evaluation_metric("BIAS", prediction_length=1)
+    assert scorer.evaluate_only
+
+
 @pytest.mark.parametrize("metric_cls", AVAILABLE_METRICS.values())
 def test_given_predictions_contain_nan_when_metric_evaluated_then_exception_is_raised(metric_cls):
     prediction_length = 5
@@ -338,7 +373,7 @@ def test_RMSLE(prediction_length, expected_result):
     assert np.isclose(ag_value, expected_result, atol=1e-5)
 
 
-@pytest.mark.parametrize("metric_name", AVAILABLE_METRICS)
+@pytest.mark.parametrize("metric_name", SELECTION_METRICS)
 def test_given_metric_is_optimized_by_median_when_model_predicts_then_median_is_pasted_to_mean_forecast(metric_name):
     pred = TimeSeriesPredictor(prediction_length=5, eval_metric=metric_name)
     pred.fit(DUMMY_TS_DATAFRAME, hyperparameters={"DeepAR": {"max_epochs": 1, "num_batches_per_epoch": 1}})
@@ -361,7 +396,7 @@ def test_when_perfect_predictions_passed_to_metric_then_score_equals_optimum(met
     assert score == eval_metric.optimum
 
 
-@pytest.mark.parametrize("metric_name", AVAILABLE_METRICS)
+@pytest.mark.parametrize("metric_name", SELECTION_METRICS)
 def test_when_better_predictions_passed_to_metric_then_score_improves(metric_name):
     prediction_length = 5
     eval_metric = check_get_evaluation_metric(metric_name, prediction_length=prediction_length)
@@ -473,7 +508,7 @@ def test_when_horizon_weight_is_zero_for_wrong_predictions_then_metric_value_is_
     assert np.allclose(score, 0.0)
 
 
-@pytest.mark.parametrize("metric_cls", AVAILABLE_METRICS.values())
+@pytest.mark.parametrize("metric_cls", SELECTION_METRICS.values())
 def test_when_horizon_weight_is_zero_for_correct_predictions_then_error_increases(
     metric_cls, partially_matching_predictions
 ):

--- a/timeseries/tests/unittests/test_metrics.py
+++ b/timeseries/tests/unittests/test_metrics.py
@@ -200,6 +200,30 @@ def test_when_no_missing_values_then_mql_equals_wql_times_mean_abs_target():
     assert np.isclose(mql_value, wql_value * mean_abs_target)
 
 
+@pytest.mark.parametrize("base_name, bias_name", [("MAE", "MAEB"), ("WAPE", "WAPEB")])
+def test_when_forecast_is_unbiased_then_bias_penalized_metric_equals_base_metric(base_name, bias_name):
+    # MAEB / WAPEB add an |aggregate bias| term to MAE / WAPE, so they equal the base metric when the forecast is
+    # unbiased (net error is zero) and strictly exceed it when the forecast is systematically biased.
+    prediction_length = 4
+    data = get_data_frame_with_item_index(["A", "B", "C"], data_length=12, columns=["target"])
+    train, test = data.train_test_split(prediction_length)
+    future = test.slice_by_timestep(-prediction_length, None)
+
+    base = check_get_evaluation_metric(base_name, prediction_length=prediction_length)
+    bias_penalized = check_get_evaluation_metric(bias_name, prediction_length=prediction_length)
+
+    # Errors alternate in sign, so the aggregate bias is zero -> bias-penalized metric equals the base metric
+    unbiased = future.rename(columns={"target": "mean"}).copy()
+    offsets = np.tile([3.0, -3.0], len(unbiased) // 2 + 1)[: len(unbiased)]
+    unbiased["mean"] = future["target"].to_numpy() + offsets
+    assert np.isclose(bias_penalized.sign * bias_penalized(test, unbiased), base.sign * base(test, unbiased))
+
+    # A constant positive offset makes the forecast systematically biased -> bias-penalized metric is larger
+    biased = future.rename(columns={"target": "mean"}).copy()
+    biased["mean"] = future["target"].to_numpy() + 5.0
+    assert bias_penalized.sign * bias_penalized(test, biased) > base.sign * base(test, biased)
+
+
 @pytest.mark.parametrize("metric_cls", AVAILABLE_METRICS.values())
 def test_given_predictions_contain_nan_when_metric_evaluated_then_exception_is_raised(metric_cls):
     prediction_length = 5


### PR DESCRIPTION
*Description of changes:*

Adds three forecast-bias metrics to `autogluon.timeseries`:

- **MAEB** (mean absolute error with bias): `MAE + |mean(f − y)|`. Scale-dependent; equals `MAE` when the forecast is unbiased.
- **WAPEB** (weighted absolute percentage error with bias): `(Σ|f − y| + |Σ(f − y)|) / Σ|y|`. Scale-free counterpart of MAEB (mirrors how `WAPE` relates to `MAE`); equals `WAPE` when unbiased. This is the metric used to rank submissions in the [VN1 Forecasting Accuracy Challenge](https://www.datasource.ai/en/home/data-science-competitions-for-startups/vn1-forecasting-accuracy-challenge-phase-1/description).
- **BIAS** (signed mean forecast bias, `mean(f − y)`): a diagnostic reported by `predictor.evaluate()`. Since its optimum is 0 and both signs indicate a worse forecast, it cannot be used as an `eval_metric` for model selection.

The bias term in MAEB/WAPEB discourages models that achieve low error by consistently under-forecasting — a common failure mode when optimizing `MAE`/`WAPE` on intermittent (sparse) time series. For that reason MAEB/WAPEB target a forecast between the median and the mean rather than the median.

All three are documented in the forecasting metrics tutorial and support `horizon_weight`. Added tests covering the unbiased-equals-base-metric property, the sign of BIAS, and that evaluate-only metrics are rejected as `eval_metric`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.