### PR TITLE
[docs] Remove double space in README intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 </div>
 
-AutoGluon, developed by AWS AI, automates machine learning tasks enabling you to easily achieve strong predictive performance in your applications.  With just a few lines of code, you can train and deploy high-accuracy machine learning and deep learning models on image, text, time series, and tabular data.
+AutoGluon, developed by AWS AI, automates machine learning tasks enabling you to easily achieve strong predictive performance in your applications. With just a few lines of code, you can train and deploy high-accuracy machine learning and deep learning models on image, text, time series, and tabular data.
 
 
 ## 💾 Installation


### PR DESCRIPTION
## Description

Removes a stray double space in the README introduction paragraph ("applications.  With" → "applications. With").

Trivial docs-only change to trigger CI.