### PR TITLE
[timeseries] Add experimental TimeSeriesPredictor.update() for ensemble re-selection on fresh data

### DIFF
--- a/timeseries/src/autogluon/timeseries/configs/hyperparameter_presets.py
+++ b/timeseries/src/autogluon/timeseries/configs/hyperparameter_presets.py
@@ -39,16 +39,4 @@ def get_hyperparameter_presets() -> dict[str, dict[str, dict[str, Any] | list[di
             ],
             "Toto2": {"model_path": "Toto-2.0-313m"},
         },
-        "experimental": {
-            "Chronos2": [
-                {},
-                {
-                    "ag_args": {"name_suffix": "SmallFineTuned"},
-                    "model_path": "autogluon/chronos-2-small",
-                    "fine_tune": True,
-                    "eval_during_fine_tune": True,
-                },
-            ],
-            "Toto2": {"model_path": "Toto-2.0-313m"},
-        },
     }

--- a/timeseries/src/autogluon/timeseries/configs/hyperparameter_presets.py
+++ b/timeseries/src/autogluon/timeseries/configs/hyperparameter_presets.py
@@ -39,4 +39,8 @@ def get_hyperparameter_presets() -> dict[str, dict[str, dict[str, Any] | list[di
             ],
             "Toto2": {"model_path": "Toto-2.0-313m"},
         },
+        "fm_only": {
+            "Chronos2": {},
+            "Toto2": {"model_path": "Toto-2.0-313m"},
+        },
     }

--- a/timeseries/src/autogluon/timeseries/configs/hyperparameter_presets.py
+++ b/timeseries/src/autogluon/timeseries/configs/hyperparameter_presets.py
@@ -39,7 +39,7 @@ def get_hyperparameter_presets() -> dict[str, dict[str, dict[str, Any] | list[di
             ],
             "Toto2": {"model_path": "Toto-2.0-313m"},
         },
-        "fm_only": {
+        "experimental": {
             "Chronos2": [
                 {},
                 {

--- a/timeseries/src/autogluon/timeseries/configs/hyperparameter_presets.py
+++ b/timeseries/src/autogluon/timeseries/configs/hyperparameter_presets.py
@@ -40,7 +40,15 @@ def get_hyperparameter_presets() -> dict[str, dict[str, dict[str, Any] | list[di
             "Toto2": {"model_path": "Toto-2.0-313m"},
         },
         "fm_only": {
-            "Chronos2": {},
+            "Chronos2": [
+                {},
+                {
+                    "ag_args": {"name_suffix": "SmallFineTuned"},
+                    "model_path": "autogluon/chronos-2-small",
+                    "fine_tune": True,
+                    "eval_during_fine_tune": True,
+                },
+            ],
             "Toto2": {"model_path": "Toto-2.0-313m"},
         },
     }

--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -336,6 +336,10 @@ class TimeSeriesLearner(AbstractLearner):
     def refit_full(self, model: str = "all") -> dict[str, str]:
         return self.load_trainer().refit_full(model=model)
 
+    def update(self, data: TimeSeriesDataFrame) -> list[str]:
+        data = self.feature_generator.transform(data)
+        return self.load_trainer().update(data=data)
+
     def backtest_predictions(
         self,
         data: TimeSeriesDataFrame | None,

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -1930,6 +1930,37 @@ class TimeSeriesPredictor:
                 )
         return refit_full_dict
 
+    def update(self, data: TimeSeriesDataFrame | pd.DataFrame | Path | str) -> list[str]:
+        """[Experimental] Re-select the ensemble on a fresh validation window computed from ``data``.
+
+        The most recent validation window from ``data`` is appended to the out-of-fold predictions from training
+        (dropping the oldest window) to re-score all models and re-fit the weighted ensemble. Base models are not
+        retrained, so this performs model selection based on more recent data.
+
+        .. warning::
+            This is experimental and unstable functionality. The API and behavior may change without warning in
+            future releases.
+
+        Parameters
+        ----------
+        data : TimeSeriesDataFrame | pd.DataFrame | Path | str
+            Fresh time series data used to compute the new validation window. Series that are too short to produce a
+            validation window are ignored.
+
+        Returns
+        -------
+        updated_models : list[str]
+            Names of the models that were updated.
+        """
+        self._assert_is_fit("update")
+        logger.warning(
+            "\tWARNING: `update` is experimental and unstable. Its API and behavior may change without warning."
+        )
+        data = self._check_and_prepare_data_frame(data)
+        # Only a single fresh validation window is computed from data, so filter as if num_val_windows=1
+        data = self._filter_useless_train_data(data, num_val_windows=(1,), val_step_size=self.prediction_length)
+        return self._learner.update(data)
+
     def _simulation_artifact(self, test_data: TimeSeriesDataFrame) -> dict:
         """[Advanced] Computes and returns the necessary information to perform offline ensemble simulation."""
 

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -1944,8 +1944,8 @@ class TimeSeriesPredictor:
         Parameters
         ----------
         data : TimeSeriesDataFrame | pd.DataFrame | Path | str
-            Fresh time series data used to compute the new validation window. Series that are too short to produce a
-            validation window are ignored.
+            Fresh time series data used to compute the new validation window. Must contain the same items (time
+            series) that were seen during training; extra items are ignored and missing items raise an error.
 
         Returns
         -------

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -1944,8 +1944,8 @@ class TimeSeriesPredictor:
         Parameters
         ----------
         data : TimeSeriesDataFrame | pd.DataFrame | Path | str
-            Fresh time series data used to compute the new validation window. Must contain the same items (time
-            series) that were seen during training; extra items are ignored and missing items raise an error.
+            Fresh time series data used to compute the new validation window. Only items (time series) present in
+            both ``data`` and the training data are used to re-fit the ensemble.
 
         Returns
         -------

--- a/timeseries/src/autogluon/timeseries/trainer/trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/trainer.py
@@ -1323,7 +1323,7 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
 
         # re-fit ensembles on the updated windows
         base_model_scores = {name: self.get_model_attribute(name, "val_score") for name in base_model_names}
-        updated_models = list(base_model_names)
+        refit_ensembles = []
         for model_name in self.get_model_names(layer=1):
             ensemble = self.load_model(model_name)
             if not isinstance(ensemble, AbstractTimeSeriesEnsembleModel):
@@ -1342,11 +1342,12 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
                 for i in range(num_windows)
             ]
             update_model(ensemble, oof_predictions)
-            updated_models.append(model_name)
+            refit_ensembles.append(model_name)
 
         self.save()
-        logger.info(f"Update complete. Models updated: {updated_models}")
+        logger.info(f"Re-scored base models and re-fit ensembles: {refit_ensembles}")
         logger.info(f"Total runtime: {time.time() - time_start:.2f} s")
+        return base_model_names + refit_ensembles
         return updated_models
 
     def get_trainable_base_models(

--- a/timeseries/src/autogluon/timeseries/trainer/trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/trainer.py
@@ -1369,12 +1369,13 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
             update_model(ensemble, oof_predictions)
             refit_ensembles.append(model_name)
 
+        # Scores changed, so the cached best model may be stale; recompute it on next prediction.
+        self.model_best = None
         self.save_val_data_per_window(data_per_window)
         self.save()
         logger.info(f"Re-scored base models and re-fit ensembles: {refit_ensembles}")
         logger.info(f"Total runtime: {time.time() - time_start:.2f} s")
         return base_model_names + refit_ensembles
-        return updated_models
 
     def get_trainable_base_models(
         self,

--- a/timeseries/src/autogluon/timeseries/trainer/trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/trainer.py
@@ -1305,10 +1305,6 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
 
         num_windows = sum(self.num_val_windows)
         base_model_names = self.get_model_names(layer=0)
-        fresh_predictions_per_window = self.backtest_predictions(
-            data=data, model_names=base_model_names, num_val_windows=1
-        )
-        fresh_data_per_window = self.backtest_targets(data=data, num_val_windows=1)
 
         def slide(old_windows: list[TimeSeriesDataFrame], fresh_windows: list[TimeSeriesDataFrame]) -> list:
             """Append the fresh window(s), dropping the oldest to keep num_windows windows in total."""
@@ -1317,6 +1313,20 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
         # On the first update, seed from the training targets; afterwards slide the stored windows so that
         # they stay aligned with the (persisted, already-slid) OOF predictions across repeated calls.
         prev_data_per_window = self.load_val_data_per_window() or self.backtest_targets(data=None)
+        # The fresh window must cover exactly the items in the stored windows (which come from training's
+        # length filter); otherwise per-window prediction arrays have mismatched shapes when the ensemble re-fits.
+        reference_items = prev_data_per_window[-1].item_ids
+        num_extra_items = data.num_items - len(data.item_ids.intersection(reference_items))
+        if num_extra_items > 0:
+            logger.warning(f"\tWARNING: `update` ignoring {num_extra_items} time series not seen during training.")
+        data = data.query("item_id in @reference_items")
+        if data.num_items < len(reference_items):
+            raise ValueError("`update` data is missing some of the time series that the models were trained on.")
+
+        fresh_predictions_per_window = self.backtest_predictions(
+            data=data, model_names=base_model_names, num_val_windows=1
+        )
+        fresh_data_per_window = self.backtest_targets(data=data, num_val_windows=1)
         data_per_window = slide(prev_data_per_window, fresh_data_per_window)
 
         def update_model(model: TimeSeriesModelBase, oof_predictions: list[TimeSeriesDataFrame]) -> None:

--- a/timeseries/src/autogluon/timeseries/trainer/trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/trainer.py
@@ -1285,6 +1285,70 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
         logger.info(f"Total runtime: {time.time() - time_start:.2f} s")
         return copy.deepcopy(self.model_refit_map)
 
+    def update(self, data: TimeSeriesDataFrame) -> list[str]:
+        time_start = time.time()
+
+        if self.model_refit_map:
+            raise NotImplementedError("`update` is not supported after `refit_full` has been called.")
+        model_layers = self._get_model_layers()
+        if any(layer > 1 for layer in model_layers.values()):
+            raise NotImplementedError("`update` is not supported for multi-layer stack ensembles.")
+
+        num_windows = sum(self.num_val_windows)
+        base_model_names = self.get_model_names(layer=0)
+        fresh_predictions_per_window = self.backtest_predictions(
+            data=data, model_names=base_model_names, num_val_windows=1
+        )
+        fresh_data_per_window = self.backtest_targets(data=data, num_val_windows=1)
+
+        def slide(old_windows: list[TimeSeriesDataFrame], fresh_windows: list[TimeSeriesDataFrame]) -> list:
+            """Append the fresh window(s), dropping the oldest to keep num_windows windows in total."""
+            return (old_windows[-(num_windows - 1) :] if num_windows > 1 else []) + fresh_windows
+
+        data_per_window = slide(self.backtest_targets(data=None), fresh_data_per_window)
+
+        def update_model(model: TimeSeriesModelBase, oof_predictions: list[TimeSeriesDataFrame]) -> None:
+            model.cache_oof_predictions(oof_predictions)
+            score_per_fold = [self._score_with_predictions(gt, pred) for pred, gt in zip(oof_predictions, data_per_window)]
+            model.val_score = float(np.mean(score_per_fold))
+            self.set_model_attribute(model=model.name, attribute="val_score", val=model.val_score)
+            self.save_model(model=model)
+
+        # slide the validation window forward for each base model and re-score
+        predictions_per_window = {}
+        for model_name in base_model_names:
+            oof_predictions = slide(self._get_model_oof_predictions(model_name), fresh_predictions_per_window[model_name])
+            predictions_per_window[model_name] = oof_predictions
+            update_model(self.load_model(model_name), oof_predictions)
+
+        # re-fit ensembles on the updated windows
+        base_model_scores = {name: self.get_model_attribute(name, "val_score") for name in base_model_names}
+        updated_models = list(base_model_names)
+        for model_name in self.get_model_names(layer=1):
+            ensemble = self.load_model(model_name)
+            if not isinstance(ensemble, AbstractTimeSeriesEnsembleModel):
+                continue
+            ensemble.fit(
+                predictions_per_window=predictions_per_window,
+                data_per_window=data_per_window,
+                model_scores=base_model_scores,
+            )
+            # re-fitting may select a different subset of base models, so sync the graph edges
+            self.model_graph.remove_edges_from(list(self.model_graph.in_edges(model_name)))
+            for base_model_name in ensemble.model_names:
+                self.model_graph.add_edge(base_model_name, model_name)
+            oof_predictions = [
+                ensemble.predict({name: predictions_per_window[name][i] for name in ensemble.model_names})
+                for i in range(num_windows)
+            ]
+            update_model(ensemble, oof_predictions)
+            updated_models.append(model_name)
+
+        self.save()
+        logger.info(f"Update complete. Models updated: {updated_models}")
+        logger.info(f"Total runtime: {time.time() - time_start:.2f} s")
+        return updated_models
+
     def get_trainable_base_models(
         self,
         hyperparameters: str | dict[str, Any],

--- a/timeseries/src/autogluon/timeseries/trainer/trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/trainer.py
@@ -98,6 +98,9 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
         self.val_step_size = val_step_size
         self.refit_every_n_windows = refit_every_n_windows
         self.hpo_results = {}
+        #: Ground-truth validation windows that the cached OOF predictions are scored against. Set by `update`
+        #: so that repeated calls slide these windows in lockstep with the (persisted) OOF predictions.
+        self.val_data_per_window: list[TimeSeriesDataFrame] | None = None
 
         self.prediction_cache: PredictionCache = get_prediction_cache(cache_predictions, self.path)
         self.prediction_cache.clear()
@@ -1305,7 +1308,10 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
             """Append the fresh window(s), dropping the oldest to keep num_windows windows in total."""
             return (old_windows[-(num_windows - 1) :] if num_windows > 1 else []) + fresh_windows
 
-        data_per_window = slide(self.backtest_targets(data=None), fresh_data_per_window)
+        # On the first update, seed from the training targets; afterwards slide the stored windows so that
+        # they stay aligned with the (persisted, already-slid) OOF predictions across repeated calls.
+        prev_data_per_window = self.val_data_per_window or self.backtest_targets(data=None)
+        data_per_window = slide(prev_data_per_window, fresh_data_per_window)
 
         def update_model(model: TimeSeriesModelBase, oof_predictions: list[TimeSeriesDataFrame]) -> None:
             model.cache_oof_predictions(oof_predictions)
@@ -1344,6 +1350,7 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
             update_model(ensemble, oof_predictions)
             refit_ensembles.append(model_name)
 
+        self.val_data_per_window = data_per_window
         self.save()
         logger.info(f"Re-scored base models and re-fit ensembles: {refit_ensembles}")
         logger.info(f"Total runtime: {time.time() - time_start:.2f} s")

--- a/timeseries/src/autogluon/timeseries/trainer/trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/trainer.py
@@ -1329,7 +1329,9 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
 
         def update_model(model: TimeSeriesModelBase, oof_predictions: list[TimeSeriesDataFrame]) -> None:
             model.cache_oof_predictions(oof_predictions)
-            score_per_fold = [self._score_with_predictions(gt, pred) for pred, gt in zip(oof_predictions, data_per_window)]
+            score_per_fold = [
+                self._score_with_predictions(gt, pred) for pred, gt in zip(oof_predictions, data_per_window)
+            ]
             model.val_score = float(np.mean(score_per_fold))
             self.set_model_attribute(model=model.name, attribute="val_score", val=model.val_score)
             self.save_model(model=model)
@@ -1337,7 +1339,9 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
         # slide the validation window forward for each base model and re-score
         predictions_per_window = {}
         for model_name in base_model_names:
-            oof_predictions = slide(self._get_model_oof_predictions(model_name), fresh_predictions_per_window[model_name])
+            oof_predictions = slide(
+                self._get_model_oof_predictions(model_name), fresh_predictions_per_window[model_name]
+            )
             oof_predictions = [window.query("item_id in @items") for window in oof_predictions]
             predictions_per_window[model_name] = oof_predictions
             update_model(self.load_model(model_name), oof_predictions)

--- a/timeseries/src/autogluon/timeseries/trainer/trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/trainer.py
@@ -1313,9 +1313,11 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
         # On the first update, seed from the training targets; afterwards slide the stored windows so that
         # they stay aligned with the (persisted, already-slid) OOF predictions across repeated calls.
         prev_data_per_window = self.load_val_data_per_window() or self.backtest_targets(data=None)
-        # The fresh window must cover exactly the items in the stored windows (which come from training's
-        # length filter); otherwise per-window prediction arrays have mismatched shapes when the ensemble re-fits.
-        reference_items = prev_data_per_window[-1].item_ids
+        # `data` must cover exactly the items common to all stored windows, else per-window prediction
+        # arrays have mismatched shapes when the ensemble re-fits.
+        reference_items = prev_data_per_window[0].item_ids
+        for window in prev_data_per_window[1:]:
+            reference_items = reference_items.intersection(window.item_ids)
         num_extra_items = data.num_items - len(data.item_ids.intersection(reference_items))
         if num_extra_items > 0:
             logger.warning(f"\tWARNING: `update` ignoring {num_extra_items} time series not seen during training.")

--- a/timeseries/src/autogluon/timeseries/trainer/trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/trainer.py
@@ -1313,23 +1313,19 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
         # On the first update, seed from the training targets; afterwards slide the stored windows so that
         # they stay aligned with the (persisted, already-slid) OOF predictions across repeated calls.
         prev_data_per_window = self.load_val_data_per_window() or self.backtest_targets(data=None)
-        # `data` must cover exactly the items common to all stored windows, else per-window prediction
-        # arrays have mismatched shapes when the ensemble re-fits.
-        reference_items = prev_data_per_window[0].item_ids
-        for window in prev_data_per_window[1:]:
-            reference_items = reference_items.intersection(window.item_ids)
-        num_extra_items = data.num_items - len(data.item_ids.intersection(reference_items))
-        if num_extra_items > 0:
-            logger.warning(f"\tWARNING: `update` ignoring {num_extra_items} time series not seen during training.")
-        data = data.query("item_id in @reference_items")
-        if data.num_items < len(reference_items):
-            raise ValueError("`update` data is missing some of the time series that the models were trained on.")
 
         fresh_predictions_per_window = self.backtest_predictions(
             data=data, model_names=base_model_names, num_val_windows=1
         )
         fresh_data_per_window = self.backtest_targets(data=data, num_val_windows=1)
         data_per_window = slide(prev_data_per_window, fresh_data_per_window)
+
+        # Keep only items present in every window, else per-window prediction arrays have mismatched
+        # shapes when the ensemble re-fits (e.g. a series may end before the latest window).
+        items = data_per_window[0].item_ids
+        for window in data_per_window[1:]:
+            items = items.intersection(window.item_ids)
+        data_per_window = [window.query("item_id in @items") for window in data_per_window]
 
         def update_model(model: TimeSeriesModelBase, oof_predictions: list[TimeSeriesDataFrame]) -> None:
             model.cache_oof_predictions(oof_predictions)
@@ -1342,6 +1338,7 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
         predictions_per_window = {}
         for model_name in base_model_names:
             oof_predictions = slide(self._get_model_oof_predictions(model_name), fresh_predictions_per_window[model_name])
+            oof_predictions = [window.query("item_id in @items") for window in oof_predictions]
             predictions_per_window[model_name] = oof_predictions
             update_model(self.load_model(model_name), oof_predictions)
 

--- a/timeseries/src/autogluon/timeseries/trainer/trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/trainer.py
@@ -130,9 +130,9 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
         val_data = self.load_val_data()
         return train_data, val_data
 
-    # Validation windows the cached OOF predictions are scored against. Stored in a file (not on the trainer)
-    # so repeated `update` calls slide them in lockstep with the OOF without bloating the trainer pickle.
     def save_val_data_per_window(self, data_per_window: list[TimeSeriesDataFrame]) -> None:
+        """Validation windows the cached OOF predictions are scored against. Stored in a file (not on the trainer)
+        so repeated `update` calls slide them in lockstep with the OOF without bloating the trainer pickle."""
         save_pkl.save(path=os.path.join(self.path_data, "val_data_per_window.pkl"), object=data_per_window)
 
     def load_val_data_per_window(self) -> list[TimeSeriesDataFrame] | None:

--- a/timeseries/src/autogluon/timeseries/trainer/trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/trainer.py
@@ -98,9 +98,6 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
         self.val_step_size = val_step_size
         self.refit_every_n_windows = refit_every_n_windows
         self.hpo_results = {}
-        #: Ground-truth validation windows that the cached OOF predictions are scored against. Set by `update`
-        #: so that repeated calls slide these windows in lockstep with the (persisted) OOF predictions.
-        self.val_data_per_window: list[TimeSeriesDataFrame] | None = None
 
         self.prediction_cache: PredictionCache = get_prediction_cache(cache_predictions, self.path)
         self.prediction_cache.clear()
@@ -132,6 +129,15 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
         train_data = self.load_train_data()
         val_data = self.load_val_data()
         return train_data, val_data
+
+    # Validation windows the cached OOF predictions are scored against. Stored in a file (not on the trainer)
+    # so repeated `update` calls slide them in lockstep with the OOF without bloating the trainer pickle.
+    def save_val_data_per_window(self, data_per_window: list[TimeSeriesDataFrame]) -> None:
+        save_pkl.save(path=os.path.join(self.path_data, "val_data_per_window.pkl"), object=data_per_window)
+
+    def load_val_data_per_window(self) -> list[TimeSeriesDataFrame] | None:
+        path = os.path.join(self.path_data, "val_data_per_window.pkl")
+        return load_pkl.load(path=path) if os.path.exists(path) else None
 
     def save(self) -> None:
         models = self.models
@@ -1310,7 +1316,7 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
 
         # On the first update, seed from the training targets; afterwards slide the stored windows so that
         # they stay aligned with the (persisted, already-slid) OOF predictions across repeated calls.
-        prev_data_per_window = self.val_data_per_window or self.backtest_targets(data=None)
+        prev_data_per_window = self.load_val_data_per_window() or self.backtest_targets(data=None)
         data_per_window = slide(prev_data_per_window, fresh_data_per_window)
 
         def update_model(model: TimeSeriesModelBase, oof_predictions: list[TimeSeriesDataFrame]) -> None:
@@ -1350,7 +1356,7 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
             update_model(ensemble, oof_predictions)
             refit_ensembles.append(model_name)
 
-        self.val_data_per_window = data_per_window
+        self.save_val_data_per_window(data_per_window)
         self.save()
         logger.info(f"Re-scored base models and re-fit ensembles: {refit_ensembles}")
         logger.info(f"Total runtime: {time.time() - time_start:.2f} s")

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -699,11 +699,15 @@ def test_when_update_called_then_ensemble_is_refit_and_all_models_can_predict(up
         assert len(preds) == fresh_data.num_items * predictor.prediction_length
 
 
-def test_when_update_called_and_predictor_reloaded_then_updated_scores_persist(update_predictor_and_data, temp_model_path):
+def test_when_update_called_and_predictor_reloaded_then_updated_scores_persist(
+    update_predictor_and_data, temp_model_path
+):
     _, fresh_data = update_predictor_and_data
     df = get_data_frame_with_variable_lengths({"A": 40, "B": 40}, freq="D")
     predictor = TimeSeriesPredictor(path=temp_model_path, prediction_length=3, verbosity=0).fit(
-        df.slice_by_timestep(None, -5), hyperparameters={"Naive": {}, "Average": {}}, num_val_windows=1,
+        df.slice_by_timestep(None, -5),
+        hyperparameters={"Naive": {}, "Average": {}},
+        num_val_windows=1,
     )
     predictor.update(df)
     scores_before = predictor.leaderboard().set_index("model")["score_val"].to_dict()
@@ -715,7 +719,9 @@ def test_when_update_called_and_predictor_reloaded_then_updated_scores_persist(u
 def test_when_update_called_after_refit_full_then_exception_is_raised(temp_model_path):
     df = get_data_frame_with_variable_lengths({"A": 40, "B": 40}, freq="D")
     predictor = TimeSeriesPredictor(path=temp_model_path, prediction_length=3, verbosity=0).fit(
-        df.slice_by_timestep(None, -5), hyperparameters={"Naive": {}}, num_val_windows=1,
+        df.slice_by_timestep(None, -5),
+        hyperparameters={"Naive": {}},
+        num_val_windows=1,
     )
     predictor.refit_full()
     with pytest.raises(NotImplementedError, match="refit_full"):
@@ -747,7 +753,9 @@ def test_when_update_called_with_short_series_then_they_are_filtered(temp_model_
 def test_when_update_items_differ_from_training_then_only_common_items_are_used(temp_model_path, update_items):
     df = get_data_frame_with_variable_lengths({"A": 40, "B": 40}, freq="D")
     predictor = TimeSeriesPredictor(path=temp_model_path, prediction_length=3, verbosity=0).fit(
-        df.slice_by_timestep(None, -5), hyperparameters={"Naive": {}}, num_val_windows=1,
+        df.slice_by_timestep(None, -5),
+        hyperparameters={"Naive": {}},
+        num_val_windows=1,
     )
     update_data = get_data_frame_with_variable_lengths({item: 40 for item in update_items}, freq="D")
     updated_models = predictor.update(update_data)  # extra items ignored, missing items dropped, no error

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -691,12 +691,21 @@ def test_when_update_called_then_ensemble_is_refit_and_all_models_can_predict(up
     updated_models = predictor.update(fresh_data)
     assert "WeightedEnsemble" in updated_models
     weights_after = predictor._trainer.load_model("WeightedEnsemble").model_to_weight
-    # ensemble was re-fit (weights re-derived from the updated validation window)
-    assert set(weights_after).issubset(set(weights_before) | set(predictor.model_names()))
+    # ensemble was re-fit: weights are re-derived over the base models on the updated validation window
+    base_model_names = set(predictor._trainer.get_model_names(layer=0))
+    assert weights_after and set(weights_after).issubset(base_model_names)
     for model in predictor.model_names():
         preds = predictor.predict(fresh_data, model=model)
         assert isinstance(preds, TimeSeriesDataFrame)
         assert len(preds) == fresh_data.num_items * predictor.prediction_length
+
+
+def test_when_predict_called_before_update_then_best_model_is_recomputed_after_update(update_predictor_and_data):
+    predictor, fresh_data = update_predictor_and_data
+    predictor.predict(fresh_data)  # caches model_best before update
+    predictor.update(fresh_data)
+    assert predictor._trainer.model_best is None
+    assert predictor.model_best == predictor._trainer.get_model_best()
 
 
 def test_when_update_called_and_predictor_reloaded_then_updated_scores_persist(

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -722,6 +722,17 @@ def test_when_update_called_after_refit_full_then_exception_is_raised(temp_model
         predictor.update(df)
 
 
+def test_when_update_called_repeatedly_with_multiple_val_windows_then_no_error(update_predictor_and_data):
+    predictor, fresh_data = update_predictor_and_data
+    assert sum(predictor._trainer.num_val_windows) > 1
+    # Simulate the sliding-window evaluation flow: each window reveals more recent data.
+    predictor.update(fresh_data.slice_by_timestep(None, -2))
+    updated_models = predictor.update(fresh_data)
+    assert "WeightedEnsemble" in updated_models
+    preds = predictor.predict(fresh_data)
+    assert len(preds) == fresh_data.num_items * predictor.prediction_length
+
+
 def test_when_update_called_with_short_series_then_they_are_filtered(temp_model_path):
     df = get_data_frame_with_variable_lengths({"A": 40, "B": 40, "SHORT": 4}, freq="D")
     predictor = TimeSeriesPredictor(path=temp_model_path, prediction_length=3, verbosity=0).fit(

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -743,23 +743,15 @@ def test_when_update_called_with_short_series_then_they_are_filtered(temp_model_
     predictor.update(df)  # should not raise; short series filtered out
 
 
-def test_when_update_called_with_extra_items_then_they_are_ignored(temp_model_path):
+@pytest.mark.parametrize("update_items", [["A", "B", "C"], ["A"]])
+def test_when_update_items_differ_from_training_then_only_common_items_are_used(temp_model_path, update_items):
     df = get_data_frame_with_variable_lengths({"A": 40, "B": 40}, freq="D")
     predictor = TimeSeriesPredictor(path=temp_model_path, prediction_length=3, verbosity=0).fit(
         df.slice_by_timestep(None, -5), hyperparameters={"Naive": {}}, num_val_windows=1,
     )
-    df_with_extra = get_data_frame_with_variable_lengths({"A": 40, "B": 40, "C": 40}, freq="D")
-    updated_models = predictor.update(df_with_extra)  # extra item C is ignored, no error
+    update_data = get_data_frame_with_variable_lengths({item: 40 for item in update_items}, freq="D")
+    updated_models = predictor.update(update_data)  # extra items ignored, missing items dropped, no error
     assert "Naive" in updated_models
-
-
-def test_when_update_called_with_missing_items_then_exception_is_raised(temp_model_path):
-    df = get_data_frame_with_variable_lengths({"A": 40, "B": 40}, freq="D")
-    predictor = TimeSeriesPredictor(path=temp_model_path, prediction_length=3, verbosity=0).fit(
-        df.slice_by_timestep(None, -5), hyperparameters={"Naive": {}}, num_val_windows=1,
-    )
-    with pytest.raises(ValueError, match="missing some of the time series"):
-        predictor.update(df.query("item_id == 'A'"))
 
 
 def test_when_excluded_model_names_provided_then_excluded_models_are_not_trained(temp_model_path):

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -687,7 +687,6 @@ def test_when_update_called_then_val_scores_change(update_predictor_and_data):
 
 def test_when_update_called_then_ensemble_is_refit_and_all_models_can_predict(update_predictor_and_data):
     predictor, fresh_data = update_predictor_and_data
-    weights_before = predictor._trainer.load_model("WeightedEnsemble").model_to_weight
     updated_models = predictor.update(fresh_data)
     assert "WeightedEnsemble" in updated_models
     weights_after = predictor._trainer.load_model("WeightedEnsemble").model_to_weight

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -725,9 +725,9 @@ def test_when_update_called_after_refit_full_then_exception_is_raised(temp_model
 def test_when_update_called_repeatedly_with_multiple_val_windows_then_no_error(update_predictor_and_data):
     predictor, fresh_data = update_predictor_and_data
     assert sum(predictor._trainer.num_val_windows) > 1
-    # Simulate the sliding-window evaluation flow: each window reveals more recent data.
-    predictor.update(fresh_data.slice_by_timestep(None, -2))
-    updated_models = predictor.update(fresh_data)
+    # Simulate the sliding-window evaluation flow: each update reveals one more recent window.
+    for end in [-4, -2, None]:
+        updated_models = predictor.update(fresh_data.slice_by_timestep(None, end))
     assert "WeightedEnsemble" in updated_models
     preds = predictor.predict(fresh_data)
     assert len(preds) == fresh_data.num_items * predictor.prediction_length

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -664,6 +664,74 @@ def test_when_refit_full_is_passed_to_fit_then_refit_full_is_skipped(temp_model_
             refit_method.assert_not_called()
 
 
+@pytest.fixture
+def update_predictor_and_data(temp_model_path):
+    df = get_data_frame_with_variable_lengths({"A": 40, "B": 40, "C": 40}, freq="D")
+    train_data = df.slice_by_timestep(None, -5)
+    predictor = TimeSeriesPredictor(path=temp_model_path, prediction_length=3, verbosity=0).fit(
+        train_data,
+        hyperparameters={"Naive": {}, "Average": {}, "SeasonalNaive": {}},
+        num_val_windows=2,
+    )
+    yield predictor, df
+
+
+def test_when_update_called_then_val_scores_change(update_predictor_and_data):
+    predictor, fresh_data = update_predictor_and_data
+    scores_before = predictor.leaderboard().set_index("model")["score_val"].to_dict()
+    predictor.update(fresh_data)
+    scores_after = predictor.leaderboard().set_index("model")["score_val"].to_dict()
+    assert set(scores_before) == set(scores_after)
+    assert any(scores_before[m] != scores_after[m] for m in scores_before)
+
+
+def test_when_update_called_then_ensemble_is_refit_and_all_models_can_predict(update_predictor_and_data):
+    predictor, fresh_data = update_predictor_and_data
+    weights_before = predictor._trainer.load_model("WeightedEnsemble").model_to_weight
+    updated_models = predictor.update(fresh_data)
+    assert "WeightedEnsemble" in updated_models
+    weights_after = predictor._trainer.load_model("WeightedEnsemble").model_to_weight
+    # ensemble was re-fit (weights re-derived from the updated validation window)
+    assert set(weights_after).issubset(set(weights_before) | set(predictor.model_names()))
+    for model in predictor.model_names():
+        preds = predictor.predict(fresh_data, model=model)
+        assert isinstance(preds, TimeSeriesDataFrame)
+        assert len(preds) == fresh_data.num_items * predictor.prediction_length
+
+
+def test_when_update_called_and_predictor_reloaded_then_updated_scores_persist(update_predictor_and_data, temp_model_path):
+    _, fresh_data = update_predictor_and_data
+    df = get_data_frame_with_variable_lengths({"A": 40, "B": 40}, freq="D")
+    predictor = TimeSeriesPredictor(path=temp_model_path, prediction_length=3, verbosity=0).fit(
+        df.slice_by_timestep(None, -5), hyperparameters={"Naive": {}, "Average": {}}, num_val_windows=1,
+    )
+    predictor.update(df)
+    scores_before = predictor.leaderboard().set_index("model")["score_val"].to_dict()
+    reloaded = TimeSeriesPredictor.load(temp_model_path)
+    scores_after = reloaded.leaderboard().set_index("model")["score_val"].to_dict()
+    assert scores_before == scores_after
+
+
+def test_when_update_called_after_refit_full_then_exception_is_raised(temp_model_path):
+    df = get_data_frame_with_variable_lengths({"A": 40, "B": 40}, freq="D")
+    predictor = TimeSeriesPredictor(path=temp_model_path, prediction_length=3, verbosity=0).fit(
+        df.slice_by_timestep(None, -5), hyperparameters={"Naive": {}}, num_val_windows=1,
+    )
+    predictor.refit_full()
+    with pytest.raises(NotImplementedError, match="refit_full"):
+        predictor.update(df)
+
+
+def test_when_update_called_with_short_series_then_they_are_filtered(temp_model_path):
+    df = get_data_frame_with_variable_lengths({"A": 40, "B": 40, "SHORT": 4}, freq="D")
+    predictor = TimeSeriesPredictor(path=temp_model_path, prediction_length=3, verbosity=0).fit(
+        df.slice_by_timestep(None, -5).query("item_id != 'SHORT'"),
+        hyperparameters={"Naive": {}},
+        num_val_windows=1,
+    )
+    predictor.update(df)  # should not raise; short series filtered out
+
+
 def test_when_excluded_model_names_provided_then_excluded_models_are_not_trained(temp_model_path):
     predictor = TimeSeriesPredictor(path=temp_model_path)
     predictor.fit(

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -743,6 +743,25 @@ def test_when_update_called_with_short_series_then_they_are_filtered(temp_model_
     predictor.update(df)  # should not raise; short series filtered out
 
 
+def test_when_update_called_with_extra_items_then_they_are_ignored(temp_model_path):
+    df = get_data_frame_with_variable_lengths({"A": 40, "B": 40}, freq="D")
+    predictor = TimeSeriesPredictor(path=temp_model_path, prediction_length=3, verbosity=0).fit(
+        df.slice_by_timestep(None, -5), hyperparameters={"Naive": {}}, num_val_windows=1,
+    )
+    df_with_extra = get_data_frame_with_variable_lengths({"A": 40, "B": 40, "C": 40}, freq="D")
+    updated_models = predictor.update(df_with_extra)  # extra item C is ignored, no error
+    assert "Naive" in updated_models
+
+
+def test_when_update_called_with_missing_items_then_exception_is_raised(temp_model_path):
+    df = get_data_frame_with_variable_lengths({"A": 40, "B": 40}, freq="D")
+    predictor = TimeSeriesPredictor(path=temp_model_path, prediction_length=3, verbosity=0).fit(
+        df.slice_by_timestep(None, -5), hyperparameters={"Naive": {}}, num_val_windows=1,
+    )
+    with pytest.raises(ValueError, match="missing some of the time series"):
+        predictor.update(df.query("item_id == 'A'"))
+
+
 def test_when_excluded_model_names_provided_then_excluded_models_are_not_trained(temp_model_path):
     predictor = TimeSeriesPredictor(path=temp_model_path)
     predictor.fit(


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Adds an **experimental** `TimeSeriesPredictor.update(data)` that re-selects and re-weights the ensemble on fresher data — without retraining base models.

- Computes a fresh validation window from `data` and slides it into the cached out-of-fold windows (drops the oldest to keep `sum(num_val_windows)` total).
- Re-scores all models on the updated windows and re-fits the weighted ensemble, syncing the model graph when the selected base models change.
- Raises `NotImplementedError` for multi-layer stack ensembles and after `refit_full`. API and behavior may change without warning.

Adds 5 unit tests covering val-score changes, ensemble re-fit + predict, persistence across save/load, the `refit_full` guard, and repeated updates with multiple validation windows.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.