### PR TITLE
Bump docs version to 1.6.0 and update SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported          |
 |---------| ------------------ |
-| 1.4.0   | :white_check_mark: |
-| < 1.4.0 | :x:                |
+| 1.6.0   | :white_check_mark: |
+| < 1.6.0 | :x:                |
 
 ## How we do security
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,8 +4,8 @@ import sys
 sys.path = [".", ".."] + sys.path
 
 project = "AutoGluon"
-release = "1.5.1"
-copyright = "2025, All authors. Licensed under Apache 2.0."
+release = "1.6.0"
+copyright = "2026, All authors. Licensed under Apache 2.0."
 
 author = "AutoGluon contributors"
 


### PR DESCRIPTION
## Description

Version bookkeeping in preparation for the v1.6.0 release.

- `docs/conf.py`: `release` `1.5.1` → `1.6.0` so the versioned/stable docs render `1.6.0` in the header (set before the release branch is cut).
- `docs/conf.py`: copyright year `2025` → `2026`.
- `SECURITY.md`: supported-versions table now lists `1.6.0` (was `1.4.0`).

`VERSION` is already `1.6.0`. Post-release, `master` will bump to the next dev version (`1.6.1`).

## Checklist

- [x] Changes are limited to version/docs bookkeeping; no code changes.