### PR TITLE
[docs] Use clean /X.Y/ scheme in versions.rst and freeze dev/stable labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 </div>
 
-AutoGluon, developed by AWS AI, automates machine learning tasks enabling you to easily achieve strong predictive performance in your applications.  With just a few lines of code, you can train and deploy high-accuracy machine learning and deep learning models on image, text, time series, and tabular data.
+AutoGluon automates machine learning tasks enabling you to easily achieve strong predictive performance in your applications.  With just a few lines of code, you can train and deploy high-accuracy machine learning and deep learning models for time series and tabular data.
 
 
 ## 💾 Installation

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@
 
 </div>
 
-AutoGluon automates machine learning tasks enabling you to easily achieve strong predictive performance in your applications.  With just a few lines of code, you can train and deploy high-accuracy machine learning and deep learning models for time series and tabular data.
+AutoGluon automates machine learning on data such as tables and time series, helping you achieve strong predictive performance with just a few lines of code.
+
+From classic ML algorithms to foundation models, the options keep multiplying — but which one should you use? AutoGluon takes care of that: it finds the combination of models that works best for your use case.
 
 
 ## 💾 Installation

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -1,14 +1,15 @@
 Available Documentation for AutoGluon
 -------------------------------------
 
-Web-based documentation is available for versions listed below:
+Web-based documentation is available for the versions listed below:
 
-- `AutoGluon dev documentation (upcoming release) <https://auto.gluon.ai/dev/index.html>`_
-- `AutoGluon stable documentation (latest release) <https://auto.gluon.ai/stable/index.html>`_
-- `AutoGluon 1.6 documentation <https://auto.gluon.ai/1.6/index.html>`_
-- `AutoGluon 1.5 documentation <https://auto.gluon.ai/1.5/index.html>`_
-- `AutoGluon 1.4 documentation <https://auto.gluon.ai/1.4/index.html>`_
-- `AutoGluon 1.3 documentation <https://auto.gluon.ai/1.3/index.html>`_
-- `AutoGluon 1.2 documentation <https://auto.gluon.ai/1.2/index.html>`_
-- `AutoGluon 1.1 documentation <https://auto.gluon.ai/1.1/index.html>`_
-- `AutoGluon 1.0 documentation <https://auto.gluon.ai/1.0/index.html>`_
+- `Upcoming release (in development) <https://auto.gluon.ai/dev/index.html>`_
+- `Latest stable release <https://auto.gluon.ai/stable/index.html>`_
+- Previous releases:
+
+  - `AutoGluon 1.5 <https://auto.gluon.ai/1.5/index.html>`_
+  - `AutoGluon 1.4 <https://auto.gluon.ai/1.4/index.html>`_
+  - `AutoGluon 1.3 <https://auto.gluon.ai/1.3/index.html>`_
+  - `AutoGluon 1.2 <https://auto.gluon.ai/1.2/index.html>`_
+  - `AutoGluon 1.1 <https://auto.gluon.ai/1.1/index.html>`_
+  - `AutoGluon 1.0 <https://auto.gluon.ai/1.0/index.html>`_

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -3,30 +3,12 @@ Available Documentation for AutoGluon
 
 Web-based documentation is available for versions listed below:
 
-- `AutoGluon 1.6.2 (dev) documentation <https://auto.gluon.ai/dev/index.html>`_
-- `AutoGluon 1.6.1 (stable) documentation <https://auto.gluon.ai/stable/index.html>`_
+- `AutoGluon dev documentation <https://auto.gluon.ai/dev/index.html>`_
+- `AutoGluon stable documentation <https://auto.gluon.ai/stable/index.html>`_
 - `AutoGluon 1.6 documentation <https://auto.gluon.ai/1.6/index.html>`_
 - `AutoGluon 1.5 documentation <https://auto.gluon.ai/1.5/index.html>`_
-- `AutoGluon 1.4.0 documentation <https://auto.gluon.ai/1.4.0/index.html>`_
-- `AutoGluon 1.3.1 documentation <https://auto.gluon.ai/1.3.1/index.html>`_
-- `AutoGluon 1.2.0 documentation <https://auto.gluon.ai/1.2.0/index.html>`_
-- `AutoGluon 1.1.1 documentation <https://auto.gluon.ai/1.1.1/index.html>`_
-- `AutoGluon 1.1.0 documentation <https://auto.gluon.ai/1.1.0/index.html>`_
-- `AutoGluon 1.0.0 documentation <https://auto.gluon.ai/1.0.0/index.html>`_
-- `AutoGluon 0.8.2 documentation <https://auto.gluon.ai/0.8.2/index.html>`_
-- `AutoGluon 0.8.1 documentation <https://auto.gluon.ai/0.8.1/index.html>`_
-- `AutoGluon 0.8.0 documentation <https://auto.gluon.ai/0.8.0/index.html>`_
-- `AutoGluon 0.7.0 documentation <https://auto.gluon.ai/0.7.0/index.html>`_
-- `AutoGluon 0.6.2 documentation <https://auto.gluon.ai/0.6.2/index.html>`_
-- `AutoGluon 0.6.1 documentation <https://auto.gluon.ai/0.6.1/index.html>`_
-- `AutoGluon 0.6.0 documentation <https://auto.gluon.ai/0.6.0/index.html>`_
-- `AutoGluon 0.5.2 documentation <https://auto.gluon.ai/0.5.2/index.html>`_
-- `AutoGluon 0.5.1 documentation <https://auto.gluon.ai/0.5.1/index.html>`_
-- `AutoGluon 0.4.2 documentation <https://auto.gluon.ai/0.4.2/index.html>`_
-- `AutoGluon 0.4.1 documentation <https://auto.gluon.ai/0.4.1/index.html>`_
-- `AutoGluon 0.4.0 documentation <https://auto.gluon.ai/0.4.0/index.html>`_
-- `AutoGluon 0.3.1 documentation <https://auto.gluon.ai/0.3.1/index.html>`_
-- `AutoGluon 0.3.0 documentation <https://auto.gluon.ai/0.3.0/index.html>`_
-- `AutoGluon 0.2.0 documentation <https://auto.gluon.ai/0.2.0/index.html>`_
-- `AutoGluon 0.1.0 documentation <https://auto.gluon.ai/0.1.0/index.html>`_
-- `AutoGluon 0.0.15 (legacy) documentation <https://auto.gluon.ai/0.0.15/index.html>`_
+- `AutoGluon 1.4 documentation <https://auto.gluon.ai/1.4/index.html>`_
+- `AutoGluon 1.3 documentation <https://auto.gluon.ai/1.3/index.html>`_
+- `AutoGluon 1.2 documentation <https://auto.gluon.ai/1.2/index.html>`_
+- `AutoGluon 1.1 documentation <https://auto.gluon.ai/1.1/index.html>`_
+- `AutoGluon 1.0 documentation <https://auto.gluon.ai/1.0/index.html>`_

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -3,8 +3,8 @@ Available Documentation for AutoGluon
 
 Web-based documentation is available for versions listed below:
 
-- `AutoGluon dev documentation <https://auto.gluon.ai/dev/index.html>`_
-- `AutoGluon stable documentation <https://auto.gluon.ai/stable/index.html>`_
+- `AutoGluon dev documentation (upcoming release) <https://auto.gluon.ai/dev/index.html>`_
+- `AutoGluon stable documentation (latest release) <https://auto.gluon.ai/stable/index.html>`_
 - `AutoGluon 1.6 documentation <https://auto.gluon.ai/1.6/index.html>`_
 - `AutoGluon 1.5 documentation <https://auto.gluon.ai/1.5/index.html>`_
 - `AutoGluon 1.4 documentation <https://auto.gluon.ai/1.4/index.html>`_

--- a/release_instructions/ReleaseInstructions.md
+++ b/release_instructions/ReleaseInstructions.md
@@ -101,7 +101,7 @@ After GitHub & PyPi release, conduct release on Conda-Forge
 After release is published, on the mainline branch:
 * Update `release` in `docs/conf.py`
 * Increment version in the `VERSION` file and `SECURITY.md`
-* Update doc links in `docs/versions.rst`
+* Add the just-released minor version as an explicit entry in `docs/versions.rst` (e.g. after releasing 1.7, add the `1.7` link pointing at `https://auto.gluon.ai/1.7/index.html`). Only the latest patch of each minor line is listed (so a patch release like 1.7.1 needs no change), and `dev`/`stable` are permanent version-less entries — so this is the only `versions.rst` change per release. Old versioned sites keep their own frozen copy of this file and are not updated; readers reach newer releases via the `dev`/`stable` links.
 * Update `README.md` sample code with new release version.
 * Send release update to internal and external slack channels and mailing lists
 * Publish any blogs / talks planned for release to generate interest.

--- a/release_instructions/ReleaseInstructions.md
+++ b/release_instructions/ReleaseInstructions.md
@@ -101,7 +101,7 @@ After GitHub & PyPi release, conduct release on Conda-Forge
 After release is published, on the mainline branch:
 * Update `release` in `docs/conf.py`
 * Increment version in the `VERSION` file and `SECURITY.md`
-* On a new minor release, move the previously-latest minor into the "Previous releases" list in `docs/versions.rst`. The latest minor is always covered by the `Latest stable release` link, so it is not listed explicitly; when a new minor ships, the one it displaces from stable gets its own `/X.Y/` entry (e.g. releasing 1.7 adds a `1.6` link). Patch releases (e.g. 1.7.1) need no change, and `dev`/`stable` are permanent version-less entries. Old versioned sites keep their own frozen copy of this file and are not updated; readers reach newer releases via the `dev`/`stable` links.
+* On a new minor release, add the minor it displaces from stable to the "Previous releases" list in `docs/versions.rst` (e.g. releasing 1.7 adds a `1.6` link). Patch releases need no change.
 * Update `README.md` sample code with new release version.
 * Send release update to internal and external slack channels and mailing lists
 * Publish any blogs / talks planned for release to generate interest.

--- a/release_instructions/ReleaseInstructions.md
+++ b/release_instructions/ReleaseInstructions.md
@@ -101,7 +101,7 @@ After GitHub & PyPi release, conduct release on Conda-Forge
 After release is published, on the mainline branch:
 * Update `release` in `docs/conf.py`
 * Increment version in the `VERSION` file and `SECURITY.md`
-* Add the just-released minor version as an explicit entry in `docs/versions.rst` (e.g. after releasing 1.7, add the `1.7` link pointing at `https://auto.gluon.ai/1.7/index.html`). Only the latest patch of each minor line is listed (so a patch release like 1.7.1 needs no change), and `dev`/`stable` are permanent version-less entries — so this is the only `versions.rst` change per release. Old versioned sites keep their own frozen copy of this file and are not updated; readers reach newer releases via the `dev`/`stable` links.
+* On a new minor release, move the previously-latest minor into the "Previous releases" list in `docs/versions.rst`. The latest minor is always covered by the `Latest stable release` link, so it is not listed explicitly; when a new minor ships, the one it displaces from stable gets its own `/X.Y/` entry (e.g. releasing 1.7 adds a `1.6` link). Patch releases (e.g. 1.7.1) need no change, and `dev`/`stable` are permanent version-less entries. Old versioned sites keep their own frozen copy of this file and are not updated; readers reach newer releases via the `dev`/`stable` links.
 * Update `README.md` sample code with new release version.
 * Send release update to internal and external slack channels and mailing lists
 * Publish any blogs / talks planned for release to generate interest.


### PR DESCRIPTION
## Description

Follow-up to #5824. Now that the `/X.Y/` doc prefixes exist in the bucket (`/1.0/` … `/1.6/`, each mapped to the latest patch in its minor line, plus `stable`/`dev`), update `versions.rst` to match.

Changes:
- List only `dev`, `stable`, and `1.0`–`1.6` using the clean `/X.Y/` scheme (dropping the old patch-level `/1.4.0/`, `/1.3.1/`, etc. and pre-1.0 entries).
- Drop the patch numbers from the `dev`/`stable` **labels** (`AutoGluon 1.6.2 (dev)` → `AutoGluon dev`).

### Why drop the labels' version numbers

The intent is to copy this `versions.rst` verbatim into every old version's site so old docs always link to the latest release via `stable`/`dev` — without ever having to touch old versions again. For that to be maintenance-free, the copied file must not name anything that changes over time. The `1.0`–`1.6` labels are fixed minor versions (safe to freeze), but `stable`/`dev` version numbers would go stale the moment the next release ships. Naming them plainly keeps the frozen copies correct forever.

### Rollout note

A reader landing on an old `/1.1/` page won't see links to versions released *after* that page was frozen — but `stable` and `dev` always carry the latest, so they're never stranded. This is intentional: old sites are frozen, and `stable`/`dev` are the evergreen path forward.

All links verified to return 200.