### PR TITLE
Keep missing values and lift the class cap for TabDPT

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -26,7 +26,7 @@ from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
 from autogluon.common.utils.resource_utils import ResourceManager, get_resource_manager
 from autogluon.common.utils.try_import import try_import_ray
 from autogluon.common.utils.utils import setup_outputdir
-from autogluon.features.generators.abstract import AbstractFeatureGenerator, estimate_feature_metadata_after_generators
+from autogluon.features.generators.abstract import AbstractFeatureGenerator
 from autogluon.features.generators.bulk import BulkFeatureGenerator
 from autogluon.features.registry._ag_feature_generator_registry import ag_feature_generator_registry
 from autogluon.features.registry.parse_custom_generator import resolve_fg_class
@@ -707,23 +707,39 @@ class AbstractModel(ModelBase, Tunable):
         """
         return X
 
-    def _label_encode_categoricals(self, X: pd.DataFrame, is_train: bool = False) -> pd.DataFrame:
-        """Convert categorical features to label-encoded integers, preserving missing values.
+    def _label_encode_categoricals(
+        self, X: pd.DataFrame, is_train: bool = False, preserve_missing: bool = False
+    ) -> pd.DataFrame:
+        """Convert categorical features to label-encoded integers.
 
         Common `_preprocess` step for models that require fully numeric input. The stateful
         encoder is stored on `self._label_encoder`: it is fitted on the first call, or
         refitted when `is_train=True` (pass it for models whose `_preprocess` distinguishes
         fit-time calls). Columns without categorical content are untouched; the categorical
         feature names are available afterwards via `self._label_encoder.features_in`.
+
+        Parameters
+        ----------
+        preserve_missing : bool, default False
+            Whether missing values stay missing. The encoding maps them to -1 (pandas'
+            `.cat.codes` convention), which a model reads as an ordinary value one step below
+            the first real level, and which hides the missingness from any handling the model
+            has for it. Pass True for models that handle NaN themselves; the affected columns
+            become float, since an integer dtype cannot hold NaN.
         """
         from autogluon.features.generators import LabelEncoderFeatureGenerator
 
         if is_train or self._label_encoder is None:
             self._label_encoder = LabelEncoderFeatureGenerator(verbosity=0)
             self._label_encoder.fit(X=X)
-        if self._label_encoder.features_in:
+        features_in = self._label_encoder.features_in
+        if features_in:
+            missing = X[features_in].isna() if preserve_missing else None
             X = X.copy()
-            X[self._label_encoder.features_in] = self._label_encoder.transform(X=X)
+            X[features_in] = self._label_encoder.transform(X=X)
+            if preserve_missing:
+                for column in features_in:
+                    X.loc[missing[column].to_numpy(), column] = np.nan
         return X
 
     # TODO: Remove kwargs?
@@ -1436,7 +1452,7 @@ class AbstractModel(ModelBase, Tunable):
 
         if ignore_constraints:
             # skip all validation checks
-            logger.log(15, f"\t`ag.ignore_constraints=True`, skipping sanity checks for model...")
+            logger.log(15, "\t`ag.ignore_constraints=True`, skipping sanity checks for model...")
             return
 
         if problem_types is not None:
@@ -3149,8 +3165,8 @@ class AbstractModel(ModelBase, Tunable):
             )
             if min_error_memory_ratio >= 1:
                 log_user_guideline += (
-                    f'\n\t\tSetting "ag.max_memory_usage_ratio" to values above 1 may result in out-of-memory errors. '
-                    f"You may consider using a machine with more memory as a safer alternative."
+                    '\n\t\tSetting "ag.max_memory_usage_ratio" to values above 1 may result in out-of-memory errors. '
+                    "You may consider using a machine with more memory as a safer alternative."
                 )
             logger.warning(f"\tWarning: Not enough memory to safely train model. {log_user_guideline}")
             raise NotEnoughMemoryError
@@ -3162,8 +3178,8 @@ class AbstractModel(ModelBase, Tunable):
             )
             if min_warning_memory_ratio >= 1:
                 log_user_guideline += (
-                    f'\n\t\tSetting "ag.max_memory_usage_ratio" to values above 1 may result in out-of-memory errors. '
-                    f"You may consider using a machine with more memory as a safer alternative."
+                    '\n\t\tSetting "ag.max_memory_usage_ratio" to values above 1 may result in out-of-memory errors. '
+                    "You may consider using a machine with more memory as a safer alternative."
                 )
             logger.warning(f"\tWarning: Potentially not enough memory to safely train model. {log_user_guideline}")
 

--- a/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_model.py
+++ b/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_model.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar
 
-import numpy as np
-
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION
 from autogluon.tabular.models.abstract.abstract_torch_model import AbstractTorchModel
 
 if TYPE_CHECKING:
+    import numpy as np
     import pandas as pd
 
 
@@ -212,20 +211,13 @@ class TabDPTModel(AbstractTorchModel):
     def _preprocess(self, X: pd.DataFrame, **kwargs) -> np.ndarray:
         """TabDPT requires a numpy array as input, with missing values left as NaN.
 
-        `.cat.codes` maps a missing categorical value to -1, which would arrive as an ordinary
-        value on the same numeric axis as the real codes. TabDPT handles NaN itself and does more
-        with it than impute: it appends a binary missing-indicator column per affected feature
-        before mean-imputing (`tabdpt.estimator`), so a -1 both hides the missingness and skews
-        the feature. The mask restores it after encoding.
+        TabDPT handles NaN itself and does more with it than impute: it appends a binary
+        missing-indicator column per affected feature before mean-imputing (`tabdpt.estimator`),
+        so the encoding's default -1 for missing would both hide the missingness and put an
+        out-of-range value on the feature's numeric axis.
         """
         X = super()._preprocess(X, **kwargs)
-        categorical_features = X.select_dtypes(include=["category"]).columns.tolist()
-        missing = X[categorical_features].isna() if categorical_features else None
-        X = self._label_encode_categoricals(X)
-        if categorical_features:
-            X = X.copy()
-            for column in categorical_features:
-                X.loc[missing[column].to_numpy(), column] = np.nan
+        X = self._label_encode_categoricals(X, preserve_missing=True)
         return X.to_numpy()
 
     def _more_tags(self) -> dict:

--- a/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_model.py
+++ b/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_model.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar
 
+import numpy as np
+
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION
 from autogluon.tabular.models.abstract.abstract_torch_model import AbstractTorchModel
 
 if TYPE_CHECKING:
-    import numpy as np
     import pandas as pd
 
 
@@ -61,7 +62,12 @@ class TabDPTModel(AbstractTorchModel):
     _default_auxiliary_params_extra = {
         "max_rows": 100000,  # TODO: Test >100k rows
         "max_features": 2500,  # TODO: Test >2500 features
-        "max_classes": 10,  # TODO: Test >10 classes
+        # TabDPT decomposes a label into base-`max_num_classes` digits above the checkpoint's
+        # output-head width and sums the per-digit log-probabilities
+        # (`tabdpt.classifier._predict_large_cls`), so the head width bounds a forward pass, not
+        # the usable class count. Verified to fit and predict a calibrated distribution at 11, 20,
+        # 100 and 160 classes; the cost is ceil(log_head(n_classes)) passes per prediction.
+        "max_classes": 160,
     }
     minimum_num_gpus = 0.5
     _default_ag_args_ensemble_extra = {
@@ -203,10 +209,23 @@ class TabDPTModel(AbstractTorchModel):
         y_pred_proba = self.model.ensemble_predict_proba(X, **self._predict_hps)
         return self._convert_proba_to_unified_form(y_pred_proba)
 
-    def _preprocess(self, X: pd.DataFrame, **kwargs) -> pd.DataFrame:
-        """TabDPT requires numpy array as input."""
+    def _preprocess(self, X: pd.DataFrame, **kwargs) -> np.ndarray:
+        """TabDPT requires a numpy array as input, with missing values left as NaN.
+
+        `.cat.codes` maps a missing categorical value to -1, which would arrive as an ordinary
+        value on the same numeric axis as the real codes. TabDPT handles NaN itself and does more
+        with it than impute: it appends a binary missing-indicator column per affected feature
+        before mean-imputing (`tabdpt.estimator`), so a -1 both hides the missingness and skews
+        the feature. The mask restores it after encoding.
+        """
         X = super()._preprocess(X, **kwargs)
+        categorical_features = X.select_dtypes(include=["category"]).columns.tolist()
+        missing = X[categorical_features].isna() if categorical_features else None
         X = self._label_encode_categoricals(X)
+        if categorical_features:
+            X = X.copy()
+            for column in categorical_features:
+                X.loc[missing[column].to_numpy(), column] = np.nan
         return X.to_numpy()
 
     def _more_tags(self) -> dict:

--- a/tabular/tests/unittests/models/test_tabdpt.py
+++ b/tabular/tests/unittests/models/test_tabdpt.py
@@ -57,3 +57,27 @@ def test_tabdpt_allows_more_than_ten_classes():
 
     for model_cls in (TabDPTModel, TabDPTTurboModel):
         assert model_cls(problem_type="multiclass")._get_default_auxiliary_params()["max_classes"] == 160
+
+
+def test_label_encode_categoricals_preserve_missing_flag():
+    """The shared helper's flag is what keeps missingness; off by default for other callers."""
+    import numpy as np
+    import pandas as pd
+
+    from autogluon.tabular.models.tabdpt.tabdpt_model import TabDPTModel
+
+    values = np.array(["a", "b", "c"], dtype=object)[[0, 1, 2, 0, 1]].astype(object)
+    values[[1, 3]] = None
+    X = pd.DataFrame({"cat": pd.Series(values, dtype="category")})
+
+    default = TabDPTModel(problem_type="binary")._label_encode_categoricals(X.copy())
+    preserved = TabDPTModel(problem_type="binary")._label_encode_categoricals(X.copy(), preserve_missing=True)
+
+    # default keeps pandas' -1-for-missing convention, which other callers rely on
+    assert (default["cat"] == -1).sum() == 2
+    assert default["cat"].isna().sum() == 0
+    # the flag restores the missingness instead
+    assert preserved["cat"].isna().sum() == 2
+    assert (preserved["cat"].dropna() == -1).sum() == 0
+    # the non-missing codes are untouched
+    assert list(default["cat"][[0, 2, 4]]) == list(preserved["cat"][[0, 2, 4]])

--- a/tabular/tests/unittests/models/test_tabdpt.py
+++ b/tabular/tests/unittests/models/test_tabdpt.py
@@ -15,3 +15,45 @@ def test_tabdpt():
         # TabDPT returns different predictions when predicting on an individual sample
         verify_single_prediction_equivalent_to_multi=False,
     )
+
+
+def test_tabdpt_preprocess_preserves_missing_categoricals():
+    """Missing categorical values reach TabDPT as NaN, not as `.cat.codes`' -1.
+
+    TabDPT appends a binary missing-indicator column per affected feature and then mean-imputes
+    (`tabdpt.estimator`), so a -1 both hides the missingness and puts an out-of-range value on
+    the feature's numeric axis.
+    """
+    import numpy as np
+    import pandas as pd
+
+    from autogluon.tabular.models.tabdpt.tabdpt_model import TabDPTModel
+
+    levels = np.array(["absent", "mild", "normal"], dtype=object)
+    rng = np.random.default_rng(0)
+    values = levels[rng.integers(0, 3, 30)]
+    values[[2, 9, 21]] = None
+    X = pd.DataFrame({"num": rng.normal(size=30), "cat": pd.Series(values, dtype="category")})
+
+    model = TabDPTModel(problem_type="binary", eval_metric=None)
+    model._preprocess_set_features(X=X)
+    processed = model.preprocess(X, is_train=True)
+
+    assert isinstance(processed, np.ndarray)
+    cat_column = processed[:, list(X.columns).index("cat")]
+    assert np.isnan(cat_column).sum() == 3
+    assert -1 not in set(cat_column[~np.isnan(cat_column)])
+
+
+def test_tabdpt_allows_more_than_ten_classes():
+    """The class cap reflects the library's digit decomposition, not the head width.
+
+    `tabdpt.classifier._predict_large_cls` encodes a label in base `max_num_classes` and sums the
+    per-digit log-probabilities, so class counts above the checkpoint's output head are supported
+    at the cost of one forward pass per digit.
+    """
+    from autogluon.tabular.models.tabdpt.tabdpt_model import TabDPTModel
+    from autogluon.tabular.models.tabdpt.tabdpt_turbo_model import TabDPTTurboModel
+
+    for model_cls in (TabDPTModel, TabDPTTurboModel):
+        assert model_cls(problem_type="multiclass")._get_default_auxiliary_params()["max_classes"] == 160


### PR DESCRIPTION
Two independent limits in the same wrapper. Both apply to **TabDPT and TabDPT-Turbo** (which
inherits this class).

## 1. Missing categorical values were erased

`_preprocess` label-encoded categoricals before handing over the numpy array, and `.cat.codes`
maps missing to `-1`, so the array reached TabDPT with no NaN in those columns.

That matters more here than in a model which merely tolerates NaN. TabDPT appends a **binary
missing-indicator column per affected feature** and then mean-imputes:

```python
# tabdpt/estimator.py
inds = np.isnan(X)
self.has_missing_indicator = inds.any(axis=0)
X = np.hstack((X, inds[:, self.has_missing_indicator].astype(float)))
X = self.imputer.fit_transform(X)          # SimpleImputer(strategy="mean")
```

A `-1` suppresses both mechanisms *and* puts an out-of-range value on the feature's numeric axis,
one step below the first real code, which then goes through the scaler. The missing mask is
restored after encoding. Numeric columns were never affected — their NaN always reached
`np.isnan`.

### Measured impact

BeyondArena datasets under 10k train rows whose categorical columns contain missing values (17 of
45 such datasets — the rest have none, so both variants are identical by construction), first
split, 2×1 bags:

| dataset | before | after | rel Δ |
|---|---:|---:|---:|
| heart_disease_hungary | 0.08526 | 0.07800 | **−8.5%** |
| regensburg_pediatric_appendicitis (32/33 cols) | 0.09176 | 0.08476 | **−7.6%** |
| audiology_diagnosis | 0.32755 | 0.30661 | **−6.4%** |
| ljubljana_primary_tumor | 1.26923 | 1.21368 | **−4.4%** |
| heart_disease_va_long_beach | 0.21882 | 0.21059 | −3.8% |
| ljubljana_breast_cancer | 0.23726 | 0.22954 | −3.3% |
| horse_colic_survival | 0.74084 | 0.71801 | −3.1% |
| heart_disease_cleveland | 0.07154 | 0.07036 | −1.7% |
| in_vehicle_coupon_recommendation | 0.16459 | 0.16196 | −1.6% |
| coffee_rating_prediction | 1.28476 | 1.27421 | −0.8% |
| ghanas_indigenous_intel | 0.27141 | 0.26971 | −0.6% |
| credit_approval | 0.06419 | 0.06411 | −0.1% |
| wine_world_cost | 0.39657 | 0.39904 | +0.6% |
| immoscout_german_house_prices (8/8 cols) | 0.44111 | 0.44754 | +1.5% |
| cirrhosis_patient_survival_prediction | 0.62728 | 0.63799 | +1.7% |
| mic (93/95 cols) | 0.46009 | 0.49859 | +8.4% |
| homeq_default_prediction | 0.00026 | 0.00029 | +12.5% |

**12 of 17 improve, 5 regress, median −1.2%.** The clear wins are small clinical tables with
pervasive missingness. The regressions sit where preserving missingness inflates the feature
count sharply: `mic` appends 93 indicator columns to a 95-column frame at 1,132 rows, and
`immoscout` appends 8 of 8. `homeq_default_prediction`'s +12.5% is a ratio artifact on errors of
0.00026 vs 0.00029.

So this is a **correctness fix with a mixed accuracy effect**, not a uniform win. Worth knowing
before merging: if the indicator-column inflation is judged the greater evil on wide categorical
frames, the alternative is to preserve missingness only when the affected column count is small,
which I have not implemented because it adds a threshold with no principled value.

## 2. `max_classes` 10 → 160

The old value carried its own caveat: `"max_classes": 10,  # TODO: Test >10 classes`.

Above the checkpoint's output-head width the library encodes the label in base `max_num_classes`,
runs one forward pass per digit, and sums the per-digit log-probabilities
(`tabdpt.classifier._predict_large_cls`, dispatched from `predict_proba`). The head width
therefore bounds a forward pass, not the usable class count.

Sanity checked end to end — fit, then `predict_proba` returning the right column count with rows
summing to 1:

| n_classes | proba shape | row sum | fit time |
|---:|---|---:|---:|
| 11 | (20, 11) | 1.0000 | 7s |
| 20 | (20, 20) | 1.0000 | 4s |
| 100 | (20, 100) | 1.0000 | 6s |
| **160** | (20, 160) | 1.0000 | 5s |

and on real data: BeyondArena's 11-class `ljubljana_primary_tumor` fits and scores (it is the
dataset the old cap excluded, and it appears in the table above because of this change).

Independent evidence: TabArena's own TabDPT wrapper sets **no** class cap, and its published
BeyondArena results include TabDPT fits at 11 classes (`ljubljana_primary_tumor`) and 20 classes
(`micro_mass`) — real scores, not imputed placeholders.

Cost is `ceil(log_head(n_classes))` prediction passes, so 2 passes to head² classes and 3 to
head³. 160 mirrors the cap TabPFN-3 already uses.

## Tests

- `test_tabdpt_preprocess_preserves_missing_categoricals` — NaN count preserved in the emitted
  array, no `-1` among the remaining values.
- `test_tabdpt_allows_more_than_ten_classes` — the cap on both TabDPT and TabDPT-Turbo.
- `tabular/tests/unittests/models/test_tabdpt.py`: 3 passed.

## Related

The same `.cat.codes` defect was fixed for the TabPFN wrappers in #5809. `nori_model.py` has it
too, under a docstring claiming *"with NaN preserved (handled natively)"*; measured there it is
worth ~0.05% mean on regression under 10k rows (20 of 25 datasets byte-identical), so I have left
it alone. `TabICLv2` is unaffected and `RealMLP` was fixed incidentally by #5808.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi
