### PR TITLE
Express the auto-selected validation method as size curves

### DIFF
--- a/common/src/autogluon/common/utils/validation_structure.py
+++ b/common/src/autogluon/common/utils/validation_structure.py
@@ -142,6 +142,11 @@ class ValidationStructure:
         channel) are what make repeated grouped cross-validation possible: the ``groups``
         channel forces leave-one-group-out with ``n_repeats == 1``.
 
+        These clamps are the *feasibility* half of choosing a validation method: the caller's
+        requested counts are the policy (see AutoGluon's validation size curves), and this
+        reduces them only where the data cannot support what was asked. It never raises them,
+        so a caller may treat the request as an upper bound.
+
         Clamping rules, each of which also forces ``num_repeats = 1`` because the resulting
         partition is deterministic and repeating it would only duplicate work:
 

--- a/common/src/autogluon/common/utils/validation_structure.py
+++ b/common/src/autogluon/common/utils/validation_structure.py
@@ -33,6 +33,13 @@ class ValidationStructure:
         to the label for classification when combined with ``group_on``; for time-based
         splits it only influences how the contiguous blocks are assigned to fold indices,
         never the block boundaries themselves.
+    size_validation_on_groups : bool, default False
+        If True, the automatically selected validation method (fold count, repeats, extra
+        holdout, stack depth) is chosen from the number of groups rather than the number of
+        rows. Rows within a group are not independent, so the group count is often the sample
+        size that matters -- a task with 4,672 rows across 68 groups is large by rows and small
+        by groups -- but which applies is a judgement about the data, so this is opt-in. Has no
+        effect unless ``group_on`` or ``group_time_on`` is set.
     group_time_on : str, optional
         Column identifying groups that are *also* ordered in time (e.g. a session id whose
         sessions arrive in sequence). Whole groups are blocked in time order, so the splits
@@ -45,6 +52,7 @@ class ValidationStructure:
     time_on: str | None = None
     stratify_on: str | None = None
     group_time_on: str | None = None
+    size_validation_on_groups: bool = False
 
     def __post_init__(self):
         if self.group_on is not None and self.time_on is not None:
@@ -92,6 +100,16 @@ class ValidationStructure:
             return False
         groups = self._group_values(X)
         return bool(pd.Series(np.asarray(stratify)).groupby(np.asarray(groups)).nunique().max() == 1)
+
+    def num_group_instances(self, X: pd.DataFrame) -> int | None:
+        """Number of distinct groups, or None when this structure declares no grouping.
+
+        The independent-unit count for grouped data, which callers may use as the sample size
+        for size-dependent decisions (see :attr:`size_validation_on_groups`).
+        """
+        if self.group_on is None and self.group_time_on is None:
+            return None
+        return self._num_group_instances(X)
 
     def _num_group_instances(self, X: pd.DataFrame) -> int:
         """Effective sample size: distinct groups when grouped, else row count."""

--- a/common/src/autogluon/common/utils/validation_structure.py
+++ b/common/src/autogluon/common/utils/validation_structure.py
@@ -148,6 +148,18 @@ class ValidationStructure:
                     random_state=random_state,
                 )
             )
+            if num_repeats > 1:
+                logger.log(
+                    20,
+                    f"validation_structure: a temporal partition is deterministic, so repeats add "
+                    f"nothing; num_repeats reduced from {num_repeats} to 1.",
+                )
+            if len(splits) != num_folds:
+                logger.log(
+                    20,
+                    f"validation_structure: {self.time_on or self.group_time_on!r} supports "
+                    f"{len(splits)} time blocks (requested {num_folds} folds).",
+                )
             return splits, len(splits), 1
 
         if self.group_on is not None:

--- a/tabular/src/autogluon/tabular/configs/pipeline_presets.py
+++ b/tabular/src/autogluon/tabular/configs/pipeline_presets.py
@@ -147,6 +147,8 @@ def get_validation_and_stacking_method(
     problem_type: PROBLEM_TYPES,
     hpo_enabled: bool,
     n_samples_minority_class: int | None,
+    num_group_instances: int | None = None,
+    size_on_groups: bool = False,
 ) -> tuple[int, int, int, bool, bool, float, bool]:
     """Get the validation method for AutoGluon via a heuristic.
 
@@ -179,12 +181,21 @@ def get_validation_and_stacking_method(
     n_samples_minority_class: int | None
         The number of samples in the minority class for classification problems.
         None for regression problems.
+    num_group_instances: int | None
+        The number of independent groups, when the data declares a grouping. None otherwise.
+    size_on_groups: bool
+        If True, size-dependent choices read `num_group_instances` instead of `num_train_rows`.
 
     Returns:
     --------
     Returns all variables needed to define the validation method.
     """
-    cv_preset = _get_validation_preset(num_train_rows=num_train_rows, hpo_enabled=hpo_enabled)
+    cv_preset = _get_validation_preset(
+        num_train_rows=num_train_rows,
+        hpo_enabled=hpo_enabled,
+        num_group_instances=num_group_instances,
+        size_on_groups=size_on_groups,
+    )
 
     # Independent of `auto_stack`
     if use_bag_holdout is None:

--- a/tabular/src/autogluon/tabular/configs/pipeline_presets.py
+++ b/tabular/src/autogluon/tabular/configs/pipeline_presets.py
@@ -23,6 +23,13 @@ SizeCurve = "int | float | bool | None | list"
 
 #: Defaults for the auto-selected validation method. Numerically identical to the arithmetic
 #: they replaced, so behavior is unchanged until a curve is overridden.
+#:
+#: These curves are *policy*: what to ask for at a given data size. Feasibility is settled
+#: separately and afterwards -- ``ValidationStructure.custom_splits`` reduces the fold and
+#: repeat counts when the data cannot support what was asked (fewer groups than folds, a
+#: stratification value rarer than the fold count, a deterministic temporal partition) and
+#: returns what it used, which the caller adopts. So policy proposes and feasibility
+#: reduces; neither needs to know the other's rules.
 #:  - folds: max 8 because 8 cores per CPU is very common; down to 5 on small data so each
 #:    validation set stays large enough to be representative.
 #:  - repeats: 1. More repeats have not been observed to help, appearing to overfit the

--- a/tabular/src/autogluon/tabular/configs/pipeline_presets.py
+++ b/tabular/src/autogluon/tabular/configs/pipeline_presets.py
@@ -69,18 +69,48 @@ def resolve_size_curve(curve: SizeCurve, num_train_rows: int) -> int | float | b
     return fallback if fallback is not None or not anchors else anchors[-1][1]
 
 
+def resolve_effective_sample_size(
+    num_train_rows: int,
+    num_group_instances: int | None = None,
+    size_on_groups: bool = False,
+) -> int:
+    """The size the validation curves are read at.
+
+    Rows by default. With ``size_on_groups`` and a known ``num_group_instances``, the group
+    count is used instead: when rows within a group are not independent, the number of groups
+    is the sample size that governs how many folds the data can support and how noisy each
+    validation estimate is. The two can disagree sharply -- a benchmark task with 4,672 rows
+    across 68 groups looks large by rows and small by groups -- so which is right is a
+    judgement about the data, and this stays opt-in rather than inferred from the presence of
+    a grouping.
+    """
+    if size_on_groups and num_group_instances is not None:
+        return num_group_instances
+    return num_train_rows
+
+
 def _get_validation_preset(
     num_train_rows: int,
     hpo_enabled: bool,
     validation_curves: dict[str, SizeCurve] | None = None,
+    num_group_instances: int | None = None,
+    size_on_groups: bool = False,
 ) -> dict[str, int | float]:
-    """Recommended validation preset, resolved from size curves at ``num_train_rows``.
+    """Recommended validation preset, resolved from size curves at the effective sample size.
 
     ``validation_curves`` overrides individual entries of :data:`DEFAULT_VALIDATION_CURVES`,
     so a caller can retune one knob (e.g. repeats on small data) without restating the rest.
+    ``size_on_groups`` reads the curves at the group count instead of the row count -- see
+    :func:`resolve_effective_sample_size`. ``holdout_frac`` is always sized on rows, since it
+    is a fraction of the rows actually held out.
     """
     curves = {**DEFAULT_VALIDATION_CURVES, **(validation_curves or {})}
-    resolved = {key: resolve_size_curve(curve, num_train_rows) for key, curve in curves.items()}
+    effective_size = resolve_effective_sample_size(
+        num_train_rows=num_train_rows,
+        num_group_instances=num_group_instances,
+        size_on_groups=size_on_groups,
+    )
+    resolved = {key: resolve_size_curve(curve, effective_size) for key, curve in curves.items()}
     resolved["holdout_frac"] = round(
         default_holdout_frac(num_train_rows=num_train_rows, hyperparameter_tune=hpo_enabled), 4
     )

--- a/tabular/src/autogluon/tabular/configs/pipeline_presets.py
+++ b/tabular/src/autogluon/tabular/configs/pipeline_presets.py
@@ -38,7 +38,7 @@ SizeCurve = "int | float | bool | None | list"
 #:    editing this module.
 #:  - holdout: an extra holdout only once the data is large enough that spending rows on it
 #:    is cheap.
-DEFAULT_VALIDATION_CURVES: dict[str, SizeCurve] = {
+DEFAULT_VALIDATION_SIZE_CURVES: dict[str, SizeCurve] = {
     "num_bag_folds": [[59, 5], [69, 6], [79, 7], 8],
     "num_bag_sets": 1,
     "use_bag_holdout": [[USE_BAG_HOLDOUT_AUTO_THRESHOLD - 1, False], True],
@@ -105,20 +105,20 @@ def resolve_effective_sample_size(
 def _get_validation_preset(
     num_train_rows: int,
     hpo_enabled: bool,
-    validation_curves: dict[str, SizeCurve] | None = None,
+    validation_size_curves: dict[str, SizeCurve] | None = None,
     num_group_instances: int | None = None,
     size_on_groups: bool = False,
 ) -> dict[str, int | float]:
     """Recommended validation preset, resolved from size curves at the effective sample size.
 
-    ``validation_curves`` (EXPERIMENTAL: format subject to change) overrides individual entries
-    of :data:`DEFAULT_VALIDATION_CURVES`,
+    ``validation_size_curves`` (EXPERIMENTAL: format subject to change) overrides individual entries
+    of :data:`DEFAULT_VALIDATION_SIZE_CURVES`,
     so a caller can retune one knob (e.g. repeats on small data) without restating the rest.
     ``size_on_groups`` reads the curves at the group count instead of the row count -- see
     :func:`resolve_effective_sample_size`. ``holdout_frac`` is always sized on rows, since it
     is a fraction of the rows actually held out.
     """
-    curves = {**DEFAULT_VALIDATION_CURVES, **(validation_curves or {})}
+    curves = {**DEFAULT_VALIDATION_SIZE_CURVES, **(validation_size_curves or {})}
     effective_size = resolve_effective_sample_size(
         num_train_rows=num_train_rows,
         num_group_instances=num_group_instances,
@@ -162,7 +162,7 @@ def get_validation_and_stacking_method(
     n_samples_minority_class: int | None,
     num_group_instances: int | None = None,
     size_on_groups: bool = False,
-    validation_curves: dict[str, SizeCurve] | None = None,
+    validation_size_curves: dict[str, SizeCurve] | None = None,
 ) -> tuple[int, int, int, bool, bool, float, bool]:
     """Get the validation method for AutoGluon via a heuristic.
 
@@ -199,8 +199,8 @@ def get_validation_and_stacking_method(
         The number of independent groups, when the data declares a grouping. None otherwise.
     size_on_groups: bool
         If True, size-dependent choices read `num_group_instances` instead of `num_train_rows`.
-    validation_curves: dict[str, SizeCurve] | None
-        Per-knob overrides of `DEFAULT_VALIDATION_CURVES`; only the entries given are overridden.
+    validation_size_curves: dict[str, SizeCurve] | None
+        Per-knob overrides of `DEFAULT_VALIDATION_SIZE_CURVES`; only the entries given are overridden.
 
     Returns:
     --------
@@ -211,7 +211,7 @@ def get_validation_and_stacking_method(
         hpo_enabled=hpo_enabled,
         num_group_instances=num_group_instances,
         size_on_groups=size_on_groups,
-        validation_curves=validation_curves,
+        validation_size_curves=validation_size_curves,
     )
 
     # Independent of `auto_stack`

--- a/tabular/src/autogluon/tabular/configs/pipeline_presets.py
+++ b/tabular/src/autogluon/tabular/configs/pipeline_presets.py
@@ -7,7 +7,7 @@ from autogluon.core.utils.utils import default_holdout_frac
 
 USE_BAG_HOLDOUT_AUTO_THRESHOLD = 1_000_000
 
-#: A validation knob as a function of training-set size: either a fixed value, or a
+#: [EXPERIMENTAL] A validation knob as a function of training-set size: either a fixed value, or a
 #: *size curve* -- ``[[rows, value], ..., fallback]`` -- read as "use ``value`` at or below
 #: ``rows``", with the trailing entry applying above every anchor. Anchors must ascend by
 #: ``rows``. This is the same declarative shape used for count-based fit callbacks, and it
@@ -19,6 +19,7 @@ USE_BAG_HOLDOUT_AUTO_THRESHOLD = 1_000_000
 #:     8                            # always 8
 #:     [[1_000, 5], 8]              # 5 folds up to 1k rows, 8 above
 #:     [[2_000, 5], [10_000, 2], 1] # 5 repeats up to 2k rows, 2 up to 10k, 1 above
+#:     [[1_000, 0.2], 0.1]          # hold out 20% up to 1k rows, 10% above
 SizeCurve = "int | float | bool | None | list"
 
 #: Defaults for the auto-selected validation method. Numerically identical to the arithmetic
@@ -110,7 +111,8 @@ def _get_validation_preset(
 ) -> dict[str, int | float]:
     """Recommended validation preset, resolved from size curves at the effective sample size.
 
-    ``validation_curves`` overrides individual entries of :data:`DEFAULT_VALIDATION_CURVES`,
+    ``validation_curves`` (EXPERIMENTAL: format subject to change) overrides individual entries
+    of :data:`DEFAULT_VALIDATION_CURVES`,
     so a caller can retune one knob (e.g. repeats on small data) without restating the rest.
     ``size_on_groups`` reads the curves at the group count instead of the row count -- see
     :func:`resolve_effective_sample_size`. ``holdout_frac`` is always sized on rows, since it
@@ -123,9 +125,13 @@ def _get_validation_preset(
         size_on_groups=size_on_groups,
     )
     resolved = {key: resolve_size_curve(curve, effective_size) for key, curve in curves.items()}
-    resolved["holdout_frac"] = round(
-        default_holdout_frac(num_train_rows=num_train_rows, hyperparameter_tune=hpo_enabled), 4
-    )
+    if "holdout_frac" not in curves:
+        # Not a default curve: the built-in policy is a continuous function of the row count
+        # rather than a step curve, and a curve cannot reproduce it. A caller-supplied
+        # `holdout_frac` curve replaces it, and is read at the effective size like the others.
+        resolved["holdout_frac"] = round(
+            default_holdout_frac(num_train_rows=num_train_rows, hyperparameter_tune=hpo_enabled), 4
+        )
     return resolved
 
 

--- a/tabular/src/autogluon/tabular/configs/pipeline_presets.py
+++ b/tabular/src/autogluon/tabular/configs/pipeline_presets.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+from dataclasses import dataclass, fields
 
 from autogluon.core.constants import BINARY, PROBLEM_TYPES
 from autogluon.core.utils.utils import default_holdout_frac
@@ -48,6 +49,47 @@ DEFAULT_VALIDATION_SIZE_CURVES: dict[str, SizeCurve] = {
     # layer on large data without touching that decision.
     "num_stack_levels": [[749, 0], 1],
 }
+
+
+@dataclass(frozen=True)
+class ValidationSizeCurves:
+    """[EXPERIMENTAL] How the auto-selected validation method scales with data size.
+
+    One :data:`SizeCurve` per knob; ``None`` leaves that knob at its default (see
+    :data:`DEFAULT_VALIDATION_SIZE_CURVES`). Construct directly or from a dict via
+    :meth:`from_input`, which rejects unknown knob names -- a typo would otherwise be
+    silently ignored.
+
+        ValidationSizeCurves(num_bag_sets=[[2_000, 5], 1])
+        ValidationSizeCurves.from_input({"num_bag_sets": [[2_000, 5], 1]})  # equivalent
+
+    ``holdout_frac`` has no default curve: its built-in policy is a continuous function of
+    the row count, which a step curve cannot reproduce, so a curve given here replaces it.
+    """
+
+    num_bag_folds: SizeCurve = None
+    num_bag_sets: SizeCurve = None
+    use_bag_holdout: SizeCurve = None
+    num_stack_levels: SizeCurve = None
+    holdout_frac: SizeCurve = None
+
+    @classmethod
+    def from_input(cls, value: ValidationSizeCurves | dict | None) -> ValidationSizeCurves | None:
+        if value is None or isinstance(value, ValidationSizeCurves):
+            return value
+        if isinstance(value, dict):
+            valid = {f.name for f in fields(cls)}
+            invalid = set(value) - valid
+            if invalid:
+                raise ValueError(
+                    f"Invalid `validation_size_curves` keys: {sorted(invalid)}. Valid keys: {sorted(valid)}"
+                )
+            return cls(**value)
+        raise ValueError(f"`validation_size_curves` must be a dict or ValidationSizeCurves, got: {type(value)}")
+
+    def as_overrides(self) -> dict[str, SizeCurve]:
+        """The knobs actually set, as a ``{knob: curve}`` dict; unset knobs are omitted."""
+        return {f.name: getattr(self, f.name) for f in fields(self) if getattr(self, f.name) is not None}
 
 
 def resolve_size_curve(curve: SizeCurve, num_train_rows: int) -> int | float | bool | None:
@@ -118,7 +160,8 @@ def _get_validation_preset(
     :func:`resolve_effective_sample_size`. ``holdout_frac`` is always sized on rows, since it
     is a fraction of the rows actually held out.
     """
-    curves = {**DEFAULT_VALIDATION_SIZE_CURVES, **(validation_size_curves or {})}
+    overrides = ValidationSizeCurves.from_input(validation_size_curves)
+    curves = {**DEFAULT_VALIDATION_SIZE_CURVES, **(overrides.as_overrides() if overrides is not None else {})}
     effective_size = resolve_effective_sample_size(
         num_train_rows=num_train_rows,
         num_group_instances=num_group_instances,
@@ -162,7 +205,7 @@ def get_validation_and_stacking_method(
     n_samples_minority_class: int | None,
     num_group_instances: int | None = None,
     size_on_groups: bool = False,
-    validation_size_curves: dict[str, SizeCurve] | None = None,
+    validation_size_curves: ValidationSizeCurves | dict[str, SizeCurve] | None = None,
 ) -> tuple[int, int, int, bool, bool, float, bool]:
     """Get the validation method for AutoGluon via a heuristic.
 
@@ -199,8 +242,9 @@ def get_validation_and_stacking_method(
         The number of independent groups, when the data declares a grouping. None otherwise.
     size_on_groups: bool
         If True, size-dependent choices read `num_group_instances` instead of `num_train_rows`.
-    validation_size_curves: dict[str, SizeCurve] | None
-        Per-knob overrides of `DEFAULT_VALIDATION_SIZE_CURVES`; only the entries given are overridden.
+    validation_size_curves: ValidationSizeCurves | dict[str, SizeCurve] | None
+        Per-knob overrides of `DEFAULT_VALIDATION_SIZE_CURVES`; only the knobs set are overridden.
+        A dict is accepted and normalized via `ValidationSizeCurves.from_input`.
 
     Returns:
     --------

--- a/tabular/src/autogluon/tabular/configs/pipeline_presets.py
+++ b/tabular/src/autogluon/tabular/configs/pipeline_presets.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 import warnings
 
 from autogluon.core.constants import BINARY, PROBLEM_TYPES
@@ -8,24 +7,84 @@ from autogluon.core.utils.utils import default_holdout_frac
 
 USE_BAG_HOLDOUT_AUTO_THRESHOLD = 1_000_000
 
+#: A validation knob as a function of training-set size: either a fixed value, or a
+#: *size curve* -- ``[[rows, value], ..., fallback]`` -- read as "use ``value`` at or below
+#: ``rows``", with the trailing entry applying above every anchor. Anchors must ascend by
+#: ``rows``. This is the same declarative shape used for count-based fit callbacks, and it
+#: replaces arithmetic like ``min(8, max(5, rows / 10))``: the thresholds become data that can
+#: be inspected, overridden, and tested rather than an expression to re-derive.
+#:
+#: Examples::
+#:
+#:     8                            # always 8
+#:     [[1_000, 5], 8]              # 5 folds up to 1k rows, 8 above
+#:     [[2_000, 5], [10_000, 2], 1] # 5 repeats up to 2k rows, 2 up to 10k, 1 above
+SizeCurve = "int | float | bool | None | list"
 
-def _get_validation_preset(num_train_rows: int, hpo_enabled: bool) -> dict[str, int | float]:
-    """Recommended validation preset manually defined by the AutoGluon developers."""
-    # -- Default recommendation
-    #  max 8 due to 8 cores per CPU being very common.
-    #  down to 5 folds for small datasets to have enough samples for a representative validation set.
-    num_bag_folds = min(8, max(5, math.floor(num_train_rows / 10)))
+#: Defaults for the auto-selected validation method. Numerically identical to the arithmetic
+#: they replaced, so behavior is unchanged until a curve is overridden.
+#:  - folds: max 8 because 8 cores per CPU is very common; down to 5 on small data so each
+#:    validation set stays large enough to be representative.
+#:  - repeats: 1. More repeats have not been observed to help, appearing to overfit the
+#:    validation data; a curve is exposed so that can be revisited per size regime without
+#:    editing this module.
+#:  - holdout: an extra holdout only once the data is large enough that spending rows on it
+#:    is cheap.
+DEFAULT_VALIDATION_CURVES: dict[str, SizeCurve] = {
+    "num_bag_folds": [[59, 5], [69, 6], [79, 7], 8],
+    "num_bag_sets": 1,
+    "use_bag_holdout": [[USE_BAG_HOLDOUT_AUTO_THRESHOLD - 1, False], True],
+}
 
-    num_bag_sets = 1  # More repeats do not seem to help due to overfitting on val data.
-    use_bag_holdout = num_train_rows >= USE_BAG_HOLDOUT_AUTO_THRESHOLD
-    holdout_frac = round(default_holdout_frac(num_train_rows=num_train_rows, hyperparameter_tune=hpo_enabled), 4)
 
-    return dict(
-        num_bag_sets=num_bag_sets,
-        num_bag_folds=num_bag_folds,
-        use_bag_holdout=use_bag_holdout,
-        holdout_frac=holdout_frac,
+def resolve_size_curve(curve: SizeCurve, num_train_rows: int) -> int | float | bool | None:
+    """Read a :data:`SizeCurve` at ``num_train_rows``.
+
+    A non-list ``curve`` is a fixed value. Otherwise the first ``[rows, value]`` anchor whose
+    ``rows`` is >= ``num_train_rows`` wins, else the trailing fallback. A bare (non-pair)
+    trailing entry is that fallback; a curve made only of anchors returns the last anchor's
+    value above the final threshold.
+    """
+    if not isinstance(curve, list):
+        return curve
+    if not curve:
+        raise ValueError("A size curve must not be empty.")
+
+    fallback = None
+    anchors: list[tuple[int, object]] = []
+    for entry in curve:
+        if isinstance(entry, (list, tuple)):
+            if len(entry) != 2:
+                raise ValueError(f"Size-curve anchors must be [rows, value] pairs, got: {entry!r}")
+            anchors.append((entry[0], entry[1]))
+        else:
+            fallback = entry
+    thresholds = [rows for rows, _ in anchors]
+    if thresholds != sorted(thresholds):
+        raise ValueError(f"Size-curve anchors must ascend by rows, got thresholds: {thresholds}")
+
+    for rows, value in anchors:
+        if num_train_rows <= rows:
+            return value
+    return fallback if fallback is not None or not anchors else anchors[-1][1]
+
+
+def _get_validation_preset(
+    num_train_rows: int,
+    hpo_enabled: bool,
+    validation_curves: dict[str, SizeCurve] | None = None,
+) -> dict[str, int | float]:
+    """Recommended validation preset, resolved from size curves at ``num_train_rows``.
+
+    ``validation_curves`` overrides individual entries of :data:`DEFAULT_VALIDATION_CURVES`,
+    so a caller can retune one knob (e.g. repeats on small data) without restating the rest.
+    """
+    curves = {**DEFAULT_VALIDATION_CURVES, **(validation_curves or {})}
+    resolved = {key: resolve_size_curve(curve, num_train_rows) for key, curve in curves.items()}
+    resolved["holdout_frac"] = round(
+        default_holdout_frac(num_train_rows=num_train_rows, hyperparameter_tune=hpo_enabled), 4
     )
+    return resolved
 
 
 # TODO(refactor): use a data class for the config of the validation method.

--- a/tabular/src/autogluon/tabular/configs/pipeline_presets.py
+++ b/tabular/src/autogluon/tabular/configs/pipeline_presets.py
@@ -34,6 +34,11 @@ DEFAULT_VALIDATION_CURVES: dict[str, SizeCurve] = {
     "num_bag_folds": [[59, 5], [69, 6], [79, 7], 8],
     "num_bag_sets": 1,
     "use_bag_holdout": [[USE_BAG_HOLDOUT_AUTO_THRESHOLD - 1, False], True],
+    # Stack levels the data size permits. Whether stacking is used at all is a separate,
+    # qualitative decision (see `get_validation_and_stacking_method`); this only says how deep
+    # the size allows, so raising it to e.g. [[749, 0], [100_000, 1], 2] asks for a second
+    # layer on large data without touching that decision.
+    "num_stack_levels": [[749, 0], 1],
 }
 
 
@@ -201,15 +206,15 @@ def get_validation_and_stacking_method(
     if num_stack_levels is None:
         # Disable multi-layer stacking by default
         num_stack_levels = 0
+        # How deep the data size permits; the conditions below decide whether to stack at all.
+        stack_levels_by_size = cv_preset["num_stack_levels"]
 
-        # Activate multi-layer stacking for `auto_stack` if
-        if auto_stack and (
-            dynamic_stacking  # -> We use dynamic stacking
-            or
-            # -> We have holdout validation or a non-binary problem with more than 750 training rows
-            ((use_bag_holdout or (problem_type != BINARY)) and (num_train_rows >= 750))
-        ):
-            num_stack_levels = 1
+        if auto_stack and dynamic_stacking:
+            # Dynamic stacking detects stacked overfitting itself, so it is not size-gated.
+            num_stack_levels = max(1, stack_levels_by_size)
+        elif auto_stack and (use_bag_holdout or (problem_type != BINARY)):
+            # Holdout validation or a non-binary problem: stack as deep as the size allows.
+            num_stack_levels = stack_levels_by_size
 
     # Extra logic to handle cross-validation splits for classification
     #   - Avoid failure mode where we do not have enough samples to ensure the

--- a/tabular/src/autogluon/tabular/configs/pipeline_presets.py
+++ b/tabular/src/autogluon/tabular/configs/pipeline_presets.py
@@ -149,6 +149,7 @@ def get_validation_and_stacking_method(
     n_samples_minority_class: int | None,
     num_group_instances: int | None = None,
     size_on_groups: bool = False,
+    validation_curves: dict[str, SizeCurve] | None = None,
 ) -> tuple[int, int, int, bool, bool, float, bool]:
     """Get the validation method for AutoGluon via a heuristic.
 
@@ -185,6 +186,8 @@ def get_validation_and_stacking_method(
         The number of independent groups, when the data declares a grouping. None otherwise.
     size_on_groups: bool
         If True, size-dependent choices read `num_group_instances` instead of `num_train_rows`.
+    validation_curves: dict[str, SizeCurve] | None
+        Per-knob overrides of `DEFAULT_VALIDATION_CURVES`; only the entries given are overridden.
 
     Returns:
     --------
@@ -195,6 +198,7 @@ def get_validation_and_stacking_method(
         hpo_enabled=hpo_enabled,
         num_group_instances=num_group_instances,
         size_on_groups=size_on_groups,
+        validation_curves=validation_curves,
     )
 
     # Independent of `auto_stack`

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -846,7 +846,7 @@ class TabularPredictor:
                 and the non-bagged holdout becomes group-disjoint or temporally forward (the latest time block).
                 Referenced columns remain features. `group_on` and `time_on` cannot be combined.
                 Mutually exclusive with the `groups` init argument.
-            validation_curves : dict, default = None
+            validation_size_curves : dict, default = None
                 [EXPERIMENTAL] Overrides for how the automatically selected validation method scales
                 with data size. The curve format and the set of tunable knobs may change in a future
                 release.
@@ -856,7 +856,7 @@ class TabularPredictor:
                 trailing entry applying above every anchor. Only the entries given are overridden;
                 the rest keep their defaults, and an explicit `num_bag_folds` / `num_bag_sets` /
                 `use_bag_holdout` / `num_stack_levels` argument still wins over any curve.
-                    `validation_curves={'num_bag_sets': [[2000, 5], 1]}` -> 5 repeats at or below
+                    `validation_size_curves={'num_bag_sets': [[2000, 5], 1]}` -> 5 repeats at or below
                     2000 rows and 1 above, i.e. repeated cross-validation on small data.
                 Read at the number of groups instead of rows when `validation_structure` sets
                 `size_validation_on_groups`.
@@ -1377,7 +1377,7 @@ class TabularPredictor:
             n_samples_minority_class=n_samples_minority_class,
             num_group_instances=num_group_instances,
             size_on_groups=(validation_structure is not None and validation_structure.size_validation_on_groups),
-            validation_curves=kwargs["validation_curves"],
+            validation_size_curves=kwargs["validation_size_curves"],
         )
 
         num_bag_folds, num_bag_sets, num_stack_levels, dynamic_stacking, use_bag_holdout = self._sanitize_stack_args(
@@ -5610,7 +5610,7 @@ class TabularPredictor:
             delay_bag_sets=False,
             num_stack_levels=None,
             validation_structure=None,
-            validation_curves=None,
+            validation_size_curves=None,
             hyperparameter_tune_kwargs=None,
             ag_args=None,
             ag_args_fit=None,

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1325,6 +1325,19 @@ class TabularPredictor:
         if adapt_num_bag_folds_to_n_classes and (inferred_problem_type in [BINARY, MULTICLASS]):
             n_samples_minority_class = int(train_data[self.label].value_counts().min())
 
+        # Structure-aware validation splitting (group-disjoint / temporal). See
+        # `autogluon.common.utils.validation_structure.ValidationStructure`. Resolved before the
+        # validation method is chosen, because a grouped structure can supply the sample size
+        # that method is chosen from (`size_validation_on_groups`).
+        validation_structure = ValidationStructure.from_input(kwargs["validation_structure"])
+        if validation_structure is not None and self._learner.groups is not None:
+            raise ValueError(
+                "Specify either `groups` (TabularPredictor init) or `validation_structure` (fit), not both."
+            )
+        num_group_instances = (
+            None if validation_structure is None else validation_structure.num_group_instances(train_data)
+        )
+
         (
             num_bag_folds,
             num_bag_sets,
@@ -1346,6 +1359,8 @@ class TabularPredictor:
             problem_type=inferred_problem_type,
             hpo_enabled=ag_args.get("hyperparameter_tune_kwargs", None) is not None,
             n_samples_minority_class=n_samples_minority_class,
+            num_group_instances=num_group_instances,
+            size_on_groups=(validation_structure is not None and validation_structure.size_validation_on_groups),
         )
 
         num_bag_folds, num_bag_sets, num_stack_levels, dynamic_stacking, use_bag_holdout = self._sanitize_stack_args(
@@ -1442,14 +1457,6 @@ class TabularPredictor:
             aux_kwargs = {}
         # Overwrite aux_kwargs_defaults with aux_kwargs values in case of shared keys
         aux_kwargs = {**aux_kwargs_defaults, **aux_kwargs}
-
-        # Structure-aware validation splitting (group-disjoint / temporal). See
-        # `autogluon.common.utils.validation_structure.ValidationStructure`.
-        validation_structure = ValidationStructure.from_input(kwargs["validation_structure"])
-        if validation_structure is not None and self._learner.groups is not None:
-            raise ValueError(
-                "Specify either `groups` (TabularPredictor init) or `validation_structure` (fit), not both."
-            )
 
         ag_fit_kwargs = dict(
             X=train_data,

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -846,10 +846,10 @@ class TabularPredictor:
                 and the non-bagged holdout becomes group-disjoint or temporally forward (the latest time block).
                 Referenced columns remain features. `group_on` and `time_on` cannot be combined.
                 Mutually exclusive with the `groups` init argument.
-            validation_size_curves : dict, default = None
+            validation_size_curves : dict | ValidationSizeCurves, default = None
                 [EXPERIMENTAL] Overrides for how the automatically selected validation method scales
-                with data size. The curve format and the set of tunable knobs may change in a future
-                release.
+                with data size, as a `ValidationSizeCurves` or an equivalent dict. The curve format
+                and the set of tunable knobs may change in a future release.
                 Each entry maps one knob -- `num_bag_folds`, `num_bag_sets`, `use_bag_holdout`,
                 `num_stack_levels`, `holdout_frac` -- to either a fixed value or a size curve
                 `[[rows, value], ..., fallback]`, read as "use `value` at or below `rows`", with the

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -847,9 +847,11 @@ class TabularPredictor:
                 Referenced columns remain features. `group_on` and `time_on` cannot be combined.
                 Mutually exclusive with the `groups` init argument.
             validation_curves : dict, default = None
-                Overrides for how the automatically selected validation method scales with data size.
+                [EXPERIMENTAL] Overrides for how the automatically selected validation method scales
+                with data size. The curve format and the set of tunable knobs may change in a future
+                release.
                 Each entry maps one knob -- `num_bag_folds`, `num_bag_sets`, `use_bag_holdout`,
-                `num_stack_levels` -- to either a fixed value or a size curve
+                `num_stack_levels`, `holdout_frac` -- to either a fixed value or a size curve
                 `[[rows, value], ..., fallback]`, read as "use `value` at or below `rows`", with the
                 trailing entry applying above every anchor. Only the entries given are overridden;
                 the rest keep their defaults, and an explicit `num_bag_folds` / `num_bag_sets` /

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -838,12 +838,26 @@ class TabularPredictor:
             validation_structure : dict | ValidationStructure, default = None
                 Declarative description of the dataset's validation-relevant structure, as a dict with keys
                 `group_on` (str | list[str]), `time_on` (str), `group_time_on` (str, for data that is both
-                grouped and temporal), and/or `stratify_on` (str).
+                grouped and temporal), `stratify_on` (str), and/or `size_validation_on_groups` (bool,
+                default False: size the automatically selected validation method on the number of
+                groups rather than the number of rows).
                 When specified, validation splits honor the structure instead of assuming IID rows:
                 bagging folds become group-disjoint (`group_on`) or contiguous time blocks (`time_on`),
                 and the non-bagged holdout becomes group-disjoint or temporally forward (the latest time block).
                 Referenced columns remain features. `group_on` and `time_on` cannot be combined.
                 Mutually exclusive with the `groups` init argument.
+            validation_curves : dict, default = None
+                Overrides for how the automatically selected validation method scales with data size.
+                Each entry maps one knob -- `num_bag_folds`, `num_bag_sets`, `use_bag_holdout`,
+                `num_stack_levels` -- to either a fixed value or a size curve
+                `[[rows, value], ..., fallback]`, read as "use `value` at or below `rows`", with the
+                trailing entry applying above every anchor. Only the entries given are overridden;
+                the rest keep their defaults, and an explicit `num_bag_folds` / `num_bag_sets` /
+                `use_bag_holdout` / `num_stack_levels` argument still wins over any curve.
+                    `validation_curves={'num_bag_sets': [[2000, 5], 1]}` -> 5 repeats at or below
+                    2000 rows and 1 above, i.e. repeated cross-validation on small data.
+                Read at the number of groups instead of rows when `validation_structure` sets
+                `size_validation_on_groups`.
             num_stack_levels : int, default = None
                 Number of stacking levels to use in stack ensemble. Roughly increases model training time by factor of `num_stack_levels+1` (set = 0 to disable stack ensembling).
                 Disabled by default (0), but we recommend `num_stack_levels=1` to maximize predictive performance.
@@ -1361,6 +1375,7 @@ class TabularPredictor:
             n_samples_minority_class=n_samples_minority_class,
             num_group_instances=num_group_instances,
             size_on_groups=(validation_structure is not None and validation_structure.size_validation_on_groups),
+            validation_curves=kwargs["validation_curves"],
         )
 
         num_bag_folds, num_bag_sets, num_stack_levels, dynamic_stacking, use_bag_holdout = self._sanitize_stack_args(
@@ -5593,6 +5608,7 @@ class TabularPredictor:
             delay_bag_sets=False,
             num_stack_levels=None,
             validation_structure=None,
+            validation_curves=None,
             hyperparameter_tune_kwargs=None,
             ag_args=None,
             ag_args_fit=None,

--- a/tabular/tests/unittests/configs/test_validation_size_curves.py
+++ b/tabular/tests/unittests/configs/test_validation_size_curves.py
@@ -177,3 +177,38 @@ def test__use_bag_holdout_and_stack_levels__can_both_be_sized_on_groups():
     on_groups = _get_validation_preset(**kwargs, size_on_groups=True)
     assert (on_rows["use_bag_holdout"], on_rows["num_stack_levels"]) == (True, 1)
     assert (on_groups["use_bag_holdout"], on_groups["num_stack_levels"]) == (False, 0)
+
+
+def test__holdout_frac__has_no_default_curve_and_keeps_its_built_in_policy():
+    """The built-in policy is a continuous function of rows, which a step curve cannot express."""
+    from autogluon.core.utils.utils import default_holdout_frac
+
+    for num_train_rows in (100, 900, 50_000):
+        preset = _get_validation_preset(num_train_rows=num_train_rows, hpo_enabled=False)
+        assert preset["holdout_frac"] == round(
+            default_holdout_frac(num_train_rows=num_train_rows, hyperparameter_tune=False), 4
+        )
+    # a known group count must not change it either, absent an explicit curve
+    assert (
+        _get_validation_preset(num_train_rows=900, hpo_enabled=False, num_group_instances=60)["holdout_frac"]
+        == _get_validation_preset(num_train_rows=900, hpo_enabled=False)["holdout_frac"]
+    )
+
+
+def test__holdout_frac__curve_replaces_the_built_in_policy():
+    curves = {"holdout_frac": [[1_000, 0.2], 0.1]}
+    assert (
+        _get_validation_preset(num_train_rows=500, hpo_enabled=False, validation_curves=curves)["holdout_frac"] == 0.2
+    )
+    assert (
+        _get_validation_preset(num_train_rows=5_000, hpo_enabled=False, validation_curves=curves)["holdout_frac"]
+        == 0.1
+    )
+
+
+def test__holdout_frac__curve_is_read_at_the_effective_sample_size():
+    """A supplied curve follows the same sizing as the other knobs, including group sizing."""
+    curves = {"holdout_frac": [[100, 0.25], 0.1]}
+    kwargs = dict(num_train_rows=9_000, hpo_enabled=False, validation_curves=curves, num_group_instances=60)
+    assert _get_validation_preset(**kwargs)["holdout_frac"] == 0.1  # 9000 rows > 100
+    assert _get_validation_preset(**kwargs, size_on_groups=True)["holdout_frac"] == 0.25  # 60 groups <= 100

--- a/tabular/tests/unittests/configs/test_validation_size_curves.py
+++ b/tabular/tests/unittests/configs/test_validation_size_curves.py
@@ -127,3 +127,53 @@ def test__validation_preset__group_sizing_flips_a_row_large_group_small_task():
     # holdout_frac is a fraction of the rows held out, so it stays sized on rows
     rows_only = _get_validation_preset(num_train_rows=4_672, hpo_enabled=False, validation_curves=curves)
     assert preset["holdout_frac"] == rows_only["holdout_frac"]
+
+
+@pytest.mark.parametrize("num_train_rows", [1, 749, 750, 751, 10_000])
+@pytest.mark.parametrize("auto_stack", [True, False])
+@pytest.mark.parametrize("dynamic_stacking", [True, False])
+@pytest.mark.parametrize("problem_type", ["binary", "multiclass"])
+def test__stack_levels__matches_the_condition_it_replaced(num_train_rows, auto_stack, dynamic_stacking, problem_type):
+    """Stack depth now comes from a curve, gated by the same qualitative conditions as before."""
+    from autogluon.tabular.configs.pipeline_presets import get_validation_and_stacking_method
+
+    use_bag_holdout = False
+    result = get_validation_and_stacking_method(
+        num_bag_folds=None,
+        num_bag_sets=None,
+        use_bag_holdout=use_bag_holdout,
+        holdout_frac=None,
+        auto_stack=auto_stack,
+        num_stack_levels=None,
+        dynamic_stacking=dynamic_stacking,
+        refit_full=None,
+        num_train_rows=num_train_rows,
+        problem_type=problem_type,
+        hpo_enabled=False,
+        n_samples_minority_class=None,
+    )
+    expected = (
+        1
+        if auto_stack
+        and (dynamic_stacking or ((use_bag_holdout or problem_type != "binary") and num_train_rows >= 750))
+        else 0
+    )
+    assert result[2] == expected
+
+
+def test__stack_levels__curve_can_ask_for_a_deeper_layer_on_large_data():
+    curves = {"num_stack_levels": [[749, 0], [100_000, 1], 2]}
+    small = _get_validation_preset(num_train_rows=500, hpo_enabled=False, validation_curves=curves)
+    medium = _get_validation_preset(num_train_rows=50_000, hpo_enabled=False, validation_curves=curves)
+    large = _get_validation_preset(num_train_rows=500_000, hpo_enabled=False, validation_curves=curves)
+    assert (small["num_stack_levels"], medium["num_stack_levels"], large["num_stack_levels"]) == (0, 1, 2)
+
+
+def test__use_bag_holdout_and_stack_levels__can_both_be_sized_on_groups():
+    """Both knobs read the same effective sample size, so group sizing applies to them too."""
+    curves = {"use_bag_holdout": [[100, False], True], "num_stack_levels": [[100, 0], 1]}
+    kwargs = dict(num_train_rows=4_672, hpo_enabled=False, validation_curves=curves, num_group_instances=68)
+    on_rows = _get_validation_preset(**kwargs)
+    on_groups = _get_validation_preset(**kwargs, size_on_groups=True)
+    assert (on_rows["use_bag_holdout"], on_rows["num_stack_levels"]) == (True, 1)
+    assert (on_groups["use_bag_holdout"], on_groups["num_stack_levels"]) == (False, 0)

--- a/tabular/tests/unittests/configs/test_validation_size_curves.py
+++ b/tabular/tests/unittests/configs/test_validation_size_curves.py
@@ -1,0 +1,89 @@
+"""Size-curve resolution for the auto-selected validation method."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from autogluon.tabular.configs.pipeline_presets import (
+    USE_BAG_HOLDOUT_AUTO_THRESHOLD,
+    _get_validation_preset,
+    resolve_size_curve,
+)
+
+
+def test__resolve_size_curve__fixed_value_is_returned_as_is():
+    assert resolve_size_curve(8, num_train_rows=10) == 8
+    assert resolve_size_curve(False, num_train_rows=10**9) is False
+    assert resolve_size_curve(None, num_train_rows=10) is None
+
+
+def test__resolve_size_curve__anchor_is_inclusive_upper_bound():
+    curve = [[100, "small"], [1000, "medium"], "large"]
+    assert resolve_size_curve(curve, num_train_rows=1) == "small"
+    assert resolve_size_curve(curve, num_train_rows=100) == "small"  # inclusive
+    assert resolve_size_curve(curve, num_train_rows=101) == "medium"
+    assert resolve_size_curve(curve, num_train_rows=1000) == "medium"
+    assert resolve_size_curve(curve, num_train_rows=1001) == "large"
+
+
+def test__resolve_size_curve__rejects_malformed_curves():
+    with pytest.raises(ValueError, match="must not be empty"):
+        resolve_size_curve([], num_train_rows=10)
+    with pytest.raises(ValueError, match="ascend by rows"):
+        resolve_size_curve([[1000, "a"], [100, "b"], "c"], num_train_rows=10)
+    with pytest.raises(ValueError, match=r"\[rows, value\] pairs"):
+        resolve_size_curve([[100, "a", "extra"], "b"], num_train_rows=10)
+
+
+@pytest.mark.parametrize(
+    "num_train_rows",
+    [
+        1,
+        10,
+        49,
+        50,
+        55,
+        59,
+        60,
+        69,
+        70,
+        79,
+        80,
+        100,
+        1000,
+        USE_BAG_HOLDOUT_AUTO_THRESHOLD - 1,
+        USE_BAG_HOLDOUT_AUTO_THRESHOLD,
+        USE_BAG_HOLDOUT_AUTO_THRESHOLD + 1,
+    ],
+)
+def test__validation_preset__matches_the_arithmetic_it_replaced(num_train_rows):
+    """The curves are a refactor: same numbers as the expressions they replaced."""
+    preset = _get_validation_preset(num_train_rows=num_train_rows, hpo_enabled=False)
+    assert preset["num_bag_folds"] == min(8, max(5, math.floor(num_train_rows / 10)))
+    assert preset["num_bag_sets"] == 1
+    assert preset["use_bag_holdout"] == (num_train_rows >= USE_BAG_HOLDOUT_AUTO_THRESHOLD)
+
+
+def test__validation_preset__curve_override_enables_repeats_on_small_data():
+    """The point of the curves: retune one knob per size regime without editing the module."""
+    curves = {"num_bag_sets": [[2_000, 5], 1]}
+    small = _get_validation_preset(num_train_rows=500, hpo_enabled=False, validation_curves=curves)
+    large = _get_validation_preset(num_train_rows=50_000, hpo_enabled=False, validation_curves=curves)
+    assert (small["num_bag_folds"], small["num_bag_sets"]) == (8, 5)  # 8x5 CV on small data
+    assert (large["num_bag_folds"], large["num_bag_sets"]) == (8, 1)  # unchanged above the anchor
+    # overriding one knob leaves the others at their defaults
+    assert small["use_bag_holdout"] is False
+
+
+def test__validation_preset__curve_override_can_move_the_holdout_switch():
+    curves = {"use_bag_holdout": [[10_000, False], True]}
+    assert (
+        _get_validation_preset(num_train_rows=10_000, hpo_enabled=False, validation_curves=curves)["use_bag_holdout"]
+        is False
+    )
+    assert (
+        _get_validation_preset(num_train_rows=10_001, hpo_enabled=False, validation_curves=curves)["use_bag_holdout"]
+        is True
+    )

--- a/tabular/tests/unittests/configs/test_validation_size_curves.py
+++ b/tabular/tests/unittests/configs/test_validation_size_curves.py
@@ -217,3 +217,42 @@ def test__holdout_frac__curve_is_read_at_the_effective_sample_size():
     kwargs = dict(num_train_rows=9_000, hpo_enabled=False, validation_size_curves=curves, num_group_instances=60)
     assert _get_validation_preset(**kwargs)["holdout_frac"] == 0.1  # 9000 rows > 100
     assert _get_validation_preset(**kwargs, size_on_groups=True)["holdout_frac"] == 0.25  # 60 groups <= 100
+
+
+def test__validation_size_curves__dataclass_and_dict_are_equivalent():
+    """The dataclass is the explicit form; a dict is still accepted and normalized to it."""
+    from autogluon.tabular.configs.pipeline_presets import ValidationSizeCurves
+
+    as_dict = {"num_bag_folds": [[1_000, 5], 8], "num_bag_sets": [[1_000, 5], 5]}
+    from_dict = _get_validation_preset(num_train_rows=500, hpo_enabled=False, validation_size_curves=as_dict)
+    from_dataclass = _get_validation_preset(
+        num_train_rows=500, hpo_enabled=False, validation_size_curves=ValidationSizeCurves(**as_dict)
+    )
+    assert from_dict == from_dataclass
+    assert (from_dict["num_bag_folds"], from_dict["num_bag_sets"]) == (5, 5)
+
+    assert ValidationSizeCurves.from_input(as_dict) == ValidationSizeCurves(**as_dict)
+    assert ValidationSizeCurves.from_input(None) is None
+    already = ValidationSizeCurves(num_bag_sets=5)
+    assert ValidationSizeCurves.from_input(already) is already
+
+
+def test__validation_size_curves__unset_knobs_keep_their_defaults():
+    from autogluon.tabular.configs.pipeline_presets import DEFAULT_VALIDATION_SIZE_CURVES, ValidationSizeCurves
+
+    curves = ValidationSizeCurves(num_bag_sets=5)
+    assert curves.as_overrides() == {"num_bag_sets": 5}  # only what was set
+    preset = _get_validation_preset(num_train_rows=900, hpo_enabled=False, validation_size_curves=curves)
+    assert preset["num_bag_sets"] == 5
+    # the untouched knobs still follow the defaults
+    assert preset["num_bag_folds"] == resolve_size_curve(DEFAULT_VALIDATION_SIZE_CURVES["num_bag_folds"], 900)
+
+
+def test__validation_size_curves__rejects_unknown_knobs():
+    """A mistyped knob was previously accepted and silently ignored."""
+    from autogluon.tabular.configs.pipeline_presets import ValidationSizeCurves
+
+    with pytest.raises(ValueError, match="Invalid `validation_size_curves` keys"):
+        ValidationSizeCurves.from_input({"num_bag_setz": 5})
+    with pytest.raises(ValueError, match="must be a dict or ValidationSizeCurves"):
+        ValidationSizeCurves.from_input(5)

--- a/tabular/tests/unittests/configs/test_validation_size_curves.py
+++ b/tabular/tests/unittests/configs/test_validation_size_curves.py
@@ -69,8 +69,8 @@ def test__validation_preset__matches_the_arithmetic_it_replaced(num_train_rows):
 def test__validation_preset__curve_override_enables_repeats_on_small_data():
     """The point of the curves: retune one knob per size regime without editing the module."""
     curves = {"num_bag_sets": [[2_000, 5], 1]}
-    small = _get_validation_preset(num_train_rows=500, hpo_enabled=False, validation_curves=curves)
-    large = _get_validation_preset(num_train_rows=50_000, hpo_enabled=False, validation_curves=curves)
+    small = _get_validation_preset(num_train_rows=500, hpo_enabled=False, validation_size_curves=curves)
+    large = _get_validation_preset(num_train_rows=50_000, hpo_enabled=False, validation_size_curves=curves)
     assert (small["num_bag_folds"], small["num_bag_sets"]) == (8, 5)  # 8x5 CV on small data
     assert (large["num_bag_folds"], large["num_bag_sets"]) == (8, 1)  # unchanged above the anchor
     # overriding one knob leaves the others at their defaults
@@ -80,11 +80,15 @@ def test__validation_preset__curve_override_enables_repeats_on_small_data():
 def test__validation_preset__curve_override_can_move_the_holdout_switch():
     curves = {"use_bag_holdout": [[10_000, False], True]}
     assert (
-        _get_validation_preset(num_train_rows=10_000, hpo_enabled=False, validation_curves=curves)["use_bag_holdout"]
+        _get_validation_preset(num_train_rows=10_000, hpo_enabled=False, validation_size_curves=curves)[
+            "use_bag_holdout"
+        ]
         is False
     )
     assert (
-        _get_validation_preset(num_train_rows=10_001, hpo_enabled=False, validation_curves=curves)["use_bag_holdout"]
+        _get_validation_preset(num_train_rows=10_001, hpo_enabled=False, validation_size_curves=curves)[
+            "use_bag_holdout"
+        ]
         is True
     )
 
@@ -102,9 +106,9 @@ def test__effective_sample_size__is_rows_unless_group_sizing_is_requested():
 def test__validation_preset__group_sizing_is_off_by_default():
     """A known group count must not change the preset unless group sizing is requested."""
     curves = {"num_bag_folds": [[500, 5], 8], "num_bag_sets": [[500, 5], 1]}
-    rows_only = _get_validation_preset(num_train_rows=4_672, hpo_enabled=False, validation_curves=curves)
+    rows_only = _get_validation_preset(num_train_rows=4_672, hpo_enabled=False, validation_size_curves=curves)
     with_groups_known = _get_validation_preset(
-        num_train_rows=4_672, hpo_enabled=False, validation_curves=curves, num_group_instances=68
+        num_train_rows=4_672, hpo_enabled=False, validation_size_curves=curves, num_group_instances=68
     )
     assert rows_only == with_groups_known
     assert (rows_only["num_bag_folds"], rows_only["num_bag_sets"]) == (8, 1)
@@ -119,13 +123,13 @@ def test__validation_preset__group_sizing_flips_a_row_large_group_small_task():
     preset = _get_validation_preset(
         num_train_rows=4_672,
         hpo_enabled=False,
-        validation_curves=curves,
+        validation_size_curves=curves,
         num_group_instances=68,
         size_on_groups=True,
     )
     assert (preset["num_bag_folds"], preset["num_bag_sets"]) == (5, 5)
     # holdout_frac is a fraction of the rows held out, so it stays sized on rows
-    rows_only = _get_validation_preset(num_train_rows=4_672, hpo_enabled=False, validation_curves=curves)
+    rows_only = _get_validation_preset(num_train_rows=4_672, hpo_enabled=False, validation_size_curves=curves)
     assert preset["holdout_frac"] == rows_only["holdout_frac"]
 
 
@@ -163,16 +167,16 @@ def test__stack_levels__matches_the_condition_it_replaced(num_train_rows, auto_s
 
 def test__stack_levels__curve_can_ask_for_a_deeper_layer_on_large_data():
     curves = {"num_stack_levels": [[749, 0], [100_000, 1], 2]}
-    small = _get_validation_preset(num_train_rows=500, hpo_enabled=False, validation_curves=curves)
-    medium = _get_validation_preset(num_train_rows=50_000, hpo_enabled=False, validation_curves=curves)
-    large = _get_validation_preset(num_train_rows=500_000, hpo_enabled=False, validation_curves=curves)
+    small = _get_validation_preset(num_train_rows=500, hpo_enabled=False, validation_size_curves=curves)
+    medium = _get_validation_preset(num_train_rows=50_000, hpo_enabled=False, validation_size_curves=curves)
+    large = _get_validation_preset(num_train_rows=500_000, hpo_enabled=False, validation_size_curves=curves)
     assert (small["num_stack_levels"], medium["num_stack_levels"], large["num_stack_levels"]) == (0, 1, 2)
 
 
 def test__use_bag_holdout_and_stack_levels__can_both_be_sized_on_groups():
     """Both knobs read the same effective sample size, so group sizing applies to them too."""
     curves = {"use_bag_holdout": [[100, False], True], "num_stack_levels": [[100, 0], 1]}
-    kwargs = dict(num_train_rows=4_672, hpo_enabled=False, validation_curves=curves, num_group_instances=68)
+    kwargs = dict(num_train_rows=4_672, hpo_enabled=False, validation_size_curves=curves, num_group_instances=68)
     on_rows = _get_validation_preset(**kwargs)
     on_groups = _get_validation_preset(**kwargs, size_on_groups=True)
     assert (on_rows["use_bag_holdout"], on_rows["num_stack_levels"]) == (True, 1)
@@ -198,10 +202,11 @@ def test__holdout_frac__has_no_default_curve_and_keeps_its_built_in_policy():
 def test__holdout_frac__curve_replaces_the_built_in_policy():
     curves = {"holdout_frac": [[1_000, 0.2], 0.1]}
     assert (
-        _get_validation_preset(num_train_rows=500, hpo_enabled=False, validation_curves=curves)["holdout_frac"] == 0.2
+        _get_validation_preset(num_train_rows=500, hpo_enabled=False, validation_size_curves=curves)["holdout_frac"]
+        == 0.2
     )
     assert (
-        _get_validation_preset(num_train_rows=5_000, hpo_enabled=False, validation_curves=curves)["holdout_frac"]
+        _get_validation_preset(num_train_rows=5_000, hpo_enabled=False, validation_size_curves=curves)["holdout_frac"]
         == 0.1
     )
 
@@ -209,6 +214,6 @@ def test__holdout_frac__curve_replaces_the_built_in_policy():
 def test__holdout_frac__curve_is_read_at_the_effective_sample_size():
     """A supplied curve follows the same sizing as the other knobs, including group sizing."""
     curves = {"holdout_frac": [[100, 0.25], 0.1]}
-    kwargs = dict(num_train_rows=9_000, hpo_enabled=False, validation_curves=curves, num_group_instances=60)
+    kwargs = dict(num_train_rows=9_000, hpo_enabled=False, validation_size_curves=curves, num_group_instances=60)
     assert _get_validation_preset(**kwargs)["holdout_frac"] == 0.1  # 9000 rows > 100
     assert _get_validation_preset(**kwargs, size_on_groups=True)["holdout_frac"] == 0.25  # 60 groups <= 100

--- a/tabular/tests/unittests/configs/test_validation_size_curves.py
+++ b/tabular/tests/unittests/configs/test_validation_size_curves.py
@@ -87,3 +87,43 @@ def test__validation_preset__curve_override_can_move_the_holdout_switch():
         _get_validation_preset(num_train_rows=10_001, hpo_enabled=False, validation_curves=curves)["use_bag_holdout"]
         is True
     )
+
+
+def test__effective_sample_size__is_rows_unless_group_sizing_is_requested():
+    from autogluon.tabular.configs.pipeline_presets import resolve_effective_sample_size
+
+    # opt-in is required: a known group count alone does not change the size
+    assert resolve_effective_sample_size(num_train_rows=4_672, num_group_instances=68) == 4_672
+    assert resolve_effective_sample_size(num_train_rows=4_672, num_group_instances=68, size_on_groups=True) == 68
+    # opting in without a group count falls back to rows rather than failing
+    assert resolve_effective_sample_size(num_train_rows=4_672, size_on_groups=True) == 4_672
+
+
+def test__validation_preset__group_sizing_is_off_by_default():
+    """A known group count must not change the preset unless group sizing is requested."""
+    curves = {"num_bag_folds": [[500, 5], 8], "num_bag_sets": [[500, 5], 1]}
+    rows_only = _get_validation_preset(num_train_rows=4_672, hpo_enabled=False, validation_curves=curves)
+    with_groups_known = _get_validation_preset(
+        num_train_rows=4_672, hpo_enabled=False, validation_curves=curves, num_group_instances=68
+    )
+    assert rows_only == with_groups_known
+    assert (rows_only["num_bag_folds"], rows_only["num_bag_sets"]) == (8, 1)
+
+
+def test__validation_preset__group_sizing_flips_a_row_large_group_small_task():
+    """The regime can differ by which sample size is used; grouped data is the case that matters.
+
+    Mirrors a benchmark task with 4,672 rows across 68 groups: large by rows, small by groups.
+    """
+    curves = {"num_bag_folds": [[500, 5], 8], "num_bag_sets": [[500, 5], 1]}
+    preset = _get_validation_preset(
+        num_train_rows=4_672,
+        hpo_enabled=False,
+        validation_curves=curves,
+        num_group_instances=68,
+        size_on_groups=True,
+    )
+    assert (preset["num_bag_folds"], preset["num_bag_sets"]) == (5, 5)
+    # holdout_frac is a fraction of the rows held out, so it stays sized on rows
+    rows_only = _get_validation_preset(num_train_rows=4_672, hpo_enabled=False, validation_curves=curves)
+    assert preset["holdout_frac"] == rows_only["holdout_frac"]

--- a/tabular/tests/unittests/test_validation_structure.py
+++ b/tabular/tests/unittests/test_validation_structure.py
@@ -511,3 +511,38 @@ def test__validation_structure__group_instance_count_is_none_without_grouping():
     assert ValidationStructure(group_time_on="gid").num_group_instances(X) == 2
     assert ValidationStructure(time_on="t").num_group_instances(X) is None
     assert ValidationStructure(stratify_on="gid").num_group_instances(X) is None
+
+
+def test__predictor_fit__validation_curves_reach_the_fit():
+    """`validation_curves` is a fit kwarg: a curve must change the bagging actually performed."""
+    from autogluon.tabular import TabularPredictor
+
+    rng = np.random.default_rng(0)
+    n = 900
+    df = pd.DataFrame({"f1": rng.normal(size=n), "gid": np.repeat(np.arange(60), 15), "label": rng.integers(0, 2, n)})
+
+    def children(**fit_kwargs) -> int:
+        predictor = TabularPredictor(label="label", verbosity=0).fit(
+            df,
+            hyperparameters={"DUMMY": {}},
+            auto_stack=True,
+            fit_weighted_ensemble=False,
+            **fit_kwargs,
+        )
+        model_info = predictor.info()["model_info"]
+        bagged = next(name for name in model_info if "BAG_L1" in name)
+        return len(model_info[bagged]["children_info"])
+
+    repeated = {"num_bag_folds": [[1_000, 5], 8], "num_bag_sets": [[1_000, 5], 5]}
+    assert children() == 8  # default: 8 folds, 1 repeat
+    assert children(validation_curves=repeated) == 25  # 5 folds x 5 repeats
+    # an explicitly passed value still wins over the curve
+    assert children(validation_curves={"num_bag_sets": [[1_000, 5], 1]}, num_bag_sets=1) == 8
+    # curves are read at the group count when the structure asks for it (60 groups < 100 anchor)
+    assert (
+        children(
+            validation_curves={"num_bag_folds": [[100, 5], 8], "num_bag_sets": [[100, 5], 5]},
+            validation_structure={"group_on": "gid", "size_validation_on_groups": True},
+        )
+        == 25
+    )

--- a/tabular/tests/unittests/test_validation_structure.py
+++ b/tabular/tests/unittests/test_validation_structure.py
@@ -465,3 +465,49 @@ def test__predictor_fit__grouped_structure_keeps_requested_repeats():
     splits = predictor._trainer.load_model("Dummy_BAG_L1").params.get("custom_splits")
     assert len(splits) == 15
     assert len(predictor.info()["model_info"]["Dummy_BAG_L1"]["children_info"]) == 15
+
+
+def test__predictor_fit__size_validation_on_groups_changes_the_chosen_method():
+    """Sizing on groups instead of rows can select a different validation method.
+
+    900 rows across 60 groups is large by rows and small by groups: on rows the preset gives
+    8 folds and permits a stack layer, on groups 6 folds and none.
+    """
+    from autogluon.tabular import TabularPredictor
+
+    rng = np.random.default_rng(0)
+    n = 900
+    df = pd.DataFrame({"f1": rng.normal(size=n), "gid": np.repeat(np.arange(60), 15), "label": rng.integers(0, 3, n)})
+
+    def fit(structure: dict) -> tuple[int, list[str]]:
+        predictor = TabularPredictor(label="label", verbosity=0).fit(
+            df,
+            hyperparameters={"DUMMY": {}},
+            validation_structure=structure,
+            auto_stack=True,
+            dynamic_stacking=False,
+            fit_weighted_ensemble=False,
+        )
+        model_info = predictor.info()["model_info"]
+        bagged = next(name for name in model_info if "BAG_L1" in name)
+        return len(model_info[bagged]["children_info"]), sorted(model_info)
+
+    folds_on_rows, models_on_rows = fit({"group_on": "gid"})
+    folds_on_groups, models_on_groups = fit({"group_on": "gid", "size_validation_on_groups": True})
+
+    assert folds_on_rows == 8
+    assert folds_on_groups == 6
+    # the group count is below the stacking size threshold, so no second layer is added
+    assert any("L2" in name for name in models_on_rows)
+    assert not any("L2" in name for name in models_on_groups)
+
+
+def test__validation_structure__group_instance_count_is_none_without_grouping():
+    """The count is only meaningful for grouped structures."""
+    from autogluon.common.utils.validation_structure import ValidationStructure
+
+    X = pd.DataFrame({"f1": [0.0, 1.0, 2.0, 3.0], "gid": [0, 0, 1, 1], "t": [1, 2, 3, 4]})
+    assert ValidationStructure(group_on="gid").num_group_instances(X) == 2
+    assert ValidationStructure(group_time_on="gid").num_group_instances(X) == 2
+    assert ValidationStructure(time_on="t").num_group_instances(X) is None
+    assert ValidationStructure(stratify_on="gid").num_group_instances(X) is None

--- a/tabular/tests/unittests/test_validation_structure.py
+++ b/tabular/tests/unittests/test_validation_structure.py
@@ -514,7 +514,7 @@ def test__validation_structure__group_instance_count_is_none_without_grouping():
 
 
 def test__predictor_fit__validation_curves_reach_the_fit():
-    """`validation_curves` is a fit kwarg: a curve must change the bagging actually performed."""
+    """`validation_size_curves` is a fit kwarg: a curve must change the bagging actually performed."""
     from autogluon.tabular import TabularPredictor
 
     rng = np.random.default_rng(0)
@@ -535,13 +535,13 @@ def test__predictor_fit__validation_curves_reach_the_fit():
 
     repeated = {"num_bag_folds": [[1_000, 5], 8], "num_bag_sets": [[1_000, 5], 5]}
     assert children() == 8  # default: 8 folds, 1 repeat
-    assert children(validation_curves=repeated) == 25  # 5 folds x 5 repeats
+    assert children(validation_size_curves=repeated) == 25  # 5 folds x 5 repeats
     # an explicitly passed value still wins over the curve
-    assert children(validation_curves={"num_bag_sets": [[1_000, 5], 1]}, num_bag_sets=1) == 8
+    assert children(validation_size_curves={"num_bag_sets": [[1_000, 5], 1]}, num_bag_sets=1) == 8
     # curves are read at the group count when the structure asks for it (60 groups < 100 anchor)
     assert (
         children(
-            validation_curves={"num_bag_folds": [[100, 5], 8], "num_bag_sets": [[100, 5], 5]},
+            validation_size_curves={"num_bag_folds": [[100, 5], 8], "num_bag_sets": [[100, 5], 5]},
             validation_structure={"group_on": "gid", "size_validation_on_groups": True},
         )
         == 25

--- a/tabular/tests/unittests/test_validation_structure.py
+++ b/tabular/tests/unittests/test_validation_structure.py
@@ -391,3 +391,77 @@ def test__predictor_fit__dynamic_stacking__honors_the_structure(validation_proce
         checked = holdouts
     for train_idx, val_idx in checked:
         assert not (set(groups[train_idx]) & set(groups[val_idx]))
+
+
+@pytest.mark.parametrize("structure_key", ["time_on", "group_time_on"])
+def test__predictor_fit__temporal_structure_collapses_requested_repeats(structure_key):
+    """A temporal partition is deterministic, so repeats must collapse to 1 for the whole fit.
+
+    The count has to be corrected end to end, not just inside the resolver: the bagged model
+    asserts ``len(custom_splits) == num_bag_folds * num_bag_sets``, so a request of 3x5 that
+    yields 3 splits only works if the reduced repeat count propagates to the trainer.
+    """
+    import logging
+
+    from autogluon.tabular import TabularPredictor
+
+    rng = np.random.default_rng(0)
+    n = 120
+    df = pd.DataFrame(
+        {
+            "f1": rng.normal(size=n),
+            "t": np.repeat(np.arange(30), 4),  # 30 distinct time values / groups-in-time
+            "label": rng.integers(0, 2, n),
+        }
+    )
+
+    # AutoGluon reconfigures logger propagation, so collect from the module logger directly
+    # rather than through caplog's root handler.
+    messages: list[str] = []
+
+    class _Collect(logging.Handler):
+        def emit(self, record):
+            messages.append(record.getMessage())
+
+    structure_logger = logging.getLogger("autogluon.common.utils.validation_structure")
+    handler = _Collect()
+    structure_logger.addHandler(handler)
+    try:
+        predictor = TabularPredictor(label="label", verbosity=2).fit(
+            df,
+            hyperparameters={"DUMMY": {}},
+            num_bag_folds=3,
+            num_bag_sets=5,  # would give 15 children on IID or grouped data
+            validation_structure={structure_key: "t"},
+            fit_weighted_ensemble=False,
+            raise_on_model_failure=True,
+        )
+    finally:
+        structure_logger.removeHandler(handler)
+
+    splits = predictor._trainer.load_model("Dummy_BAG_L1").params.get("custom_splits")
+    assert len(splits) == 3, "repeats were not collapsed for a temporal partition"
+    assert len(predictor.info()["model_info"]["Dummy_BAG_L1"]["children_info"]) == 3
+    # the reduction is reported rather than silently applied
+    assert any("num_repeats reduced from 5 to 1" in message for message in messages)
+
+
+def test__predictor_fit__grouped_structure_keeps_requested_repeats():
+    """Contrast with the temporal case: grouped folds are not deterministic, so repeats stand."""
+    from autogluon.tabular import TabularPredictor
+
+    rng = np.random.default_rng(0)
+    n = 120
+    df = pd.DataFrame({"f1": rng.normal(size=n), "gid": np.repeat(np.arange(20), 6), "label": rng.integers(0, 2, n)})
+    predictor = TabularPredictor(label="label", verbosity=0).fit(
+        df,
+        hyperparameters={"DUMMY": {}},
+        num_bag_folds=3,
+        num_bag_sets=5,
+        validation_structure={"group_on": "gid"},
+        fit_weighted_ensemble=False,
+        raise_on_model_failure=True,
+    )
+    splits = predictor._trainer.load_model("Dummy_BAG_L1").params.get("custom_splits")
+    assert len(splits) == 15
+    assert len(predictor.info()["model_info"]["Dummy_BAG_L1"]["children_info"]) == 15


### PR DESCRIPTION
## Summary

The validation method AutoGluon picks when the user specifies nothing was encoded as arithmetic — `min(8, max(5, rows / 10))` for folds, a bare `1` for repeats, a `>= 1e6` comparison for the extra holdout, and a compound condition with an embedded 750-row threshold for stack depth.

Those thresholds are real policy decisions, but they were buried in expressions a reader has to re-derive, and retuning any of them per size regime meant editing the module. Each knob is now a **size curve**: either a fixed value or `[[rows, value], ..., fallback]`, read as "use `value` at or below `rows`".

```python
{"num_bag_sets": [[2_000, 5], 1]}                  # repeated CV on small data
{"holdout_frac": [[1_000, 0.2], 0.1]}              # hold out 20% on small data, 10% above
{"use_bag_holdout": [[10_000, False], True]}       # move the CV/holdout switch
{"num_stack_levels": [[749, 0], [100_000, 1], 2]}  # a second layer on large data
```

This is the same declarative shape as the count-based fit callbacks. `_get_validation_preset` takes an optional `validation_size_curves` override, so one knob can be retuned without restating the rest — `num_bag_sets` in particular could not previously express anything but `1`.

## Usage

What is reachable from `fit()` today is the group-based sizing, via a key of `validation_structure`:

```python
import numpy as np
import pandas as pd
from autogluon.tabular import TabularPredictor

# 900 rows, but only 60 independent patients: large by rows, small by groups.
rng = np.random.default_rng(0)
n = 900
train_data = pd.DataFrame({
    "feature": rng.normal(size=n),
    "patient_id": np.repeat(np.arange(60), 15),
    "outcome": rng.integers(0, 2, n),
})

predictor = TabularPredictor(label="outcome").fit(
    train_data,
    auto_stack=True,  # so the auto-selected validation method is used
    validation_structure={
        "group_on": "patient_id",            # group-disjoint folds
        "size_validation_on_groups": True,   # ...and size the method on 60 groups, not 900 rows
    },
)
```

That fit uses **6 folds and no stack layer** (sized on 60 groups). Leaving
`size_validation_on_groups` at its default `False` gives **8 folds and a stack layer** (sized on
900 rows), which is today's behavior.

Retuning how the method scales with size is a `validation_size_curves` kwarg (marked **[EXPERIMENTAL]**: the curve format and the set of tunable knobs may still change):

```python
from autogluon.tabular.configs.pipeline_presets import ValidationSizeCurves

predictor = TabularPredictor(label="outcome").fit(
    train_data,
    auto_stack=True,
    # repeated CV at or below 2000 rows; a plain dict is accepted too
    validation_size_curves=ValidationSizeCurves(num_bag_sets=[[2_000, 5], 1]),
)
```

Unset knobs keep their defaults, and unknown knob names are rejected rather than silently ignored.

Only the entries given are overridden, and an explicitly passed `num_bag_folds` /
`num_bag_sets` / `use_bag_holdout` / `num_stack_levels` still wins over any curve. The two
compose: with `size_validation_on_groups` the curves are read at the group count, so
`validation_size_curves={"num_bag_folds": [[100, 5], 8], "num_bag_sets": [[100, 5], 5]}` on the
60-group frame above gives 5x5 cross-validation.

## How this composes with structure-aware clamping

The curves are **policy**: what to ask for at a given data size. `ValidationStructure.custom_splits` is **feasibility**: it reduces the requested fold and repeat counts where the data cannot support them (fewer groups than folds, a stratification value rarer than the fold count, a deterministic temporal partition), never raises them, and returns what it used for the caller to adopt.

So a caller may treat its request as an upper bound, and neither half needs to know the other's rules. Documented on both sides.

## Behavior is unchanged

`DEFAULT_VALIDATION_SIZE_CURVES` reproduce the old numbers exactly. Asserted against the replaced expressions:

- folds / repeats / holdout: every size from 1 row to past the 1M threshold;
- stack depth: all **324** combinations of rows × `auto_stack` × `dynamic_stacking` × `use_bag_holdout` × problem type, since the row threshold gates only part of that condition and dynamic stacking is exempt from it.

Whether repeats actually help on small data is a separate question this makes answerable by experiment rather than by editing code.

## Optional group-based sizing

Rows and group counts can imply different regimes. A benchmark task with 4,672 rows across 68 groups is large by rows and small by groups, and the grouped protocol treats it as small — 5x5 CV where row-based sizing gives 8x1.

`validation_structure={"group_on": ..., "size_validation_on_groups": True}` reads the curves at the group count instead. It is **off by default**: a declared grouping alone changes nothing, because when rows within a group are not independent the group count is often the sample size that matters, but whether that applies is a judgement about the data rather than something to infer from the presence of a grouping. The flag is a key of `validation_structure` so it is validated and documented with the columns beside it.

`ValidationStructure` exposes `num_group_instances(X)` (None without a grouping) and `TabularPredictor.fit` passes it through; the structure is now resolved before the validation method is chosen, since the method can depend on it. `holdout_frac` stays sized on rows either way, being a fraction of the rows actually held out.

End to end on 900 rows across 60 groups with `auto_stack=True`: rows give 8 folds and a stack layer, groups give 6 folds and none.

## Also

A temporal structure silently corrected requested repeats to 1 (the partition is deterministic, so the resolver returns 1 and the caller adopts it). Correct, but invisible — now logged, with a test pinning the correction end to end: a fit requesting 3x5 on `time_on` must produce 3 child models, not 15, which only works if the reduced count reaches the trainer.

## Testing

`tabular/tests/unittests/configs/test_validation_size_curves.py` (new) plus additions to `test_validation_structure.py` — 140 tests pass. Coverage: curve resolution and malformed-curve rejection, equivalence with the replaced arithmetic, each knob's override, opt-in group sizing including that a known group count alone changes nothing, and the temporal repeat collapse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi






