### PR TITLE
TabDPT: default to sequential fold fitting

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_model.py
+++ b/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_model.py
@@ -66,6 +66,12 @@ class TabDPTModel(AbstractTorchModel):
     minimum_num_gpus = 0.5
     _default_ag_args_ensemble_extra = {
         "refit_folds": True,
+        # Sequential fold fitting is much faster for TabDPT: a child fit is near-instant
+        # (in-context model), so parallel fold workers pay far more in per-worker CUDA
+        # context + checkpoint loading than they save. Benchmarked on 1 GPU with an
+        # 8-fold bag: sequential is 2-4x faster than any parallel fold split
+        # (0.125/0.25/0.5 GPU per fold) at both 600 and 30k train rows.
+        "fold_fitting_strategy": "sequential_local",
     }
     default_resources_physical_cores_only = True
     default_num_gpus = 1


### PR DESCRIPTION
## Description

Adds `"fold_fitting_strategy": "sequential_local"` to `TabDPTModel._default_ag_args_ensemble_extra` (inherited by `TabDPTTurboModel`), so bagged TabDPT fits its folds sequentially by default instead of in parallel Ray workers.

## Motivation

A TabDPT child fit is near-instant (in-context model: fit = store data + build context, ~0.25s per fold after the first). Parallel fold fitting pays a per-worker Ray process spawn + fresh CUDA context + checkpoint load that far exceeds the work being parallelized. TabDPT's `minimum_num_gpus = 0.5` opts it into 2-worker parallel fold fitting whenever a full GPU is granted, so the default path was consistently slower — and could deadlock outright when the Ray pool is smaller than the resources the predictor detects.

## Benchmarks

**Single GPU, 8-fold bag, TabDPT-Turbo, 16 CPUs** (parallel splits below 0.5 GPU/fold require lowering `minimum_num_gpus`; measured with `refit_folds=False` to isolate the fold phase):

| mode | workers x GPU | anneal (598 rows) wall s | bank-marketing (30k rows) wall s |
|------|---------------|--------------------------|----------------------------------|
| **sequential** | 1 x 1.0 | **8.6** | **20.0** |
| parallel | 2 x 0.5 | 31.9 | 44.8 |
| parallel | 4 x 0.25 | 21.3 | 33.6 |
| parallel | 8 x 0.125 | 19.7 | 30.0 |

Validation scores are bit-identical across all modes.

**End-to-end A/B on a benchmark sweep** (TabArena tiny suite, first split, 18 datasets, 4-model portfolio incl. TabDPT-Turbo, one RTX PRO 6000 per job): TabDPT-Turbo bag fits drop 4.2-10.6x per dataset (445s -> 63s total across the 13 datasets that fit it), total sweep wall clock drops ~30%, metric errors unchanged (13/16 bit-identical, rest <=1e-6 drift) and leaderboard Elo/rank/winrate identical to every printed digit.

The caveat: on much larger datasets where a per-fold fit+OOF-predict takes minutes, the fixed worker overhead would amortize and parallel folds could win. The default targets the common case; users can still opt back in via `ag_args_ensemble: {"fold_fitting_strategy": "parallel_local"}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi