### PR TITLE
Support xgboost v3.3: shared fit/predict category space for enable_categorical

### DIFF
--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -39,7 +39,7 @@ extras_require = {
         "catboost>=1.2,<1.3",
     ],
     "xgboost": [
-        "xgboost>=2.0,<3.3",  # <{N+1} upper cap, where N is the latest released minor version
+        "xgboost>=2.0,<3.4",  # <{N+1} upper cap, where N is the latest released minor version
     ],
     "realmlp": [
         "pytabkit>=1.7.2,<1.8",

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -5,7 +5,6 @@ import math
 import os
 import time
 
-import numpy as np
 import pandas as pd
 
 from autogluon.common.features.types import R_BOOL, R_CATEGORY, R_FLOAT, R_INT
@@ -85,16 +84,20 @@ class XGBoostModel(AbstractModel):
         if self._ohe:
             X = self._ohe_generator.transform(X)
         else:
-            # FIXME: same code as in RealMLP, make it a general function in the future.
-            # Avoid bad dtype for cat categories in later ordinal encoding.
-            # Maps unseen categories to a new high integer.
+            # Ordinal-encode categoricals into a code space shared by fit and predict: every
+            # column is declared with the full code range of the fit-time category mapping,
+            # so train and predict frames carry identical category sets. Required by
+            # xgboost >= 3.3, which records the fit-time categories and rejects predict-time
+            # values outside them (per-frame category sets only contain the values a frame
+            # happens to observe, so predict-time codes for levels unobserved at fit would be
+            # rejected). Categories unseen at fit and missing values become NaN (missing).
             if self._category_mapping is not None:
                 for col in self._cat_col_names:
                     mapping = self._category_mapping[col]
-                    X[col] = X[col].astype(object).map(mapping)
-                    nan_mask = X[col].isna()
-                    X[col] = X[col].fillna(-1).astype(int).astype("category")
-                    X.loc[nan_mask, col] = np.nan
+                    # unseen categories and NaN map to -1, which the declared range excludes,
+                    # so pandas turns them into NaN
+                    codes = X[col].astype(object).map(mapping).fillna(-1).astype(int)
+                    X[col] = pd.Categorical(codes, categories=range(len(mapping)))
 
         return X
 

--- a/tabular/tests/unittests/models/test_xgboost.py
+++ b/tabular/tests/unittests/models/test_xgboost.py
@@ -1,3 +1,7 @@
+import numpy as np
+import pandas as pd
+
+from autogluon.core.metrics import get_metric
 from autogluon.tabular.models.xgboost.xgboost_model import XGBoostModel
 from autogluon.tabular.testing import FitHelper
 
@@ -17,3 +21,47 @@ def test_xgboost_binary_enable_categorical():
     )
     dataset_name = "toy_binary"
     FitHelper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, refit_full=False)
+
+
+def test_xgboost_enable_categorical_predict_time_categories():
+    """Prediction with enable_categorical=True must handle categories that fit never observed.
+
+    xgboost >= 3.3 records the fit-time categories and rejects predict-time values outside
+    them, so the model's ordinal encoding must put fit and predict frames in one shared
+    category space: declared-but-unobserved levels stay predictable, and truly novel
+    categories or NaN are treated as missing.
+    """
+    rng = np.random.default_rng(0)
+    n = 100
+    levels = ["a", "b", "c", "rare"]
+    X_train = pd.DataFrame(
+        {
+            "num": rng.normal(size=n),
+            # "rare" is a declared level that never occurs in the training rows
+            "cat": pd.Categorical(rng.choice(["a", "b", "c"], size=n), categories=levels),
+        }
+    )
+    y_train = pd.Series(rng.integers(0, 2, size=n))
+    model = XGBoostModel(
+        name="XGB",
+        path="",
+        problem_type="binary",
+        eval_metric=get_metric("log_loss", problem_type="binary"),
+        hyperparameters={"enable_categorical": True, "n_estimators": 10},
+    )
+    model.fit(X=X_train, y=y_train)
+
+    X_test = pd.DataFrame(
+        {
+            "num": rng.normal(size=4),
+            "cat": pd.Categorical(["a", "rare", None, "b"], categories=levels),
+        }
+    )
+    y_pred_proba = model.predict_proba(X_test)
+    assert len(y_pred_proba) == len(X_test)
+
+    # a category the fit never declared is treated as missing rather than raising
+    X_test_novel = X_test.copy()
+    X_test_novel["cat"] = pd.Categorical(["z"] * len(X_test))
+    y_pred_proba_novel = model.predict_proba(X_test_novel)
+    assert len(y_pred_proba_novel) == len(X_test_novel)

--- a/uv.lock
+++ b/uv.lock
@@ -595,7 +595,8 @@ all = [
     { name = "spacy" },
     { name = "torch" },
     { name = "transformers" },
-    { name = "xgboost" },
+    { name = "xgboost", version = "3.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "xgboost", version = "3.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 catboost = [
     { name = "catboost" },
@@ -658,7 +659,8 @@ tabarena = [
     { name = "tabpfn" },
     { name = "torch" },
     { name = "transformers" },
-    { name = "xgboost" },
+    { name = "xgboost", version = "3.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "xgboost", version = "3.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 tabdpt = [
     { name = "tabdpt" },
@@ -693,7 +695,8 @@ tests = [
     { name = "torch" },
 ]
 xgboost = [
-    { name = "xgboost" },
+    { name = "xgboost", version = "3.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "xgboost", version = "3.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 
 [package.metadata]
@@ -778,9 +781,9 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'all'" },
     { name = "transformers", marker = "extra == 'mitra'" },
     { name = "transformers", marker = "extra == 'tabarena'" },
-    { name = "xgboost", marker = "extra == 'all'", specifier = ">=2.0,<3.3" },
-    { name = "xgboost", marker = "extra == 'tabarena'", specifier = ">=2.0,<3.3" },
-    { name = "xgboost", marker = "extra == 'xgboost'", specifier = ">=2.0,<3.3" },
+    { name = "xgboost", marker = "extra == 'all'", specifier = ">=2.0,<3.4" },
+    { name = "xgboost", marker = "extra == 'tabarena'", specifier = ">=2.0,<3.4" },
+    { name = "xgboost", marker = "extra == 'xgboost'", specifier = ">=2.0,<3.4" },
 ]
 provides-extras = ["lightgbm", "catboost", "xgboost", "realmlp", "interpret", "fastai", "tabm", "tabpfn", "tabdpt", "tabpfnmix", "mitra", "tabicl", "ray", "skex", "imodels", "skl2onnx", "all", "tabarena", "tests"]
 
@@ -6940,11 +6943,17 @@ wheels = [
 name = "xgboost"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+]
 dependencies = [
-    { name = "numpy" },
-    { name = "nvidia-nccl-cu12", marker = "sys_platform == 'linux'" },
+    { name = "numpy", marker = "python_full_version < '3.12'" },
+    { name = "nvidia-nccl-cu12", marker = "python_full_version < '3.12' and sys_platform == 'linux'" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/91/bb/1eb0242409d22db725d7a88088e6cfd6556829fb0736f9ff69aa9f1e9455/xgboost-3.2.0.tar.gz", hash = "sha256:99b0e9a2a64896cdaf509c5e46372d336c692406646d20f2af505003c0c5d70d", size = 1263936, upload-time = "2026-02-10T11:03:05.542Z" }
 wheels = [
@@ -6953,6 +6962,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/96/9f/d9914a7b8df842832850b1a18e5f47aaa071c217cdd1da2ae9deb291018b/xgboost-3.2.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:852eabc6d3b3702a59bf78dbfdcd1cb9c4d3a3b6e5ed1f8781d8b9512354fdd2", size = 131100954, upload-time = "2026-02-10T11:02:42.704Z" },
     { url = "https://files.pythonhosted.org/packages/79/98/679de17c2caa4fd3b0b4386ecf7377301702cb0afb22930a07c142fcb1d8/xgboost-3.2.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:99b4a6bbcb47212fec5cf5fbe12347215f073c08967431b0122cfbd1ee70312c", size = 131748579, upload-time = "2026-02-10T10:54:40.424Z" },
     { url = "https://files.pythonhosted.org/packages/1f/3d/1661dd114a914a67e3f7ab66fa1382e7599c2a8c340f314ad30a3e2b4d08/xgboost-3.2.0-py3-none-win_amd64.whl", hash = "sha256:0d169736fd836fc13646c7ab787167b3a8110351c2c6bc770c755ee1618f0442", size = 101681668, upload-time = "2026-02-10T10:59:31.202Z" },
+]
+
+[[package]]
+name = "xgboost"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+]
+dependencies = [
+    { name = "numpy", marker = "python_full_version >= '3.12'" },
+    { name = "nvidia-nccl-cu12", marker = "python_full_version >= '3.12' and sys_platform == 'linux'" },
+    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/41/846d4de2b8fc694073fd3ac5052caf68caa1ea11cb7fa32d7ad9c049b232/xgboost-3.3.0.tar.gz", hash = "sha256:58bcb8a4cace648cdab7b94fa4f16d2c9ff26d90dd4d26907168106fa06d8746", size = 1224702, upload-time = "2026-06-17T21:26:50.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/72/3b68983c0215ef65d48e9eeb1f168c3c6e3d62a61ece605de3209c79cae1/xgboost-3.3.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:07688a377046b8640897b62421150bf73c6cc7101823474ec6ad08b93290f587", size = 2553505, upload-time = "2026-06-17T21:21:32.146Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/62/b49e756822b29909d0c95ed334662dc6c7c81a99ec6bc10dc18e69f3d6e7/xgboost-3.3.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:af7cea10f418b7c251ddc8da440f57bdab2990b5fc9f74a35a92b0f150ea287d", size = 2376040, upload-time = "2026-06-17T21:22:01.981Z" },
+    { url = "https://files.pythonhosted.org/packages/47/3a/a0adcd1ee28f525bd5c9dc3ebe78a7599bf97c22866d6449f967b829e338/xgboost-3.3.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:624a83aeb1e7ba081719795db179f4ce6fff12e79de05cd9baf15ee48fd22f0e", size = 98180629, upload-time = "2026-06-17T21:24:00.804Z" },
+    { url = "https://files.pythonhosted.org/packages/47/1f/8b3e578cfd8e3bcdb4374e2bbe0b40b4e5320accb5cbdcf535ecc512eb5c/xgboost-3.3.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:f59edaf28eccd1c519788607c72ed907ee6cedfa933d706620bc1612d24b354e", size = 98716607, upload-time = "2026-06-17T21:26:21.058Z" },
+    { url = "https://files.pythonhosted.org/packages/07/6b/087fd5d28fdbb90d385c50ee9308a820241b82feebdf42e72e19a48e4b32/xgboost-3.3.0-py3-none-win_amd64.whl", hash = "sha256:b06057f6a018fc04e6b3e0c15568ca636b8151a5b5f333478e500fcaf4fc7594", size = 69522696, upload-time = "2026-06-17T21:20:53.707Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Follow-up to #5783, which capped xgboost at `<3.3` because 3.3.0 crashed `XGBoostModel`'s `enable_categorical=True` path (used by the 2025 zeroshot portfolio configs). This fixes the path and raises the cap to `<3.4`.

**Note: stacked on #5783** — merge that first; this diff includes it until then.

### The fix

xgboost 3.3 records the fit-time categories of each categorical column and rejects predict-time values outside them (probed: declared-but-unobserved levels and NaN are fine; only values absent from the fit frame's *declared* category list raise). The `enable_categorical` ordinal encoding built each frame's category set from the values that frame happened to observe, so a predict frame containing a level unobserved at fit crashed with `Found a category not in the training set`.

The encoding now declares the full code range of the fit-time category mapping on every frame — fit and predict share one category space:

```python
codes = X[col].astype(object).map(mapping).fillna(-1).astype(int)
X[col] = pd.Categorical(codes, categories=range(len(mapping)))
```

Categories unseen at fit and missing values become NaN (missing), matching the previous effective behavior.

### Version handling

- Cap raised to `<3.4`; `uv.lock` forks xgboost by Python version (3.2.0 for `<3.12`, 3.3.0 for `>=3.12`) since 3.3.0 requires Python ≥3.12.
- The now-default `enable_categorical` in 3.3 doesn't affect AutoGluon's default path (OHE — xgboost never sees category dtypes there); AutoGluon's own `enable_categorical` hyperparameter keeps controlling the behavior explicitly.

## Verification

- **No behavior change on ≤3.2**: the new encoding is bit-identical to the old one on xgboost 3.2.0 across four small TabArena datasets (blood-transfusion, credit-g, anneal, QSAR_fish_toxicity) in both `enable_categorical` modes (8/8 cells).
- **3.3.0 works**: all 8 cells run, including the previously-crashing anneal case. Comparing 3.2.0 vs 3.3.0 with identical code in the same Python 3.12 environment: blood-transfusion and anneal are bit-identical; QSAR and credit-g drift slightly (~0.02 log-loss/RMSE in a no-early-stopping regime) — QSAR is numeric-only, so this is upstream 3.3 core-algorithm drift, unrelated to categoricals or this change.
- **New unit test** (`test_xgboost_enable_categorical_predict_time_categories`) covers the predict-time cases that previously had no coverage: declared-but-unobserved level, NaN, and a novel category (treated as missing). Tests pass on 3.2.0 (py3.11) and 3.3.0 (py3.12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi