### PR TITLE
[tabular] Silence the replace-downcast FutureWarning in label cleaning

### DIFF
--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -569,9 +569,12 @@ class DefaultLearner(AbstractTabularLearner):
             X = copy.deepcopy(X)
 
             # treat None, NaN, INF, NINF as NA
-            # `.infer_objects(copy=False)` retains the pre-pandas-2.2 dtype behavior of `replace`
-            # explicitly, avoiding the "Downcasting behavior in `replace` is deprecated" FutureWarning.
-            X[self.label] = X[self.label].replace([np.inf, -np.inf], np.nan).infer_objects(copy=False)
+            # The option context keeps `replace` from downcasting internally (which logs the
+            # "Downcasting behavior in `replace` is deprecated" FutureWarning whenever the label
+            # arrives as a numeric-valued object column); `.infer_objects(copy=False)` then applies
+            # the same downcast explicitly, so values and dtype match the pre-pandas-2.2 behavior.
+            with pd.option_context("future.no_silent_downcasting", True):
+                X[self.label] = X[self.label].replace([np.inf, -np.inf], np.nan).infer_objects(copy=False)
             invalid_labels = X[self.label].isna()
             if invalid_labels.any():
                 first_invalid_label_idx = invalid_labels.idxmax()


### PR DESCRIPTION
`_check_for_non_finite_values` already chained `.infer_objects(copy=False)` onto the inf-to-NaN `replace`, and its comment claimed that avoids the pandas FutureWarning:

```
FutureWarning: Downcasting behavior in `replace` is deprecated and will be removed in a future version.
```

It does not: the warning is emitted by `replace` itself when it downcasts internally, which happens whenever the label arrives as a numeric-valued object column (common for raw CSV data), before `infer_objects` runs. A 121-dataset benchmark sweep logged it 25 times.

Wrapping the call in `pd.option_context("future.no_silent_downcasting", True)` stops `replace` from downcasting, so it has nothing to warn about, and leaves the explicit `infer_objects` to apply the same downcast. This is the documented migration for the deprecation. Verified through the learner: an object label of floats still resolves to `float64` with identical values and zero warnings, and an inf label is still rejected with the same `ValueError`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi
