### PR TITLE
Allow xgboost v3.2

### DIFF
--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -39,7 +39,7 @@ extras_require = {
         "catboost>=1.2,<1.3",
     ],
     "xgboost": [
-        "xgboost>=2.0,<3.2",  # <{N+1} upper cap, where N is the latest released minor version
+        "xgboost>=2.0,<3.3",  # <{N+1} upper cap, where N is the latest released minor version
     ],
     "realmlp": [
         "pytabkit>=1.7.2,<1.8",

--- a/uv.lock
+++ b/uv.lock
@@ -778,9 +778,9 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'all'" },
     { name = "transformers", marker = "extra == 'mitra'" },
     { name = "transformers", marker = "extra == 'tabarena'" },
-    { name = "xgboost", marker = "extra == 'all'", specifier = ">=2.0,<3.2" },
-    { name = "xgboost", marker = "extra == 'tabarena'", specifier = ">=2.0,<3.2" },
-    { name = "xgboost", marker = "extra == 'xgboost'", specifier = ">=2.0,<3.2" },
+    { name = "xgboost", marker = "extra == 'all'", specifier = ">=2.0,<3.3" },
+    { name = "xgboost", marker = "extra == 'tabarena'", specifier = ">=2.0,<3.3" },
+    { name = "xgboost", marker = "extra == 'xgboost'", specifier = ">=2.0,<3.3" },
 ]
 provides-extras = ["lightgbm", "catboost", "xgboost", "realmlp", "interpret", "fastai", "tabm", "tabpfn", "tabdpt", "tabpfnmix", "mitra", "tabicl", "ray", "skex", "imodels", "skl2onnx", "all", "tabarena", "tests"]
 
@@ -6938,7 +6938,7 @@ wheels = [
 
 [[package]]
 name = "xgboost"
-version = "3.1.3"
+version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -6946,13 +6946,13 @@ dependencies = [
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/db/ff3eb8ff8cdf87a57cbb0f484234b4353178587236c4c84c1d307165c1f8/xgboost-3.1.3.tar.gz", hash = "sha256:0aeaa59d7ba09221a6fa75f70406751cfafdf3f149d0a91b197a1360404a28f3", size = 1237662, upload-time = "2026-01-10T00:20:13.458Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/bb/1eb0242409d22db725d7a88088e6cfd6556829fb0736f9ff69aa9f1e9455/xgboost-3.2.0.tar.gz", hash = "sha256:99b0e9a2a64896cdaf509c5e46372d336c692406646d20f2af505003c0c5d70d", size = 1263936, upload-time = "2026-02-10T11:03:05.542Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/a9/8668a5662c497c32ab127b7ca57d91153f499b31c725969a1e4147782e64/xgboost-3.1.3-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:e16a6c352ee1a4c19372a7b2bb75129e10e63adeeabd3d11f21b7787378e5a50", size = 2378032, upload-time = "2026-01-10T00:18:14.103Z" },
-    { url = "https://files.pythonhosted.org/packages/52/39/ec5c53228b091387e934d3d419e8e3a5ce98c1650d458987d6e254a15304/xgboost-3.1.3-py3-none-macosx_12_0_arm64.whl", hash = "sha256:a7a1d59f3529de0ad9089c59b6cc595cd7b4424feabcc06463c4bde41f202f74", size = 2211477, upload-time = "2026-01-10T00:18:34.409Z" },
-    { url = "https://files.pythonhosted.org/packages/99/f7/ceb06e6b959e5a8b303883482ecad346495641947679e3f735ae8ac1caa7/xgboost-3.1.3-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:2e31482633883b2e95fda6055db654bbfac82e10d91ad3d9929086ebd28eb1c4", size = 115346575, upload-time = "2026-01-10T00:19:11.44Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/9c/9d4ad7f586698bad52a570d2bf81138e500a5d9f32723c2b4ed1dd9252d8/xgboost-3.1.3-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:687504d1d76dc797df08b0dbe8b83d58629cdc06df52378f617164d16142bf2c", size = 115926894, upload-time = "2026-01-10T00:19:49.123Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/d8/4d4ae25452577f2dfabc66b60e712e7c01f9fe6c389fa88c546c2f427c4d/xgboost-3.1.3-py3-none-win_amd64.whl", hash = "sha256:3fe349b4c6030f0d66e166a3a6b7d470e776d530ea240d77335e36144cbe132a", size = 72011993, upload-time = "2026-01-10T00:17:42.98Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/49/6e4cdd877c24adf56cb3586bc96d93d4dcd780b5ea1efb32e1ee0de08bae/xgboost-3.2.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:2f661966d3e322536d9c448090a870fcba1e32ee5760c10b7c46bac7a342079a", size = 2507014, upload-time = "2026-02-10T10:50:57.44Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f1/c09ef1add609453aa3ba5bafcd0d1c1a805c1263c0b60138ec968f8ec296/xgboost-3.2.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:eabbd40d474b8dbf6cb3536325f9150b9e6f0db32d18de9914fb3227d0bef5b7", size = 2328527, upload-time = "2026-02-10T10:51:17.502Z" },
+    { url = "https://files.pythonhosted.org/packages/96/9f/d9914a7b8df842832850b1a18e5f47aaa071c217cdd1da2ae9deb291018b/xgboost-3.2.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:852eabc6d3b3702a59bf78dbfdcd1cb9c4d3a3b6e5ed1f8781d8b9512354fdd2", size = 131100954, upload-time = "2026-02-10T11:02:42.704Z" },
+    { url = "https://files.pythonhosted.org/packages/79/98/679de17c2caa4fd3b0b4386ecf7377301702cb0afb22930a07c142fcb1d8/xgboost-3.2.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:99b4a6bbcb47212fec5cf5fbe12347215f073c08967431b0122cfbd1ee70312c", size = 131748579, upload-time = "2026-02-10T10:54:40.424Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1661dd114a914a67e3f7ab66fa1382e7599c2a8c340f314ad30a3e2b4d08/xgboost-3.2.0-py3-none-win_amd64.whl", hash = "sha256:0d169736fd836fc13646c7ab787167b3a8110351c2c6bc770c755ee1618f0442", size = 101681668, upload-time = "2026-02-10T10:59:31.202Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Raises the xgboost upper cap from `<3.2` to `<3.3` (xgboost 3.2.0 released), plus the matching `uv.lock` update (xgboost 3.1.3 → 3.2.0; no new transitive dependencies).

## Verification (xgboost 3.2.0 vs 3.1.3)

- **Unit tests**: `test_xgboost.py` passes on 3.2.0.
- **Results**: `XGBoostModel` fits (fixed seed) on four small TabArena datasets — blood-transfusion-service-center (binary), credit-g (binary, categorical-heavy), anneal (multiclass), QSAR_fish_toxicity (regression) — each with `enable_categorical` False (OHE path) and True (native path). 6/8 cases produce bit-identical prediction probabilities; the two anneal cases drift at the 1e-5 probability level with marginally *better* log loss, consistent with 3.2.0's adaptive CPU histogram block sizing. Outputs are deterministic within-version (verified with repeat runs).
- **Runtime**: differences are within run-to-run machine noise (repeat runs of the same version show larger spread than the version deltas).

## Why the cap stops at <3.3

xgboost **3.3.0** (latest) is deliberately excluded:

1. It enables categorical support by default, and its new categorical container **validates predict-time categories against those observed in the training data**. `XGBoostModel`'s `enable_categorical=True` path — used by the shipped 2025 zeroshot portfolio configs — ordinal-recodes categories in a way that produces predict-time codes outside that set (declared-but-unobserved levels, unseen→sentinel mapping), which now hard-errors at predict: `XGBoostError: Found a category not in the training set` (reproduced on the anneal task; tolerated through 3.2).
2. 3.3.0 requires Python ≥3.12.

Everything that does run on 3.3.0 is bit-identical to 3.2.0 (verified in a Python 3.12 environment), so once the categorical preprocessing is reworked to match 3.3's train-observed-categories contract, the cap can move to `<3.4` in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi