### PR TITLE
Stop losing missing categorical values in the TabPFN wrappers

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
@@ -86,7 +86,6 @@ class TabPFNModel(AbstractTorchModel):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._cat_features = None
         self._cat_indices = None
         # `ag.max_batch_size="auto"` resolved against the training size during `_fit`.
         self._max_batch_size_resolved: int | None = None
@@ -111,17 +110,18 @@ class TabPFNModel(AbstractTorchModel):
         ordinary level, so TabPFN sees no missing values in those columns and its missing-value
         handling never runs. Passing the dtype through keeps the missingness and is cheaper
         (`category` stores one code byte per row plus a level table, against float64's eight).
+
+        The indices are still needed. TabPFN infers a column's modality from its dtype, and a
+        `category` column whose levels are integers reads as numeric (`_is_numeric_pandas_series`
+        coerces it), so without them anything above `min_unique_for_numerical` levels is treated
+        as NUMERICAL rather than CATEGORICAL. AutoGluon's default `CategoryFeatureGenerator`
+        minimizes memory by re-coding levels to integers, which makes that the common case.
         """
         X = super()._preprocess(X, **kwargs)
 
         if is_train:
-            # Detect/set cat features and indices
-            self._cat_indices = []
             categorical_features = X.select_dtypes(include=["category"]).columns.tolist()
-            if categorical_features:
-                if self._cat_features is None:
-                    self._cat_features = categorical_features
-                self._cat_indices = [X.columns.get_loc(col) for col in self._cat_features]
+            self._cat_indices = [X.columns.get_loc(column) for column in categorical_features]
 
         return X
 

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
@@ -102,15 +102,25 @@ class TabPFNModel(AbstractTorchModel):
         return {k: default_model_map.get(k, v) for k, v in fallback.items()}
 
     def _preprocess(self, X: pd.DataFrame, is_train=False, **kwargs) -> pd.DataFrame:
+        """Record which columns are categorical; leave their values as `category` dtype.
+
+        TabPFN casts every column named in `categorical_features_indices` back to `category`
+        itself (`tabpfn.preprocessing.clean.fix_dtypes`) and ordinal-encodes from there, so it
+        needs the indices but not encoded values. Label-encoding first is worse than redundant:
+        `.cat.codes` maps missing values to -1, and the cast back to `category` then makes -1 an
+        ordinary level, so TabPFN sees no missing values in those columns and its missing-value
+        handling never runs. Passing the dtype through keeps the missingness and is cheaper
+        (`category` stores one code byte per row plus a level table, against float64's eight).
+        """
         X = super()._preprocess(X, **kwargs)
-        X = self._label_encode_categoricals(X, is_train=is_train)
 
         if is_train:
             # Detect/set cat features and indices
             self._cat_indices = []
-            if self._label_encoder.features_in:
+            categorical_features = X.select_dtypes(include=["category"]).columns.tolist()
+            if categorical_features:
                 if self._cat_features is None:
-                    self._cat_features = self._label_encoder.features_in[:]
+                    self._cat_features = categorical_features
                 self._cat_indices = [X.columns.get_loc(col) for col in self._cat_features]
 
         return X

--- a/tabular/tests/unittests/models/test_tabpfn3.py
+++ b/tabular/tests/unittests/models/test_tabpfn3.py
@@ -38,3 +38,37 @@ def test_tabpfn3_and_2_6_have_no_feature_cap():
     assert TabPFNv26Model()._get_default_auxiliary_params()["max_features"] is None
     # The 2.5 base is unchanged, which is what makes the explicit None load-bearing.
     assert TabPFNModel()._get_default_auxiliary_params()["max_features"] == 2000
+
+
+def test_tabpfn_preprocess_preserves_missing_categoricals():
+    """Categorical columns reach TabPFN as `category` dtype, with missing values intact.
+
+    Label-encoding them first loses the missingness: `.cat.codes` maps missing to -1, and
+    TabPFN casts every column named in `categorical_features_indices` back to `category`
+    (`tabpfn.preprocessing.clean.fix_dtypes`), which turns that -1 into an ordinary level. The
+    model then sees no missing values in those columns. Applies to every TabPFN version, since
+    they share this `_preprocess`.
+    """
+    import numpy as np
+    import pandas as pd
+
+    from autogluon.tabular.models.tabpfnv2.tabpfnv2_6_model import TabPFNv26Model
+
+    for model_cls in (TabPFN3Model, TabPFNv26Model):
+        levels = np.array(["absent", "mild", "normal"], dtype=object)
+        rng = np.random.default_rng(0)
+        values = levels[rng.integers(0, 3, 40)]
+        values[[3, 11, 27]] = None
+        X = pd.DataFrame({"num": rng.normal(size=40), "cat": pd.Series(values, dtype="category")})
+
+        model = model_cls(problem_type="binary", eval_metric=None)
+        model._preprocess_set_features(X=X)
+        processed = model.preprocess(X, is_train=True)
+
+        assert str(processed["cat"].dtype) == "category", model_cls.__name__
+        assert processed["cat"].isna().sum() == 3, model_cls.__name__
+        assert -1 not in set(processed["cat"].cat.categories), model_cls.__name__
+        # the indices TabPFN is told about still point at the categorical column
+        assert model._cat_indices == [X.columns.get_loc("cat")], model_cls.__name__
+        # untouched numeric column
+        assert processed["num"].equals(X["num"]), model_cls.__name__

--- a/tabular/tests/unittests/models/test_tabpfn3.py
+++ b/tabular/tests/unittests/models/test_tabpfn3.py
@@ -68,7 +68,9 @@ def test_tabpfn_preprocess_preserves_missing_categoricals():
         assert str(processed["cat"].dtype) == "category", model_cls.__name__
         assert processed["cat"].isna().sum() == 3, model_cls.__name__
         assert -1 not in set(processed["cat"].cat.categories), model_cls.__name__
-        # the indices TabPFN is told about still point at the categorical column
+        # the indices TabPFN is told about still point at the categorical column: it infers
+        # modality from dtype, and an integer-levelled `category` column reads as numeric, so
+        # without them such a column would be treated as NUMERICAL.
         assert model._cat_indices == [X.columns.get_loc("cat")], model_cls.__name__
         # untouched numeric column
         assert processed["num"].equals(X["num"]), model_cls.__name__


### PR DESCRIPTION
## Problem

`TabPFNModel._preprocess` label-encodes categorical columns before handing them to TabPFN:

```python
X = self._label_encode_categoricals(X, is_train=is_train)
```

which runs `LabelEncoderFeatureGenerator`:

```python
def convert_category_to_int(X: DataFrame) -> DataFrame:
    X = X.apply(lambda x: x.cat.codes)   # pandas maps MISSING to -1
```

TabPFN then casts every column named in `categorical_features_indices` back to `category` itself:

```python
# tabpfn/preprocessing/clean.py, fix_dtypes
X[cat_indices] = X[cat_indices].astype("category")
```

so the `-1` becomes an ordinary category level. TabPFN sees **no missing values** in those
columns and its missing-value handling never runs; on a column that is mostly missing it instead
reads a highly informative category. Confirmed with instrumentation: both wrappers produce
identical modality decisions (all columns `CATEGORICAL`, thresholds
`max_unique_for_category=30`, `min_unique_for_numerical=4`) and identical
`categorical_features_indices` — only the values differ.

## Isolated measurement

120-row frame, one reported categorical column with 25 missing values, partition / reported
indices / seed held fixed:

| frame | missing represented as | max \|Δ predict_proba\| |
|---|---|---:|
| `category` dtype | 25 NaN | reference |
| `.cat.codes` | 25 rows at −1, 0 NaN | **0.096397** (v3), **0.033440** (v2.6) |
| `.cat.codes`, −1 restored to NaN | 25 NaN | **0.000000** |

Label-encoding by itself is harmless — the third row proves that. Only the lost missingness
moves predictions.

## Fix

Record the categorical indices and leave the values as `category` dtype. TabPFN needs the
indices, not encoded values, and ordinal-encodes from the dtype itself. This is also cheaper
than any encoded form: `category` stores one code byte per row plus a level table, against
float64's eight bytes per row (measured at 100k rows / 4 levels: 100,416 B vs 800,000 B).

## End-to-end verification

BeyondArena's `audiology_diagnosis` — 69 categorical columns, 7 with missing values, `bser`
missing in 196 of 199 rows. Same experiment with only the wrapper swapped, all four core splits:

| split | before | after | TabArena's own wrapper |
|---:|---:|---:|---:|
| 0 | 0.20912 | 0.21011 | 0.21011 |
| 1 | 0.50491 | 0.46785 | 0.46785 |
| 2 | 0.31384 | 0.25668 | 0.25668 |
| 3 | 0.24806 | 0.24438 | 0.24438 |

After the change AutoGluon reproduces TabArena's `TA-TabPFN-3` wrapper **exactly** — that
wrapper has passed the dtype through from the start, which is what made the discrepancy
findable. Mean error on this dataset improves by 0.024 (8.2%).

- New test `test_tabpfn_preprocess_preserves_missing_categoricals`, covering TabPFN-3 and
  TabPFN-2.6 (dtype preserved, NaN count preserved, no `-1` level, indices still correct,
  numeric column untouched).
- `tabular/tests/unittests/models/test_tabpfn3.py`: 2 passed, 1 skipped (the skip is the
  pre-existing license-gated fit test).
- End-to-end bagged fit + predict on a frame with missing categoricals still works.

## Scope

Shared by every TabPFN version through this base class: **TabPFN-2.5, RealTabPFN-2.5,
TabPFN-2.6, TabPFN-3**.

## Same defect elsewhere, not fixed here

`_label_encode_categoricals` is documented as *"preserving missing values"*, which is not what
`.cat.codes` does. Two other foundation-model wrappers rely on it and lose missingness the same
way, with no `categorical_features_indices` to soften the landing — the `-1` arrives as an
ordinary value inside a continuous feature:

- `nori_model.py`: `X = self._label_encode_categoricals(X)` then `to_numpy(float32)`, under a
  docstring that says *"with NaN preserved (handled natively)"*.
- `tabdpt_model.py`: the same pattern.

`TabICLv2` is unaffected (no `_preprocess`, values pass through) and `RealMLP` is unaffected
(its `_category_mapping` restores NaN via a mask). I have left Nori and TabDPT alone rather than
change models this PR has not measured; happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi
