### PR TITLE
[tabular] Work around the tabicl all-NaN categorical predict crash in the wrapper

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
+++ b/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
@@ -120,6 +120,31 @@ class TabICLModel(AbstractTorchModel):
 
         return reg_checkpoint
 
+    def _preprocess(self, X: pd.DataFrame, is_train: bool = False, **kwargs) -> pd.DataFrame:
+        """Cast `category` columns that are entirely missing in a prediction batch to object dtype.
+
+        Temporary workaround for https://github.com/soda-inria/tabicl/issues/143 (tabicl<=2.1.1):
+        tabicl masks features that are all-NaN in the batch and fills them with the float 0.0, which
+        poisons a `category` column, and its fitted `OrdinalEncoder` then crashes
+        (`TypeError: ufunc 'isnan' not supported`). Happens whenever a categorical column is entirely
+        missing within one prediction batch, e.g. an out-of-fold validation split during bagging. As
+        an object column the same fill is dtype-legal and the 0.0 values go down the encoder's
+        unknown-value path, which is the behavior tabicl's masking intends. The columns are all-NaN,
+        so the cast loses nothing. Remove once the pinned tabicl carries the upstream fix.
+        """
+        X = super()._preprocess(X, **kwargs)
+        if not is_train:
+            all_nan_categoricals = [
+                col
+                for col, dtype in X.dtypes.items()
+                if isinstance(dtype, pd.CategoricalDtype) and X[col].isna().all()
+            ]
+            if all_nan_categoricals:
+                X = X.copy(deep=False)
+                for col in all_nan_categoricals:
+                    X[col] = pd.Series(np.nan, index=X.index, dtype=object)
+        return X
+
     def _fit(
         self,
         X: pd.DataFrame,
@@ -152,7 +177,7 @@ class TabICLModel(AbstractTorchModel):
             device=device,
             n_jobs=num_cpus,
         )
-        X = self.preprocess(X, y=y)
+        X = self.preprocess(X, y=y, is_train=True)
         self.model = self.model.fit(
             X=X,
             y=y,


### PR DESCRIPTION
When a `category` column is entirely missing in a prediction batch, tabicl (<=2.1.1) masks the feature and fills it with the float `0.0`, which poisons the dtype; with string category levels its fitted `OrdinalEncoder` then crashes:

```
TypeError: ufunc 'isnan' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
```

Upstream issue: https://github.com/soda-inria/tabicl/issues/143

Bagged fits hit this whenever a categorical column happens to be all-NaN within one out-of-fold validation split. In a 121-dataset benchmark run (8-fold bagging), TabICLv2 was lost on 5 datasets to this, with the model skipped and the ensemble silently degraded. Plain `fit()` users are mostly shielded because the default feature generator re-codes category levels to ints, and integer fit-time categories survive sklearn's `isnan` check; the crash needs string levels reaching the model (e.g. custom feature generators that preserve raw dtypes).

## Fix

`TabICLModel._preprocess` now casts batch-wide all-NaN `category` columns to object dtype at predict time. The same fill is then dtype-legal and the `0.0` values go down the encoder's unknown-value path, which is what tabicl's masking intends. The columns are all-NaN, so the cast loses nothing, and non-triggering batches take a copy-free early exit. `_fit` passes `is_train=True` so the cast stays out of the fit path, matching the TabPFN wrapper's convention. One wrapper covers both the tabicl classifier and regressor, which share the fill.

Casting to `float64` instead does not work: the crash site is sklearn's `OrdinalEncoder._check_unknown`, which takes its numeric branch for numeric batch values and then calls `isnan` on the string fit-time categories.

Temporary by design - the code comment cites the upstream issue and says to remove the cast once the pinned tabicl carries the fix.

## Verification

- Model-level repro (string category levels, all-NaN batch): crashes on master with the exact error above, predicts after this change with finite probabilities.
- Non-triggering batches are untouched (bit-identical predictions at the tabicl level).
- Regression path verified as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi

