### PR TITLE
[timeseries] Silence noisy model loading logs for Chronos and TFT

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/chronos/chronos2.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/chronos2.py
@@ -9,6 +9,7 @@ from typing_extensions import Self
 
 from autogluon.timeseries.dataset import TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
+from autogluon.timeseries.utils.warning_filters import warning_filter
 
 logger = logging.getLogger(__name__)
 
@@ -280,11 +281,12 @@ class Chronos2Model(AbstractTimeSeriesModel):
         device = self.get_hyperparameter("device") or ("cuda" if self._is_gpu_available() else "cpu")
 
         assert self.model_path is not None
-        pipeline = Chronos2Pipeline.from_pretrained(
-            self.model_path,
-            device_map=device,
-            revision=self.get_hyperparameter("revision"),
-        )
+        with warning_filter(all_warnings=True):
+            pipeline = Chronos2Pipeline.from_pretrained(
+                self.model_path,
+                device_map=device,
+                revision=self.get_hyperparameter("revision"),
+            )
 
         self._model_pipeline = pipeline
 

--- a/timeseries/src/autogluon/timeseries/models/chronos/model.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/model.py
@@ -312,12 +312,13 @@ class ChronosModel(AbstractTimeSeriesModel):
         device = self.device or ("cuda" if gpu_available else "cpu")
 
         assert self.model_path is not None
-        pipeline = BaseChronosPipeline.from_pretrained(
-            self.model_path,
-            device_map=device,
-            torch_dtype=self.torch_dtype,
-            revision=self.get_hyperparameter("revision"),
-        )
+        with warning_filter(all_warnings=True):
+            pipeline = BaseChronosPipeline.from_pretrained(
+                self.model_path,
+                device_map=device,
+                torch_dtype=self.torch_dtype,
+                revision=self.get_hyperparameter("revision"),
+            )
 
         self._model_pipeline = pipeline
 

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract.py
@@ -255,6 +255,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
             "max_epochs": init_args["max_epochs"],
             "callbacks": self.callbacks,
             "enable_progress_bar": False,
+            "enable_model_summary": False,
             "default_root_dir": self.path,
         }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Suppresses noisy output printed while loading/fitting some time series models, without hiding anything useful.

- **Chronos & Chronos-2** (`models/chronos/model.py`, `chronos2.py`): wrap the `from_pretrained(...)` call in the existing `warning_filter(all_warnings=True)`. This silences the `TqdmWarning: IProgress not found ...` warning and the "sending unauthenticated requests to the HF Hub" warning. The actual download/weight-loading progress bar is left intact.
- **TFT** (`models/gluonts/abstract.py`): add `enable_model_summary=False` to the Lightning trainer kwargs (next to the existing `enable_progress_bar=False`). Lightning 2.7 started printing a large rich model-summary table on every fit; this disables it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.