### PR TITLE
Remove the feature cap on TabPFN-2.6 and TabPFN-3

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfn3_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfn3_model.py
@@ -37,7 +37,13 @@ class TabPFN3Model(TabPFNModel):
 
     _default_auxiliary_params_extra = {
         "max_rows": 500_000,
-        "max_features": 2500,
+        # No feature cap: TabPFN-2.6 and -3 handle very wide data well, and on BeyondArena's
+        # widest tasks (up to 22k columns) they are the two strongest methods of 28. Set to None
+        # rather than removed, because the base TabPFNModel (2.5) caps at 2000 and subclass
+        # `_default_auxiliary_params_extra` entries are merged base-most first, so an absent key
+        # would inherit that tighter cap instead of lifting it. Memory remains bounded by
+        # `_estimate_memory_usage_static`, which is what skips a fit that genuinely will not fit.
+        "max_features": None,
         "max_classes": 160,
         # max_batch_size (prediction chunking) is the model's only bound on
         # test-side VRAM (peak grows linearly in unchunked prediction rows);

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_6_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_6_model.py
@@ -25,7 +25,13 @@ class TabPFNv26Model(TabPFNModel):
 
     _default_auxiliary_params_extra = {
         "max_rows": 100_000,
-        "max_features": 2500,
+        # No feature cap: TabPFN-2.6 and -3 handle very wide data well, and on BeyondArena's
+        # widest tasks (up to 22k columns) they are the two strongest methods of 28. Set to None
+        # rather than removed, because the base TabPFNModel (2.5) caps at 2000 and subclass
+        # `_default_auxiliary_params_extra` entries are merged base-most first, so an absent key
+        # would inherit that tighter cap instead of lifting it. Memory remains bounded by
+        # `_estimate_memory_usage_static`, which is what skips a fit that genuinely will not fit.
+        "max_features": None,
         "max_classes": 10,
         "model_telemetry": False,
     }

--- a/tabular/tests/unittests/models/test_tabpfn3.py
+++ b/tabular/tests/unittests/models/test_tabpfn3.py
@@ -21,3 +21,20 @@ def test_tabpfn3():
         # TabPFN returns different predictions when predicting on an individual sample
         verify_single_prediction_equivalent_to_multi=False,
     )
+
+
+def test_tabpfn3_and_2_6_have_no_feature_cap():
+    """TabPFN-2.6 and -3 must not cap features, while the 2.5 base still does.
+
+    `ag.max_features` skips a fit outright, and these two models are the strongest methods on
+    BeyondArena's widest tasks (up to 22k columns), so a cap would exclude them exactly where
+    they win. The cap must be `None` rather than absent: `_default_auxiliary_params_extra`
+    entries merge base-most class first, so an absent key would inherit the 2.5 base's cap.
+    """
+    from autogluon.tabular.models.tabpfnv2.tabpfnv2_5_model import TabPFNModel
+    from autogluon.tabular.models.tabpfnv2.tabpfnv2_6_model import TabPFNv26Model
+
+    assert TabPFN3Model()._get_default_auxiliary_params()["max_features"] is None
+    assert TabPFNv26Model()._get_default_auxiliary_params()["max_features"] is None
+    # The 2.5 base is unchanged, which is what makes the explicit None load-bearing.
+    assert TabPFNModel()._get_default_auxiliary_params()["max_features"] == 2000


### PR DESCRIPTION
## Summary

`TabPFNv26Model` and `TabPFN3Model` both set `ag.max_features = 2500`. That check raises an `AssertionError` at fit time, so the model is skipped outright on wider data. Both models handle much wider data well, and the cap excluded them precisely where they are strongest.

## Evidence

BeyondArena has nine datasets with more than 1000 features. Ranked over those (`core` protocol, 53 tasks, 28 methods, official results, no imputation):

| # | Model | Elo | 95% CI |
|---:|---|---:|---|
| 1 | TabPFN-2.6 (default) | 1333 | +103/−55 |
| 2 | TabPFN-3 (default) | 1296 | +180/−105 |
| 3 | RealMLP (tuned + ensembled) | 1221 | +124/−73 |

Narrowing to the four datasets whose column count exceeds the 2500 cap — 22215, 15154, 12600 and 6771 columns, 33 of the 53 tasks — and ranking by mean per-task rank:

| Model | mean rank (of 28) |
|---|---:|
| **TabPFN-3 (default)** | **6.29** |
| **TabPFN-2.6 (default)** | **7.42** |
| Linear (default) | 9.00 |
| … | |
| TabICLv2 (default) | 22.64 |

Both models have complete, non-imputed coverage of all 33 tasks.

Those results come from TabArena's own TabPFN wrappers, which deliberately impose no feature cap — `TabPFNv26Model` there carries the comment *"We do not put a limit on number of classes or features anymore for the sake of the benchmark"*, and TabArena's `TabPFN3Model` sets none either. So the benchmark has been exercising these models far beyond 2500 features, with the best results in the field, while AutoGluon's own wrappers would have skipped those datasets. This aligns AutoGluon with what the benchmark already validates.

## Why `None` and not removing the key

`_default_auxiliary_params_extra` entries are merged base-most class first, and the TabPFN-2.5 base (`TabPFNModel`) caps at 2000. Deleting the key from the subclasses would therefore *tighten* the cap to 2000 rather than lift it. Setting `None` is what disables the check (`if max_features is not None`). Verified on the resolved defaults:

| class | `max_features` |
|---|---|
| `TabPFNModel` (2.5, unchanged) | 2000 |
| `TabPFNv26Model` | None |
| `TabPFN3Model` | None |

## Risk

Very wide inputs will now be attempted rather than skipped. Memory stays bounded by each model's `_estimate_memory_usage_static`, which is the mechanism that skips a fit that genuinely will not fit — a feature-count threshold is a blunt proxy for that, and here it was excluding workloads the models handle best. `max_rows` and `max_classes` are untouched.

## Testing

`test_tabpfn3_and_2_6_have_no_feature_cap` asserts both models resolve to no cap and that the 2.5 base still caps at 2000, which is what makes the explicit `None` load-bearing. It needs no checkpoints or GPU, so unlike the existing fit tests (skipped pending licensed weights) it runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi
