### PR TITLE
Lift Nori and TabDPT-Turbo feature caps, clamp Nori's GPU estimate

### DIFF
--- a/tabular/src/autogluon/tabular/models/nori/nori_model.py
+++ b/tabular/src/autogluon/tabular/models/nori/nori_model.py
@@ -49,13 +49,26 @@ class NoriModel(AbstractTorchModel):
     """Default prediction chunk size (``ag.max_batch_size``); also the query-batch
     bound assumed by the GPU memory estimate."""
 
+    _INTERNAL_MAX_FEATURES: int = 256
+    """Width the model actually sees, however wide the input is.
+
+    Nori's inference config (``reg_allordinal_poly10_adaptive_svd256.json``, the default for every
+    problem type) runs ``HighDimFeatureSelector`` with ``svd_components=256`` and
+    ``n_features_threshold=256``, so anything wider is SVD-projected to 256 components before the
+    model. Its ``MaxFeatureSubsampler`` (500) never fires as a result. Measured VRAM confirms it:
+    it climbs with input width up to 256 features and is flat from there to 5000.
+    """
+
     _default_auxiliary_params_extra = {
         # Nori attends queries over the full context with no internal chunking:
         # measured predict-phase VRAM is ~5 GB at 10k rows x 10 features,
         # ~21 GB at 10k x 100, and ~58 GB at the 50k-row cap (100 features),
         # so the cap only fits on high-memory GPUs.
         "max_rows": 50000,
-        "max_features": 2000,
+        # No feature cap: the model sees at most `_INTERNAL_MAX_FEATURES` columns whatever the
+        # input width (see that attribute), so a wide fit costs no more memory than a 256-feature
+        # one -- measured 8.8 GB at both 256 and 5000 features.
+        "max_features": None,
         # Chunk prediction: an unchunked 50k-query predict against a 50k-row
         # context fails with a CUDA kernel-configuration error (after ~76 GB);
         # 10k-query chunks on the same context run fine.
@@ -165,13 +178,19 @@ class NoriModel(AbstractTorchModel):
         This is substantial for a small model: measured peaks reach 95 GB on a
         24k-row x 387-feature task, so the estimate matters for scheduling.
         Calibrated on 30 real regression tasks (100 to 45k rows, 5 to 1024
-        features): 1.0-2.2x of measured, no underestimates.
+        features): 1.0-2.2x of measured, no underestimates. The feature count is clamped to
+        `_INTERNAL_MAX_FEATURES`, since wider inputs are projected down before the model.
         """
         n_train, n_features = X.shape
         max_batch_size = (hyperparameters or {}).get("ag.max_batch_size")
         if not isinstance(max_batch_size, int):
             max_batch_size = cls._DEFAULT_MAX_BATCH_SIZE
         n_test = min(max_batch_size, n_train)
+
+        # Clamp to the width the model actually sees: beyond `_INTERNAL_MAX_FEATURES` the input is
+        # SVD-projected, so scaling with the raw width overestimates badly (6.9x measured at 5000
+        # features). Clamped, the estimate holds at 1.0-1.1x of measured from 100 to 5000 features.
+        n_features = min(n_features, cls._INTERNAL_MAX_FEATURES)
 
         n_cells = n_train * n_features
         cell_saturation = 1e6

--- a/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_turbo_model.py
+++ b/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_turbo_model.py
@@ -22,6 +22,22 @@ class TabDPTTurboModel(TabDPTModel):
     ag_key = "TABDPT-TURBO"
     ag_name = "TabDPT-Turbo"
 
+    _INTERNAL_MAX_FEATURES: int = 128
+    """Width the model actually sees, however wide the input is.
+
+    ``tabdpt``'s estimator sets ``max_features = model.num_features`` -- an architectural bound,
+    since the encoder is ``nn.Linear(num_features, ninp)`` -- which is 128 for the pinned
+    checkpoint. Wider inputs are PCA-projected down to it (``feature_reduction="pca"``, the
+    default) and narrower ones are padded up to it, so every fit is exactly this wide.
+    """
+
+    _default_auxiliary_params_extra = {
+        # No feature cap: the input is projected or padded to `_INTERNAL_MAX_FEATURES` columns
+        # regardless of its width, so memory does not track the raw feature count -- which is why
+        # the GPU estimate below has no feature term. Measured 1.23 GB from 200 to 5000 features.
+        "max_features": None,
+    }
+
     _checkpoint_filename: ClassVar[str] = "tabdpt1_2.safetensors"
     _constructor_defaults: ClassVar[dict[str, object]] = {
         "normalizer": "standard",

--- a/tabular/tests/unittests/models/test_nori.py
+++ b/tabular/tests/unittests/models/test_nori.py
@@ -141,3 +141,27 @@ def test_nori_device_hyperparameter_dropped(monkeypatch):
     preds = _fit_nori({"device": "cpu"})
     assert len(preds) == 5
     assert _CAPTURED["init_kwargs"].get("device") in ("cpu", "cuda")
+
+
+def test_no_feature_cap_and_estimate_saturates():
+    """Nori sees at most 256 columns, so the cap is lifted and the estimate must not exceed it.
+
+    Its inference config SVD-projects anything wider than 256 features down to 256 components
+    before the model, so a wide fit costs no more memory than a 256-feature one. Measured peak VRAM
+    at 1000 rows is 8.80 GB at 256 features and 8.89 GB at 5000 — flat — while the unclamped
+    estimate reached 61 GB (6.9x measured), enough to have a wide fit skipped for lack of VRAM.
+    """
+    assert NoriModel()._get_default_auxiliary_params()["max_features"] is None
+
+    def estimate(n_features: int) -> int:
+        X = pd.DataFrame(np.zeros((1000, n_features), dtype="float32"))
+        return NoriModel._estimate_gpu_memory_usage_static(X=X)
+
+    # Below the internal width the estimate still scales with the input.
+    assert estimate(100) < estimate(200) < estimate(NoriModel._INTERNAL_MAX_FEATURES)
+    # At and beyond it, the estimate is constant, because the model's view is.
+    saturated = estimate(NoriModel._INTERNAL_MAX_FEATURES)
+    for n_features in (300, 1_000, 5_000):
+        assert estimate(n_features) == saturated
+    # Still above the measured 8.89 GB peak at 5000 features: clamping must not underestimate.
+    assert saturated > 8.9 * 1024**3

--- a/tabular/tests/unittests/models/test_tabdpt_turbo.py
+++ b/tabular/tests/unittests/models/test_tabdpt_turbo.py
@@ -15,3 +15,29 @@ def test_tabdpt_turbo():
         # TabDPT returns different predictions when predicting on an individual sample
         verify_single_prediction_equivalent_to_multi=False,
     )
+
+
+def test_no_feature_cap():
+    """TabDPT-Turbo pads or projects every input to a fixed width, so a feature cap has no basis.
+
+    `tabdpt` sets `max_features = model.num_features` (128 for the pinned checkpoint) — an
+    architectural bound, since the encoder is `nn.Linear(num_features, ninp)`. Wider inputs are
+    PCA-projected down to it, narrower ones padded up. Measured peak VRAM is 1.23 GB from 200
+    features through 5000, and the GPU estimate has no feature term for the same reason.
+    """
+    aux = TabDPTTurboModel()._get_default_auxiliary_params()
+    assert aux["max_features"] is None
+    # The base TabDPT keeps its cap: only the Turbo checkpoint's width was measured.
+    from autogluon.tabular.models.tabdpt.tabdpt_model import TabDPTModel
+
+    assert TabDPTModel()._get_default_auxiliary_params()["max_features"] == 2500
+
+    # The estimate is feature-independent, matching the fixed-width encoding.
+    import numpy as np
+    import pandas as pd
+
+    narrow = pd.DataFrame(np.zeros((1000, 10), dtype="float32"))
+    wide = pd.DataFrame(np.zeros((1000, 5_000), dtype="float32"))
+    assert TabDPTTurboModel._estimate_gpu_memory_usage_static(
+        X=narrow
+    ) == TabDPTTurboModel._estimate_gpu_memory_usage_static(X=wide)


### PR DESCRIPTION
## Summary

Nori and TabDPT-Turbo both reduce features internally before the model sees them, so neither their `ag.max_features` caps nor Nori's feature-scaled memory estimate reflects what a wide fit actually costs.

- **Nori** — its inference config (`reg_allordinal_poly10_adaptive_svd256.json`, the default for *every* problem type via `api.py`) runs `HighDimFeatureSelector` with `svd_components=256, n_features_threshold=256`, so anything wider is SVD-projected to 256 components. Its own `MaxFeatureSubsampler` (500) never fires as a result.
- **TabDPT-Turbo** — `tabdpt`'s estimator sets `max_features = model.num_features`, an *architectural* bound since the encoder is `nn.Linear(num_features, ninp)`. That is **128** for the pinned `tabdpt1_2` checkpoint. Wider inputs are PCA-projected down to it (`feature_reduction="pca"`, the default); narrower ones are padded up to it, so every fit is exactly 128 columns wide.

## Measured

Peak VRAM (NVML, process-level) at 1000 train rows on one RTX PRO 6000, sweeping features with the caps bypassed:

| features | 100 | 200 | 250 | **256** | 300 | 500 | 1000 | 2000 | 5000 |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| Nori-30M | 4.34 | 6.90 | 8.63 | **8.80** | 8.79 | 8.80 | 8.79 | 8.81 | 8.89 |
| TabDPT-Turbo | 1.16 | 1.23 | 1.23 | 1.23 | 1.23 | 1.23 | 1.23 | 1.23 | 1.24 |

Nori climbs with input width up to 256 features and is flat from there to 5000 — the knee sits exactly at the SVD threshold. TabDPT-Turbo is flat throughout. A fit at the old caps costs the same memory as one at 256 / 128 features, so the caps only excluded work these models handle. Same reasoning that retired the TabPFN caps in #5797.

## Nori's GPU estimate

It scaled with the raw feature count, so it kept extrapolating past the point where the model stops growing:

| features | 256 | 500 | 1000 | 2000 | 5000 |
|---|---:|---:|---:|---:|---:|
| measured | 8.80 GB | 8.80 | 8.79 | 8.81 | 8.89 |
| estimate before | 9.03 GB | 16.30 | 31.20 | 38.65 | **61.00** |
| ratio | 1.03x | 1.85x | 3.55x | 4.39x | **6.86x** |
| estimate after | 9.03 GB | 9.03 | 9.03 | 9.03 | 9.03 |
| ratio | 1.03x | 1.03x | 1.03x | 1.02x | 1.02x |

Worth fixing beyond cosmetics: the VRAM-aware fold budgeting added in #5791 divides available VRAM by this estimate, so a 5000-feature Nori fit was budgeted at 61 GB — one fold per 96 GB GPU, and on a 40 GB card a `NotEnoughCudaMemoryError` skip, for a fit that needs 8.8 GB.

Clamping the feature term to the projected width holds the estimate at 1.0–1.1x of measured across 100–5000 features, and it still never underestimates (9.03 GB against a 8.89 GB peak at 5000). Below 256 features nothing changes.

TabDPT-Turbo's estimate needs no equivalent change — it already has no feature term, and its docstring already attributes that to the "fixed-width encoding of a subsampled context", i.e. the same mechanism.

## Scope

The base `TabDPTModel` keeps its 2500 cap: only the Turbo checkpoint's width was measured, and a different checkpoint can have a different `num_features`. `max_rows`, `max_classes` and `max_batch_size` are untouched on both models — the row-side bounds are real, Nori's in particular (~58 GB at its 50k-row cap).

## Testing

- `test_no_feature_cap_and_estimate_saturates` (Nori) — no cap; the estimate still scales below the internal width, is constant at and above it, and stays above the measured 5000-feature peak so the clamp cannot underestimate.
- `test_no_feature_cap` (TabDPT-Turbo) — no cap, the base TabDPT cap is intact, and the estimate is identical for 10 and 5000 features.

`test_nori.py` + `test_tabdpt_turbo.py`: 6 passed, 1 skipped (the pre-existing skip for the optional checkpoint).

Sweeps are reproducible via `tabarena_membench`: `python scripts/tmp_run_nori_tabdpt_features.py --features 100 200 300 400`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi
