### PR TITLE
Disable use_child_oof when custom_splits are given

### DIFF
--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -330,6 +330,17 @@ class BaggedEnsembleModel(AbstractModel):
         if use_child_oof and groups is not None:
             logger.log(20, f"\tForcing `use_child_oof=False` because `groups` is specified")
             use_child_oof = False
+        if use_child_oof and self.params.get("custom_splits", None) is not None:
+            # `use_child_oof` replaces cross-validation with the child model's own internal
+            # estimate (e.g. a random forest's out-of-bag predictions), which is built by
+            # resampling rows independently. Explicit splits are supplied precisely when rows are
+            # NOT independent -- group-disjoint or forward-in-time validation -- so that estimate
+            # would leak across the boundary the splits exist to enforce, and score far better
+            # than an honest one. Same reasoning as the `groups` case above; this covers the
+            # channel that grouped / temporal validation actually arrives through (`custom_splits`
+            # from `ag_args_ensemble`, or resolved from a `validation_structure`).
+            logger.log(20, "\tForcing `use_child_oof=False` because `custom_splits` is specified")
+            use_child_oof = False
         if use_child_oof:
             if self.is_fit():
                 # TODO: We may want to throw an exception instead and avoid calling fit more than once

--- a/core/tests/unittests/models/test_bagged_ensemble_model.py
+++ b/core/tests/unittests/models/test_bagged_ensemble_model.py
@@ -3,6 +3,7 @@ import pandas as pd
 
 from autogluon.common.utils.cv_splitter import CVSplitter
 from autogluon.core.models import BaggedEnsembleModel
+from autogluon.core.models.dummy.dummy_model import DummyModel
 
 
 def test_generate_fold_configs():
@@ -128,3 +129,69 @@ def test_generate_fold_configs_with_offset_index():
     # iloc access with those positional indices gives the correct labels
     assert X.iloc[test_idx_0].index[0] == 1000
     assert X.iloc[test_idx_1].index[0] == 1000 + n // 2
+
+
+class OofCapableDummyModel(DummyModel):
+    """A DummyModel that reports its own out-of-fold predictions, as forests / KNN do.
+
+    Module scope rather than nested in a test, so a fitted bag can be pickled.
+    """
+
+    def predict_proba_oof(self, X, y=None, **kwargs):
+        return self.predict_proba(X=X)
+
+    def _more_tags(self):
+        return {"valid_oof": True}
+
+
+def test_use_child_oof_disabled_by_custom_splits():
+    """`use_child_oof` must yield to explicit splits, which exist to prevent leakage.
+
+    A child's internal out-of-bag estimate resamples rows independently, so on grouped or
+    temporal data it scores across the very boundary the splits enforce. `custom_splits` is the
+    channel grouped / temporal validation arrives through (directly via `ag_args_ensemble`, or
+    resolved from a `validation_structure`), so it must force real cross-validation -- as
+    `groups` already did.
+    """
+    n_rows = 12
+    X = pd.DataFrame({"a": range(n_rows)})
+    y = pd.Series([0, 1] * (n_rows // 2))
+    splits = [
+        (np.arange(4, n_rows), np.arange(0, 4)),
+        (np.setdiff1d(np.arange(n_rows), np.arange(4, 8)), np.arange(4, 8)),
+        (np.arange(0, 8), np.arange(8, n_rows)),
+    ]
+
+    bagged = BaggedEnsembleModel(
+        model_base=DummyModel(),
+        hyperparameters={"use_child_oof": True, "custom_splits": splits, "fold_fitting_strategy": "sequential_local"},
+    )
+    bagged.fit(X=X, y=y, k_fold=len(splits))
+
+    # One child per supplied split (not the single child `use_child_oof` would have trained),
+    # and every row has an out-of-fold prediction from the fold that held it out.
+    assert bagged.n_children == len(splits)
+    assert len(bagged._oof_pred_proba) == n_rows
+
+    # The realized folds are the ones that were passed in.
+    realized = [tuple(val_idx) for _, val_idx in bagged._cv_splitters[0].split(X=X, y=y)]
+    assert realized == [tuple(val_idx) for _, val_idx in splits]
+
+
+def test_use_child_oof_kept_without_custom_splits():
+    """Without explicit splits there is no boundary to violate, so `use_child_oof` still applies.
+
+    The counterpart of the test above: the guard must be specific to explicit splits rather than
+    disabling `use_child_oof` generally.
+    """
+    X = pd.DataFrame({"a": range(12)})
+    y = pd.Series([0, 1] * 6)
+
+    bagged = BaggedEnsembleModel(
+        model_base=OofCapableDummyModel(),
+        hyperparameters={"use_child_oof": True, "fold_fitting_strategy": "sequential_local"},
+    )
+    bagged.fit(X=X, y=y, k_fold=3)
+
+    # A single child, whose own estimate stands in for cross-validation.
+    assert bagged.n_children == 1


### PR DESCRIPTION
## Summary

`use_child_oof` replaces cross-validation with the child model's own internal estimate — a forest's out-of-bag predictions, KNN's leave-one-out. That estimate resamples rows independently, so on grouped or temporal data it scores across the very boundary the validation splits exist to enforce, and reports a validation score that is too good.

`BaggedEnsembleModel._fit` already guarded against this for the `groups` channel:

```python
if use_child_oof and groups is not None:
    logger.log(20, "\tForcing `use_child_oof=False` because `groups` is specified")
    use_child_oof = False
```

But grouped and temporal validation reaches a bagged model as **`custom_splits`**, not as `groups`: either passed directly via `ag_args_ensemble`, or resolved by the learner from a `validation_structure` (#5756). So the guard never fired for either, and those models reported leaked validation scores. This adds the same guard for `custom_splits`.

## Why it matters

Measured on a grouped task (127 rows across 21 patient groups, 3 folds), `ExtraTrees` validation `roc_auc`:

| validation source | score_val |
|---|---|
| out-of-bag estimate (`use_child_oof`, before) | **0.991** |
| real patient-disjoint 3-fold CV (after) | **0.840** |

For reference, LightGBM on the same folds scores 0.685. Validation scores drive model selection and weighted-ensemble weighting, so a 0.15 inflation on one model family distorts both — and it distorts them specifically on the data where honest validation matters most. After the fix, every model in the fit uses the identical supplied partition.

`use_child_oof=True` is a model-level default for `RandomForest`, `ExtraTrees` (`rf_model.py`) and `KNN` (`knn_model.py`), so the guard is placed centrally in `BaggedEnsembleModel._fit` rather than per model.

## Scope

Keyed on `custom_splits` being present, which is the general statement of the problem: a caller who supplies explicit splits wants those splits honored, and `use_child_oof` ignores them entirely. It is not narrowed to grouped/temporal because there is no case where supplying explicit splits and then not using them is correct.

Behavior is unchanged when no `custom_splits` are given — ordinary IID bagging keeps using `use_child_oof`, so forests and KNN still train one child instead of `k`.

## Related

A nearby path is left reachable, and is arguably worse: when `use_child_oof` is set for a model with **no** dedicated `predict_proba_oof`, `_fit` warns and falls back to in-sample `predict_proba` (`"This model may have heavily overfit validation scores"`). This change pre-empts that whenever explicit splits are present, but it remains reachable otherwise.

## Testing

Two tests in `core/tests/unittests/models/test_bagged_ensemble_model.py`:

- `test_use_child_oof_disabled_by_custom_splits` — with `use_child_oof=True` **and** `custom_splits`, asserts one child per supplied split (not the single child `use_child_oof` would train), an out-of-fold prediction for every row, and that the realized folds are the ones passed in.
- `test_use_child_oof_kept_without_custom_splits` — without splits, a `valid_oof`-capable child still trains a single child, so the guard stays specific rather than disabling the feature generally.

Also run: `core/tests/unittests/models/test_bagged_ensemble_model.py` (4 passed), `tabular/tests/unittests/models/advanced/test_model_random_seed.py` (15 passed, the existing suite that exercises `use_child_oof`), `tabular/tests/unittests/test_validation_structure.py` + `configs/test_validation_size_curves.py` (96 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi
