### PR TITLE
[timeseries] Fix UndefinedVariableError in update() on Python 3.10/3.11

### DIFF
--- a/timeseries/src/autogluon/timeseries/trainer/trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/trainer.py
@@ -1325,7 +1325,7 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
         items = data_per_window[0].item_ids
         for window in data_per_window[1:]:
             items = items.intersection(window.item_ids)
-        data_per_window = [window.query("item_id in @items") for window in data_per_window]
+        data_per_window = [window.loc[items] for window in data_per_window]
 
         def update_model(model: TimeSeriesModelBase, oof_predictions: list[TimeSeriesDataFrame]) -> None:
             model.cache_oof_predictions(oof_predictions)

--- a/timeseries/src/autogluon/timeseries/trainer/trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/trainer.py
@@ -1342,7 +1342,7 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
             oof_predictions = slide(
                 self._get_model_oof_predictions(model_name), fresh_predictions_per_window[model_name]
             )
-            oof_predictions = [window.query("item_id in @items") for window in oof_predictions]
+            oof_predictions = [window.loc[items] for window in oof_predictions]
             predictions_per_window[model_name] = oof_predictions
             update_model(self.load_model(model_name), oof_predictions)
 


### PR DESCRIPTION
## Description

`TimeSeriesPredictor.update()` raised `pandas.errors.UndefinedVariableError: local variable 'items' is not defined` on Python 3.10 and 3.11, while passing on 3.12.

### Root cause

In `TimeSeriesTrainer.update()`:

```python
items = data_per_window[0].item_ids
for window in data_per_window[1:]:
    items = items.intersection(window.item_ids)
data_per_window = [window.query("item_id in @items") for window in data_per_window]
```

`DataFrame.query("... @items")` resolves the `@items` reference by inspecting the **caller's stack frame** for a local named `items`. On Python 3.10/3.11 a list comprehension runs in its **own** stack frame (locals: only `window` and `.0`), so `items` — which lives in the enclosing method frame — is invisible, and pandas raises `UndefinedVariableError`.

[PEP 709](https://peps.python.org/pep-0709/) inlined comprehensions in Python 3.12, collapsing the separate frame, which is why the tests passed on 3.12 but failed on 3.10/3.11. Not flaky — deterministic per interpreter version.

### Fix

Replace the `query` call with `.loc[items]` index selection. Since `items` is an `Index` of item ids and `item_id` is the leading `MultiIndex` level, `.loc[items]` selects exactly those items with no stack-frame introspection, so it works on all supported Python versions (and avoids the `query` expression-engine overhead).

## Testing

`tests/unittests/test_predictor.py -k update` — all 11 tests pass.
