### PR TITLE
[core] Stop bagged fold children from re-validating fit constraints on their slice

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -1418,6 +1418,14 @@ class AbstractModel(ModelBase, Tunable):
                             cudnn.deterministic = torch_cudnn_deterministic_og
         return out
 
+    #: Set on bagged fold children before fitting: the containing bag already validated the fit
+    #: constraints (`ag.min_rows`, `ag.min_cells`, ...) against the full training data, which is
+    #: what the constraints are defined over. A fold child sees only a (k-1)/k slice of that data,
+    #: so re-validating on the slice rejects models the bag correctly accepted — a dataset whose
+    #: full split satisfies `ag.min_rows` but whose fold slices do not would otherwise fail every
+    #: child and lose the model entirely.
+    _fit_constraints_validated_upstream: bool = False
+
     # FIXME: Simply log a message that the model is being skipped instead of logging a traceback.
     def validate_fit_args(self, X: pd.DataFrame, feature_metadata: FeatureMetadata | None = None, **kwargs):
         """
@@ -1435,6 +1443,9 @@ class AbstractModel(ModelBase, Tunable):
             ag.max_classes
             ag.ignore_constraints
         """
+        if self._fit_constraints_validated_upstream:
+            logger.log(15, "\tFit constraints were validated upstream on the full training data, skipping...")
+            return
         if self.is_initialized():
             aux_params = self.aux_params
         else:

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -1447,9 +1447,11 @@ class AbstractModel(ModelBase, Tunable):
             logger.log(15, "\tFit constraints were validated upstream on the full training data, skipping...")
             return
         if self.is_initialized():
+            params_aux_dict = self.params_aux
             aux_params = self.aux_params
         else:
-            aux_params = AuxiliaryParams.from_dict(self._get_params_aux())
+            params_aux_dict = self._get_params_aux()
+            aux_params = AuxiliaryParams.from_dict(params_aux_dict)
 
         problem_types: list[str] | None = aux_params.problem_types
         max_classes: int | None = aux_params.max_classes
@@ -1503,15 +1505,37 @@ class AbstractModel(ModelBase, Tunable):
                 feature_metadata = self._feature_metadata
 
             if feature_metadata is not None:
-                feature_generator = self.get_preprocessor()
+                # Resolve the model-specific preprocessor from the same params-aux source the
+                # constraint values above came from: `get_preprocessor()`'s internal lookup reads
+                # the initialized `params_aux`, which is empty before `initialize()` runs — and the
+                # bag validates its child template uninitialized, so the feature checks silently
+                # used the raw feature count for models whose preprocessing changes it (TabPrep).
+                feature_generator = self.get_preprocessor(
+                    ag_params=self._get_ag_params(params_aux=params_aux_dict).get(
+                        "model_specific_feature_generator_kwargs", None
+                    )
+                )
                 if feature_generator is not None:
                     # TODO: Can be faster if can calculate new_feature_metadata w/o fitting feature generator
-                    new_feature_metadata = self._estimate_dtypes_after_preprocessing_cheap(
-                        X=X,
-                        y=kwargs["y"],
-                        feature_generator=feature_generator,
-                    )
-                    n_features = len(new_feature_metadata.get_features())
+                    try:
+                        new_feature_metadata = self._estimate_dtypes_after_preprocessing_cheap(
+                            X=X,
+                            y=kwargs["y"],
+                            feature_generator=feature_generator,
+                        )
+                    except Exception as err:
+                        # The estimate fits the model-specific preprocessor on a sample, which can
+                        # fail for reasons the real fit would not hit (e.g. generators that need
+                        # more rows than the sample has). A failed estimate should degrade the
+                        # feature checks to the raw count, not fail the model here.
+                        logger.log(
+                            15,
+                            f"\tEstimating the post-preprocessing feature count failed for model "
+                            f"'{self.name}' ({err!r}); validating feature constraints against the "
+                            f"raw feature count instead.",
+                        )
+                    else:
+                        n_features = len(new_feature_metadata.get_features())
 
             if min_features is not None and n_features < min_features:
                 raise ConstraintViolationError(

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -3445,9 +3445,14 @@ class AbstractModel(ModelBase, Tunable):
             )
         if init_params is None:
             init_params = {}
+        # Before `init_random_seed` runs (e.g. constraint validation on an unfit model), the seed
+        # holds the "NOTSET" sentinel, which generators pass into components that reject it (an
+        # sklearn splitter raises on a non-int seed). Fall back to the class default seed then;
+        # real fits initialize the seed before any preprocessor is built, so they are unaffected.
+        random_seed = self.random_seed if self.random_seed != "NOTSET" else self.default_random_seed
         _init_params = dict(
             verbosity=0,
-            random_state=self.random_seed,
+            random_state=random_seed,
             target_type=self.problem_type,
         )
         _init_params.update(**init_params)

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -876,6 +876,11 @@ class BaggedEnsembleModel(AbstractModel):
         num_gpus: float = None,
         **kwargs,
     ):
+        # This bag's `validate_fit_args` already validated the fit constraints against the full
+        # training data, for itself and for the child template. Every fold model is a deepcopy of
+        # `model_base` fit on a (k-1)/k slice, so re-validating there would reject models the bag
+        # correctly accepted (e.g. `ag.min_rows` satisfied by the full split but not by a slice).
+        model_base._fit_constraints_validated_upstream = True
         fold_fitting_strategy_cls = self._get_fold_fitting_strategy(model_base=model_base, num_gpus=num_gpus)
         # TODO: Preprocess data here instead of repeatedly
         # FIXME: Raise exception if multiclass/binary and a single val fold contains all instances of a class. (Can happen if custom groups is specified)

--- a/core/tests/unittests/models/test_bagged_fit_constraints.py
+++ b/core/tests/unittests/models/test_bagged_fit_constraints.py
@@ -13,8 +13,8 @@ import pandas as pd
 import pytest
 
 from autogluon.core.models import BaggedEnsembleModel
-from autogluon.core.models.dummy.dummy_model import DummyModel
 from autogluon.core.models.abstract.abstract_model import ConstraintViolationError
+from autogluon.core.models.dummy.dummy_model import DummyModel
 
 
 def _make_data(n: int):

--- a/core/tests/unittests/models/test_bagged_fit_constraints.py
+++ b/core/tests/unittests/models/test_bagged_fit_constraints.py
@@ -66,3 +66,47 @@ def test_flag_survives_the_fold_copy(tmp_path):
     assert base._fit_constraints_validated_upstream is False
     base._fit_constraints_validated_upstream = True
     assert copy.deepcopy(base)._fit_constraints_validated_upstream is True
+
+
+def _validate_with_estimate(tmp_path, estimate_n_features, max_features, estimate_raises=False):
+    """Run `validate_fit_args` on an uninitialized model whose model-specific preprocessing
+    changes the feature count, with the post-preprocessing estimate mocked."""
+    from unittest import mock
+
+    from autogluon.common.features.feature_metadata import FeatureMetadata
+
+    X, y = _make_data(80)
+    model = DummyModel(
+        path=str(tmp_path),
+        name="Dummy",
+        problem_type="binary",
+        eval_metric="accuracy",
+        hyperparameters={"ag.max_features": max_features},
+    )
+    estimated = mock.MagicMock()
+    estimated.get_features.return_value = [f"f{i}" for i in range(estimate_n_features)]
+    with (
+        mock.patch.object(model, "get_preprocessor", return_value=mock.MagicMock()),
+        mock.patch.object(
+            model,
+            "_estimate_dtypes_after_preprocessing_cheap",
+            side_effect=RuntimeError("estimate failed") if estimate_raises else None,
+            return_value=None if estimate_raises else estimated,
+        ),
+    ):
+        model.validate_fit_args(X=X, y=y, feature_metadata=FeatureMetadata.from_df(X))
+
+
+def test_feature_constraints_use_post_preprocessing_count_before_initialization(tmp_path):
+    """The bag validates its child template uninitialized. The feature checks must still see the
+    post-preprocessing feature count, not the raw one, for models whose model-specific
+    preprocessing changes it (e.g. TabPrep): raw 1 feature passes max_features=20, but the
+    estimated 56 must be rejected."""
+    with pytest.raises(ConstraintViolationError, match="found 56 features"):
+        _validate_with_estimate(tmp_path, estimate_n_features=56, max_features=20)
+
+
+def test_feature_constraint_estimate_failure_falls_back_to_raw_count(tmp_path):
+    """A failing post-preprocessing estimate degrades the feature checks to the raw count rather
+    than failing the model at validation time."""
+    _validate_with_estimate(tmp_path, estimate_n_features=0, max_features=20, estimate_raises=True)

--- a/core/tests/unittests/models/test_bagged_fit_constraints.py
+++ b/core/tests/unittests/models/test_bagged_fit_constraints.py
@@ -110,3 +110,16 @@ def test_feature_constraint_estimate_failure_falls_back_to_raw_count(tmp_path):
     """A failing post-preprocessing estimate degrades the feature checks to the raw count rather
     than failing the model at validation time."""
     _validate_with_estimate(tmp_path, estimate_n_features=0, max_features=20, estimate_raises=True)
+
+
+def test_preprocessor_construction_resolves_the_seed_sentinel(tmp_path):
+    """Before `init_random_seed` runs, `random_seed` holds the "NOTSET" sentinel. Generators built
+    for pre-fit constraint validation must receive the class default seed instead: an sklearn
+    splitter inside a generator (e.g. out-of-fold target encoding) raises on a non-int seed, which
+    previously crashed the post-preprocessing feature estimate."""
+    from autogluon.features.generators import IdentityFeatureGenerator
+
+    model = DummyModel(path=str(tmp_path), name="Dummy", problem_type="binary", eval_metric="accuracy")
+    assert model.random_seed == "NOTSET"
+    generator = model._init_preprocessor(preprocessor_cls=IdentityFeatureGenerator, init_params={})
+    assert generator.random_state == model.default_random_seed

--- a/core/tests/unittests/models/test_bagged_fit_constraints.py
+++ b/core/tests/unittests/models/test_bagged_fit_constraints.py
@@ -1,0 +1,68 @@
+"""Bagged fits validate fit constraints against the full training data, not per-fold slices.
+
+The bag's `validate_fit_args` checks itself and the child template against the full training
+split; each fold child then trains on a (k-1)/k slice. Without the upstream-validation flag the
+children re-validated on their slices, so a dataset whose full split satisfies `ag.min_rows` but
+whose slices do not failed every child and lost the model entirely.
+"""
+
+import copy
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from autogluon.core.models import BaggedEnsembleModel
+from autogluon.core.models.dummy.dummy_model import DummyModel
+from autogluon.core.models.abstract.abstract_model import ConstraintViolationError
+
+
+def _make_data(n: int):
+    rng = np.random.default_rng(0)
+    X = pd.DataFrame({"a": rng.normal(size=n)})
+    y = pd.Series(rng.choice([0, 1], size=n))
+    return X, y
+
+
+def _make_bag(tmp_path, min_rows: int) -> BaggedEnsembleModel:
+    base = DummyModel(
+        path=str(tmp_path),
+        name="Dummy",
+        problem_type="binary",
+        eval_metric="accuracy",
+        hyperparameters={"ag.min_rows": min_rows},
+    )
+    return BaggedEnsembleModel(
+        model_base=base,
+        path=str(tmp_path),
+        name="Dummy_BAG",
+        hyperparameters={"use_child_oof": False, "save_bag_folds": True},
+    )
+
+
+def test_min_rows_between_fold_and_full_size_fits(tmp_path):
+    """Full split 80 >= min_rows 75 > fold slice 70: the bag accepts the model, so every fold
+    child must fit rather than re-reject its slice."""
+    X, y = _make_data(80)
+    bag = _make_bag(tmp_path, min_rows=75)
+    bag.validate_fit_args(X=X, y=y)  # what the trainer checks before fitting: must accept
+    bag.fit(X=X, y=y, k_fold=8)
+    assert bag.n_children == 8
+
+
+def test_min_rows_above_full_size_still_rejected(tmp_path):
+    """A genuine violation (full split 60 < min_rows 75) must still be rejected at the bag level,
+    which is where the trainer turns it into a skip."""
+    X, y = _make_data(60)
+    bag = _make_bag(tmp_path, min_rows=75)
+    with pytest.raises(ConstraintViolationError):
+        bag.validate_fit_args(X=X, y=y)
+
+
+def test_flag_survives_the_fold_copy(tmp_path):
+    """Fold models are deepcopies of the model base, so the upstream-validation flag set by the
+    bag must carry over to them."""
+    base = DummyModel(path=str(tmp_path), name="Dummy", problem_type="binary", eval_metric="accuracy")
+    assert base._fit_constraints_validated_upstream is False
+    base._fit_constraints_validated_upstream = True
+    assert copy.deepcopy(base)._fit_constraints_validated_upstream is True


### PR DESCRIPTION
`BaggedEnsembleModel.validate_fit_args` checks the fit constraints against the full training data, for itself and for the child template - the split the constraints are defined over. But each fold child's own `fit()` re-ran `validate_fit_args` on its (k-1)/k slice, so a dataset whose full split satisfies `ag.min_rows` while its slices do not passes the bag check and then fails all k children:

```
Warning: Exception caused LightGBM_r8_BAG_L1 to fail during training... Skipping this model.
    ConstraintViolationError: ag.min_rows=50000 for model 'S1F3', but found 45530 rows.
```

## Impact

- With 8x1 bagging the effective floor of `ag.min_rows=50000` is 57,143 rows, not 50,000. In a full TabArena run of the 1.6 `extreme`/`noncommercial` presets, SDSS17 (52,035 rows) lost all three tail models (`LightGBM_r8`, `CatBoost`, `RealMLP_r9`) on every one of its nine splits, silently degrading the ensemble. Any dataset in the `[min_rows, min_rows * k/(k-1))` window is affected.
- The k near-instant ray worker failures plus forced cancellation of sibling fold tasks also races ray's task manager: one task in that run died to a fatal `task_manager.cc: Check failed: it != submissible_tasks_.end()` (ray 2.52.1, ~1 crash per ~100 such storms), killing the whole predictor fit. Removing the doomed launches removes the exposure.

## Fix

The bag marks its model base `_fit_constraints_validated_upstream = True` before fold fitting. Fold models are deepcopies of the base (both the sequential and ray paths), inherit the flag, and skip `validate_fit_args`. Genuine violations are still rejected at the bag level, where the trainer turns them into clean skips.

## Verification

- Repro (80 rows, `ag.min_rows: 75`, 8-fold: full split passes, slices of 70 fail): on master the model is skipped after the fold storm; with this change it fits and appears in the leaderboard.
- A genuine violation (60 rows < 75) is still skipped at the bag level, with other models unaffected.
- New tests cover the between-fold-and-full-size fit, the bag-level rejection, and flag propagation through deepcopy; the existing bagged-ensemble and abstract-model suites pass (37 tests).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi


## Follow-up in this PR: feature constraints and feature-count-changing preprocessing

Making the bag the only validation point exposed a gap in its feature checks: `get_preprocessor()`'s internal lookup reads the initialized `params_aux`, which is empty before `initialize()`, and the bag validates its child template uninitialized - so `ag.max_features` / `ag.min_features` / cell checks compared against the raw column count for models whose model-specific preprocessing changes it (e.g. TabPrep pipelines). On master, the post-preprocessing count was only ever consulted by the child-side re-validation this PR removes.

The preprocessor is now resolved from the same pre-initialization params-aux source the constraint values already come from, so the estimate runs at the bag level: raw 6 features expanding to 56 under an arithmetic pipeline is rejected by `ag.max_features=20` at the bag ("found 56 features"), verified end to end. The full TabPrep pipeline initially crashed this estimate, and the root cause was in the construction path, not the data: `_init_preprocessor` injects `random_state=self.random_seed` into every generator, which is the `"NOTSET"` sentinel before `init_random_seed` runs - exactly the state a bag validates its child template in. The out-of-fold target encoder hands that seed to an sklearn splitter, which raises, and `CVSplitter`'s bare `except:` then misroutes into its pandas-only rare-class workaround, which crashes on the generator's numpy inputs. The sentinel now resolves to `default_random_seed` at construction (real fits initialize the seed before any preprocessor is built, so they are unchanged), and the pre-fit estimate produces the identical feature count to an initialized model (957 features for the TabPrep pipeline on the repro data, both paths). A raw-count fallback with a log line remains as defense for estimates that fail for data-dependent reasons. All behaviors are covered by new tests; the full constraint/bagged/abstract suites pass (43 tests).

Follow-up candidates outside this PR: `CVSplitter`'s bare `except:` treats any splitter failure as the sklearn rare-class bug, and its workaround assumes pandas inputs.

