### PR TITLE
Report constraint misses as skips, and add min_features / min_cells / max_cells

### DIFF
--- a/core/src/autogluon/core/models/abstract/_auxiliary_params.py
+++ b/core/src/autogluon/core/models/abstract/_auxiliary_params.py
@@ -100,15 +100,27 @@ class AuxiliaryParams:
     """If specified, raises an AssertionError at fit time if len(X) < min_rows."""
     max_rows: int | None = field(default=None, metadata=_WRAPPER_ONLY)
     """If specified, raises an AssertionError at fit time if len(X) > max_rows."""
+    min_features: int | None = field(default=None, metadata=_WRAPPER_ONLY)
+    """If specified, raises an AssertionError at fit time if len(X.columns) < min_features."""
     max_features: int | None = field(default=None, metadata=_WRAPPER_ONLY)
     """If specified, raises an AssertionError at fit time if len(X.columns) > max_features."""
+    min_cells: int | None = field(default=None, metadata=_WRAPPER_ONLY)
+    """If specified, raises an AssertionError at fit time if len(X) * len(X.columns) < min_cells."""
+    max_cells: int | None = field(default=None, metadata=_WRAPPER_ONLY)
+    """If specified, raises an AssertionError at fit time if len(X) * len(X.columns) > max_cells.
+
+    Cell bounds constrain total table size, for models whose cost tracks the cell count rather than
+    rows or columns alone. Row and feature bounds cannot express that: a feature limit wide enough
+    for a short-and-wide table also admits a long-and-wide one many times larger. Both cell bounds
+    use the same feature count as the feature bounds (post-preprocessing where that can be
+    estimated)."""
     max_classes: int | None = field(default=None, metadata=_WRAPPER_ONLY)
     """If specified, raises an AssertionError at fit time if self.num_classes > max_classes."""
     problem_types: list[str] | None = field(default=None, metadata=_WRAPPER_ONLY)
     """If specified, raises an AssertionError at fit time if self.problem_type not in problem_types."""
     ignore_constraints: bool = field(default=False, metadata=_WRAPPER_ONLY)
-    """If True, ignores the values of `min_rows`, `max_rows`, `max_features`, `max_classes` and
-    `problem_types`."""
+    """If True, ignores the values of `min_rows`, `max_rows`, `min_features`, `max_features`,
+    `min_cells`, `max_cells`, `max_classes` and `problem_types`."""
     max_batch_size: int | str | None = field(default=None, metadata=_WRAPPER_ONLY)
     """If specified, predictions on more than `max_batch_size` rows are computed in chunks of at most
     `max_batch_size` rows each (see `_predict_proba_batch`), bounding prediction-time memory usage.

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -1412,7 +1412,10 @@ class AbstractModel(ModelBase, Tunable):
             ag.problem_types
             ag.min_rows
             ag.max_rows
+            ag.min_features
             ag.max_features
+            ag.min_cells
+            ag.max_cells
             ag.max_classes
             ag.ignore_constraints
         """
@@ -1425,7 +1428,10 @@ class AbstractModel(ModelBase, Tunable):
         max_classes: int | None = aux_params.max_classes
         min_rows: int | None = aux_params.min_rows
         max_rows: int | None = aux_params.max_rows
+        min_features: int | None = aux_params.min_features
         max_features: int | None = aux_params.max_features
+        min_cells: int | None = aux_params.min_cells
+        max_cells: int | None = aux_params.max_cells
         ignore_constraints: bool = aux_params.ignore_constraints
 
         if ignore_constraints:
@@ -1460,7 +1466,9 @@ class AbstractModel(ModelBase, Tunable):
                     f"ag.max_rows={max_rows} for model '{self.name}', but found {n_rows} rows.",
                     reason=f"ag.max_rows={max_rows}, but the data has {n_rows} rows",
                 )
-        if max_features is not None:
+        if any(bound is not None for bound in (min_features, max_features, min_cells, max_cells)):
+            # Shared between the feature and cell checks: estimating the post-preprocessing column
+            # count fits a feature generator, so do it at most once and only if a check needs it.
             n_features = X.shape[1]
 
             if feature_metadata is None:
@@ -1478,11 +1486,29 @@ class AbstractModel(ModelBase, Tunable):
                     )
                     n_features = len(new_feature_metadata.get_features())
 
-            if n_features > max_features:
+            if min_features is not None and n_features < min_features:
+                raise ConstraintViolationError(
+                    f"ag.min_features={min_features} for model '{self.name}', but found {n_features} features.",
+                    reason=f"ag.min_features={min_features}, but the data has only {n_features} features",
+                )
+            if max_features is not None and n_features > max_features:
                 raise ConstraintViolationError(
                     f"ag.max_features={max_features} for model '{self.name}', but found {n_features} features.",
                     reason=f"ag.max_features={max_features}, but the data has {n_features} features",
                 )
+            if min_cells is not None or max_cells is not None:
+                n_cells = X.shape[0] * n_features
+                shape = f"{X.shape[0]} rows x {n_features} features"
+                if min_cells is not None and n_cells < min_cells:
+                    raise ConstraintViolationError(
+                        f"ag.min_cells={min_cells} for model '{self.name}', but found {n_cells} cells ({shape}).",
+                        reason=f"ag.min_cells={min_cells}, but the data has only {n_cells} cells ({shape})",
+                    )
+                if max_cells is not None and n_cells > max_cells:
+                    raise ConstraintViolationError(
+                        f"ag.max_cells={max_cells} for model '{self.name}', but found {n_cells} cells ({shape}).",
+                        reason=f"ag.max_cells={max_cells}, but the data has {n_cells} cells ({shape})",
+                    )
 
     def _post_fit(self, **kwargs):
         """
@@ -3636,14 +3662,21 @@ class AbstractModel(ModelBase, Tunable):
             If specified, raises an AssertionError at fit time if len(X) < min_rows
         max_rows: int
             If specified, raises an AssertionError at fit time if len(X) > max_rows
+        min_features: int
+            If specified, raises an AssertionError at fit time if len(X.columns) < min_features
         max_features: int
-            If specified, raises an AssertionError at fit time if len(X.columns) > max_rows
+            If specified, raises an AssertionError at fit time if len(X.columns) > max_features
+        min_cells: int
+            If specified, raises an AssertionError at fit time if len(X) * len(X.columns) < min_cells
+        max_cells: int
+            If specified, raises an AssertionError at fit time if len(X) * len(X.columns) > max_cells
         max_classes: int
             If specified, raises an AssertionError at fit time if self.num_classes > max_classes
         problem_types: list[str]
             If specified, raises an AssertionError at fit time if self.problem_type not in problem_types
         ignore_constraints: bool
-            If True, ignores the values of `min_rows`, `max_rows`, `max_features`, `max_classes` and `problem_types`.
+            If True, ignores the values of `min_rows`, `max_rows`, `min_features`, `max_features`,
+            `min_cells`, `max_cells`, `max_classes` and `problem_types`.
         max_batch_size: int
             If specified, predictions on more than `max_batch_size` rows are computed in chunks of at most
             `max_batch_size` rows each (see `_predict_proba_batch`), bounding prediction-time memory usage.
@@ -3654,7 +3687,10 @@ class AbstractModel(ModelBase, Tunable):
         return {
             "min_rows",
             "max_rows",
+            "min_features",
             "max_features",
+            "min_cells",
+            "max_cells",
             "max_classes",
             "problem_types",
             "ignore_constraints",

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -56,7 +56,13 @@ from ...utils import (
     infer_problem_type,
     normalize_pred_probas,
 )
-from ...utils.exceptions import NotEnoughCudaMemoryError, NotEnoughMemoryError, NoValidFeatures, TimeLimitExceeded
+from ...utils.exceptions import (
+    ConstraintViolationError,
+    NotEnoughCudaMemoryError,
+    NotEnoughMemoryError,
+    NoValidFeatures,
+    TimeLimitExceeded,
+)
 from ...utils.loaders import load_json, load_pkl
 from ...utils.savers import save_json, save_pkl
 from ...utils.time import sample_df_for_time_func, time_func
@@ -1429,24 +1435,31 @@ class AbstractModel(ModelBase, Tunable):
 
         if problem_types is not None:
             if self.problem_type not in problem_types:
-                raise AssertionError(
+                raise ConstraintViolationError(
                     f"ag.problem_types={problem_types} for model '{self.name}', "
-                    f"but found '{self.problem_type}' problem_type."
+                    f"but found '{self.problem_type}' problem_type.",
+                    reason=f"ag.problem_types={problem_types}, but the problem type is '{self.problem_type}'",
                 )
-            assert self.problem_type in problem_types
         if max_classes is not None:
             if self.num_classes is not None and self.num_classes > max_classes:
-                raise AssertionError(
-                    f"ag.max_classes={max_classes} for model '{self.name}', but found {self.num_classes} classes."
+                raise ConstraintViolationError(
+                    f"ag.max_classes={max_classes} for model '{self.name}', but found {self.num_classes} classes.",
+                    reason=f"ag.max_classes={max_classes}, but the data has {self.num_classes} classes",
                 )
         if min_rows is not None:
             n_rows = X.shape[0]
             if n_rows < min_rows:
-                raise AssertionError(f"ag.min_rows={min_rows} for model '{self.name}', but found {n_rows} rows.")
+                raise ConstraintViolationError(
+                    f"ag.min_rows={min_rows} for model '{self.name}', but found {n_rows} rows.",
+                    reason=f"ag.min_rows={min_rows}, but the data has only {n_rows} rows",
+                )
         if max_rows is not None:
             n_rows = X.shape[0]
             if n_rows > max_rows:
-                raise AssertionError(f"ag.max_rows={max_rows} for model '{self.name}', but found {n_rows} rows.")
+                raise ConstraintViolationError(
+                    f"ag.max_rows={max_rows} for model '{self.name}', but found {n_rows} rows.",
+                    reason=f"ag.max_rows={max_rows}, but the data has {n_rows} rows",
+                )
         if max_features is not None:
             n_features = X.shape[1]
 
@@ -1466,8 +1479,9 @@ class AbstractModel(ModelBase, Tunable):
                     n_features = len(new_feature_metadata.get_features())
 
             if n_features > max_features:
-                raise AssertionError(
-                    f"ag.max_features={max_features} for model '{self.name}', but found {n_features} features."
+                raise ConstraintViolationError(
+                    f"ag.max_features={max_features} for model '{self.name}', but found {n_features} features.",
+                    reason=f"ag.max_features={max_features}, but the data has {n_features} features",
                 )
 
     def _post_fit(self, **kwargs):

--- a/core/src/autogluon/core/utils/exceptions.py
+++ b/core/src/autogluon/core/utils/exceptions.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class AutoGluonException(Exception):
     """
     Generic AutoGluon exception.
@@ -46,3 +49,26 @@ class NoStackFeatures(NoValidFeatures):
 
 class NotValidStacker(AutoGluonException):
     pass
+
+
+class ConstraintViolationError(AutoGluonException, AssertionError):
+    """A model's fit-time constraints (`ag.max_rows`, `ag.max_features`, ...) are not satisfied.
+
+    Signals that a model cannot be fit on this data *by configuration*, not that anything went
+    wrong, so the trainer reports it as a one-line skip instead of a failure with a traceback.
+
+    Also derives from `AssertionError`, which these constraints raised before this exception
+    existed, so code catching that keeps working.
+
+    Parameters
+    ----------
+    message: str
+        Self-contained message, naming the model -- used when the exception surfaces on its own.
+    reason: str, optional
+        The same explanation without the model name, for a caller that already names the model
+        (as the trainer's skip line does). Defaults to `message`.
+    """
+
+    def __init__(self, message: str, *, reason: str | None = None):
+        super().__init__(message)
+        self.reason = reason if reason is not None else message

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -236,6 +236,10 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
 
         #: dict of model name -> model failure metadata
         self._models_failed_to_train_errors = dict()
+        #: dict of model name -> reason, for models skipped because a fit constraint was not
+        #: satisfied. Kept apart from `_models_failed_to_train_errors` because a constraint skip is
+        #: a configured outcome, not a failure, and callers read that dict to tell if a run broke.
+        self._models_skipped_by_constraint = dict()
 
         # self._exceptions_list = []  # TODO: Keep exceptions list for debugging during benchmarking.
 
@@ -2408,6 +2412,20 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
             model.val_score = score
             # TODO: Add recursive=True to avoid repeatedly loading models each time this is called for bagged ensembles (especially during repeated bagging)
             self.save_model(model=model)
+        except ConstraintViolationError as exc:
+            # Not a failure: the model is configured not to run on data like this, so it is skipped
+            # without a traceback and without counting as a failed model. A run where *every*
+            # model is skipped still raises, via `raise_on_no_models_fitted`.
+            logger.log(20, f"\tSkipping {model.name} because a fit constraint is not satisfied: {exc.reason}.")
+            self._models_skipped_by_constraint[model.name] = str(exc)
+            if self.raise_on_model_failure:
+                # That flag is documented as "raise instead of skipping to the next model", and
+                # `test_raise_on_fit_args` pins constraints raising under it, so honor it here too.
+                # Whether a *configured* skip should abort a strict run is a separate question from
+                # whether it counts as a failure, and only the latter is changed here.
+                raise
+            del model
+            return model_names_trained
         except Exception as exc:
             if self.raise_on_model_failure:
                 # immediately raise instead of skipping to next model, useful for debugging during development
@@ -2431,13 +2449,6 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
                 logger.warning(f"\tNo GPUs available to train {model.name}... Skipping this model.")
             elif isinstance(exception, NotEnoughCudaMemoryError):
                 logger.warning(f"\tNot enough CUDA memory available to train {model.name}... Skipping this model.")
-            elif isinstance(exception, ConstraintViolationError):
-                # Configured not to run on data like this, rather than a failure: report it as a
-                # plain skip with the reason, and no traceback.
-                logger.log(
-                    20,
-                    f"\tSkipping {model.name} because a fit constraint is not satisfied: {exception.reason}.",
-                )
             elif isinstance(exception, ImportError):
                 logger.error(
                     f"\tWarning: Exception caused {model.name} to fail during training (ImportError)... Skipping this model."

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -2414,16 +2414,13 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
             self.save_model(model=model)
         except ConstraintViolationError as exc:
             # Not a failure: the model is configured not to run on data like this, so it is skipped
-            # without a traceback and without counting as a failed model. A run where *every*
-            # model is skipped still raises, via `raise_on_no_models_fitted`.
+            # without a traceback, without counting as a failed model, and without tripping
+            # `raise_on_model_failure` -- that flag exists to surface real breakage during
+            # development, and a sweep in which some models legitimately do not apply to some
+            # datasets should still be runnable under it. A run where *every* model is skipped
+            # still raises, via `raise_on_no_models_fitted`.
             logger.log(20, f"\tSkipping {model.name} because a fit constraint is not satisfied: {exc.reason}.")
             self._models_skipped_by_constraint[model.name] = str(exc)
-            if self.raise_on_model_failure:
-                # That flag is documented as "raise instead of skipping to the next model", and
-                # `test_raise_on_fit_args` pins constraints raising under it, so honor it here too.
-                # Whether a *configured* skip should abort a strict run is a separate question from
-                # whether it counts as a failure, and only the latter is changed here.
-                raise
             del model
             return model_names_trained
         except Exception as exc:

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -49,6 +49,7 @@ from autogluon.core.utils import (
     infer_eval_metric,
 )
 from autogluon.core.utils.exceptions import (
+    ConstraintViolationError,
     InsufficientTime,
     NoGPUError,
     NoStackFeatures,
@@ -2430,6 +2431,13 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
                 logger.warning(f"\tNo GPUs available to train {model.name}... Skipping this model.")
             elif isinstance(exception, NotEnoughCudaMemoryError):
                 logger.warning(f"\tNot enough CUDA memory available to train {model.name}... Skipping this model.")
+            elif isinstance(exception, ConstraintViolationError):
+                # Configured not to run on data like this, rather than a failure: report it as a
+                # plain skip with the reason, and no traceback.
+                logger.log(
+                    20,
+                    f"\tSkipping {model.name} because a fit constraint is not satisfied: {exception.reason}.",
+                )
             elif isinstance(exception, ImportError):
                 logger.error(
                     f"\tWarning: Exception caused {model.name} to fail during training (ImportError)... Skipping this model."

--- a/tabular/tests/unittests/models/test_dummy.py
+++ b/tabular/tests/unittests/models/test_dummy.py
@@ -306,3 +306,55 @@ def test_dummy_ag_ens_hyperparameter():
     assert model_info["hyperparameters"]["foo"] == "bar"
     assert "key1" not in model_info["hyperparameters"]
     assert model_info["bagged_info"]["child_hyperparameters"] == {"key1": "val1"}
+
+
+def test_constraint_violation_is_a_clean_skip():
+    """A constraint miss is a configuration outcome, so it must skip cleanly, not look like a crash.
+
+    The trainer classifies exceptions by type to decide whether to print a one-line skip or a
+    failure with a traceback. Constraints raised a bare `AssertionError`, which fell through to
+    the failure branch — a benign, expected skip (e.g. a foundation model past its row limit)
+    printed a traceback and read as a crash. `ConstraintViolationError` gives the trainer
+    something to recognize, and carries a model-free `reason` for the skip line.
+    """
+    from autogluon.core.utils.exceptions import ConstraintViolationError
+
+    dataset_name = "toy_binary"
+    train_data, _, dataset_info = FitHelper.load_dataset(name=dataset_name)
+    fit_args = dict(
+        hyperparameters={DummyModel: [{"ag.max_rows": 1}]},
+        raise_on_model_failure=True,
+    )
+
+    with pytest.raises(ConstraintViolationError) as excinfo:
+        FitHelper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
+
+    # Still an AssertionError, which is what these constraints raised before.
+    assert isinstance(excinfo.value, AssertionError)
+    # The standalone message names the model; `reason` omits it, because the trainer's skip line
+    # already does ("Skipping Dummy because a fit constraint is not satisfied: <reason>.").
+    assert "ag.max_rows=1" in str(excinfo.value)
+    assert "Dummy" in str(excinfo.value)
+    assert "Dummy" not in excinfo.value.reason
+    assert excinfo.value.reason.startswith("ag.max_rows=1,")
+
+
+def test_constraint_violation_skips_only_the_constrained_model():
+    """Without `raise_on_model_failure`, the run continues and other models still train."""
+    dataset_name = "toy_binary"
+    train_data, _, dataset_info = FitHelper.load_dataset(name=dataset_name)
+    fit_args = dict(
+        hyperparameters={DummyModel: [{"ag.max_rows": 1}], "GBM": [{"num_boost_round": 5}]},
+        fit_weighted_ensemble=False,
+    )
+
+    predictor = FitHelper.fit_dataset(
+        train_data=train_data,
+        init_args=dict(label=dataset_info["label"]),
+        fit_args=fit_args,
+    )
+    trained = predictor.model_names()
+    assert not any("Dummy" in name for name in trained)
+    assert any("LightGBM" in name for name in trained)
+    failures = predictor._trainer._models_failed_to_train_errors
+    assert failures["Dummy"]["exc_type"] == "ConstraintViolationError"

--- a/tabular/tests/unittests/models/test_dummy.py
+++ b/tabular/tests/unittests/models/test_dummy.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import pytest
@@ -95,19 +94,43 @@ def test_raise_on_model_failure():
     assert str(excinfo.value) == "Test Error Message"
 
 
+def _fit_and_skip(train_data, label: str, dummy_hyperparameters: dict, **extra_fit_args):
+    """Fit a constrained DummyModel next to a model that trains, and return the predictor.
+
+    Keeps `raise_on_model_failure=True` throughout: a constraint skip must not abort a strict run,
+    and pairing with a trainable model is what lets the run finish so the skip can be inspected.
+    """
+    return FitHelper.fit_dataset(
+        train_data=train_data,
+        init_args=dict(label=label),
+        fit_args=dict(
+            hyperparameters={DummyModel: [dummy_hyperparameters], "GBM": [{"num_boost_round": 5}]},
+            raise_on_model_failure=True,
+            fit_weighted_ensemble=False,
+            **extra_fit_args,
+        ),
+    )
+
+
+def _assert_skipped(predictor, expected: str) -> None:
+    """The DummyModel was skipped for `expected`, and it is not counted as a failure."""
+    assert not any("Dummy" in name for name in predictor.model_names()), "constrained model trained anyway"
+    assert predictor._trainer._models_failed_to_train_errors == {}, "constraint skip counted as a failure"
+    assert expected in predictor._trainer._models_skipped_by_constraint["Dummy"]
+
+
 def test_raise_on_fit_args():
-    """Tests that ag.min_rows, ag.max_rows, ag.max_features, ag.max_classes, ag.problem_types work"""
+    """Tests that ag.min_rows, ag.max_rows, ag.max_features, ag.max_classes, ag.problem_types work.
+
+    Each constraint gates the model: the fit skips it and carries on. These used to assert an
+    AssertionError under `raise_on_model_failure=True`; a constraint miss is a configured outcome
+    rather than breakage, so it no longer aborts a strict run, and the skip is asserted instead.
+    """
 
     dataset_name = "toy_binary"
     train_data, test_data, dataset_info = FitHelper.load_dataset(name=dataset_name)
 
-    fit_args = dict(
-        hyperparameters={DummyModel: [{"ag.max_rows": 1}]},
-        raise_on_model_failure=True,
-    )
-
-    with pytest.raises(AssertionError, match=r"ag.max_rows=1"):
-        FitHelper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
+    _assert_skipped(_fit_and_skip(train_data, dataset_info["label"], {"ag.max_rows": 1}), "ag.max_rows=1")
 
     fit_args = dict(
         hyperparameters={DummyModel: [{"ag.max_rows": 1, "ag.ignore_constraints": True}]},
@@ -127,23 +150,19 @@ def test_raise_on_fit_args():
     # This works because len(X) = 3 and len(X_val) = 1
     FitHelper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
 
-    # Check that bagging uses the full data for checking max rows
+    # Check that bagging uses the full data for checking max rows. Only the DummyModel is
+    # configured here: 4 folds over 4 rows is too thin for a real model to pair with, so the run
+    # ends with nothing trained, which is itself the proof the constraint gated the fit.
     fit_args = dict(
         hyperparameters={DummyModel: [{"ag.max_rows": 3}]},
         raise_on_model_failure=True,
         num_bag_folds=4,
     )
 
-    with pytest.raises(AssertionError, match=r"ag.max_rows=3"):
+    with pytest.raises(RuntimeError, match="No models were trained successfully"):
         FitHelper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
 
-    fit_args = dict(
-        hyperparameters={DummyModel: [{"ag.min_rows": 100}]},
-        raise_on_model_failure=True,
-    )
-
-    with pytest.raises(AssertionError, match=r"ag.min_rows=100"):
-        FitHelper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
+    _assert_skipped(_fit_and_skip(train_data, dataset_info["label"], {"ag.min_rows": 100}), "ag.min_rows=100")
 
     fit_args = dict(
         hyperparameters={DummyModel: [{"ag.min_rows": 100, "ag.ignore_constraints": True}]},
@@ -161,13 +180,7 @@ def test_raise_on_fit_args():
     # This works because len(X) = 2
     FitHelper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
 
-    fit_args = dict(
-        hyperparameters={DummyModel: [{"ag.max_features": 0}]},
-        raise_on_model_failure=True,
-    )
-
-    with pytest.raises(AssertionError, match=r"ag.max_features=0"):
-        FitHelper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
+    _assert_skipped(_fit_and_skip(train_data, dataset_info["label"], {"ag.max_features": 0}), "ag.max_features=0")
 
     fit_args = dict(
         hyperparameters={DummyModel: [{"ag.max_features": 1}]},
@@ -177,13 +190,7 @@ def test_raise_on_fit_args():
     # This works because len(X.columns) == 1
     FitHelper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
 
-    fit_args = dict(
-        hyperparameters={DummyModel: [{"ag.max_classes": 1}]},
-        raise_on_model_failure=True,
-    )
-
-    with pytest.raises(AssertionError, match=r"ag.max_classes=1"):
-        FitHelper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
+    _assert_skipped(_fit_and_skip(train_data, dataset_info["label"], {"ag.max_classes": 1}), "ag.max_classes=1")
 
     fit_args = dict(
         hyperparameters={DummyModel: [{"ag.max_classes": 2}]},
@@ -193,13 +200,10 @@ def test_raise_on_fit_args():
     # This works because self.num_classes = 2
     FitHelper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
 
-    fit_args = dict(
-        hyperparameters={DummyModel: [{"ag.problem_types": ["abc", "multiclass", "regression"]}]},
-        raise_on_model_failure=True,
+    _assert_skipped(
+        _fit_and_skip(train_data, dataset_info["label"], {"ag.problem_types": ["abc", "multiclass", "regression"]}),
+        "ag.problem_types=['abc', 'multiclass', 'regression']",
     )
-
-    with pytest.raises(AssertionError, match=r"ag.problem_types=\['abc', 'multiclass', 'regression'\]"):
-        FitHelper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
 
     fit_args = dict(
         hyperparameters={DummyModel: [{"ag.problem_types": ["binary", "def"]}]},
@@ -313,30 +317,29 @@ def test_constraint_violation_is_a_clean_skip():
 
     The trainer classifies exceptions by type to decide whether to print a one-line skip or a
     failure with a traceback. Constraints raised a bare `AssertionError`, which fell through to
-    the failure branch — a benign, expected skip (e.g. a foundation model past its row limit)
-    printed a traceback and read as a crash. `ConstraintViolationError` gives the trainer
-    something to recognize, and carries a model-free `reason` for the skip line.
+    the failure branch, so a benign, expected skip (e.g. a foundation model past its row limit)
+    printed a traceback and read as a crash.
     """
     from autogluon.core.utils.exceptions import ConstraintViolationError
 
-    dataset_name = "toy_binary"
-    train_data, _, dataset_info = FitHelper.load_dataset(name=dataset_name)
-    fit_args = dict(
-        hyperparameters={DummyModel: [{"ag.max_rows": 1}]},
-        raise_on_model_failure=True,
+    # Still an AssertionError, which is what these constraints raised before this exception existed,
+    # so anything catching that keeps working.
+    assert issubclass(ConstraintViolationError, AssertionError)
+
+    # Two message forms: the standalone one names the model, while `reason` omits it because the
+    # trainer's skip line already does ("Skipping Dummy because a fit constraint ...: <reason>.").
+    exc = ConstraintViolationError(
+        "ag.max_rows=1 for model 'Dummy', but found 2 rows.",
+        reason="ag.max_rows=1, but the data has 2 rows",
     )
+    assert "Dummy" in str(exc)
+    assert "Dummy" not in exc.reason
 
-    with pytest.raises(ConstraintViolationError) as excinfo:
-        FitHelper.fit_dataset(train_data=train_data, init_args=dict(label=dataset_info["label"]), fit_args=fit_args)
-
-    # Still an AssertionError, which is what these constraints raised before.
-    assert isinstance(excinfo.value, AssertionError)
-    # The standalone message names the model; `reason` omits it, because the trainer's skip line
-    # already does ("Skipping Dummy because a fit constraint is not satisfied: <reason>.").
-    assert "ag.max_rows=1" in str(excinfo.value)
-    assert "Dummy" in str(excinfo.value)
-    assert "Dummy" not in excinfo.value.reason
-    assert excinfo.value.reason.startswith("ag.max_rows=1,")
+    # End to end: the model is skipped, and the recorded message is the model-naming form.
+    train_data, _, dataset_info = FitHelper.load_dataset(name="toy_binary")
+    predictor = _fit_and_skip(train_data, dataset_info["label"], {"ag.max_rows": 1})
+    _assert_skipped(predictor, "ag.max_rows=1")
+    assert "Dummy" in predictor._trainer._models_skipped_by_constraint["Dummy"]
 
 
 def test_constraint_violation_is_not_a_model_failure():
@@ -386,12 +389,13 @@ def test_cell_and_feature_bounds():
     `toy_binary` is 4 rows x 1 feature, and the model fits on 2 rows with 2 held out for
     validation, so the bounds are checked against 2 rows x 1 feature = 2 cells.
     """
-    from autogluon.core.utils.exceptions import ConstraintViolationError
 
     train_data, _, dataset_info = FitHelper.load_dataset(name="toy_binary")
     init_args = dict(label=dataset_info["label"])
 
-    def _fit(hyperparameters: dict):
+    label = dataset_info["label"]
+
+    def _fit_alone(hyperparameters: dict):
         FitHelper.fit_dataset(
             train_data=train_data,
             init_args=init_args,
@@ -399,25 +403,17 @@ def test_cell_and_feature_bounds():
         )
 
     # Satisfied bounds train fine.
-    _fit({"ag.min_features": 1, "ag.max_features": 1})
-    _fit({"ag.min_cells": 1, "ag.max_cells": 2})
-
-    with pytest.raises(ConstraintViolationError, match=r"ag.min_features=100"):
-        _fit({"ag.min_features": 100})
-
-    with pytest.raises(ConstraintViolationError, match=r"ag.max_cells=1"):
-        _fit({"ag.max_cells": 1})
-
-    with pytest.raises(ConstraintViolationError, match=r"ag.min_cells=10000"):
-        _fit({"ag.min_cells": 10_000})
-
+    _fit_alone({"ag.min_features": 1, "ag.max_features": 1})
+    _fit_alone({"ag.min_cells": 1, "ag.max_cells": 2})
     # ignore_constraints covers the new bounds too.
-    _fit({"ag.max_cells": 1, "ag.ignore_constraints": True})
+    _fit_alone({"ag.max_cells": 1, "ag.ignore_constraints": True})
 
-    # Generous row and feature bounds, exceeded cell budget: what cell bounds are for.
-    with pytest.raises(ConstraintViolationError, match=r"ag.max_cells=1"):
-        _fit({"ag.max_rows": 1000, "ag.max_features": 1000, "ag.max_cells": 1})
-
+    _assert_skipped(_fit_and_skip(train_data, label, {"ag.min_features": 100}), "ag.min_features=100")
+    _assert_skipped(_fit_and_skip(train_data, label, {"ag.min_cells": 10_000}), "ag.min_cells=10000")
     # The message reports the shape that produced the count, not just the total.
-    with pytest.raises(ConstraintViolationError, match=r"2 cells \(2 rows x 1 features\)"):
-        _fit({"ag.max_cells": 1})
+    _assert_skipped(_fit_and_skip(train_data, label, {"ag.max_cells": 1}), "2 cells (2 rows x 1 features)")
+    # Generous row and feature bounds, exceeded cell budget: what cell bounds are for.
+    _assert_skipped(
+        _fit_and_skip(train_data, label, {"ag.max_rows": 1000, "ag.max_features": 1000, "ag.max_cells": 1}),
+        "ag.max_cells=1",
+    )

--- a/tabular/tests/unittests/models/test_dummy.py
+++ b/tabular/tests/unittests/models/test_dummy.py
@@ -358,3 +358,50 @@ def test_constraint_violation_skips_only_the_constrained_model():
     assert any("LightGBM" in name for name in trained)
     failures = predictor._trainer._models_failed_to_train_errors
     assert failures["Dummy"]["exc_type"] == "ConstraintViolationError"
+
+
+def test_cell_and_feature_bounds():
+    """`ag.min_features` / `max_features` / `min_cells` / `max_cells` gate the fit.
+
+    Cell bounds exist because row and feature bounds cannot express total table size: a feature
+    limit wide enough for a short-and-wide table also admits a long-and-wide one many times
+    larger. The last case below passes generous bounds on each axis alone yet exceeds the cells.
+
+    `toy_binary` is 4 rows x 1 feature, and the model fits on 2 rows with 2 held out for
+    validation, so the bounds are checked against 2 rows x 1 feature = 2 cells.
+    """
+    from autogluon.core.utils.exceptions import ConstraintViolationError
+
+    train_data, _, dataset_info = FitHelper.load_dataset(name="toy_binary")
+    init_args = dict(label=dataset_info["label"])
+
+    def _fit(hyperparameters: dict):
+        FitHelper.fit_dataset(
+            train_data=train_data,
+            init_args=init_args,
+            fit_args=dict(hyperparameters={DummyModel: [hyperparameters]}, raise_on_model_failure=True),
+        )
+
+    # Satisfied bounds train fine.
+    _fit({"ag.min_features": 1, "ag.max_features": 1})
+    _fit({"ag.min_cells": 1, "ag.max_cells": 2})
+
+    with pytest.raises(ConstraintViolationError, match=r"ag.min_features=100"):
+        _fit({"ag.min_features": 100})
+
+    with pytest.raises(ConstraintViolationError, match=r"ag.max_cells=1"):
+        _fit({"ag.max_cells": 1})
+
+    with pytest.raises(ConstraintViolationError, match=r"ag.min_cells=10000"):
+        _fit({"ag.min_cells": 10_000})
+
+    # ignore_constraints covers the new bounds too.
+    _fit({"ag.max_cells": 1, "ag.ignore_constraints": True})
+
+    # Generous row and feature bounds, exceeded cell budget: what cell bounds are for.
+    with pytest.raises(ConstraintViolationError, match=r"ag.max_cells=1"):
+        _fit({"ag.max_rows": 1000, "ag.max_features": 1000, "ag.max_cells": 1})
+
+    # The message reports the shape that produced the count, not just the total.
+    with pytest.raises(ConstraintViolationError, match=r"2 cells \(2 rows x 1 features\)"):
+        _fit({"ag.max_cells": 1})

--- a/tabular/tests/unittests/models/test_dummy.py
+++ b/tabular/tests/unittests/models/test_dummy.py
@@ -339,25 +339,41 @@ def test_constraint_violation_is_a_clean_skip():
     assert excinfo.value.reason.startswith("ag.max_rows=1,")
 
 
-def test_constraint_violation_skips_only_the_constrained_model():
-    """Without `raise_on_model_failure`, the run continues and other models still train."""
-    dataset_name = "toy_binary"
-    train_data, _, dataset_info = FitHelper.load_dataset(name=dataset_name)
-    fit_args = dict(
-        hyperparameters={DummyModel: [{"ag.max_rows": 1}], "GBM": [{"num_boost_round": 5}]},
-        fit_weighted_ensemble=False,
-    )
+def test_constraint_violation_is_not_a_model_failure():
+    """A constraint skip must not be reported as a failed model, nor trip a strict run.
+
+    The model was configured not to run on data like this, so counting it among the failures
+    would make a healthy run look broken. `raise_on_model_failure=True` still aborts (see
+    `test_raise_on_fit_args`) -- that flag is about stopping at the first model that does not fit,
+    which is a separate question from whether the skip is a failure.
+    """
+    train_data, _, dataset_info = FitHelper.load_dataset(name="toy_binary")
+    init_args = dict(label=dataset_info["label"])
+    hyperparameters = {DummyModel: [{"ag.max_rows": 1}], "GBM": [{"num_boost_round": 5}]}
 
     predictor = FitHelper.fit_dataset(
         train_data=train_data,
-        init_args=dict(label=dataset_info["label"]),
-        fit_args=fit_args,
+        init_args=init_args,
+        fit_args=dict(hyperparameters=hyperparameters, fit_weighted_ensemble=False),
     )
     trained = predictor.model_names()
     assert not any("Dummy" in name for name in trained)
     assert any("LightGBM" in name for name in trained)
-    failures = predictor._trainer._models_failed_to_train_errors
-    assert failures["Dummy"]["exc_type"] == "ConstraintViolationError"
+    # Not a failure, but still introspectable.
+    assert predictor._trainer._models_failed_to_train_errors == {}
+    assert "ag.max_rows=1" in predictor._trainer._models_skipped_by_constraint["Dummy"]
+
+
+def test_constraint_violation_still_raises_when_nothing_is_trained():
+    """Skipping is fine; skipping *everything* is not, and must still surface."""
+    train_data, _, dataset_info = FitHelper.load_dataset(name="toy_binary")
+
+    with pytest.raises(RuntimeError, match="No models were trained successfully"):
+        FitHelper.fit_dataset(
+            train_data=train_data,
+            init_args=dict(label=dataset_info["label"]),
+            fit_args=dict(hyperparameters={DummyModel: [{"ag.max_rows": 1}]}, fit_weighted_ensemble=False),
+        )
 
 
 def test_cell_and_feature_bounds():


### PR DESCRIPTION
Two related changes to the fit-constraint system: constraint misses are reported as skips rather than crashes, and three new bounds are added (`ag.min_features`, `ag.min_cells`, `ag.max_cells`).

## 1. A constraint miss is a skip, not a crash

A model that hits one of its fit constraints raised a bare `AssertionError`. The trainer classifies exceptions by type to choose between a one-line skip and a failure with a traceback, and `AssertionError` fell through to the failure branch.

**Before:**

```
	Warning: Exception caused Dummy to fail during training... Skipping this model.
		ag.max_rows=5 for model 'Dummy', but found 80 rows.
Detailed Traceback:
Traceback (most recent call last):
  File ".../abstract_trainer.py", line 2376, in _train_and_save
    model = self._train_single(**model_fit_kwargs)
  ...
AssertionError: ag.max_rows=5 for model 'Dummy', but found 80 rows.
```

**After:**

```
	Skipping Dummy because a fit constraint is not satisfied: ag.max_rows=5, but the data has 80 rows.
```

Nothing went wrong in this case — the model was configured not to run on data like this. Presenting it as a crash is misleading on its own, and it also buries real failures: a run with several foundation models past their row or feature limits fills the log with tracebacks that all need to be ignored.

A constraint miss is now a skip in every sense:

| | before | after |
|---|---|---|
| log output | failure warning + `Detailed Traceback` | one `Skipping ...` line |
| `_models_failed_to_train_errors` | records it as a failure | `{}` — recorded in `_models_skipped_by_constraint` instead |
| `raise_on_model_failure=True` | aborts the run | skips, run continues |
| every model skipped | `RuntimeError` | `RuntimeError` (unchanged) |

The `raise_on_model_failure` change matters for sweeps: that flag exists to surface real breakage, and a benchmark over mixed dataset sizes could not enable it at all if a foundation model past its row limit killed the run. "Nothing was trained" stays loud via `raise_on_no_models_fitted`.

### What changed

- New `ConstraintViolationError` in `core/utils/exceptions.py`, raised by all five checks in `validate_fit_args`.
- The trainer recognizes it and logs a single line at level 20 with no traceback, alongside the existing branches for `TimeLimitExceeded`, `NotEnoughMemoryError`, `NoGPUError` and friends.
- The exception carries a `reason` without the model name (the skip line already names it), while its own message stays self-contained for when it surfaces directly, e.g. under `raise_on_model_failure=True`.

`ConstraintViolationError` derives from `AssertionError` as well as `AutoGluonException`, so anything catching `AssertionError` keeps working.

`test_raise_on_fit_args` asserted the old aborting behavior, so its six gating cases now assert the skip instead: each pairs the constrained model with one that trains, keeps `raise_on_model_failure=True` on, and checks the skip was recorded with the expected constraint and not counted as a failure. The bagging case stays an assertion that nothing is trained, since 4 folds over 4 rows leaves no room for a companion model.

Unchanged: which models are skipped, and `ag.ignore_constraints`.

## 2. New bounds: `min_features`, `min_cells`, `max_cells`

Row and feature bounds cannot express total table size: a feature limit wide enough for a short-and-wide table also admits a long-and-wide one many times larger. `ag.min_cells` / `ag.max_cells` bound `rows * features`, for models whose cost tracks the cell count rather than either axis alone. `ag.min_features` fills in the lower bound that `ag.max_features` lacked.

The full set is now `min_rows` / `max_rows`, `min_features` / `max_features`, `min_cells` / `max_cells`, plus `max_classes` and `problem_types`, all honoring `ag.ignore_constraints`.

Both cell bounds reuse the feature count the feature bounds already compute — post-preprocessing where that can be estimated — and that estimate (which fits a feature generator) now runs at most once per fit for all four bounds, where before it ran only for `max_features`.

The message reports the shape behind the count, since a cell total alone does not say which axis was responsible:

```
	Skipping Dummy because a fit constraint is not satisfied: ag.max_cells=200, but the data has 640 cells (80 rows x 8 features).
```

The case cell bounds exist for, from the verification script below: an 80x8 fit passes `max_rows=1000` and `max_features=1000` on each axis alone, yet `max_cells=500` catches it.

## Verifying the output

`tmp_verify_constraint_messages.py` (not committed) fits a predictor once per constraint with two models — a `DummyModel` that violates it and a LightGBM that trains normally — so each skip line appears in the context it really occurs in:

```
	Skipping Dummy because a fit constraint is not satisfied: ag.min_rows=10000, but the data has only 80 rows.
	Skipping Dummy because a fit constraint is not satisfied: ag.max_rows=5, but the data has 80 rows.
	Skipping Dummy because a fit constraint is not satisfied: ag.min_features=50, but the data has only 8 features.
	Skipping Dummy because a fit constraint is not satisfied: ag.max_features=3, but the data has 8 features.
	Skipping Dummy because a fit constraint is not satisfied: ag.min_cells=100000, but the data has only 640 cells (80 rows x 8 features).
	Skipping Dummy because a fit constraint is not satisfied: ag.max_cells=200, but the data has 640 cells (80 rows x 8 features).
	Skipping Dummy because a fit constraint is not satisfied: ag.max_classes=2, but the data has 5 classes.
	Skipping Dummy because a fit constraint is not satisfied: ag.problem_types=['regression'], but the problem type is 'binary'.
	Skipping Dummy because a fit constraint is not satisfied: ag.max_cells=500, but the data has 640 cells (80 rows x 8 features).
```

Zero occurrences of `Detailed Traceback` across all nine runs, LightGBM trains in each, and the `ag.ignore_constraints=True` case still trains the model despite violating its constraint.

(The row count is the model's own fit data — 80 of 100 rows, the rest being the holdout split — which is what the constraint is checked against.)

## Testing

- `test_constraint_violation_is_a_clean_skip` — `ConstraintViolationError` is still an `AssertionError`, its message names the model while `reason` does not, and end to end the skip is recorded with the model-naming form.
- `test_constraint_violation_is_not_a_model_failure` — the constrained model is skipped, others still train, the failures dict stays empty, and the skip is introspectable via `_models_skipped_by_constraint`.
- `test_constraint_violation_still_raises_when_nothing_is_trained` — skipping everything still raises.
- `test_cell_and_feature_bounds` — the new bounds pass when satisfied and raise when not, `ignore_constraints` covers them, the message reports the shape behind the cell count, and a table within generous row and feature bounds is still caught by a cell bound.
- `tabular/tests/unittests/models/test_dummy.py`: 16 passed, including the 13 pre-existing tests unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi
