### PR TITLE
[docs] Fix versioned docs publishing (build /X.Y/ from release tags)

### DIFF
--- a/.github/workflow_scripts/build_all_docs.sh
+++ b/.github/workflow_scripts/build_all_docs.sh
@@ -45,6 +45,7 @@ fi
 
 setup_build_contrib_env
 install_all_no_tests
+export_docs_version_label "$BRANCH"
 
 LOCAL_DOC_PATH=_build/html
 

--- a/.github/workflow_scripts/build_all_docs.sh
+++ b/.github/workflow_scripts/build_all_docs.sh
@@ -19,17 +19,7 @@ then
     if [[ -n $PR_NUMBER ]]; then path=$PR_NUMBER; else path=$BRANCH; fi
     site=$bucket.s3-website-us-west-2.amazonaws.com/$path/$COMMIT_SHA  # site is the actual bucket location that will serve the doc
 else
-    if [[ $BRANCH == 'master' ]]
-    then
-        path='dev'
-    else
-        if [[ $BRANCH == 'dev' ]]
-        then
-            path='dev-branch'
-        else
-            path=$BRANCH
-        fi
-    fi
+    path=$(docs_publish_path "$BRANCH")
     bucket='autogluon.mxnet.io'
     site=$bucket/$path  # site is the actual bucket location that will serve the doc
 fi

--- a/.github/workflow_scripts/build_doc.sh
+++ b/.github/workflow_scripts/build_doc.sh
@@ -12,6 +12,7 @@ function build_doc {
     setup_build_contrib_env
     bash docs/build_pip_install.sh
     setup_mmcv
+    export_docs_version_label "$BRANCH"
 
     if [[ -n $PR_NUMBER ]]; then
         BUCKET="autogluon-ci"

--- a/.github/workflow_scripts/copy_docs.sh
+++ b/.github/workflow_scripts/copy_docs.sh
@@ -20,20 +20,7 @@ then
     flags='--delete'
     cacheControl=''
 else
-    if [[ $BRANCH == 'master' ]]
-    then
-        path='dev'
-    elif [[ $BRANCH == 'dev' ]]
-    then
-        path='dev-branch'
-    elif [[ $BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
-    then
-        # Release tag vX.Y.Z -> publish to bare major.minor path (/X.Y/); patches refresh the same page
-        version=${BRANCH#v}
-        path=${version%.*}
-    else
-        path=$BRANCH
-    fi
+    path=$(docs_publish_path "$BRANCH")
     bucket='autogluon.mxnet.io'
     site=$bucket/$path
     if [[ $BRANCH == 'master' ]]; then flags=''; else flags='--delete'; fi

--- a/.github/workflow_scripts/copy_docs.sh
+++ b/.github/workflow_scripts/copy_docs.sh
@@ -23,13 +23,16 @@ else
     if [[ $BRANCH == 'master' ]]
     then
         path='dev'
+    elif [[ $BRANCH == 'dev' ]]
+    then
+        path='dev-branch'
+    elif [[ $BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+    then
+        # Release tag vX.Y.Z -> publish to bare major.minor path (/X.Y/); patches refresh the same page
+        version=${BRANCH#v}
+        path=${version%.*}
     else
-        if [[ $BRANCH == 'dev' ]]
-        then
-            path='dev-branch'
-        else
-            path=$BRANCH
-        fi
+        path=$BRANCH
     fi
     bucket='autogluon.mxnet.io'
     site=$bucket/$path

--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -12,12 +12,6 @@ function docs_publish_path {
     then
         # Release tag vX.Y.Z -> bare major.minor (/X.Y/); patch releases refresh the same page
         echo "${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
-    elif [[ $ref =~ ^v[0-9] ]]
-    then
-        # Looks like a release tag but isn't vX.Y.Z (e.g. v1.7.0rc1). Refuse rather than
-        # publish a stray prefix to the docs bucket.
-        echo "Refusing to publish docs for non-release ref '$ref'" >&2
-        return 1
     else
         echo "$ref"
     fi

--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -1,3 +1,28 @@
+# Map a pushed ref name to the path it is published under on the docs bucket.
+# Single source of truth shared by build_all_docs.sh and copy_docs.sh.
+function docs_publish_path {
+    local ref="$1"
+    if [[ $ref == 'master' ]]
+    then
+        echo 'dev'
+    elif [[ $ref == 'dev' ]]
+    then
+        echo 'dev-branch'
+    elif [[ $ref =~ ^v([0-9]+)\.([0-9]+)\.[0-9]+$ ]]
+    then
+        # Release tag vX.Y.Z -> bare major.minor (/X.Y/); patch releases refresh the same page
+        echo "${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+    elif [[ $ref =~ ^v[0-9] ]]
+    then
+        # Looks like a release tag but isn't vX.Y.Z (e.g. v1.7.0rc1). Refuse rather than
+        # publish a stray prefix to the docs bucket.
+        echo "Refusing to publish docs for non-release ref '$ref'" >&2
+        return 1
+    else
+        echo "$ref"
+    fi
+}
+
 function setup_build_env {
     python -m pip install --upgrade pip
     python -m pip install tox

--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -17,10 +17,8 @@ function docs_publish_path {
     fi
 }
 
-# Label shown in the docs page title. Only set for release tags, where the built
-# commit's `release` (a patch version) differs from the /X.Y/ path we publish to.
-# Must be exported before every sphinx-build, since tutorials and the rest of the
-# site are built by separate invocations.
+# Title label for release tags, whose `release` is a patch version but publish to /X.Y/.
+# Exported before every sphinx-build: tutorials and the rest of the site build separately.
 function export_docs_version_label {
     local ref="$1"
     if [[ $ref =~ ^v([0-9]+)\.([0-9]+)\.[0-9]+$ ]]

--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -17,6 +17,18 @@ function docs_publish_path {
     fi
 }
 
+# Label shown in the docs page title. Only set for release tags, where the built
+# commit's `release` (a patch version) differs from the /X.Y/ path we publish to.
+# Must be exported before every sphinx-build, since tutorials and the rest of the
+# site are built by separate invocations.
+function export_docs_version_label {
+    local ref="$1"
+    if [[ $ref =~ ^v([0-9]+)\.([0-9]+)\.[0-9]+$ ]]
+    then
+        export AG_DOCS_VERSION_LABEL="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+    fi
+}
+
 function setup_build_env {
     python -m pip install --upgrade pip
     python -m pip install tox

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -5,11 +5,14 @@ on:
     branches:
       - master
       - stable
+    tags:
+      - 'v*'  # release tags (vX.Y.Z) trigger versioned docs build -> /X.Y/
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number || github.event.pull_request.head.sha }}
+  # Per-ref so a tag/branch push never cancels a build for a different ref
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -6,8 +6,7 @@ on:
       - master
       - stable
     tags:
-      # Release tags vX.Y.Z trigger a versioned docs build -> /X.Y/. Deliberately narrow so
-      # pre-release tags (v1.7.0rc1) don't publish a stray prefix to the docs bucket.
+      # Build /X.Y/ docs. Narrow on purpose: pre-release tags must not publish.
       - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -6,7 +6,9 @@ on:
       - master
       - stable
     tags:
-      - 'v*'  # release tags (vX.Y.Z) trigger versioned docs build -> /X.Y/
+      # Release tags vX.Y.Z trigger a versioned docs build -> /X.Y/. Deliberately narrow so
+      # pre-release tags (v1.7.0rc1) don't publish a stray prefix to the docs bucket.
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,10 +5,6 @@ sys.path = [".", ".."] + sys.path
 
 project = "AutoGluon"
 release = "1.6.2"
-# Docs are published per major.minor (/1.6/), so show that in the page title
-# regardless of the patch/dev suffix in `release`.
-version = ".".join(release.split(".")[:2])
-html_title = f"{project} {version} documentation"
 copyright = "2026, All authors. Licensed under Apache 2.0."
 
 author = "AutoGluon contributors"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,6 +5,10 @@ sys.path = [".", ".."] + sys.path
 
 project = "AutoGluon"
 release = "1.6.2"
+# Docs are published per major.minor (/1.6/), so show that in the page title
+# regardless of the patch/dev suffix in `release`.
+version = ".".join(release.split(".")[:2])
+html_title = f"{project} {version} documentation"
 copyright = "2026, All authors. Licensed under Apache 2.0."
 
 author = "AutoGluon contributors"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,6 +5,9 @@ sys.path = [".", ".."] + sys.path
 
 project = "AutoGluon"
 release = "1.6.2"
+# CI sets this when publishing to a versioned path (/X.Y/) so the title shows the
+# published version instead of the dev version pinned in `release` above.
+html_title = f"{project} {os.environ.get('AG_DOCS_VERSION_LABEL', release)} documentation"
 copyright = "2026, All authors. Licensed under Apache 2.0."
 
 author = "AutoGluon contributors"

--- a/docs/install.md
+++ b/docs/install.md
@@ -260,7 +260,7 @@ Note that the above example is only valid while the branch still exists. A user 
 
 :::{dropdown} Install nightly builds
 
-AutoGluon offers nightly builds that can be installed using the `--pre` argument. Nightly builds have the latest features but have not been as rigorously tested as stable releases.
+Nightly builds have the latest unreleased features but have not been as rigorously tested as stable releases. Prefer the stable install instructions above unless you specifically need an unreleased fix.
 
 ```bash
 pip install -U uv

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -3,10 +3,12 @@ Available Documentation for AutoGluon
 
 Web-based documentation is available for versions listed below:
 
-- `AutoGluon 1.4.1 (dev) documentation <https://auto.gluon.ai/dev/index.html>`_
-- `AutoGluon 1.4.0 (stable) documentation <https://auto.gluon.ai/stable/index.html>`_
+- `AutoGluon 1.6.2 (dev) documentation <https://auto.gluon.ai/dev/index.html>`_
+- `AutoGluon 1.6.1 (stable) documentation <https://auto.gluon.ai/stable/index.html>`_
+- `AutoGluon 1.6 documentation <https://auto.gluon.ai/1.6/index.html>`_
+- `AutoGluon 1.5 documentation <https://auto.gluon.ai/1.5/index.html>`_
+- `AutoGluon 1.4.0 documentation <https://auto.gluon.ai/1.4.0/index.html>`_
 - `AutoGluon 1.3.1 documentation <https://auto.gluon.ai/1.3.1/index.html>`_
-- `AutoGluon 1.3.0 documentation <https://auto.gluon.ai/1.3.0/index.html>`_
 - `AutoGluon 1.2.0 documentation <https://auto.gluon.ai/1.2.0/index.html>`_
 - `AutoGluon 1.1.1 documentation <https://auto.gluon.ai/1.1.1/index.html>`_
 - `AutoGluon 1.1.0 documentation <https://auto.gluon.ai/1.1.0/index.html>`_

--- a/release_instructions/ReleaseInstructions.md
+++ b/release_instructions/ReleaseInstructions.md
@@ -65,8 +65,6 @@
 * Update the `stable` documentation to the new release:
   * Delete the `stable` branch.
   * Create new `stable` branch from the `vX.Y.Z` tag (They should be identical).
-  * Add and push any change in `docs/README.md` (i.e. space) to ensure the `stable` branch is different from the `vX.Y.Z` tag's commit.
-    * This is required for GH Action to execute CI continuous integration step if `vX.Y.Z` and `stable` hashes are matching.
   * Wait for CI build of the `stable` branch to pass
   * Check that website has updated to align with the release docs.
 * Perform version release by going to https://github.com/autogluon/autogluon/releases and click 'Draft a new release' in top right.

--- a/release_instructions/ReleaseInstructions.md
+++ b/release_instructions/ReleaseInstructions.md
@@ -58,13 +58,13 @@
   * Merge a PR that adds the new `docs/whats_new/vX.Y.Z.md` file. Ensure you also update the `docs/whats_new/index.md` in the same PR.
     * DO NOT commit the `docs/whats_new/vX.Y.Z_paste_to_github.md` file that is created. This is only used for pasting the GitHub release notes.
 * Versioned docs are published automatically from the `vX.Y.Z` release tag (see the Release step below). CI computes the URL from the tag: `vX.Y.Z` publishes to `https://auto.gluon.ai/X.Y/index.html` (bare `major.minor`, no `v`). Patch releases refresh the same `/X.Y/` page.
-  * No separate `X.Y.Z` release branch is needed to publish docs. (The old flow cut such a branch to strip `--pre` install warnings and rewrite `blob/master` -> `blob/stable` notebook links; the `stable` docs still get these via the `stable` branch below. Versioned `/X.Y/` docs are built from the tagged master commit and keep `master` notebook links.)
+  * No separate `X.Y.Z` release branch is needed. The `stable` branch below is still required — it is what publishes `/stable/`.
 
 ## Release
 
 * Update the `stable` documentation to the new release:
   * Delete the `stable` branch.
-  * Create new `stable` branch from `vX.Y.Z` branch (They should be identical).
+  * Create new `stable` branch from the `vX.Y.Z` tag (They should be identical).
   * Add and push any change in `docs/README.md` (i.e. space) to ensure the `stable` branch is different from the `vX.Y.Z` tag's commit.
     * This is required for GH Action to execute CI continuous integration step if `vX.Y.Z` and `stable` hashes are matching.
   * Wait for CI build of the `stable` branch to pass

--- a/release_instructions/ReleaseInstructions.md
+++ b/release_instructions/ReleaseInstructions.md
@@ -57,21 +57,15 @@
   * Review with at least 2 core maintainers to ensure release notes are correct.
   * Merge a PR that adds the new `docs/whats_new/vX.Y.Z.md` file. Ensure you also update the `docs/whats_new/index.md` in the same PR.
     * DO NOT commit the `docs/whats_new/vX.Y.Z_paste_to_github.md` file that is created. This is only used for pasting the GitHub release notes.
-* Cut a release branch with format `X.Y.Z` (no v) - this branch is required to publish docs to versioned path
-  * Clone from master branch
-  * Add 1 commit to the release branch to remove pre-release warnings and update install instructions to remove `--pre`: [Old diff](https://github.com/autogluon/autogluon/commit/1d66194d4685b06e884bbf15dcb97580cbfb9261)
-  * Add 1 commit that converts notebook links from `master` to `stable` by running this command from the root project directory: `LC_ALL=C find docs/tutorials/ -type f -exec sed -i '' 's#blob/master/docs#blob/stable/docs#' {} +`
-  * Update links to AG sub-modules website to be stable ones, i.e. cloud
-  * Push release branch
-  * Build the release branch docs in [CI](https://ci.gluon.ai/job/autogluon/).
-  * Once CI passes, verify it's available at `https://auto.gluon.ai/0.x.y/index.html`
+* Versioned docs are published automatically from the `vX.Y.Z` release tag (see the Release step below). CI computes the URL from the tag: `vX.Y.Z` publishes to `https://auto.gluon.ai/X.Y/index.html` (bare `major.minor`, no `v`). Patch releases refresh the same `/X.Y/` page.
+  * No separate `X.Y.Z` release branch is needed to publish docs. (The old flow cut such a branch to strip `--pre` install warnings and rewrite `blob/master` -> `blob/stable` notebook links; the `stable` docs still get these via the `stable` branch below. Versioned `/X.Y/` docs are built from the tagged master commit and keep `master` notebook links.)
 
 ## Release
 
 * Update the `stable` documentation to the new release:
   * Delete the `stable` branch.
   * Create new `stable` branch from `vX.Y.Z` branch (They should be identical).
-  * Add and push any change in `docs/README.md` (i.e. space) to ensure `stable` branch is different from `0.x.y`. 
+  * Add and push any change in `docs/README.md` (i.e. space) to ensure the `stable` branch is different from the `vX.Y.Z` tag's commit.
     * This is required for GH Action to execute CI continuous integration step if `vX.Y.Z` and `stable` hashes are matching.
   * Wait for CI build of the `stable` branch to pass
   * Check that website has updated to align with the release docs.
@@ -86,6 +80,7 @@
     * DO NOT use `docs/whats_new/vX.Y.Z.md` -> This will break GitHub's contributor detection logic due to the URLs present around the GitHub aliases. This is why we need to use the `_paste_to_github.md` variant.
     * Ensure release notes look correct and make any final formatting fixes.
   * Click 'Publish release' and the release will go live.
+  * Publishing the `vX.Y.Z` tag triggers CI, which builds the versioned docs and publishes them to `https://auto.gluon.ai/X.Y/index.html`. Once CI passes, verify the page is available and correct.
 * Wait ~10 minutes and then locally test that the PyPi package is available and working with the latest release version, ask team members to also independently verify.
 
 ## Conda-Forge Release


### PR DESCRIPTION
## Problem

Versioned doc pages stopped publishing. `auto.gluon.ai/1.6/` doesn't exist, and older pages use inconsistent schemes (`/1.4.0/`, `/v1.5.0/`).

1. **#5728** scoped the push trigger to `branches: [master, stable]`. Once `branches:` is set, tag pushes stop triggering CI — the `v1.6.0`/`v1.6.1` tags built nothing.
2. On push the concurrency key collapsed to `Continuous Integration-` (both operands empty), so any push cancelled any other in-flight push build. This is why `/dev/` went stale.
3. Publish path was `basename $github.ref`, so tags and branches produced duplicate schemes.

## Fix

- **`continuous_integration.yml`** — add `tags: ['v[0-9]+.[0-9]+.[0-9]+']`; make concurrency per-ref. The pattern is narrow on purpose: `'v*'` would match `v1.7.0rc1`, and the sync uses `--delete`.
- **`env_setup.sh`** — new `docs_publish_path`: `master`→`dev`, `vX.Y.Z`→`X.Y`, else verbatim. Now shared by `copy_docs.sh` and `build_all_docs.sh`, which had drifting copies of this logic.
- **`conf.py` + `build_doc.sh`** — `/1.6/` is built from `v1.6.1`, so the title said "1.6.1". CI now exports `AG_DOCS_VERSION_LABEL` for release tags; exported for both sphinx-build invocations since tutorials build separately from the rest of the site.
- **`install.md`** — nightly dropdown points readers at the stable instructions.
- **`versions.rst`** — fix dev/stable versions, add `/1.6/` `/1.5/`, drop nonexistent `/1.3.0/`. These two links 404 until rollout.
- **`ReleaseInstructions.md`** — document tag-based publishing; drop the `X.Y.Z` release branch and the `docs/README.md` space commit (unnecessary — `stable` builds fine at a commit identical to a tag). The `stable` branch step stays; it publishes `/stable/`.

## Rollout (after merge)

No tagging — v1.6.1 is the last release; 1.6.2 is the dev version.

1. Copy `s3://autogluon.mxnet.io/stable/` → `/1.6/` (`stable` is identical to the `v1.6.1` tree).
2. Copy `/v1.5.0/` → `/1.5/`, keeping the original. Pre-1.5 are already bare.
3. Verify both return 200, then reconcile `versions.rst`.

Copied pages keep their original title; `/X.Y/` gets the clean one at the next tagged release. Note a tag push runs the full CI suite (~24 jobs), not just docs — restricting that is a follow-up.
