### PR TITLE
Allow tabpfn v8.1-8.2 and tabicl v2.1

### DIFF
--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -50,6 +50,9 @@ extras_require = {
     "fastai": [
         "spacy<3.9",
         "torch",  # version range defined in `core/_setup_utils.py`
+        # Held below 2.8.8: that release requires fastcore>=1.14.6, but the highest fastcore 1.x
+        # is 1.14.5, so it is unreachable under the fastcore<2 cap below. Lifting that cap needs
+        # the removed L.starmap usage replaced first.
         "fastai>=2.3.1,<2.8.8",  # Cap for major version
         "fastcore<2",  # Breaking change in v2: removed L.starmap, which breaks fastai models
     ],
@@ -57,7 +60,7 @@ extras_require = {
         "torch",  # version range defined in `core/_setup_utils.py`
     ],
     "tabpfn": [
-        "tabpfn>=8.0,<8.1",  # <{N+1} upper cap, where N is the latest released minor version; >=8.0 for the TabPFN-3 checkpoints
+        "tabpfn>=8.0,<8.3",  # <{N+1} upper cap, where N is the latest released minor version; >=8.0 for the TabPFN-3 checkpoints
     ],
     "tabdpt": [
         "tabdpt>=1.2,<1.3",  # >=1.2 for TabDPT-Turbo; v1.1 weights stay pinned per model class
@@ -77,7 +80,7 @@ extras_require = {
         "einops>=0.7,<0.9",
     ],
     "tabicl": [
-        "tabicl>=2.0,<2.1",
+        "tabicl>=2.0,<2.2",  # <{N+1} upper cap, where N is the latest released minor version
     ],
     # NOTE: synthefy-nori (used by NoriModel) is deliberately NOT declared as an extra.
     # It requires huggingface_hub>=1.0, which is incompatible with the huggingface_hub<1.0

--- a/uv.lock
+++ b/uv.lock
@@ -765,12 +765,12 @@ requires-dist = [
     { name = "tabdpt", marker = "extra == 'tabarena'", specifier = ">=1.2,<1.3" },
     { name = "tabdpt", marker = "extra == 'tabdpt'", specifier = ">=1.2,<1.3" },
     { name = "tabdpt", marker = "extra == 'tests'", specifier = ">=1.2,<1.3" },
-    { name = "tabicl", marker = "extra == 'tabarena'", specifier = ">=2.0,<2.1" },
-    { name = "tabicl", marker = "extra == 'tabicl'", specifier = ">=2.0,<2.1" },
-    { name = "tabicl", marker = "extra == 'tests'", specifier = ">=2.0,<2.1" },
-    { name = "tabpfn", marker = "extra == 'tabarena'", specifier = ">=8.0,<8.1" },
-    { name = "tabpfn", marker = "extra == 'tabpfn'", specifier = ">=8.0,<8.1" },
-    { name = "tabpfn", marker = "extra == 'tests'", specifier = ">=8.0,<8.1" },
+    { name = "tabicl", marker = "extra == 'tabarena'", specifier = ">=2.0,<2.2" },
+    { name = "tabicl", marker = "extra == 'tabicl'", specifier = ">=2.0,<2.2" },
+    { name = "tabicl", marker = "extra == 'tests'", specifier = ">=2.0,<2.2" },
+    { name = "tabpfn", marker = "extra == 'tabarena'", specifier = ">=8.0,<8.3" },
+    { name = "tabpfn", marker = "extra == 'tabpfn'", specifier = ">=8.0,<8.3" },
+    { name = "tabpfn", marker = "extra == 'tests'", specifier = ">=8.0,<8.3" },
     { name = "torch", marker = "extra == 'all'", specifier = ">=2.10,<2.14" },
     { name = "torch", marker = "extra == 'fastai'", specifier = ">=2.10,<2.14" },
     { name = "torch", marker = "extra == 'mitra'", specifier = ">=2.10,<2.14" },
@@ -873,15 +873,6 @@ requires-dist = [
     { name = "utilsforecast", specifier = ">=0.2.3,<0.2.12" },
 ]
 provides-extras = ["tests", "ray", "all"]
-
-[[package]]
-name = "backoff"
-version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
-]
 
 [[package]]
 name = "beartype"
@@ -1681,15 +1672,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/86/b2/d6fc3f2347f43dada79e5ff118493e8109c98400a0e29a1d5264a3aa479b/distlib-0.4.1.tar.gz", hash = "sha256:c3804d0d2d4b5fcd44036eb860cb6660485fcdf5c2aba53dc324d805837ea65b", size = 610526, upload-time = "2026-06-02T11:17:40.691Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/18/3497c4fa83a76dcb154923fd2075522e8dd6995ecee4093c00ae18160046/distlib-0.4.1-py2.py3-none-any.whl", hash = "sha256:9c2c552c68cbadc619f2d0ed3a69e27c351a3f4c9baa9ffb7df9e9cdc3d19a97", size = 469216, upload-time = "2026-06-02T11:17:38.779Z" },
-]
-
-[[package]]
-name = "distro"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
 ]
 
 [[package]]
@@ -3652,15 +3634,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nvidia-ml-py"
-version = "13.610.43"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/b5/a8fbc356f768fa5c9cfd646668fd7d34bf55bdd1c6e20754642a64d930d4/nvidia_ml_py-13.610.43.tar.gz", hash = "sha256:65437eb73d68d0c62c931ca4d45038472faff03bd0b8729abba4b899f70d60f2", size = 52109, upload-time = "2026-06-01T18:54:08.829Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/45/caa600acfab94560807a20a64b5830d2cd3c3202b7f1328644d70b7d6bd8/nvidia_ml_py-13.610.43-py3-none-any.whl", hash = "sha256:f13c72698edef492f985cc225f14faafe68ae065a2e407f45bdf6f4b9b43fde8", size = 53163, upload-time = "2026-06-01T18:54:07.704Z" },
-]
-
-[[package]]
 name = "nvidia-ml-py3"
 version = "7.352.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4285,21 +4258,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/29/7b3de57cd86430fd00d71bc5a8a078bf2c63d4ada7fdfb30853fe976a19f/plum_dispatch-2.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36662d76ae6d87aaa041fade036d2242f0b88b68c9fb4c96b7ba0026320065d3", size = 204734, upload-time = "2026-04-28T08:38:30.398Z" },
     { url = "https://files.pythonhosted.org/packages/ba/98/23d19326af0da251bb98a39f517ab6da983e5aad5eb9cc398b60933df2cc/plum_dispatch-2.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:a0d16daf09482a6588025e9f133a338d99474e8dd3c3dbbc4c5282a4fffe5a0e", size = 152624, upload-time = "2026-04-28T08:38:31.886Z" },
     { url = "https://files.pythonhosted.org/packages/64/a7/ee4d01d26032b060d379f44a29124180f756d907e3840d3bc450f8a0d2a7/plum_dispatch-2.9.0-py3-none-any.whl", hash = "sha256:5a516cdac5460343937a2b813562ac00b0eeac973ac023916e538610bdf34397", size = 45328, upload-time = "2026-04-28T08:38:33.022Z" },
-]
-
-[[package]]
-name = "posthog"
-version = "7.18.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "backoff" },
-    { name = "distro" },
-    { name = "requests" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/41/d7922b23d9f3dec427286b13f8f15b12c08eea3950a6cfd53979a54aed91/posthog-7.18.0.tar.gz", hash = "sha256:560230cf9616ac1fde5e3bfba1c666ab69e8488e5417005f86f91f7c6ef74252", size = 229913, upload-time = "2026-06-05T13:56:22.577Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/33/cb300af867a22c5e1680f6d1ebe5242ebe7de8280a82a5759e16211e28ee/posthog-7.18.0-py3-none-any.whl", hash = "sha256:9913586a958e5e81dbb1cdc4d4bedc8f95a268807b17ad03b5c55d2adff55dd7", size = 268498, upload-time = "2026-06-05T13:56:20.855Z" },
 ]
 
 [[package]]
@@ -6153,7 +6111,7 @@ wheels = [
 
 [[package]]
 name = "tabicl"
-version = "2.0.3"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "einops" },
@@ -6167,14 +6125,14 @@ dependencies = [
     { name = "torch" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/c0/63b5f976a35dcb5e2c2c027b82c13354ed48ef5294f979275a112cd3a2d8/tabicl-2.0.3.tar.gz", hash = "sha256:28600805a82b9d806c810c1e6e3c25767988c332ff61d6a65189371c14ee3d1f", size = 1427845, upload-time = "2026-03-02T20:43:06.295Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/c3/ef8bcc7645bc1eedae4563df6429f6f5438aaea5e293682a9367bf2c2ddb/tabicl-2.1.1.tar.gz", hash = "sha256:7abdb1fa878e7a1edfa1c6606bf4189e9cccc20935e8011d7e690f4693c9c5c5", size = 224680, upload-time = "2026-04-29T15:57:46.302Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/8b/cee614e8d43f98aeb07b40e0ad40d854badc46b4c2879512eef469d390d1/tabicl-2.0.3-py3-none-any.whl", hash = "sha256:16c8524d5039922df0d94389d4511e384c7b8a00e9aabedce0bbf672379e339d", size = 206513, upload-time = "2026-03-02T20:43:07.844Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d3/f6eadcef58322b1b0253df1c17d9230db9934274f52e0d952458f6c6ab41/tabicl-2.1.1-py3-none-any.whl", hash = "sha256:cb4405cc93335c688bc9bcb703c7944032fcf542b43ebb66820f1a5acb5651b1", size = 252909, upload-time = "2026-04-29T15:57:47.775Z" },
 ]
 
 [[package]]
 name = "tabpfn"
-version = "8.0.8"
+version = "8.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "einops" },
@@ -6192,35 +6150,13 @@ dependencies = [
     { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "tabpfn-common-utils" },
     { name = "torch" },
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/65/3e8de3115a1588c58d190a6c26aa8499303f625c6a811eb9dba42d4fa888/tabpfn-8.0.8.tar.gz", hash = "sha256:0bdbc438f2920fb98232a136ee79e01d06499f3883491704ddae332d205e7a43", size = 764626, upload-time = "2026-06-10T15:27:42.401Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/da/657c9c8d6ec9a72eb4c27d8e02e1e5d20faf188783cfd44d1ba591d4fcce/tabpfn-8.2.0.tar.gz", hash = "sha256:05361a6d68654fee182809718b29bb7b1add233b51148479e946bb46bf39df4e", size = 770054, upload-time = "2026-07-28T15:00:52.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/b5/bd2262ddf99193c440b96e4a4e1609ef02017bc030dd23e9da2d92e111fa/tabpfn-8.0.8-py3-none-any.whl", hash = "sha256:b6c945c8bf23b86f595697fcfa4ce58d84105441baf7e1313edc7865d7d29658", size = 753248, upload-time = "2026-06-10T15:27:40.466Z" },
-]
-
-[[package]]
-name = "tabpfn-common-utils"
-version = "0.2.21"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "filelock" },
-    { name = "numpy" },
-    { name = "nvidia-ml-py" },
-    { name = "pandas" },
-    { name = "platformdirs" },
-    { name = "posthog" },
-    { name = "requests" },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/6d/3035d1d809e1243c1785ef218a21d87ce6c5a5750dcbb09d32e15e2c981f/tabpfn_common_utils-0.2.21.tar.gz", hash = "sha256:dc4f00c8a5e759fa91210eb19adfebe201ec49edc354075fe6e65031b0f76053", size = 1982106, upload-time = "2026-04-28T07:31:44.536Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/55/97fb9d02a5d4e28abd9e76b90b9ab2366df828588024d713ebb37750aead/tabpfn_common_utils-0.2.21-py3-none-any.whl", hash = "sha256:480b2f24a6150bc10a49485ca5e88885ffa476499ddc3d0c5f8080b379955cb9", size = 39799, upload-time = "2026-04-28T07:31:43.099Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b4/3e919ea30abb4b9bf633d86704284f028b567e1d24187338924567e0f4b5/tabpfn-8.2.0-py3-none-any.whl", hash = "sha256:c9432bd301038764db210723e1a49569c4285310a2ecbecd1972241c9d6df290", size = 732336, upload-time = "2026-07-28T15:00:50.766Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps `tabpfn` to `<8.3` and `tabicl` to `<2.2`, following the `<{N+1}` upper-cap convention (latest released minors are 8.2 and 2.1).

`fastai` is deliberately **not** bumped — see below.

## Testing

Installed tabpfn 8.2.0 and tabicl 2.1.1, then ran the affected model tests: `test_tabicl`, `test_tabpfn3`, and `test_tabular_nn_fastai` — **15 passed, 1 skipped**.

`test_tabpfnv2` fails locally, but identically on the currently-supported tabpfn 8.0.8, so it is a pre-existing environment failure (a CUDA-hidden subprocess check) rather than a regression from this bump. Verified by downgrading and re-running the same test.

## Lock changes

`uv.lock` gains tabpfn 8.2.0 / tabicl 2.1.1 and *loses* four packages: tabpfn 8.2.0 drops its `tabpfn-common-utils[telemetry-interactive]` dependency, which was pulling in `backoff`, `distro`, `nvidia-ml-py` and `posthog`.

## Why fastai stays at `<2.8.8`

fastai 2.8.8 requires `fastcore>=1.14.6`, but the highest released fastcore 1.x is **1.14.5** — so 2.8.8 is unreachable under the existing `fastcore<2` cap. That cap is load-bearing: fastcore v2 removed `L.starmap`, which the fastai models use.

Supporting fastai 2.8.8 is therefore a code change rather than a version bump — the `L.starmap` usage has to be replaced before `fastcore<2` can be lifted. Worth noting that a plain `pip install -U fastai` silently upgrades fastcore to 2.x to satisfy the requirement, so this is easy to break accidentally in a dev environment.

The reasoning is recorded as a comment next to the pin so the next person does not retry the bump blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi