### PR TITLE
Apply TabICL's pinned checkpoint, add a batch tier, lower the row cap

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
+++ b/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
@@ -52,7 +52,9 @@ class TabICLModel(AbstractTorchModel):
 
     _default_auxiliary_params_extra = {
         # TODO: Instead of caps, should we subsample for large datasets?
-        "max_rows": 1000000,  # TODO: What should be the cap? 1 million rows works, but unsure if it is good
+        # Measured peak VRAM is already ~83 GB at 100k rows x 100 features, so a 1M-row fit is far
+        # outside what a single GPU serves; 500k keeps the cap within reach of a large card.
+        "max_rows": 500000,
         "max_features": 2000,  # TODO: What should be the cap? 10k features works, but unsure if it is good
         # No prediction chunking: tabicl batches internally (VRAM-adaptive with
         # OOM-halving), and each external chunk would re-encode the full training
@@ -81,12 +83,20 @@ class TabICLModel(AbstractTorchModel):
 
     @staticmethod
     def _get_batch_size(n_cells: int):
+        """Datasets-per-batch for tabicl's internal batching, by table size in cells.
+
+        tabicl halves the batch on OOM, so these are starting points rather than hard limits; the
+        tiers exist to avoid paying for a failed attempt first. The smallest tier matters because
+        the column-embedding output, shape ``(batch_size, n_rows, n_columns, embed_dim)``, is
+        tabicl's dominant allocation, so on the largest tables even 2 is too many.
+        """
         if n_cells <= 4_000_000:
             return 8
-        elif n_cells <= 6_000_000:
+        if n_cells <= 6_000_000:
             return 4
-        else:
+        if n_cells <= 500_000_000:
             return 2
+        return 1
 
     def get_checkpoint_version(self, hyperparameter: dict) -> str:
         clf_checkpoint = self.default_classification_model
@@ -133,6 +143,10 @@ class TabICLModel(AbstractTorchModel):
         model_cls = self.get_model_cls()
         hyp = self._get_model_params()
         hyp["batch_size"] = hyp.get("batch_size", self._get_batch_size(X.shape[0] * X.shape[1]))
+        # Pin the checkpoint rather than inheriting whatever the installed tabicl defaults to, and
+        # resolve the per-problem-type form of the `checkpoint_version` hyperparameter (a bare
+        # string, or a `(classification, regression)` tuple) that the library itself does not accept.
+        hyp["checkpoint_version"] = self.get_checkpoint_version(hyperparameter=hyp)
         self.model = model_cls(
             **hyp,
             device=device,

--- a/tabular/tests/unittests/models/test_tabicl.py
+++ b/tabular/tests/unittests/models/test_tabicl.py
@@ -14,3 +14,55 @@ def test_tabicl():
         verify_load_wo_cuda=True,
         verify_single_prediction_equivalent_to_multi=True,
     )
+
+
+def test_checkpoint_version_is_passed_to_the_model():
+    """The pinned checkpoint must reach the estimator, not just be declared on the class.
+
+    `get_checkpoint_version` existed but was never called, so the pin had no effect and the
+    documented `(classification, regression)` tuple form was forwarded to tabicl raw, which does
+    not accept it. The pin is currently identical to tabicl's own default, so nothing would look
+    wrong today -- it would only diverge silently once tabicl ships a new default checkpoint.
+    """
+    from unittest.mock import patch
+
+    import numpy as np
+    import pandas as pd
+
+    X = pd.DataFrame({"a": np.arange(20, dtype="float32"), "b": np.arange(20, dtype="float32")})
+    y = pd.Series([0, 1] * 10)
+
+    for problem_type, expected in (
+        ("binary", TabICLModel.default_classification_model),
+        ("regression", TabICLModel.default_regression_model),
+    ):
+        model = TabICLModel(problem_type=problem_type, eval_metric="accuracy" if problem_type == "binary" else "rmse")
+        with patch.object(TabICLModel, "get_model_cls") as get_model_cls:
+            try:
+                model.fit(X=X, y=y, num_cpus=1, num_gpus=0)
+            except Exception:  # noqa: BLE001 - the mocked estimator cannot actually fit
+                pass
+        kwargs = get_model_cls.return_value.call_args.kwargs
+        assert kwargs["checkpoint_version"] == expected
+
+
+def test_checkpoint_version_hyperparameter_forms():
+    """A bare string applies to both problem types; a tuple selects by problem type."""
+    for problem_type, tuple_expected in (("binary", "clf.ckpt"), ("regression", "reg.ckpt")):
+        model = TabICLModel(problem_type=problem_type)
+        assert model.get_checkpoint_version({}) == (
+            TabICLModel.default_classification_model
+            if problem_type == "binary"
+            else TabICLModel.default_regression_model
+        )
+        assert model.get_checkpoint_version({"checkpoint_version": "custom.ckpt"}) == "custom.ckpt"
+        assert model.get_checkpoint_version({"checkpoint_version": ("clf.ckpt", "reg.ckpt")}) == tuple_expected
+
+
+def test_batch_size_tiers_and_row_cap():
+    """Batch size steps down with table size, bottoming out at 1 for the largest tables."""
+    assert TabICLModel._get_batch_size(1_000_000) == 8
+    assert TabICLModel._get_batch_size(5_000_000) == 4
+    assert TabICLModel._get_batch_size(500_000_000) == 2
+    assert TabICLModel._get_batch_size(500_000_001) == 1
+    assert TabICLModel()._get_default_auxiliary_params()["max_rows"] == 500_000


### PR DESCRIPTION
## Summary

Three changes to `TabICLModel`, the first a latent bug found by comparing against TabArena's wrapper, which calls a method AutoGluon only declares.

### 1. The pinned checkpoint was never applied

`get_checkpoint_version` is defined on the class and referenced nowhere in the repo. TabArena's identical method is wired into its fit:

```python
hyp["checkpoint_version"] = self.get_checkpoint_version(hyperparameter=hyp)
```

AutoGluon builds `hyp` the same way and then never adds the key, so `default_classification_model` / `default_regression_model` were dead too and the fit inherited whatever checkpoint the installed `tabicl` defaults to.

**Today that is the same file** (`tabicl-classifier-v2-20260212.ckpt` is both our pin and tabicl's default), which is why nothing looks wrong. It would diverge silently the first time tabicl ships a new default checkpoint — precisely what a pin exists to prevent, and invisible because nothing reads the attribute.

It also fixes a live smaller bug. The method documents accepting `checkpoint_version` as a `(classification, regression)` tuple, but since `**hyp` goes straight to the estimator, that tuple reached `tabicl` raw, where a tuple is not a valid checkpoint. Resolving through the method is what unpacks it by problem type.

### 2. A fourth batch-size tier

`_get_batch_size` bottomed out at 2; TabArena's adds `1` above 500M cells. tabicl halves the batch on OOM, so this only avoids paying for a failed attempt first — but the column-embedding output, shape `(batch_size, n_rows, n_columns, embed_dim)`, is tabicl's dominant allocation, so on the largest tables even 2 is too many. Still reachable under the new row cap: 500k rows x 2000 features is 1e9 cells.

### 3. `ag.max_rows`: 1M -> 500k

The previous value carried `TODO: What should be the cap? 1 million rows works, but unsure if it is good`. Measured peak VRAM is already ~83 GB at 100k rows x 100 features, so a 1M-row fit is far outside what a single GPU serves.

## Not included

`disk_offload_dir` is deliberately left unset. TabArena passes a per-instance tempdir; the practical effect of `None` is narrower than it first looks. There is no default directory (`has_disk = self.disk_offload_dir is not None`), so leaving it unset removes the disk tier from tabicl's GPU -> CPU -> disk cascade. Under `offload_mode='auto'` that only matters when VRAM *and* RAM are both tight, where the fallback is a swap-backed CPU allocation rather than an error. It is worth adding as a deliberate robustness change with its own reasoning, not folded in here.

## Testing

- `test_checkpoint_version_is_passed_to_the_model` — the pinned checkpoint reaches the estimator for both problem types. Verified it fails without the one-line fix, so it actually pins the behavior rather than passing vacuously.
- `test_checkpoint_version_hyperparameter_forms` — the default, the bare-string form, and the tuple form each resolve correctly per problem type.
- `test_batch_size_tiers_and_row_cap` — all four tiers, including the boundary at 500M cells, plus the new row cap.

`test_tabicl.py`: 4 passed (the pre-existing fit test unmodified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi
