### PR TITLE
[core] Stop the spurious param-collision warning on refit-full templates

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -2405,6 +2405,26 @@ class AbstractModel(ModelBase, Tunable):
             hyperparameters[AG_ARGS_FIT] = self._user_params_aux.copy()
         return hyperparameters
 
+    @staticmethod
+    def _update_hyperparameters_with_params_trained(hyperparameters: dict, params_trained: dict) -> None:
+        """Merge ``params_trained`` into ``hyperparameters`` in place, keeping one encoding per parameter.
+
+        ``hyperparameters`` as emitted by :meth:`get_hyperparameters_init` carries auxiliary
+        parameters inside the ``ag_args_fit`` sub-dict, while ``params_trained`` carries them
+        ``ag.``-prefixed at the top level (e.g. ``"ag.max_rows": None``, recorded after fit so a
+        refit-full template skips the row-cap check). A plain ``dict.update`` would leave both
+        encodings of the same parameter in the merged dict, and the template's
+        ``_init_user_params`` would then log a spurious "present in both `ag_args_fit` and
+        `hyperparameters`" warning aimed at genuine user double-specification. Routing the
+        prefixed keys into the ``ag_args_fit`` sub-dict keeps the same precedence (the trained
+        value wins) with a single encoding, so the warning fires only for real user collisions.
+        """
+        for key, value in params_trained.items():
+            if isinstance(key, str) and key.startswith(AG_ARG_PREFIX):
+                hyperparameters.setdefault(AG_ARGS_FIT, {})[key[len(AG_ARG_PREFIX) :]] = value
+            else:
+                hyperparameters[key] = value
+
     def convert_to_template(self):
         """
         After calling this function, returned model should be able to be fit as if it was new, as well as deep-copied.
@@ -2436,7 +2456,7 @@ class AbstractModel(ModelBase, Tunable):
             params["hyperparameters"][AG_ARGS_FIT].get("max_memory_usage_ratio", 1.0) * 1.25
         )
 
-        params["hyperparameters"].update(self.params_trained)
+        self._update_hyperparameters_with_params_trained(params["hyperparameters"], self.params_trained)
         params["name"] = params["name"] + REFIT_FULL_SUFFIX
         template = self.__class__(**params)
 

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -1294,7 +1294,7 @@ class BaggedEnsembleModel(AbstractModel):
     def convert_to_refit_full_template_child(self) -> AbstractModel:
         refit_params_trained = self._get_compressed_params_trained()
         refit_params = copy.deepcopy(self._get_model_base().get_params())
-        refit_params["hyperparameters"].update(refit_params_trained)
+        self._update_hyperparameters_with_params_trained(refit_params["hyperparameters"], refit_params_trained)
         refit_child_template = self._child_type(**refit_params)
 
         return refit_child_template

--- a/core/tests/unittests/models/abstract_model/test_update_hyperparameters_with_params_trained.py
+++ b/core/tests/unittests/models/abstract_model/test_update_hyperparameters_with_params_trained.py
@@ -1,0 +1,62 @@
+import copy
+from unittest import mock
+
+from autogluon.core.models import AbstractModel
+from autogluon.core.models.abstract import abstract_model as abstract_model_module
+
+
+def _assert_merge(hyperparameters, params_trained, expected):
+    params_trained_og = copy.deepcopy(params_trained)
+    AbstractModel._update_hyperparameters_with_params_trained(hyperparameters, params_trained)
+    assert hyperparameters == expected
+    assert params_trained == params_trained_og  # Ensure no outer context update
+
+
+def test_prefixed_key_routes_into_ag_args_fit():
+    """An `ag.`-prefixed trained param must land in the `ag_args_fit` sub-dict rather than at the
+    top level, so the merged dict carries one encoding per parameter and constructing a template
+    from it does not log the "present in both" collision warning."""
+    _assert_merge(
+        hyperparameters={"ag_args_fit": {"max_rows": 100}},
+        params_trained={"ag.max_rows": None},
+        expected={"ag_args_fit": {"max_rows": None}},
+    )
+
+
+def test_prefixed_key_creates_ag_args_fit():
+    _assert_merge(
+        hyperparameters={},
+        params_trained={"ag.max_rows": 3},
+        expected={"ag_args_fit": {"max_rows": 3}},
+    )
+
+
+def test_unprefixed_keys_update_top_level():
+    _assert_merge(
+        hyperparameters={"n_estimators": 1, "ag_args_fit": {"max_rows": 100}},
+        params_trained={"n_estimators": 7, "learning_rate": 0.1},
+        expected={"n_estimators": 7, "learning_rate": 0.1, "ag_args_fit": {"max_rows": 100}},
+    )
+
+
+def test_merged_dict_initializes_without_collision_warning():
+    """End-to-end over `_init_user_params`: the merged dict must produce the same params_aux the
+    old dual-encoding produced, without the collision warning."""
+    hyperparameters = {"ag_args_fit": {"max_rows": 100}}
+    AbstractModel._update_hyperparameters_with_params_trained(hyperparameters, {"ag.max_rows": None})
+    with mock.patch.object(abstract_model_module.logger, "warning") as warning:
+        params, params_aux = AbstractModel._init_user_params(params=hyperparameters)
+    assert params == {}
+    assert params_aux == {"max_rows": None}
+    assert not any("present in both" in str(call) for call in warning.call_args_list)
+
+
+def test_genuine_user_collision_still_warns():
+    """The warning stays for a user who really specifies a parameter both ways."""
+    with mock.patch.object(abstract_model_module.logger, "warning") as warning:
+        params, params_aux = AbstractModel._init_user_params(
+            params={"ag_args_fit": {"max_rows": 100}, "ag.max_rows": 5}
+        )
+    assert params == {}
+    assert params_aux == {"max_rows": 5}
+    assert any("present in both" in str(call) for call in warning.call_args_list)


### PR DESCRIPTION
Fitting any row-capped model logs a spurious warning per model, including every `presets="extreme"` fit:

```
Warning: TabICLModel hyperparameter "ag.max_rows" is present in both `ag_args_fit` and `hyperparameters`. Will use `hyperparameters` value.
```

The collision is manufactured internally, not user error. Building a refit-full template merges `params_trained` into the hyperparameters emitted by `get_params()`, and the two encode auxiliary parameters differently: the emitted dict carries them inside `ag_args_fit`, while `params_trained` carries them `ag.`-prefixed at the top level (`"ag.max_rows": None` is recorded after a capped fit so the refit template skips the row-cap check). A plain `dict.update` left both encodings of the same parameter in one dict, and the template's `_init_user_params` warned as if the user had specified it twice.

`_update_hyperparameters_with_params_trained` now routes prefixed keys into the `ag_args_fit` sub-dict at both merge sites (the bagged child template and the non-bagged template). Precedence is unchanged: the trained value still wins, verified end to end on a `presets="extreme"` fit (0 warnings, and the refit child's `max_rows` still resolves to `None` after a capped fit). The warning still fires when a user genuinely specifies a parameter both ways, which the new tests assert.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi
