### PR TITLE
[timeseries] Move chronos import inside warning_filter to silence TqdmWarning

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/chronos/chronos2.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/chronos2.py
@@ -276,12 +276,13 @@ class Chronos2Model(AbstractTimeSeriesModel):
         return TimeSeriesDataFrame(forecast_df)
 
     def load_model_pipeline(self):
-        from chronos.chronos2.pipeline import Chronos2Pipeline
-
         device = self.get_hyperparameter("device") or ("cuda" if self._is_gpu_available() else "cpu")
 
         assert self.model_path is not None
+        # importing chronos triggers `import tqdm.auto`, which emits a TqdmWarning if ipywidgets is missing
         with warning_filter(all_warnings=True):
+            from chronos.chronos2.pipeline import Chronos2Pipeline
+
             pipeline = Chronos2Pipeline.from_pretrained(
                 self.model_path,
                 device_map=device,

--- a/timeseries/src/autogluon/timeseries/models/chronos/model.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/model.py
@@ -298,8 +298,6 @@ class ChronosModel(AbstractTimeSeriesModel):
         return minimum_resources
 
     def load_model_pipeline(self, is_training: bool = False):
-        from chronos import BaseChronosPipeline
-
         gpu_available = self._is_gpu_available()
 
         if not gpu_available and self.min_num_gpus > 0:
@@ -312,7 +310,10 @@ class ChronosModel(AbstractTimeSeriesModel):
         device = self.device or ("cuda" if gpu_available else "cpu")
 
         assert self.model_path is not None
+        # importing chronos triggers `import tqdm.auto`, which emits a TqdmWarning if ipywidgets is missing
         with warning_filter(all_warnings=True):
+            from chronos import BaseChronosPipeline
+
             pipeline = BaseChronosPipeline.from_pretrained(
                 self.model_path,
                 device_map=device,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Follow-up to #5805. That PR wrapped Chronos `from_pretrained(...)` in `warning_filter`, but the `TqdmWarning: IProgress not found` still appeared.

Root cause: the warning is emitted **at import time** of `tqdm.auto` (in `tqdm/autonotebook.py`), not when a progress bar is drawn. Importing `chronos` transitively imports `tqdm.auto`, so the warning fires during the `from chronos ...` import statement — which was *outside* the `warning_filter` block.

Fix: move the lazy `chronos` import inside the `warning_filter(all_warnings=True)` block in both `ChronosModel` and `Chronos2Model`, so the import-time warning is suppressed. The download progress bar itself is unaffected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.