### PR TITLE
Fix OOF alignment for the weighted ensemble; size curves override auto_stack and gain dynamic_stacking

### DIFF
--- a/tabular/src/autogluon/tabular/configs/pipeline_presets.py
+++ b/tabular/src/autogluon/tabular/configs/pipeline_presets.py
@@ -268,20 +268,30 @@ def get_validation_and_stacking_method(
     if refit_full is None:
         refit_full = False
 
-    # Changed by `auto_stack`
+    # Changed by `auto_stack` -- except where the caller gave a curve for the knob. Supplying a
+    # curve is itself a request for size-driven selection of that knob, so `auto_stack` does not
+    # get to overrule it: without this, `auto_stack=False` (the default) silently replaced an
+    # explicit `num_bag_folds` curve with 0, i.e. no bagging and no out-of-fold predictions at all.
+    # Knobs the caller left out still follow `auto_stack` exactly as before.
+    curve_overrides = ValidationSizeCurves.from_input(validation_size_curves)
+    specified = set(curve_overrides.as_overrides()) if curve_overrides is not None else set()
+
     if num_bag_folds is None:
         # `num_bag_folds == 0` -> only use holdout validation
-        num_bag_folds = cv_preset["num_bag_folds"] if auto_stack else 0
+        num_bag_folds = cv_preset["num_bag_folds"] if (auto_stack or "num_bag_folds" in specified) else 0
     if num_bag_sets is None:
         # `num_bag_sets == 1` -> no repeats
-        num_bag_sets = cv_preset["num_bag_sets"] if auto_stack else 1
+        num_bag_sets = cv_preset["num_bag_sets"] if (auto_stack or "num_bag_sets" in specified) else 1
     if num_stack_levels is None:
         # Disable multi-layer stacking by default
         num_stack_levels = 0
         # How deep the data size permits; the conditions below decide whether to stack at all.
         stack_levels_by_size = cv_preset["num_stack_levels"]
 
-        if auto_stack and dynamic_stacking:
+        if "num_stack_levels" in specified:
+            # An explicit curve is the answer, not an input to the auto_stack conditions below.
+            num_stack_levels = stack_levels_by_size
+        elif auto_stack and dynamic_stacking:
             # Dynamic stacking detects stacked overfitting itself, so it is not size-gated.
             num_stack_levels = max(1, stack_levels_by_size)
         elif auto_stack and (use_bag_holdout or (problem_type != BINARY)):

--- a/tabular/src/autogluon/tabular/configs/pipeline_presets.py
+++ b/tabular/src/autogluon/tabular/configs/pipeline_presets.py
@@ -63,8 +63,10 @@ class ValidationSizeCurves:
         ValidationSizeCurves(num_bag_sets=[[2_000, 5], 1])
         ValidationSizeCurves.from_input({"num_bag_sets": [[2_000, 5], 1]})  # equivalent
 
-    ``holdout_frac`` has no default curve: its built-in policy is a continuous function of
-    the row count, which a step curve cannot reproduce, so a curve given here replaces it.
+    ``holdout_frac`` and ``dynamic_stacking`` have no default curve, because neither built-in
+    policy is a step function of size: ``holdout_frac`` is a continuous function of the row count,
+    and ``dynamic_stacking`` is derived from another knob (it defaults to ``not use_bag_holdout``).
+    A curve given here replaces that policy.
     """
 
     num_bag_folds: SizeCurve = None
@@ -72,6 +74,7 @@ class ValidationSizeCurves:
     use_bag_holdout: SizeCurve = None
     num_stack_levels: SizeCurve = None
     holdout_frac: SizeCurve = None
+    dynamic_stacking: SizeCurve = None
 
     @classmethod
     def from_input(cls, value: ValidationSizeCurves | dict | None) -> ValidationSizeCurves | None:
@@ -258,13 +261,21 @@ def get_validation_and_stacking_method(
         validation_size_curves=validation_size_curves,
     )
 
+    # Which knobs the caller gave a curve for. Supplying one is itself a request for size-driven
+    # selection of that knob, so it is honored wherever a knob would otherwise be decided by
+    # `auto_stack` or derived from another knob.
+    curve_overrides = ValidationSizeCurves.from_input(validation_size_curves)
+    specified = set(curve_overrides.as_overrides()) if curve_overrides is not None else set()
+
     # Independent of `auto_stack`
     if use_bag_holdout is None:
         use_bag_holdout = cv_preset["use_bag_holdout"]
     if holdout_frac is None:
         holdout_frac = cv_preset["holdout_frac"]
     if dynamic_stacking is None:
-        dynamic_stacking = not use_bag_holdout
+        # Without a curve, DyStack follows from whether a bag-holdout is used; a curve replaces
+        # that derivation, so it can be sized independently.
+        dynamic_stacking = cv_preset["dynamic_stacking"] if "dynamic_stacking" in specified else not use_bag_holdout
     if refit_full is None:
         refit_full = False
 
@@ -273,9 +284,6 @@ def get_validation_and_stacking_method(
     # get to overrule it: without this, `auto_stack=False` (the default) silently replaced an
     # explicit `num_bag_folds` curve with 0, i.e. no bagging and no out-of-fold predictions at all.
     # Knobs the caller left out still follow `auto_stack` exactly as before.
-    curve_overrides = ValidationSizeCurves.from_input(validation_size_curves)
-    specified = set(curve_overrides.as_overrides()) if curve_overrides is not None else set()
-
     if num_bag_folds is None:
         # `num_bag_folds == 0` -> only use holdout validation
         num_bag_folds = cv_preset["num_bag_folds"] if (auto_stack or "num_bag_folds" in specified) else 0

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -859,11 +859,13 @@ class TabularPredictor:
                 with data size, as a `ValidationSizeCurves` or an equivalent dict. The curve format
                 and the set of tunable knobs may change in a future release.
                 Each entry maps one knob -- `num_bag_folds`, `num_bag_sets`, `use_bag_holdout`,
-                `num_stack_levels`, `holdout_frac` -- to either a fixed value or a size curve
+                `num_stack_levels`, `holdout_frac`, `dynamic_stacking` -- to either a fixed value or a size curve
                 `[[rows, value], ..., fallback]`, read as "use `value` at or below `rows`", with the
                 trailing entry applying above every anchor. Only the entries given are overridden;
                 the rest keep their defaults, and an explicit `num_bag_folds` / `num_bag_sets` /
-                `use_bag_holdout` / `num_stack_levels` argument still wins over any curve.
+                `use_bag_holdout` / `num_stack_levels` / `dynamic_stacking` argument still wins over any
+                curve. A knob given a curve is not overridden by `auto_stack`, since supplying the curve
+                is itself a request for size-driven selection of it.
                     `validation_size_curves={'num_bag_sets': [[2000, 5], 1]}` -> 5 repeats at or below
                     2000 rows and 1 above, i.e. repeated cross-validation on small data.
                 Read at the number of groups instead of rows when `validation_structure` sets

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -1039,24 +1039,15 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         X_stack_preds = self.get_inputs_to_stacker(
             X, base_models=base_model_names, fit=fit, use_orig_features=False, use_val_cache=use_val_cache
         )
-        if fit:
-            # Drop rows no base model validated. Their out-of-fold predictions are NaN (see
-            # `BaggedEnsembleModel._predict_proba_oof`), so keeping them would have the ensemble
-            # optimize weights against, and be scored on, rows where it has no base predictions --
-            # while the base models it is compared against are scored only on their covered rows
-            # (`score_with_oof`). Dropping keeps both sides on the same rows, so the leaderboard
-            # stays comparable. Safe here because the weighted ensemble is fit unbagged (k_fold=1),
-            # so no positional fold indices are invalidated by the reindex.
-            covered = X_stack_preds.notna().all(axis=1)
-            if not covered.all():
-                logger.log(
-                    20,
-                    f"\tWeighted ensemble: excluding {int((~covered).sum())} of {len(covered)} rows "
-                    f"with no out-of-fold predictions from the base models.",
-                )
-                X_stack_preds = X_stack_preds[covered]
-                X = X[covered]
-                y = y[covered]
+        # Rows no base model validated have NaN out-of-fold predictions (see
+        # `BaggedEnsembleModel._predict_proba_oof`). The ensemble cannot optimize weights against
+        # them, so they are excluded from its fit -- but only from the fit: `generate_weighted
+        # _ensemble` restores full-length, row-aligned out-of-fold predictions afterwards, marking
+        # those rows uncovered. Anything else would leave the ensemble's OOF a different length
+        # from every other model's and so not addressable by training-frame row.
+        covered_rows = X_stack_preds.notna().all(axis=1) if fit else None
+        if covered_rows is not None and covered_rows.all():
+            covered_rows = None
         if self.weight_evaluation:
             X, w = extract_column(
                 X, self.sample_weight
@@ -1073,6 +1064,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         return self.generate_weighted_ensemble(
             X=X_stack_preds,
             y=y,
+            covered_rows=covered_rows,
             level=level,
             base_model_names=base_model_names,
             k_fold=1,
@@ -2145,6 +2137,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         y,
         level,
         base_model_names,
+        covered_rows: pd.Series | None = None,
         k_fold=1,
         n_repeats=1,
         stack_name=None,
@@ -2217,6 +2210,17 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         w = None
         if self.weight_evaluation:
             X, w = extract_column(X, self.sample_weight)
+        if covered_rows is not None:
+            # Fit on the rows the base models actually validated; alignment is restored below.
+            logger.log(
+                20,
+                f"\tWeighted ensemble: fitting on {int(covered_rows.sum())} of {len(covered_rows)} rows "
+                f"({int((~covered_rows).sum())} have no out-of-fold predictions from the base models).",
+            )
+            X = X[covered_rows]
+            y = y[covered_rows]
+            if w is not None:
+                w = w[covered_rows]
         models = self._train_multi(
             X=X,
             y=y,
@@ -2235,6 +2239,9 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
             ),  # FIXME: Is this the right way to do this?
             total_resources=total_resources,
         )
+        if covered_rows is not None:
+            for weighted_ensemble_model_name in models:
+                self._restore_oof_alignment(weighted_ensemble_model_name, covered_rows=covered_rows)
         for weighted_ensemble_model_name in models:
             if check_if_best and weighted_ensemble_model_name in self.get_model_names():
                 if self.model_best is None:
@@ -2246,6 +2253,34 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
                         # new best model
                         self.model_best = weighted_ensemble_model_name
         return models
+
+    def _restore_oof_alignment(self, model_name: str, covered_rows: pd.Series) -> None:
+        """Re-index a model's out-of-fold predictions onto the full training frame.
+
+        A model fit on a subset of rows holds out-of-fold predictions for only those rows, so its
+        array is a different length from every other model's and cannot be addressed by
+        training-frame row -- anything pairing it with ``y`` breaks (temperature scaling was the
+        first such consumer found). This scatters the predictions back to full length and marks the
+        remaining rows uncovered by leaving their fold count at zero, which is the same
+        representation a bagged model uses for rows no fold validated: ``predict_proba_oof``
+        returns NaN there and ``score_with_oof`` masks them out.
+        """
+        model = self.load_model(model_name=model_name)
+        if not isinstance(model, BaggedEnsembleModel):
+            return
+        model._load_oof()
+        oof, repeats = model._oof_pred_proba, model._oof_pred_model_repeats
+        if oof is None or len(oof) == len(covered_rows):
+            return  # nothing to restore
+
+        covered_idx = np.flatnonzero(covered_rows.to_numpy())
+        full_oof = np.zeros((len(covered_rows), *oof.shape[1:]), dtype=oof.dtype)
+        full_oof[covered_idx] = oof
+        full_repeats = np.zeros(len(covered_rows), dtype=repeats.dtype)
+        full_repeats[covered_idx] = repeats
+        model._oof_pred_proba = full_oof
+        model._oof_pred_model_repeats = full_repeats
+        model.save()
 
     def _train_single(
         self,
@@ -4906,6 +4941,20 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         else:  # bagged mode
             y_val_probs = self.get_model_oof(model_name_og)
             y_val = self.load_y().to_numpy()
+            # Rows no fold validated carry NaN (see `BaggedEnsembleModel._predict_proba_oof`), and
+            # temperature scaling would return NaN if they were included. Scoring masks the same
+            # rows out (`score_with_oof`), so calibrating on the covered rows keeps the two
+            # consistent. Only reachable when the validation scheme leaves rows unvalidated, as
+            # forward-chaining temporal splits do with the earliest time block.
+            covered = ~np.isnan(np.asarray(y_val_probs, dtype=float)).reshape(len(y_val_probs), -1).any(axis=1)
+            if not covered.all():
+                logger.log(
+                    15,
+                    f"Calibration: using {int(covered.sum())} of {len(covered)} rows for {model_name} "
+                    f"({int((~covered).sum())} have no out-of-fold prediction).",
+                )
+                y_val_probs = y_val_probs[covered]
+                y_val = y_val[covered]
 
         y_val_probs_og = y_val_probs
         if self.problem_type == BINARY:

--- a/tabular/tests/unittests/configs/test_validation_size_curves.py
+++ b/tabular/tests/unittests/configs/test_validation_size_curves.py
@@ -9,6 +9,7 @@ import pytest
 from autogluon.tabular.configs.pipeline_presets import (
     USE_BAG_HOLDOUT_AUTO_THRESHOLD,
     _get_validation_preset,
+    get_validation_and_stacking_method,
     resolve_size_curve,
 )
 
@@ -256,3 +257,57 @@ def test__validation_size_curves__rejects_unknown_knobs():
         ValidationSizeCurves.from_input({"num_bag_setz": 5})
     with pytest.raises(ValueError, match="must be a dict or ValidationSizeCurves"):
         ValidationSizeCurves.from_input(5)
+
+
+def _resolve(*, auto_stack: bool, curves, num_train_rows: int = 400):
+    """The (folds, sets, stack_levels) the validation method resolves to."""
+    num_bag_folds, num_bag_sets, num_stack_levels, _, _, _, _ = get_validation_and_stacking_method(
+        num_bag_folds=None,
+        num_bag_sets=None,
+        use_bag_holdout=None,
+        holdout_frac=None,
+        auto_stack=auto_stack,
+        num_stack_levels=None,
+        dynamic_stacking=None,
+        refit_full=None,
+        num_train_rows=num_train_rows,
+        problem_type="binary",
+        hpo_enabled=False,
+        n_samples_minority_class=None,
+        num_group_instances=None,
+        size_on_groups=False,
+        validation_size_curves=curves,
+    )
+    return num_bag_folds, num_bag_sets, num_stack_levels
+
+
+def test__auto_stack_does_not_override_an_explicit_curve():
+    """A curve for a knob is a request for size-driven selection of it, which `auto_stack` cannot undo.
+
+    Without this, `auto_stack=False` (the default) replaced an explicit `num_bag_folds` curve with
+    0 -- no bagging and so no out-of-fold predictions -- silently turning a benchmark run of bagged
+    models into unbagged holdout fits.
+    """
+    curves = {"num_bag_folds": [[500, 5], 8], "num_bag_sets": [[500, 5], 1]}
+    # 400 rows sits in the first anchor of both curves.
+    assert _resolve(auto_stack=False, curves=curves) == (5, 5, 0)
+    assert _resolve(auto_stack=True, curves=curves)[:2] == (5, 5)
+
+
+def test__auto_stack_still_governs_knobs_without_a_curve():
+    """Unchanged behavior where the caller said nothing: `auto_stack` decides."""
+    assert _resolve(auto_stack=False, curves=None) == (0, 1, 0)
+    assert _resolve(auto_stack=True, curves=None) == (8, 1, 1)
+
+
+def test__explicit_curves_apply_per_knob():
+    """Only the knobs given a curve escape `auto_stack`; the rest keep their gated defaults."""
+    folds, sets, _ = _resolve(auto_stack=False, curves={"num_bag_sets": 3})
+    assert sets == 3, "the specified knob is honored"
+    assert folds == 0, "the unspecified knob still follows auto_stack=False"
+
+
+def test__explicit_stack_curve_is_not_gated_by_auto_stack():
+    """A `num_stack_levels` curve is the answer, not an input to the auto_stack conditions."""
+    _, _, stack_levels = _resolve(auto_stack=False, curves={"num_stack_levels": 2})
+    assert stack_levels == 2

--- a/tabular/tests/unittests/configs/test_validation_size_curves.py
+++ b/tabular/tests/unittests/configs/test_validation_size_curves.py
@@ -311,3 +311,46 @@ def test__explicit_stack_curve_is_not_gated_by_auto_stack():
     """A `num_stack_levels` curve is the answer, not an input to the auto_stack conditions."""
     _, _, stack_levels = _resolve(auto_stack=False, curves={"num_stack_levels": 2})
     assert stack_levels == 2
+
+
+def _resolve_dynamic_stacking(curves, *, dynamic_stacking=None, use_bag_holdout=None, num_train_rows: int = 400):
+    """The (dynamic_stacking, use_bag_holdout) the validation method resolves to."""
+    _, _, _, resolved_ds, resolved_ubh, _, _ = get_validation_and_stacking_method(
+        num_bag_folds=None,
+        num_bag_sets=None,
+        use_bag_holdout=use_bag_holdout,
+        holdout_frac=None,
+        auto_stack=True,
+        num_stack_levels=0,
+        dynamic_stacking=dynamic_stacking,
+        refit_full=None,
+        num_train_rows=num_train_rows,
+        problem_type="binary",
+        hpo_enabled=False,
+        n_samples_minority_class=None,
+        num_group_instances=None,
+        size_on_groups=False,
+        validation_size_curves=curves,
+    )
+    return resolved_ds, resolved_ubh
+
+
+def test__dynamic_stacking_curve_replaces_the_derived_default():
+    """`dynamic_stacking` has no default curve: it is derived from `use_bag_holdout` unless given one."""
+    # Derived: 400 rows -> use_bag_holdout False -> DyStack on.
+    assert _resolve_dynamic_stacking(None) == (True, False)
+    # A curve replaces that derivation in either direction.
+    assert _resolve_dynamic_stacking({"dynamic_stacking": False})[0] is False
+    assert _resolve_dynamic_stacking({"dynamic_stacking": True})[0] is True
+
+
+def test__dynamic_stacking_curve_is_read_at_the_sample_size():
+    """A step curve sizes DyStack independently of any other knob."""
+    curve = {"dynamic_stacking": [[1_000, False], True]}
+    assert _resolve_dynamic_stacking(curve, num_train_rows=400)[0] is False
+    assert _resolve_dynamic_stacking(curve, num_train_rows=5_000)[0] is True
+
+
+def test__explicit_dynamic_stacking_argument_beats_its_curve():
+    """As for every other knob, an explicit argument wins over the curve."""
+    assert _resolve_dynamic_stacking({"dynamic_stacking": True}, dynamic_stacking=False)[0] is False

--- a/tabular/tests/unittests/test_validation_structure.py
+++ b/tabular/tests/unittests/test_validation_structure.py
@@ -743,3 +743,52 @@ def test__holdout__group_column_dropped_by_feature_generation():
     )
     groups = data["gid"]
     assert not (set(groups.iloc[train_idx]) & set(groups.iloc[val_idx]))
+
+
+def test__holdout_coverage__weighted_ensemble_oof_stays_row_aligned():
+    """A partially-covered validation scheme must not leave the ensemble's OOF a different length.
+
+    Forward-chaining never validates the earliest time block, so the weighted ensemble cannot
+    optimize weights on those rows and is fit without them. Its out-of-fold predictions must still
+    be addressable by training-frame row, or anything pairing them with `y` breaks -- temperature
+    scaling did exactly that, raising `Expected input batch_size (725) to match target batch_size
+    (900)`. The uncovered rows are marked NaN, the same representation a bagged model uses for rows
+    no fold validated.
+    """
+    from autogluon.tabular import TabularPredictor
+
+    rng = np.random.default_rng(0)
+    n_rows = 900
+    data = pd.DataFrame(
+        {
+            "f1": rng.normal(size=n_rows),
+            "f2": rng.normal(size=n_rows),
+            "ts": pd.to_datetime("2026-01-01") + pd.to_timedelta(np.sort(rng.integers(0, 90, size=n_rows)), unit="D"),
+        }
+    )
+    # multiclass + log_loss is what makes `calibrate=True` actually calibrate.
+    data["y"] = rng.integers(0, 3, size=n_rows)
+
+    predictor = TabularPredictor(label="y", problem_type="multiclass", eval_metric="log_loss", verbosity=0).fit(
+        data,
+        hyperparameters={"GBM": [{"num_boost_round": 10}]},
+        num_bag_folds=4,
+        num_bag_sets=1,
+        num_stack_levels=0,
+        dynamic_stacking=False,
+        fit_weighted_ensemble=True,
+        calibrate=True,
+        validation_structure={"time_on": "ts", "temporal_forward_only": True},
+    )
+
+    ensemble = next(m for m in predictor.model_names() if "WeightedEnsemble" in m)
+    n_train_rows = len(predictor._trainer.load_y())
+    oof = np.asarray(predictor._trainer.get_model_oof(ensemble), dtype=float)
+
+    # Row-aligned to the training frame, with the unvalidated rows marked rather than missing.
+    assert oof.shape[0] == n_train_rows
+    uncovered = np.isnan(oof).any(axis=1)
+    assert uncovered.any(), "expected the earliest time block to be unvalidated"
+    assert not uncovered.all()
+    # The ensemble is still scored, on its covered rows.
+    assert predictor.leaderboard(silent=True).set_index("model").loc[ensemble, "score_val"] is not None


### PR DESCRIPTION
Three changes to how partial out-of-fold coverage and size curves are handled. The first two were found by the same BeyondArena preset run.

## 1. The weighted ensemble's OOF was not row-aligned

Fixes a bug introduced in #5796. When a validation scheme leaves rows unvalidated, that PR dropped those rows before fitting the weighted ensemble. It fixed the scoring comparison it set out to fix, but left the ensemble's out-of-fold predictions **shorter than every other model's**, so they were no longer addressable by training-frame row. Any consumer pairing them with `y` breaks — temperature scaling was the first one found:

```
ValueError: Expected input batch_size (8829) to match target batch_size (9933)
```

Hit on a multiclass BeyondArena task under forward-chaining temporal validation, where it killed the entire fit (all five models had trained successfully, then `_post_fit` -> `calibrate_model` raised).

Three conditions are needed, which is why it escaped the tests in #5796: partial out-of-fold coverage (only forward-chaining produces it), calibration actually running (`calibrate="auto"` triggers on classification with log_loss), and the weighted ensemble being the calibrated model. In that BeyondArena set only one of four tasks was multiclass; the three regression tasks never calibrate.

## Fix

Dropping rows was the wrong shape of fix. The rows are still excluded from the ensemble's **fit** — it has no base-model predictions for them and cannot optimize weights against them — but its out-of-fold predictions are now scattered back to full length afterwards, with the unvalidated rows left at fold count zero.

That is exactly the representation a bagged model already uses for rows no fold validated: `predict_proba_oof` returns NaN there, and `score_with_oof` masks them out. So the array is row-aligned for every consumer, and the "uncovered" marker is the existing convention rather than a new one.

Calibration then skips those rows explicitly instead of feeding NaN into temperature scaling, which keeps it on the same rows scoring uses.

Verified end to end on the failing shape (multiclass, forward-chaining, `calibrate=True`):

| | before | after |
|---|---|---|
| ensemble OOF length | 725 (training frame is 900) | **900** |
| rows marked uncovered | n/a — they were absent | 175 (NaN) |
| calibration | `ValueError` | `using 725 of 900 rows`, temperature tuned |
| fit outcome | dead | completes |

### Scope

Only reachable when the validation scheme leaves rows unvalidated, which today means `validation_structure.temporal_forward_only`. Full-coverage runs produce no uncovered rows, so `covered_rows` is `None` and neither the subset-fit nor the restore path is taken.

## 2. `auto_stack` silently discarded explicit size curves

Supplying a `validation_size_curves` entry for a knob is itself a request for size-driven selection of that knob, but the fold and repeat counts were gated on `auto_stack` regardless:

```python
num_bag_folds = cv_preset["num_bag_folds"] if auto_stack else 0
```

So with `auto_stack=False` (the default), an explicit `num_bag_folds` curve was replaced by **0** — no bagging, and therefore no out-of-fold predictions at all. Nothing warns; the fit succeeds as an unbagged holdout. It turned the first launch of a BeyondArena preset run into 32 unbagged fits, only caught because the model names lacked their `_BAG_L1` suffix.

It was also inconsistent within the same function: `use_bag_holdout` and `holdout_frac` from the same curves object were already honored irrespective of `auto_stack`, so passing curves half-worked.

| case (400 rows, curve `num_bag_folds=[[500, 5], 8]`) | folds | sets | before |
|---|---:|---:|---|
| explicit curves, `auto_stack=False` | **5** | **5** | 0 / 1 |
| explicit curves, `auto_stack=True` | 5 | 5 | unchanged |
| no curves, `auto_stack=False` | 0 | 1 | unchanged |
| no curves, `auto_stack=True` | 8 | 1 | unchanged |
| curve for `num_bag_sets` only, `auto_stack=False` | 0 | 3 | folds stay gated |

Knobs the caller left unspecified still follow `auto_stack` exactly as before, so a run passing no curves is unaffected. The distinction is per knob.

## 3. `dynamic_stacking` as a size curve

It was the one validation knob with no way to express it as a function of data size: it defaulted to `not use_bag_holdout`, so sizing it meant sizing bag-holdout, which is a different decision.

It joins `holdout_frac` as a knob with **no default curve**, since neither built-in policy is a step function of size — `holdout_frac` is continuous in the row count, and `dynamic_stacking` is derived from another knob. A curve replaces that policy and is read at the effective sample size like the rest:

```python
validation_size_curves={"dynamic_stacking": [[1000, False], True]}   # off below 1k rows, on above
```

Unchanged without a curve: the derivation from `use_bag_holdout` still applies, and an explicit `dynamic_stacking` argument still wins over a curve.

## Testing

`test__auto_stack_does_not_override_an_explicit_curve`, `test__auto_stack_still_governs_knobs_without_a_curve`, `test__explicit_curves_apply_per_knob` and `test__explicit_stack_curve_is_not_gated_by_auto_stack` cover the table above, including that the unchanged rows stay unchanged.

`test__dynamic_stacking_curve_replaces_the_derived_default`, `test__dynamic_stacking_curve_is_read_at_the_sample_size` and `test__explicit_dynamic_stacking_argument_beats_its_curve` cover the new knob: the derived default when no curve is given, a step curve sized independently of bag-holdout, and the explicit argument still winning.

`test__holdout_coverage__weighted_ensemble_oof_stays_row_aligned` fits multiclass with log_loss, forward-chaining and `calibrate=True`, then asserts the ensemble's OOF is the length of the training frame, that some rows are marked NaN and not all, and that the ensemble is still scored. Verified it reproduces the original `ValueError` when the fix is reverted.

Suites run: `configs/` + `test_validation_structure.py` (164 passed), `models/test_dummy.py` and `core/.../test_bagged_ensemble_model.py` (57 passed between them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi
