### PR TITLE
[docs] Match the v1.6.0 spotlight table's row labels to the #5812 PR description

### DIFF
--- a/docs/whats_new/v1.6.0.md
+++ b/docs/whats_new/v1.6.0.md
@@ -22,9 +22,9 @@ This release supports Python versions 3.10, 3.11, 3.12, and 3.13. Loading models
 
 | method | elo | rank | improvability (%) | train s | infer s |
 |---|---:|---:|---:|---:|---:|
-| `noncommercial` | **1821** | 6.2 | 5.8 | 159 | 7.0 |
+| AutoGluon 1.6 `noncommercial` | **1821** | 6.2 | 5.8 | 159 | 7.0 |
 | TabFM (default) | 1791 | 7.0 | 5.1 | 613 | 138.4 |
-| `extreme` | **1745** | 8.5 | 6.8 | 137 | 6.2 |
+| AutoGluon 1.6 `extreme` | **1745** | 8.5 | 6.8 | 137 | 6.2 |
 | AutoGluon 1.5 `extreme` (4h) | 1638 | 12.9 | 7.9 | 3758 | 27.4 |
 | TabPFN-3 (default) | 1632 | 13.2 | 9.1 | 26 | 2.4 |
 | AutoGluon 1.4 `best` (4h) | 1516 | 20.0 | 12.1 | 8869 | 33.8 |


### PR DESCRIPTION
Follow-up to #5794, which merged just before this label fix landed on its branch: the spotlight table's first and third rows now read `AutoGluon 1.6 noncommercial` and `AutoGluon 1.6 extreme`, matching the table in the #5812 PR description. Labels only; every number is unchanged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi