### PR TITLE
Add forward-chaining temporal validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,8 @@ multimodal/src/autogluon/multimodal/version.py
 
 AutogluonModels
 lightning_logs
+
+# Datasets and fitted predictors written by the test suite. Left unanchored because the location
+# depends on the directory pytest was run from (repo root, `tabular/`, ...), and no tracked file
+# lives under a `datasets` directory.
+datasets/

--- a/common/src/autogluon/common/utils/validation_structure.py
+++ b/common/src/autogluon/common/utils/validation_structure.py
@@ -46,6 +46,22 @@ class ValidationStructure:
         are simultaneously group-disjoint and forward in time, and the non-bagged holdout is
         the latest groups. Use this for data that is both grouped and temporal; combining
         ``group_on`` with ``time_on`` is not supported, as their semantics would be ambiguous.
+    temporal_forward_only : bool, default False
+        Restrict temporal validation to forward-chaining (an expanding window): fold *i*
+        validates time block *i+1* and trains only on the blocks before it, so a model is never
+        trained on data from after the window it is scored on.
+
+        The default (False) is leave-one-block-out: every block is validated exactly once and
+        trained on for every other fold, which covers all rows but trains most folds partly on
+        the future. Forward-chaining removes that lookahead at two costs:
+
+        1. **The earliest block is never validated.** It is training data only, so those rows
+           get no out-of-fold prediction. Callers that consume out-of-fold predictions must
+           handle the gap -- see :meth:`uncovered_rows`.
+        2. **Folds train on less data.** Fold 0 sees one block; only the last sees nearly all.
+
+        Requires at least 3 blocks (2 folds plus the initial training block), and has no effect
+        unless ``time_on`` or ``group_time_on`` is set.
     """
 
     group_on: str | list[str] | None = None
@@ -53,6 +69,7 @@ class ValidationStructure:
     stratify_on: str | None = None
     group_time_on: str | None = None
     size_validation_on_groups: bool = False
+    temporal_forward_only: bool = False
 
     def __post_init__(self):
         if self.group_on is not None and self.time_on is not None:
@@ -65,6 +82,10 @@ class ValidationStructure:
         if all(v is None for v in (self.group_on, self.time_on, self.stratify_on, self.group_time_on)):
             raise ValueError(
                 "ValidationStructure requires at least one of `group_on`, `time_on`, `stratify_on`, `group_time_on`."
+            )
+        if self.temporal_forward_only and self.time_on is None and self.group_time_on is None:
+            raise ValueError(
+                "`temporal_forward_only` requires `time_on` or `group_time_on`; there is no time order to chain along."
             )
 
     @classmethod
@@ -159,6 +180,27 @@ class ValidationStructure:
         num_repeats = max(1, num_repeats if num_repeats is not None else 1)
 
         if self.time_on is not None or self.group_time_on is not None:
+            if self.temporal_forward_only:
+                # One more block than folds: the earliest is training data for every fold and is
+                # itself never validated.
+                labels = self._temporal_labels(X, n_blocks=num_folds + 1)
+                splits = _forward_chaining_splits(labels)
+                if len(splits) < 2:
+                    # One fold is a single forward holdout, not cross-validation; bagging needs >= 2.
+                    raise ValueError(
+                        f"`temporal_forward_only` needs at least 3 time blocks to form 2 folds, but "
+                        f"{self.time_on or self.group_time_on!r} supports only {labels.nunique()} "
+                        f"(yielding {len(splits)} fold(s)). Use the default temporal splits, or a "
+                        f"non-bagged holdout, for data this coarse in time."
+                    )
+                uncovered = len(X) - sum(len(val_idx) for _, val_idx in splits)
+                logger.log(
+                    20,
+                    f"validation_structure: forward-chaining over {len(splits) + 1} time blocks -> "
+                    f"{len(splits)} folds; the earliest block ({uncovered} rows) is never validated, so "
+                    f"those rows get no out-of-fold prediction.",
+                )
+                return splits, len(splits), 1
             labels = self._temporal_labels(X, n_blocks=num_folds)
             # Route the block labels through GroupKFold rather than emitting them in
             # chronological order: the partition set is the same either way, but this
@@ -234,6 +276,21 @@ class ValidationStructure:
             splits.extend(repeat_splits)
         _validate_splits(splits, n_rows=len(X), stratify=self._stratify_values(X, y))
         return splits, num_folds, num_repeats
+
+    def uncovered_rows(self, X: pd.DataFrame, y: pd.Series, **kwargs) -> np.ndarray:
+        """Positional indices of rows no fold validates, i.e. rows that get no out-of-fold prediction.
+
+        Empty for every configuration except ``temporal_forward_only``, whose earliest time block
+        is training data only. Callers that consume out-of-fold predictions should exclude these
+        rows: a bagged model leaves them at the accumulator's initial value rather than marking
+        them missing, so downstream they read as a prediction of 0 rather than as absent.
+
+        ``**kwargs`` are forwarded to :meth:`custom_splits` (``num_folds``, ``random_state``, ...)
+        so the answer matches the splits that call produces.
+        """
+        splits, _, _ = self.custom_splits(X, y, **kwargs)
+        covered = np.concatenate([val_idx for _, val_idx in splits]) if splits else np.array([], dtype=int)
+        return np.setdiff1d(np.arange(len(X)), covered)
 
     # ── column access helpers ────────────────────────────────────────────────────
 
@@ -399,6 +456,25 @@ def _splits_from_labels(labels: pd.Series) -> list[tuple[np.ndarray, np.ndarray]
     for label in sorted(pd.unique(values)):
         val_idx = np.flatnonzero(values == label)
         train_idx = np.flatnonzero(values != label)
+        if len(train_idx) == 0 or len(val_idx) == 0:
+            continue
+        splits.append((train_idx, val_idx))
+    return splits
+
+
+def _forward_chaining_splits(labels: pd.Series) -> list[tuple[np.ndarray, np.ndarray]]:
+    """Expanding-window positional splits: fold *i* validates block *i+1*, trains on blocks <= *i*.
+
+    With ``n`` blocks this yields ``n - 1`` folds. The earliest block appears only in training
+    sets, so it is never validated -- unlike leave-one-block-out, the returned splits do not
+    cover every row. No fold ever trains on a row later than its validation window.
+    """
+    values = np.asarray(labels)
+    ordered = sorted(pd.unique(values))
+    splits = []
+    for i, label in enumerate(ordered[1:], start=1):
+        val_idx = np.flatnonzero(values == label)
+        train_idx = np.flatnonzero(np.isin(values, ordered[:i]))
         if len(train_idx) == 0 or len(val_idx) == 0:
             continue
         splits.append((train_idx, val_idx))

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -212,10 +212,27 @@ class BaggedEnsembleModel(AbstractModel):
 
     @staticmethod
     def _predict_proba_oof(oof_pred_proba, oof_pred_model_repeats, return_type=np.float32) -> np.array:
-        oof_pred_model_repeats_without_0 = np.where(oof_pred_model_repeats == 0, 1, oof_pred_model_repeats)
+        """Average each row's fold predictions, emitting NaN for rows no fold validated.
+
+        A row with ``oof_pred_model_repeats == 0`` was never in a validation fold, so it has no
+        out-of-fold prediction. The accumulator still holds its initial 0 for that row, so
+        returning it as-is would present a fabricated prediction of 0 as a real one -- silently
+        wrong for anything that consumes out-of-fold predictions as features (a stacker) or as a
+        score (the weighted ensemble). NaN says "missing" instead, which consumers can detect;
+        ``score_with_oof`` masks these rows out via the same ``repeats`` array.
+
+        Partial coverage arises when folds are fit incrementally (``k_fold_start`` /
+        ``k_fold_end``) and when the validation scheme deliberately leaves rows unvalidated, as
+        forward-chaining temporal splits do with the earliest time block.
+        """
+        uncovered = oof_pred_model_repeats == 0
+        oof_pred_model_repeats_without_0 = np.where(uncovered, 1, oof_pred_model_repeats)
         if oof_pred_proba.ndim == 2:
             oof_pred_model_repeats_without_0 = oof_pred_model_repeats_without_0[:, None]
-        return (oof_pred_proba / oof_pred_model_repeats_without_0).astype(return_type)
+        oof_pred_proba = (oof_pred_proba / oof_pred_model_repeats_without_0).astype(return_type)
+        if uncovered.any():
+            oof_pred_proba[uncovered] = np.nan
+        return oof_pred_proba
 
     def _init_misc(self, **kwargs):
         child = self._get_model_base().convert_to_template()

--- a/core/tests/unittests/models/test_bagged_ensemble_model.py
+++ b/core/tests/unittests/models/test_bagged_ensemble_model.py
@@ -195,3 +195,50 @@ def test_use_child_oof_kept_without_custom_splits():
 
     # A single child, whose own estimate stands in for cross-validation.
     assert bagged.n_children == 1
+
+
+def test_oof_is_nan_for_rows_no_fold_validated():
+    """Rows outside every validation fold must read as missing, not as a prediction of 0.
+
+    The out-of-fold accumulator starts at 0, so a row no fold validated would otherwise emerge as
+    a confident 0 — silently wrong for anything consuming out-of-fold predictions as features or
+    as a score. Partial coverage is reachable via explicit splits that skip rows, which is what
+    forward-chaining temporal validation does with its earliest time block.
+    """
+    n_rows = 12
+    X = pd.DataFrame({"a": range(n_rows)})
+    y = pd.Series([0, 1] * (n_rows // 2))
+    # Expanding-window splits: rows 0-3 are training data only and never validated.
+    splits = [
+        (np.arange(0, 4), np.arange(4, 8)),
+        (np.arange(0, 8), np.arange(8, n_rows)),
+    ]
+
+    bagged = BaggedEnsembleModel(
+        model_base=DummyModel(),
+        hyperparameters={"custom_splits": splits, "fold_fitting_strategy": "sequential_local"},
+    )
+    bagged.fit(X=X, y=y, k_fold=len(splits))
+
+    oof = bagged.predict_proba_oof()
+    uncovered = np.arange(0, 4)
+    covered = np.arange(4, n_rows)
+    assert np.isnan(np.asarray(oof, dtype=float)[uncovered]).all()
+    assert not np.isnan(np.asarray(oof, dtype=float)[covered]).any()
+
+    # Scoring already excludes the uncovered rows, so a score is still produced.
+    assert bagged.score_with_oof(y=y) is not None
+
+
+def test_oof_has_no_nan_when_every_row_is_validated():
+    """The ordinary case is untouched: full coverage means no NaN."""
+    X = pd.DataFrame({"a": range(12)})
+    y = pd.Series([0, 1] * 6)
+
+    bagged = BaggedEnsembleModel(
+        model_base=DummyModel(),
+        hyperparameters={"fold_fitting_strategy": "sequential_local"},
+    )
+    bagged.fit(X=X, y=y, k_fold=3)
+
+    assert not np.isnan(np.asarray(bagged.predict_proba_oof(), dtype=float)).any()

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -846,6 +846,14 @@ class TabularPredictor:
                 and the non-bagged holdout becomes group-disjoint or temporally forward (the latest time block).
                 Referenced columns remain features. `group_on` and `time_on` cannot be combined.
                 Mutually exclusive with the `groups` init argument.
+                `temporal_forward_only` (bool, default False) switches temporal validation from
+                leave-one-block-out to forward-chaining: fold `i` validates time block `i+1` and trains
+                only on earlier blocks, so no fold is trained on data from after the window it is scored
+                on. The earliest block is then training data only and gets no out-of-fold prediction, so
+                folds train on less data, and stacking is not supported alongside it
+                (`num_stack_levels > 0`, `dynamic_stacking`). The weighted ensemble is supported: it
+                excludes the unvalidated rows, so its validation score stays comparable to the base
+                models'.
             validation_size_curves : dict | ValidationSizeCurves, default = None
                 [EXPERIMENTAL] Overrides for how the automatically selected validation method scales
                 with data size, as a `ValidationSizeCurves` or an equivalent dict. The curve format
@@ -1390,6 +1398,33 @@ class TabularPredictor:
             use_bag_holdout_was_auto=use_bag_holdout_was_auto,
             dynamic_stacking_was_auto=dynamic_stacking_was_auto,
         )
+
+        if validation_structure is not None and validation_structure.temporal_forward_only:
+            # Forward-chaining leaves the earliest time block unvalidated, so those rows have no
+            # out-of-fold prediction. A bagged model leaves them at the OOF accumulator's initial
+            # value, which reads downstream as a prediction of 0 rather than as missing. Validation
+            # *scoring* of a bagged model already excludes them (`score_with_oof` masks on
+            # `_oof_pred_model_repeats > 0`), but everything that consumes out-of-fold predictions
+            # across all rows does not:
+            # The weighted ensemble handles this: `stack_new_level_aux` drops rows whose base-model
+            # out-of-fold predictions are NaN, so it optimizes weights and is scored on the same
+            # rows the base models are scored on. A stacker does not: a higher layer would train on
+            # those rows with NaN for every lower-layer feature, and its own validation score would
+            # cover rows it has no real features for. Refuse that until the trainer drops uncovered
+            # rows at layers above the first.
+            unsupported = []
+            if num_stack_levels > 0:
+                unsupported.append(f"num_stack_levels={num_stack_levels}")
+            if dynamic_stacking:
+                unsupported.append("dynamic_stacking=True")
+            if unsupported:
+                raise ValueError(
+                    "`validation_structure.temporal_forward_only=True` cannot be combined with "
+                    f"{', '.join(unsupported)}. Forward-chaining leaves the earliest time block "
+                    "without out-of-fold predictions, so a higher stacking layer would have no real "
+                    "features for those rows. Set num_stack_levels=0 and dynamic_stacking=False, or "
+                    "use the default leave-one-block-out temporal splits."
+                )
         if auto_stack:
             logger.log(
                 20,

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -1034,6 +1034,24 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         X_stack_preds = self.get_inputs_to_stacker(
             X, base_models=base_model_names, fit=fit, use_orig_features=False, use_val_cache=use_val_cache
         )
+        if fit:
+            # Drop rows no base model validated. Their out-of-fold predictions are NaN (see
+            # `BaggedEnsembleModel._predict_proba_oof`), so keeping them would have the ensemble
+            # optimize weights against, and be scored on, rows where it has no base predictions --
+            # while the base models it is compared against are scored only on their covered rows
+            # (`score_with_oof`). Dropping keeps both sides on the same rows, so the leaderboard
+            # stays comparable. Safe here because the weighted ensemble is fit unbagged (k_fold=1),
+            # so no positional fold indices are invalidated by the reindex.
+            covered = X_stack_preds.notna().all(axis=1)
+            if not covered.all():
+                logger.log(
+                    20,
+                    f"\tWeighted ensemble: excluding {int((~covered).sum())} of {len(covered)} rows "
+                    f"with no out-of-fold predictions from the base models.",
+                )
+                X_stack_preds = X_stack_preds[covered]
+                X = X[covered]
+                y = y[covered]
         if self.weight_evaluation:
             X, w = extract_column(
                 X, self.sample_weight

--- a/tabular/tests/unittests/test_validation_structure.py
+++ b/tabular/tests/unittests/test_validation_structure.py
@@ -546,3 +546,154 @@ def test__predictor_fit__validation_curves_reach_the_fit():
         )
         == 25
     )
+
+
+def test__custom_splits__temporal_forward_only__never_trains_on_the_future():
+    """Forward-chaining: every fold's training rows precede its validation window."""
+    X, y = _toy_temporal(n=200)
+    vs = ValidationStructure(time_on="ts", temporal_forward_only=True)
+    splits, num_folds, num_repeats = vs.custom_splits(X, y, num_folds=4, num_repeats=1)
+
+    assert (num_folds, num_repeats) == (4, 1)
+    assert len(splits) == 4
+    for train_idx, val_idx in splits:
+        assert X["ts"].iloc[train_idx].max() < X["ts"].iloc[val_idx].min()
+
+    # Expanding window: each fold trains on everything validated so far, so train sets grow and
+    # validation windows advance in time.
+    train_sizes = [len(train_idx) for train_idx, _ in splits]
+    assert train_sizes == sorted(train_sizes)
+    assert train_sizes[0] < train_sizes[-1]
+    val_starts = [X["ts"].iloc[val_idx].min() for _, val_idx in splits]
+    assert val_starts == sorted(val_starts)
+
+
+def test__custom_splits__temporal_forward_only__earliest_block_is_never_validated():
+    """The cost of forward-chaining: the first block has no out-of-fold prediction."""
+    X, y = _toy_temporal(n=200)
+    vs = ValidationStructure(time_on="ts", temporal_forward_only=True)
+    splits, _, _ = vs.custom_splits(X, y, num_folds=4, num_repeats=1)
+
+    validated = np.concatenate([val_idx for _, val_idx in splits])
+    # Each validated row appears exactly once, but not every row is validated.
+    assert len(validated) == len(np.unique(validated))
+    assert len(validated) < len(X)
+
+    uncovered = vs.uncovered_rows(X, y, num_folds=4, num_repeats=1)
+    assert len(uncovered) == len(X) - len(validated)
+    # The gap is the earliest block: it precedes every validation window.
+    assert X["ts"].iloc[uncovered].max() <= min(X["ts"].iloc[val_idx].min() for _, val_idx in splits)
+
+
+def test__custom_splits__leave_one_block_out_covers_every_row():
+    """The default temporal mode is the trade-off's other side: full coverage, some lookahead."""
+    X, y = _toy_temporal(n=200)
+    vs = ValidationStructure(time_on="ts")
+    splits, _, _ = vs.custom_splits(X, y, num_folds=4, num_repeats=1)
+
+    validated = np.concatenate([val_idx for _, val_idx in splits])
+    assert sorted(validated) == list(range(len(X)))
+    assert len(vs.uncovered_rows(X, y, num_folds=4, num_repeats=1)) == 0
+    # At least one fold trains on rows later than its validation window (the lookahead).
+    assert any(X["ts"].iloc[tr].max() > X["ts"].iloc[va].max() for tr, va in splits)
+
+
+def test__temporal_forward_only__requires_a_time_column():
+    with pytest.raises(ValueError, match="requires `time_on` or `group_time_on`"):
+        ValidationStructure(group_on="gid", temporal_forward_only=True)
+
+
+def test__temporal_forward_only__group_time_on_blocks_whole_groups():
+    """`group_time_on` forward-chains over whole groups, staying group-disjoint."""
+    n_groups, rows_per_group = 12, 5
+    gids = np.repeat(np.arange(n_groups), rows_per_group)
+    X = pd.DataFrame({"num": np.arange(len(gids), dtype=float), "sid": gids})
+    y = pd.Series(np.tile([0, 1, 0, 1, 1], n_groups))
+
+    vs = ValidationStructure(group_time_on="sid", temporal_forward_only=True)
+    splits, _, _ = vs.custom_splits(X, y, num_folds=3, num_repeats=1)
+
+    for train_idx, val_idx in splits:
+        train_groups = set(X["sid"].iloc[train_idx])
+        val_groups = set(X["sid"].iloc[val_idx])
+        assert not (train_groups & val_groups)
+        # Forward in group order too.
+        assert max(train_groups) < min(val_groups)
+
+
+def test__temporal_forward_only__too_few_blocks_raises():
+    X = pd.DataFrame({"num": [0.0, 1.0, 2.0, 3.0], "ts": pd.to_datetime(["2026-01-01"] * 2 + ["2026-01-02"] * 2)})
+    y = pd.Series([0, 1, 0, 1])
+    vs = ValidationStructure(time_on="ts", temporal_forward_only=True)
+    with pytest.raises(ValueError, match="at least 3 time blocks"):
+        vs.custom_splits(X, y, num_folds=4, num_repeats=1)
+
+
+def test__temporal_forward_only__weighted_ensemble_is_scored_on_covered_rows():
+    """The weighted ensemble must be scored on the same rows as the models it is ranked against.
+
+    Forward-chaining leaves the earliest time block unvalidated. Base models exclude those rows
+    from their validation score (`score_with_oof` masks on fold coverage), so the ensemble must
+    too -- otherwise its score covers a different row set and best-model selection is comparing
+    unlike numbers. With a single base model at weight 1.0 the two scores must coincide exactly.
+    """
+    from autogluon.tabular import TabularPredictor
+
+    rng = np.random.default_rng(0)
+    n = 300
+    data = pd.DataFrame(
+        {
+            "num": rng.normal(size=n),
+            "ts": pd.to_datetime("2026-01-01") + pd.to_timedelta(np.sort(rng.integers(0, 60, size=n)), unit="D"),
+        }
+    )
+    data["y"] = 3.0 * data["num"] + rng.normal(scale=0.5, size=n)
+
+    predictor = TabularPredictor(label="y", problem_type="regression", verbosity=0).fit(
+        data,
+        hyperparameters={"GBM": [{"num_boost_round": 20}]},
+        num_bag_folds=4,
+        num_bag_sets=1,
+        num_stack_levels=0,
+        dynamic_stacking=False,
+        fit_weighted_ensemble=True,
+        validation_structure={"time_on": "ts", "temporal_forward_only": True},
+    )
+
+    leaderboard = predictor.leaderboard(silent=True).set_index("model")["score_val"]
+    base = [m for m in leaderboard.index if "WeightedEnsemble" not in m]
+    ensemble = [m for m in leaderboard.index if "WeightedEnsemble" in m]
+    assert len(base) == 1 and len(ensemble) == 1
+    assert leaderboard[ensemble[0]] == pytest.approx(leaderboard[base[0]])
+
+    # The unvalidated rows are reported as missing rather than as a prediction of 0.
+    oof = np.asarray(predictor._trainer.get_model_oof(base[0]), dtype=float)
+    assert np.isnan(oof).any()
+    assert not np.isnan(oof).all()
+
+
+def test__temporal_forward_only__stacking_is_refused():
+    """Stacking is not supported alongside forward-chaining, and says so."""
+    from autogluon.tabular import TabularPredictor
+
+    rng = np.random.default_rng(0)
+    n = 200
+    data = pd.DataFrame(
+        {
+            "num": rng.normal(size=n),
+            "ts": pd.to_datetime("2026-01-01") + pd.to_timedelta(np.sort(rng.integers(0, 40, size=n)), unit="D"),
+        }
+    )
+    data["y"] = rng.normal(size=n)
+
+    with pytest.raises(ValueError, match="cannot be combined with num_stack_levels"):
+        TabularPredictor(label="y", problem_type="regression", verbosity=0).fit(
+            data,
+            hyperparameters={"GBM": [{"num_boost_round": 5}]},
+            num_bag_folds=3,
+            num_bag_sets=1,
+            num_stack_levels=1,
+            dynamic_stacking=False,
+            fit_weighted_ensemble=False,
+            validation_structure={"time_on": "ts", "temporal_forward_only": True},
+        )


### PR DESCRIPTION
## Summary

Temporal validation is currently leave-one-block-out: each contiguous time block is validated once and trained on for every *other* fold. That covers every row, but most folds train partly on data from **after** the window they are scored on. On a 1173-row temporal task (`garments_worker_productivity`, `time_on='date'`):

| fold | validation window | train rows *after* the val window |
|---|---|---|
| 0 | Feb 16 – Mar 10 | 0 |
| 1 | Jan 1 – Jan 22 | 780 of 780 |
| 2 | Jan 24 – Feb 15 | 388 |

At 8 folds, 7 of 8 folds train on the future.

This adds `ValidationStructure.temporal_forward_only`: an expanding window where fold *i* validates block *i+1* and trains only on earlier blocks, so no fold is ever trained on data from after its validation window. Same task, same requested fold counts:

| | default | `temporal_forward_only=True` |
|---|---|---|
| train rows after the val window | 780 / 388 / 0 | **0 on every fold** |
| train sizes (3 folds) | 785 / 780 / 781 | 299 → 580 → 884 |
| rows with out-of-fold predictions | 1173 / 1173 | 874 / 1173 |

The cost is inherent to forward-chaining: the earliest block is training data only and is never validated, so those rows have no out-of-fold prediction. `uncovered_rows()` reports them. Folds also train on less data, and only the last sees nearly all of it. Requires at least 3 blocks (2 folds plus the initial training block).

## Making partial coverage honest

Supporting this exposed a pre-existing hazard. A bagged model's out-of-fold accumulator starts at zero, and `_predict_proba_oof` divided rows with no fold prediction by a substituted 1 — so an unvalidated row emerged as a confident prediction of **0**. Validation *scoring* already excluded such rows (`score_with_oof` masks on `_oof_pred_model_repeats > 0`), but the weighted ensemble did not: it optimized weights against those rows and was scored on them.

The result was two leaderboard numbers computed over different row sets and then compared to pick `model_best`. Measured with 61 of 300 rows unvalidated:

| | score_val |
|---|---|
| `LightGBM_BAG_L1` (reported, masked to its 239 covered rows) | −1.318491 |
| `WeightedEnsemble_L2` of that one model at weight 1.0 (before) | **−1.693790** |
| that same model's OOF scored over all 300 rows, zeros included | −1.693790 |

An ensemble that is one model at weight 1.0 must score identically to that model. It did not, and the discrepancy was exactly the contamination.

Two changes fix it:

- `BaggedEnsembleModel._predict_proba_oof` emits **NaN** for rows no fold validated, so "missing" is representable instead of being spelled `0`. NaN rather than dropping rows keeps positional row alignment intact — `custom_splits` are positional indices into the full frame, so dropping upstream would misalign them.
- `stack_new_level_aux` drops rows whose base-model out-of-fold predictions are NaN before fitting the weighted ensemble, so it optimizes and is scored on the same rows the base models are scored on. The single-model ensemble now reports −1.318491, matching its base exactly.

**Full-coverage runs are unaffected**: no row is uncovered, so no NaN is ever produced and the arithmetic is unchanged. Partial coverage was already reachable before this PR via incremental fold fitting (`k_fold_start` / `k_fold_end`), where the same fabricated zeros applied.

A side benefit: feeding NaN to `EnsembleSelection` now raises instead of silently optimizing against fabricated zeros, so this class of bug cannot recur quietly.

## Not supported: stacking above layer 1

`num_stack_levels > 0` and `dynamic_stacking` raise when combined with `temporal_forward_only`. A higher layer would train on rows with no real lower-layer features, and its own validation score would cover rows it has no features for. Supporting it means teaching the trainer to drop uncovered rows per level — deliberately left out of this PR, as it changes the shared stacking path for every configuration.

## Testing

`common` / `core`:
- out-of-fold predictions are NaN exactly for rows no fold validated, and scoring still succeeds
- no NaN when every row is validated (the ordinary case)

`ValidationStructure` (`tabular/tests/unittests/test_validation_structure.py`):
- every fold's training rows precede its validation window; train sizes grow; validation windows advance
- the earliest block is unvalidated and `uncovered_rows` agrees with the splits
- the default mode still covers every row *and* exhibits the lookahead (the trade-off pinned from both sides)
- `group_time_on` forward-chains over whole groups while staying group-disjoint
- `temporal_forward_only` without a time column raises; fewer than 3 blocks raises

End-to-end through `TabularPredictor`:
- weighted ensemble score equals its single base model's score, and out-of-fold predictions contain NaN
- stacking alongside forward-chaining raises

Suites run: 6 core bagged-ensemble tests, 104 tabular validation tests (`test_validation_structure.py` + `configs/test_validation_size_curves.py`), 15 `test_model_random_seed.py` tests (the existing suite exercising bagging/OOF).

## Also included

A `.gitignore` entry for the `datasets/` directories the tabular tests write fitted predictors into. Their location follows pytest's working directory, so they appear as hundreds of untracked pickles at the repo root or under `tabular/`; only `tabular/tests/unittests/datasets` was ignored. Unanchored, since no tracked file lives under a `datasets` directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi
