### PR TITLE
Fix RealMLP crashing at predict time on preserved category dtypes

### DIFF
--- a/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
+++ b/tabular/src/autogluon/tabular/models/realmlp/realmlp_model.py
@@ -64,6 +64,8 @@ class RealMLPModel(AbstractTorchModel):
         self._indicator_columns = None
         self._features_bool = None
         self._bool_to_cat = None
+        self._cat_col_names = None
+        self._category_mapping = None
 
     def get_model_cls(self, default_hyperparameters: Literal["td", "td_s"] = "td"):
         from pytabkit import (
@@ -190,11 +192,12 @@ class RealMLPModel(AbstractTorchModel):
 
         X = self.preprocess(X, y=y, is_train=True, bool_to_cat=bool_to_cat, impute_bool=impute_bool)
 
-        # FIXME: In rare cases can cause exceptions if name_categories=False, unknown why
+        # `_cat_col_names` is recorded by `_preprocess` on the training call, so fit and predict
+        # name the same columns. Deriving it here from `X` instead would work at fit time but
+        # leave `_preprocess` without the list it needs to re-code categories at predict time.
         extra_fit_kwargs = {}
         if name_categories:
-            cat_col_names = X.select_dtypes(include="category").columns.tolist()
-            extra_fit_kwargs["cat_col_names"] = cat_col_names
+            extra_fit_kwargs["cat_col_names"] = self._cat_col_names
 
         if X_val is not None:
             X_val = self.preprocess(X_val)
@@ -256,6 +259,32 @@ class RealMLPModel(AbstractTorchModel):
         if self._bool_to_cat and self._features_bool:
             # FIXME: Use CategoryFeatureGenerator? Or tell the model which is category
             X[self._features_bool] = X[self._features_bool].astype("category")
+
+        if is_train:
+            self._cat_col_names = X.select_dtypes(include="category").columns.tolist()
+
+        # Re-code every category column to integer codes fixed at fit time, and send unseen
+        # categories to one reserved code above them.
+        #
+        # RealMLP ordinal-encodes categories downstream, and sklearn's unknown-value check
+        # dispatches on the dtype of the values being transformed while calling `np.isnan` on the
+        # *fitted* categories. A column whose category dtype or numpy view differs between the fit
+        # frame and a later frame therefore raises `ufunc 'isnan' not supported for the input
+        # types` instead of encoding. That happens whenever upstream preprocessing preserves raw
+        # category dtypes rather than normalising them (integer categories read as float64 once a
+        # frame contains an unseen value, object elsewhere), so the model cannot rely on the two
+        # frames agreeing. Fixing the codes here makes them agree by construction.
+        if self._cat_col_names:
+            if self._category_mapping is None:
+                self._category_mapping = {
+                    col: {category: code for code, category in enumerate(X[col].cat.categories)}
+                    for col in self._cat_col_names
+                }
+            for col in self._cat_col_names:
+                mapping = self._category_mapping[col]
+                nan_mask = X[col].isna()
+                X[col] = X[col].astype(object).map(mapping).fillna(len(mapping)).astype(int).astype("category")
+                X.loc[nan_mask, col] = np.nan
         return X
 
     def _set_default_params(self):

--- a/tabular/tests/unittests/models/test_realmlp.py
+++ b/tabular/tests/unittests/models/test_realmlp.py
@@ -13,3 +13,54 @@ def test_realmlp():
         model_hyperparameters=model_hyperparameters,
         verify_load_wo_cuda=True,
     )
+
+
+def test_realmlp_category_codes_are_stable_across_fit_and_predict():
+    """Category codes must be fixed at fit time, whatever dtypes the frames carry.
+
+    RealMLP ordinal-encodes categories downstream, and sklearn's unknown-value check dispatches
+    on the dtype of the values being transformed while calling ``np.isnan`` on the *fitted*
+    categories. A column whose category dtype differs between the fit frame and a predict frame
+    therefore raised ``ufunc 'isnan' not supported for the input types``. Preprocessing must
+    hand the encoder identical integer codes both times.
+    """
+    import numpy as np
+    import pandas as pd
+
+    from autogluon.tabular.models.realmlp.realmlp_model import RealMLPModel
+
+    rng = np.random.default_rng(0)
+    n = 60
+    # int-valued and object-valued categories side by side, the mix that makes the numpy view of
+    # one column differ from another and from itself once a frame holds an unseen value.
+    train = pd.DataFrame(
+        {
+            "num": rng.normal(size=n),
+            "cat_int": pd.Categorical(rng.integers(1, 6, size=n)),
+            "cat_str": pd.Categorical(rng.choice(list("abc"), size=n)),
+        }
+    )
+    y = pd.Series(rng.integers(0, 2, size=n))
+
+    model = RealMLPModel(problem_type="binary", eval_metric=None)
+    model._preprocess_set_features(X=train)
+    processed_train = model.preprocess(train, y=y, is_train=True, bool_to_cat=True, impute_bool=False)
+
+    # Every category column is int-coded, so the downstream encoder sees one dtype.
+    for col in model._cat_col_names:
+        assert processed_train[col].cat.categories.dtype.kind in "iu", col
+
+    # A predict frame with an unseen category and a different category dtype still maps onto the
+    # fit-time codes rather than shifting them.
+    predict = pd.DataFrame(
+        {
+            "num": rng.normal(size=5),
+            "cat_int": pd.Categorical([1, 2, 3, 4, 99]),  # 99 unseen
+            "cat_str": pd.Categorical(["a", "b", "c", "a", "zz"]),  # zz unseen
+        }
+    )
+    processed_predict = model.preprocess(predict)
+    for col in model._cat_col_names:
+        assert processed_predict[col].cat.categories.dtype.kind in "iu", col
+        unseen_code = len(model._category_mapping[col])
+        assert unseen_code in set(processed_predict[col].dropna().astype(int)), col


### PR DESCRIPTION
**Stacked on #5806** — based on `per-group-splits-cvsplitter`, so this diff is the RealMLP fix
alone while the branch carries all four fixes. Retarget to `master` once #5806 merges.

## Problem

RealMLP raises at *predict* time on some datasets:

```
autogluon/tabular/models/realmlp/realmlp_model.py, in _predict_proba
pytabkit/models/data/conversion.py:105, in transform
sklearn/preprocessing/_encoders.py:1597, in transform          (OrdinalEncoder)
sklearn/utils/_encode.py:315, in _check_unknown
    if xp.any(xp.isnan(known_values)):
TypeError: ufunc 'isnan' not supported for the input types
```

sklearn's unknown-value check dispatches on the dtype of the values being transformed, but calls
`np.isnan` on the **fitted** categories:

```python
if values.dtype.kind in "OUS":   # object/string → safe, set-based path
    ...
else:                            # numeric → isnan path
    if np.isnan(known_values).any()
```

Instrumented at the failure point:

```
values.dtype=int64 (kind i) sample=[3, 3, 1] | known.dtype=object sample=[1, 2, 3, 4, 5, 6]
```

The encoder was fitted with **object** categories and applied to **int64** values — same column,
different dtype on the two sides.

## Why the two frames disagree

Logging pytabkit's converter across folds of one dataset, the numpy view of a single category
column varies by frame:

```
--- FIT ---                                    --- PREDICT ---
Browser:     as_numpy=float64 cat_dtype=int64      Browser: as_numpy=int64  cat_dtype=int64
TrafficType: as_numpy=float64 cat_dtype=int64      Browser: as_numpy=object cat_dtype=object
```

`int64` when the frame is clean, `float64` once it holds a NaN (integer categories cannot stay
integer), `object` where the category dtype itself is object. pytabkit fits the encoder on one
frame and applies it to another, so any of those mismatches trips the isnan dispatch.

This is unreachable under AutoGluon's own default preprocessing, which re-codes every category
column to compact integer codes — a bare `TabularPredictor` on the same data, including a
held-out test split, is fine. It is reachable when upstream preprocessing deliberately preserves
raw category dtypes, as TabArena's benchmark pipeline does:

```python
# Disable memory minimization to keep the original cat dtypes and pass them to the model
super().__init__(minimize_memory=False, **kwargs)   # NoCatAsStringCategoryFeatureGenerator
```

RealMLP crashed on 2 of 90 tasks under that pipeline. It is also why the FIXME here said "In rare
cases can cause exceptions if name_categories=False, unknown why".

## Fix

`_preprocess` now re-codes every category column to integer codes **fixed at fit time**, sending
unseen categories to one reserved code above them, so the encoder sees identical dtypes on both
sides by construction. `cat_col_names` is recorded during the training preprocess instead of
being derived locally in `_fit`, so fit and predict name the same columns.

This is the counterpart of the `name_categories` handling already in the file. TabArena's own
`RealMLPModel` has carried exactly this re-coding from the start — comment: *"Avoid bad dtype for
cat categories in later ordinal encoding. Maps unseen categories to a new high integer."* — and
AutoGluon's port kept only the `name_categories` half, which is why the two wrappers behave
differently on the same data.

## Verification

Same dataset, same preprocessing, same splits, same 8×1 bagging — only the wrapper differs:

| wrapper | before | after |
|---|---|---|
| `autogluon...realmlp_model` | **TypeError** | **ok, test error 0.0769** |
| `tabarena.models.realmlp.model` | ok, test error 0.0768 | — |

The failing dataset is `online_shoppers_purchasing_intention_dataset` (12330 rows, 7 category
columns spanning object / int64 / bool categories).

- Stock path unaffected: a bare `TabularPredictor` fit + predict on the same data still succeeds
  with an unchanged validation score.
- New test `test_realmlp_category_codes_are_stable_across_fit_and_predict`, asserting int codes on
  both sides and that unseen categories land on the reserved code.
- `tabular/tests/unittests/models/test_realmlp.py`: 2 passed.

Arguably sklearn should also not call `np.isnan` on non-numeric `known_values`, but this side is
the one AutoGluon controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi
