### PR TITLE
[timeseries] Do not impute real dynamic covariates in the unified pipeline

### DIFF
--- a/docs/tutorials/timeseries/advanced/forecasting-custom-model.ipynb
+++ b/docs/tutorials/timeseries/advanced/forecasting-custom-model.ipynb
@@ -277,7 +277,8 @@
     "    - data may contain covariates (incl. static features) with schema described in `self.covariate_metadata`\n",
     "        - real-valued covariates have dtype `float32`\n",
     "        - categorical covariates have dtype `category`\n",
-    "        - covariates do not contain any missing values\n",
+    "        - real dynamic covariates may contain missing values (`NaN`) unless the model sets `allow_nan_covariates=False` (default), in which case AutoGluon imputes them in `preprocess`\n",
+    "        - categorical covariates are mode-filled by the feature generator and do not contain missing values\n",
     "    - static features, if present, are available as `data.static_features`\n",
     "- Predictions returned by `_predict` must satisfy:\n",
     "    - returns predictions as a `TimeSeriesDataFrame` object\n",
@@ -376,7 +377,7 @@
    "source": [
     "Before we use the model in standalone mode, we need to apply the general AutoGluon preprocessing to the data.\n",
     "\n",
-    "The `TimeSeriesFeatureGenerator` captures preprocessing steps like normalizing the data types and imputing the missing values in the covariates."
+    "The `TimeSeriesFeatureGenerator` captures preprocessing steps like normalizing the data types and imputing missing values in categorical covariates and static features. Real dynamic covariates may retain `NaN` values so models with native missing-value support (e.g. Chronos-2) can use them; other models impute real covariates in `preprocess`."
    ]
   },
   {

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -337,7 +337,10 @@ class TimeSeriesModelBase(ModelBase, ABC):
         https://scikit-learn.org/stable/_sources/developers/develop.rst.txt.
 
         List of currently supported tags:
-        - allow_nan: Can the model handle data with missing values represented by np.nan?
+        - allow_nan: Can the model handle missing values in the **target** column represented by np.nan?
+        - allow_nan_covariates: Can the model handle missing values in real dynamic covariates (past/known)?
+            If False (default), real covariate NaNs are imputed in :meth:`preprocess` with ffill/bfill and the
+            training median. Models with native NaN support (e.g. Chronos-2) should set this to True.
         - can_refit_full: Does it make sense to retrain the model without validation data?
             See `autogluon.core.models.abstract._tags._DEFAULT_TAGS` for more details.
         - can_use_train_data: Can the model use train_data if it's provided to model.fit()?
@@ -345,6 +348,7 @@ class TimeSeriesModelBase(ModelBase, ABC):
         """
         return {
             "allow_nan": False,
+            "allow_nan_covariates": False,
             "can_refit_full": False,
             "can_use_train_data": True,
             "can_use_val_data": False,
@@ -439,6 +443,8 @@ class AbstractTimeSeriesModel(TimeSeriesModelBase, TimeSeriesTunable, metaclass=
         self.target_scaler: TargetScaler | None
         self.covariate_scaler: CovariateScaler | None
         self.covariate_regressor: CovariateRegressor | None
+        # Median of real dynamic covariates on train data; used when allow_nan_covariates is False
+        self._covariates_real_median: pd.Series | None = None
 
     def _initialize_transforms_and_regressor(self) -> None:
         self.target_scaler = get_target_scaler(self.get_hyperparameters().get("target_scaler"), target=self.target)
@@ -538,6 +544,12 @@ class AbstractTimeSeriesModel(TimeSeriesModelBase, TimeSeriesTunable, metaclass=
         start_time = time.monotonic()
         self._initialize_transforms_and_regressor()
 
+        # Impute real covariates before scalers/regressors so sklearn transforms see finite values.
+        # Models with allow_nan_covariates=True skip this and keep native NaN handling.
+        if not self._get_tags().get("allow_nan_covariates", False):
+            self._fit_real_covariate_imputer(train_data)
+            train_data, _ = self._impute_real_covariates(train_data, None)
+
         if self.target_scaler is not None:
             train_data = self.target_scaler.fit_transform(train_data)
 
@@ -560,6 +572,8 @@ class AbstractTimeSeriesModel(TimeSeriesModelBase, TimeSeriesTunable, metaclass=
             train_data, _ = self.preprocess(train_data, is_train=True)
 
         if self._get_tags()["can_use_val_data"] and val_data is not None:
+            if not self._get_tags().get("allow_nan_covariates", False):
+                val_data, _ = self._impute_real_covariates(val_data, None)
             if self.target_scaler is not None:
                 val_data = self.target_scaler.transform(val_data)
             if self.covariate_scaler is not None:
@@ -656,6 +670,12 @@ class AbstractTimeSeriesModel(TimeSeriesModelBase, TimeSeriesTunable, metaclass=
             data is given as a separate forecast item in the dictionary, keyed by the `item_id`s
             of input items.
         """
+        # Impute real covariates before scalers so transforms receive finite values
+        if not self._get_tags().get("allow_nan_covariates", False):
+            if self._covariates_real_median is None:
+                self._fit_real_covariate_imputer(data)
+            data, known_covariates = self._impute_real_covariates(data, known_covariates)
+
         if self.target_scaler is not None:
             data = self.target_scaler.fit_transform(data)
         if self.covariate_scaler is not None:
@@ -797,5 +817,55 @@ class AbstractTimeSeriesModel(TimeSeriesModelBase, TimeSeriesTunable, metaclass=
         is_train: bool = False,
         **kwargs,
     ) -> tuple[TimeSeriesDataFrame, TimeSeriesDataFrame | None]:
-        """Method that implements model-specific preprocessing logic."""
+        """Method that implements model-specific preprocessing logic.
+
+        By default, imputes real dynamic covariates when the model does not set ``allow_nan_covariates=True``.
+        Subclasses that override this method should call ``super().preprocess(...)`` first (or apply the same
+        covariate imputation) so that NaN covariates are handled consistently.
+        """
+        if not self._get_tags().get("allow_nan_covariates", False):
+            if is_train or self._covariates_real_median is None:
+                self._fit_real_covariate_imputer(data)
+            data, known_covariates = self._impute_real_covariates(data, known_covariates)
+        return data, known_covariates
+
+    def _fit_real_covariate_imputer(self, data: TimeSeriesDataFrame) -> None:
+        """Store train medians for real dynamic covariates used when imputing NaNs at predict time."""
+        real_cols = [c for c in self.covariate_metadata.covariates_real if c in data.columns]
+        if real_cols:
+            self._covariates_real_median = data[real_cols].median()
+        else:
+            self._covariates_real_median = pd.Series(dtype="float64")
+
+    def _impute_real_covariates(
+        self,
+        data: TimeSeriesDataFrame,
+        known_covariates: TimeSeriesDataFrame | None = None,
+    ) -> tuple[TimeSeriesDataFrame, TimeSeriesDataFrame | None]:
+        """Impute real past/known covariates with ffill, bfill, and train median (copy-safe)."""
+        real_cols = [c for c in self.covariate_metadata.covariates_real if c in data.columns]
+        if real_cols:
+            data = data.copy(deep=False)
+            filled = data[real_cols].fill_missing_values()
+            if filled.isna().any(axis=None):
+                median = self._covariates_real_median
+                if median is None:
+                    median = filled.median()
+                filled = filled.fillna(median)
+            for col in real_cols:
+                data[col] = filled[col]
+
+        if known_covariates is not None:
+            known_real = [c for c in self.covariate_metadata.known_covariates_real if c in known_covariates.columns]
+            if known_real:
+                known_covariates = known_covariates.copy(deep=False)
+                filled_known = known_covariates[known_real].fill_missing_values()
+                if filled_known.isna().any(axis=None):
+                    median = self._covariates_real_median
+                    if median is None:
+                        median = filled_known.median()
+                    filled_known = filled_known.fillna(median)
+                for col in known_real:
+                    known_covariates[col] = filled_known[col]
+
         return data, known_covariates

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -118,6 +118,9 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
         is_train: bool = False,
         **kwargs,
     ) -> tuple[TimeSeriesDataFrame, TimeSeriesDataFrame | None]:
+        data, known_covariates = super().preprocess(
+            data, known_covariates=known_covariates, is_train=is_train, **kwargs
+        )
         if is_train:
             # All-NaN series are removed; partially-NaN series in train_data are handled inside _generate_train_val_dfs
             all_nan_items = data.item_ids[

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/per_step.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/per_step.py
@@ -241,6 +241,9 @@ class PerStepTabularModel(AbstractTimeSeriesModel):
         is_train: bool = False,
         **kwargs,
     ):
+        data, known_covariates = super().preprocess(
+            data, known_covariates=known_covariates, is_train=is_train, **kwargs
+        )
         # TODO: Make this toggleable with a hyperparameter
         # We add a scaled version of non-boolean known real covariates, same as in MLForecast models
         if is_train:

--- a/timeseries/src/autogluon/timeseries/models/chronos/chronos2.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/chronos2.py
@@ -404,6 +404,8 @@ class Chronos2Model(AbstractTimeSeriesModel):
         do_fine_tune = self.get_hyperparameter("fine_tune")
         return {
             "allow_nan": True,
+            # Chronos-2 natively masks missing covariates; do not impute them away upstream
+            "allow_nan_covariates": True,
             "can_use_train_data": do_fine_tune,
             "can_use_val_data": do_fine_tune,
         }

--- a/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
+++ b/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
@@ -80,6 +80,9 @@ class AbstractLocalModel(AbstractTimeSeriesModel):
         is_train: bool = False,
         **kwargs,
     ) -> tuple[TimeSeriesDataFrame, TimeSeriesDataFrame | None]:
+        data, known_covariates = super().preprocess(
+            data, known_covariates=known_covariates, is_train=is_train, **kwargs
+        )
         if not self._get_tags()["allow_nan"]:
             data = data.fill_missing_values()
         return data, known_covariates

--- a/timeseries/src/autogluon/timeseries/utils/features.py
+++ b/timeseries/src/autogluon/timeseries/utils/features.py
@@ -119,12 +119,17 @@ class TimeSeriesFeatureGenerator:
 
     All covariates & static features are converted into either float or categorical dtype.
 
-    Missing values in the target column are left as-is but missing values in static features & covariates are imputed.
+    Missing values in the target column are left as-is. Missing values in static features and **categorical**
+    covariates are imputed here. Missing values in **real** dynamic covariates (past / known) are left as-is so
+    that models can handle them natively (e.g. Chronos-2) or impute in model-specific preprocessing via
+    :meth:`impute_real_covariates`.
+
     Imputation logic is as follows:
     1. For all categorical columns (static, past, known), we fill missing values with the mode of the training set.
     2. For real static features, we impute missing values with the median of the training set.
-    3. For real covariates (past, known), we ffill + bfill within each time series. If for some time series all
-        covariate values are missing, we fill them with the median of the training set.
+    3. For real covariates (past, known), missing values are preserved. Models that cannot handle NaNs should call
+       :meth:`impute_real_covariates` (ffill + bfill within each series, then train median for all-NaN series).
+       Training medians are still computed during fit for that purpose.
 
     Parameters
     ----------
@@ -271,8 +276,8 @@ class TimeSeriesFeatureGenerator:
 
         df_out = self._concat_dfs(dfs_to_concat)
         df_out.index = index
-        ts_df = TimeSeriesDataFrame(df_out, static_features=self._impute_static_features(static_features_df))
-        return self._impute_covariates(ts_df, column_names=self.covariate_metadata.covariates_real)
+        # Real dynamic covariates may contain NaNs; models impute if needed (see allow_nan_covariates tag).
+        return TimeSeriesDataFrame(df_out, static_features=self._impute_static_features(static_features_df))
 
     @staticmethod
     def _concat_dfs(dfs_to_concat: list[pd.DataFrame]) -> pd.DataFrame:
@@ -281,15 +286,46 @@ class TimeSeriesFeatureGenerator:
         else:
             return pd.concat(dfs_to_concat, axis=1, copy=False)
 
+    def impute_real_covariates(
+        self, ts_df: TimeSeriesDataFrame, column_names: list[str] | None = None
+    ) -> TimeSeriesDataFrame:
+        """Impute missing values in real-valued dynamic covariates with ffill, bfill, and train median.
+
+        Used by models that cannot handle NaNs in covariates. The unified feature generator leaves real
+        dynamic covariate NaNs in place so models with native NaN support can keep them.
+
+        Parameters
+        ----------
+        ts_df
+            Data frame whose real covariate columns may contain NaNs.
+        column_names
+            Columns to impute. Defaults to all real past/known covariates seen during fit.
+        """
+        assert self._is_fit, f"{self.__class__.__name__} has not been fit yet"
+        if column_names is None:
+            column_names = self.covariate_metadata.covariates_real
+        return self._impute_covariates(ts_df, column_names=column_names)
+
     def _impute_covariates(self, ts_df: TimeSeriesDataFrame, column_names: list[str]) -> TimeSeriesDataFrame:
-        """Impute missing values in selected columns with ffill, bfill, and median imputation."""
-        if len(column_names) > 0:
-            # ffill + bfill covariates that have at least some observed values
-            covariates_real = ts_df[column_names].fill_missing_values()
-            # If for some items covariates consist completely of NaNs, fill them with median of training data
-            if np.isnan(covariates_real.to_numpy()).any():
-                covariates_real.fillna(self._train_covariates_real_median, inplace=True)
-            ts_df[column_names] = covariates_real
+        """Impute missing values in selected columns with ffill, bfill, and median imputation.
+
+        Operates on a shallow copy so the caller's frame is not modified in place (important when multiple
+        models share the same transformed dataset).
+        """
+        if len(column_names) == 0:
+            return ts_df
+        column_names = [c for c in column_names if c in ts_df.columns]
+        if len(column_names) == 0:
+            return ts_df
+        ts_df = ts_df.copy(deep=False)
+        # ffill + bfill covariates that have at least some observed values
+        covariates_real = ts_df[column_names].fill_missing_values()
+        # If for some items covariates consist completely of NaNs, fill them with median of training data
+        if np.isnan(covariates_real.to_numpy()).any():
+            assert self._train_covariates_real_median is not None
+            covariates_real = covariates_real.fillna(self._train_covariates_real_median)
+        for col in column_names:
+            ts_df[col] = covariates_real[col]
         return ts_df
 
     def _impute_static_features(self, static_df: pd.DataFrame | None) -> pd.DataFrame | None:
@@ -337,8 +373,8 @@ class TimeSeriesFeatureGenerator:
 
         df_out = self._concat_dfs(dfs_to_concat)
         df_out.index = index
-        ts_df = TimeSeriesDataFrame(df_out, static_features=self._impute_static_features(static_features_df))
-        return self._impute_covariates(ts_df, column_names=self.covariate_metadata.covariates_real)
+        # Real dynamic covariates may contain NaNs; models impute if needed (see allow_nan_covariates tag).
+        return TimeSeriesDataFrame(df_out, static_features=self._impute_static_features(static_features_df))
 
     def transform_future_known_covariates(
         self, known_covariates: TimeSeriesDataFrame | None
@@ -349,12 +385,8 @@ class TimeSeriesFeatureGenerator:
             self._check_required_columns_are_present(
                 known_covariates, required_column_names=self.known_covariates_names, data_frame_name="known_covariates"
             )
-            known_covariates = TimeSeriesDataFrame(
-                self.known_covariates_pipeline.transform(pd.DataFrame(known_covariates))
-            )
-            return self._impute_covariates(
-                known_covariates, column_names=self.covariate_metadata.known_covariates_real
-            )
+            # Real known covariates may contain NaNs; models impute if needed.
+            return TimeSeriesDataFrame(self.known_covariates_pipeline.transform(pd.DataFrame(known_covariates)))
         else:
             return None
 

--- a/timeseries/tests/unittests/models/chronos/test_chronos2.py
+++ b/timeseries/tests/unittests/models/chronos/test_chronos2.py
@@ -12,6 +12,11 @@ from ..common import CHRONOS2_MODEL_PATH, DEVICE_TEST_CASES
 
 
 class TestChronos2Inference:
+    def test_when_chronos2_initialized_then_allow_nan_covariates_is_true(self, tmp_path):
+        model = Chronos2Model(path=str(tmp_path), hyperparameters={"model_path": CHRONOS2_MODEL_PATH})
+        assert model._get_tags()["allow_nan_covariates"] is True
+        assert model._get_tags()["allow_nan"] is True
+
     @pytest.fixture()
     def chronos2_model(self, tmp_path_factory):
         return Chronos2Model(

--- a/timeseries/tests/unittests/models/test_abstract.py
+++ b/timeseries/tests/unittests/models/test_abstract.py
@@ -108,6 +108,63 @@ def test_when_support_model_covariate_properties_are_accessed_then_their_values_
     assert model.supports_static_features == model.__class__._supports_static_features
 
 
+def test_when_allow_nan_covariates_false_then_preprocess_imputes_real_covariates(temp_model_path):
+    from ..common import get_data_frame_with_covariates
+
+    data = get_data_frame_with_covariates(
+        covariates_real=["known_real", "past_real"],
+        covariates_cat=[],
+    )
+    data.iloc[0:3, data.columns.get_loc("known_real")] = float("nan")
+    data.iloc[5:8, data.columns.get_loc("past_real")] = float("nan")
+    covariate_metadata = CovariateMetadata(
+        known_covariates_real=["known_real"],
+        past_covariates_real=["past_real"],
+    )
+    model = ConcreteTimeSeriesModel(
+        path=temp_model_path,
+        freq=data.freq,
+        covariate_metadata=covariate_metadata,
+    )
+    assert model._get_tags()["allow_nan_covariates"] is False
+
+    model.fit(train_data=data)
+    # Re-introduce NaNs after fit (fit preprocess already filled train_data copy)
+    data_with_nan = data.copy()
+    data_with_nan.iloc[0:3, data_with_nan.columns.get_loc("known_real")] = float("nan")
+    data_with_nan.iloc[5:8, data_with_nan.columns.get_loc("past_real")] = float("nan")
+    data_out, _ = model.preprocess(data_with_nan, is_train=False)
+
+    assert not data_out[["known_real", "past_real"]].isna().any(axis=None)
+    # Copy-safe: original still has NaNs
+    assert data_with_nan[["known_real", "past_real"]].isna().any(axis=None)
+
+
+def test_when_allow_nan_covariates_true_then_preprocess_preserves_real_nan(temp_model_path):
+    from ..common import get_data_frame_with_covariates
+
+    class NanCovariateModel(ConcreteTimeSeriesModel):
+        def _more_tags(self):
+            return {**super()._more_tags(), "allow_nan_covariates": True}
+
+    data = get_data_frame_with_covariates(covariates_real=["known_real", "past_real"])
+    data.iloc[0:3, data.columns.get_loc("known_real")] = float("nan")
+    covariate_metadata = CovariateMetadata(
+        known_covariates_real=["known_real"],
+        past_covariates_real=["past_real"],
+    )
+    model = NanCovariateModel(
+        path=temp_model_path,
+        freq=data.freq,
+        covariate_metadata=covariate_metadata,
+    )
+    model.fit(train_data=data)
+    data_with_nan = data.copy()
+    data_with_nan.iloc[0:3, data_with_nan.columns.get_loc("known_real")] = float("nan")
+    data_out, _ = model.preprocess(data_with_nan, is_train=False)
+    assert data_out["known_real"].isna().any()
+
+
 def test_when_model_is_initialized_with_ag_args_fit_then_they_are_included_in_get_params(train_data, temp_model_path):
     model = ConcreteTimeSeriesModel(
         path=temp_model_path,

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -31,6 +31,7 @@ TESTABLE_PREDICTION_LENGTHS = [1, 5]
 class TestAllModelsInitialization:
     EXPECTED_MODEL_TAGS = [
         "allow_nan",
+        "allow_nan_covariates",
         "can_refit_full",
         "can_use_train_data",
         "can_use_val_data",

--- a/timeseries/tests/unittests/test_learner.py
+++ b/timeseries/tests/unittests/test_learner.py
@@ -385,7 +385,13 @@ def test_when_train_data_has_static_or_dynamic_feat_then_leaderboard_works(
     assert ("score_test" in leaderboard.columns) == pred_data_present
 
 
-def test_when_features_are_all_nan_and_learner_is_loaded_then_mode_or_median_are_imputed(temp_model_path):
+def test_when_features_are_all_nan_and_learner_is_loaded_then_cats_and_static_are_imputed_reals_preserved(
+    temp_model_path,
+):
+    """Learner-level feature generator fills categorical and static features; real dynamic covariates keep NaNs.
+
+    Real covariate imputation is delegated to each model (see allow_nan_covariates tag).
+    """
     covariates_cat = ["known_cat", "past_cat"]
     covariates_real = ["known_real", "past_real"]
     data = get_data_frame_with_covariates(
@@ -419,9 +425,9 @@ def test_when_features_are_all_nan_and_learner_is_loaded_then_mode_or_median_are
     with mock.patch("autogluon.timeseries.trainer.TimeSeriesTrainer.predict") as trainer_predict:
         loaded_learner.predict(data_with_nan, known_covariates=known_covariates_with_nan)
         trainer_predict_call_args = trainer_predict.call_args[1]
-        imputed_data = trainer_predict_call_args["data"]
-        imputed_known_covariates = trainer_predict_call_args["known_covariates"]
-        imputed_static = imputed_data.static_features
+        transformed_data = trainer_predict_call_args["data"]
+        transformed_known_covariates = trainer_predict_call_args["known_covariates"]
+        transformed_static = transformed_data.static_features
 
     def get_mode(series: pd.Series):
         # series.mode() can result in ties. We copy tiebreaking logic from CategoryFeatureGenerator
@@ -429,15 +435,15 @@ def test_when_features_are_all_nan_and_learner_is_loaded_then_mode_or_median_are
 
     for col in covariates_cat:
         column_mode_train = get_mode(data_transformed[col])
-        assert (imputed_data[col] == column_mode_train).all()
+        assert (transformed_data[col] == column_mode_train).all()
         if col in known_covariates_names:
-            assert (imputed_known_covariates[col] == column_mode_train).all()
+            assert (transformed_known_covariates[col] == column_mode_train).all()
 
+    # Real dynamic covariates are left as NaN at the learner boundary
     for col in covariates_real:
-        column_median_train = data_transformed[col].median()
-        assert np.allclose(imputed_data[col], column_median_train)
+        assert transformed_data[col].isna().all()
         if col in known_covariates_names:
-            assert np.allclose(imputed_known_covariates[col], column_median_train)
+            assert transformed_known_covariates[col].isna().all()
 
-    assert (imputed_static["static_cat"] == get_mode(data_transformed.static_features["static_cat"])).all()
-    assert np.allclose(imputed_static["static_real"], data_transformed.static_features["static_real"].median())
+    assert (transformed_static["static_cat"] == get_mode(data_transformed.static_features["static_cat"])).all()
+    assert np.allclose(transformed_static["static_real"], data_transformed.static_features["static_real"].median())

--- a/timeseries/tests/unittests/utils/test_features.py
+++ b/timeseries/tests/unittests/utils/test_features.py
@@ -169,7 +169,9 @@ def test_when_covariates_contain_missing_values_then_cats_filled_and_real_nans_p
         assert known_covariates_transformed is None
     else:
         known_cat = [c for c in known_covariates_names if c in feat_generator.covariate_metadata.known_covariates_cat]
-        known_real = [c for c in known_covariates_names if c in feat_generator.covariate_metadata.known_covariates_real]
+        known_real = [
+            c for c in known_covariates_names if c in feat_generator.covariate_metadata.known_covariates_real
+        ]
         if known_cat:
             assert not known_covariates_transformed[known_cat].isna().any(axis=None)
         if known_real:

--- a/timeseries/tests/unittests/utils/test_features.py
+++ b/timeseries/tests/unittests/utils/test_features.py
@@ -137,9 +137,10 @@ def test_when_known_covariates_have_non_numeric_non_cat_dtypes_then_they_can_be_
 
 @pytest.mark.parametrize("use_fit_transform", [True, False])
 @pytest.mark.parametrize("known_covariates_names", [[], ["real_1", "cat_1"], ["real_1", "real_2", "cat_1", "cat_2"]])
-def test_when_covariates_contain_missing_values_then_they_are_filled_during_transform(
+def test_when_covariates_contain_missing_values_then_cats_filled_and_real_nans_preserved(
     known_covariates_names, use_fit_transform
 ):
+    """Categorical covariates are mode-filled; real dynamic covariates keep NaNs for model-side handling."""
     prediction_length = 5
     data_full = get_data_frame_with_covariates(covariates_cat=["cat_1", "cat_2"], covariates_real=["real_1", "real_2"])
     data_full.iloc[[0, 1, 8, 9, 10, 12, 15, -2, -1]] = float("nan")
@@ -153,14 +154,60 @@ def test_when_covariates_contain_missing_values_then_they_are_filled_during_tran
     else:
         feat_generator.fit(data)
         data_transformed = feat_generator.transform(data)
-    assert not data_transformed[feat_generator.covariate_metadata.covariates].isna().any(axis=None)
+
+    cat_cols = feat_generator.covariate_metadata.covariates_cat
+    real_cols = feat_generator.covariate_metadata.covariates_real
+    if cat_cols:
+        assert not data_transformed[cat_cols].isna().any(axis=None)
+    # Real dynamic covariates must keep missing values so models can impute or mask them
+    if real_cols:
+        assert data_transformed[real_cols].isna().any(axis=None)
     assert data_transformed["target"].isna().any()
 
     known_covariates_transformed = feat_generator.transform_future_known_covariates(known_covariates)
     if known_covariates_names == []:
         assert known_covariates_transformed is None
     else:
-        assert not known_covariates_transformed[known_covariates_names].isna().any(axis=None)
+        known_cat = [c for c in known_covariates_names if c in feat_generator.covariate_metadata.known_covariates_cat]
+        known_real = [c for c in known_covariates_names if c in feat_generator.covariate_metadata.known_covariates_real]
+        if known_cat:
+            assert not known_covariates_transformed[known_cat].isna().any(axis=None)
+        if known_real:
+            assert known_covariates_transformed[known_real].isna().any(axis=None)
+
+
+@pytest.mark.parametrize("use_fit_transform", [True, False])
+@pytest.mark.parametrize("known_covariates_names", [[], ["real_1", "cat_1"], ["real_1", "real_2", "cat_1", "cat_2"]])
+def test_when_impute_real_covariates_called_then_real_nans_are_filled(known_covariates_names, use_fit_transform):
+    prediction_length = 5
+    data_full = get_data_frame_with_covariates(covariates_cat=["cat_1", "cat_2"], covariates_real=["real_1", "real_2"])
+    data_full.iloc[[0, 1, 8, 9, 10, 12, 15, -2, -1]] = float("nan")
+    data_full.loc[data_full.item_ids[1]] = float("nan")
+
+    data, known_covariates = data_full.get_model_inputs_for_scoring(prediction_length, known_covariates_names)
+    feat_generator = TimeSeriesFeatureGenerator(target="target", known_covariates_names=known_covariates_names)
+
+    if use_fit_transform:
+        data_transformed = feat_generator.fit_transform(data)
+    else:
+        feat_generator.fit(data)
+        data_transformed = feat_generator.transform(data)
+
+    data_imputed = feat_generator.impute_real_covariates(data_transformed)
+    real_cols = feat_generator.covariate_metadata.covariates_real
+    if real_cols:
+        assert not data_imputed[real_cols].isna().any(axis=None)
+        # Copy-safe: original transformed frame still has NaNs
+        assert data_transformed[real_cols].isna().any(axis=None)
+
+    if known_covariates_names:
+        known_covariates_transformed = feat_generator.transform_future_known_covariates(known_covariates)
+        known_real = feat_generator.covariate_metadata.known_covariates_real
+        if known_real:
+            known_imputed = feat_generator.impute_real_covariates(
+                known_covariates_transformed, column_names=known_real
+            )
+            assert not known_imputed[known_real].isna().any(axis=None)
 
 
 @pytest.mark.parametrize("use_fit_transform", [True, False])


### PR DESCRIPTION
*Issue #, if available:* fixes #5825

## Description

Covariate counterpart of #3995 (native missing values in the **target**). That work left real dynamic covariates always imputed in `TimeSeriesFeatureGenerator`; this PR leaves those NaNs for models to handle, which matters for sparse covariates and for Chronos-2 (native NaN masks).

## Implementation notes

- Stop unconditional ffill/bfill/median imputation of real past/known covariates in `TimeSeriesFeatureGenerator`. Categorical covariates and static features are still filled as before; target NaNs remain model-delegated via `allow_nan`.
- Add model tag `allow_nan_covariates` (default `False`). Models without native NaN-covariate support impute in `fit`/`predict` before covariate scalers/regressors (ffill + bfill + train median; copy-safe so multi-model predict does not mutate a shared frame).
- Chronos-2 sets `allow_nan_covariates=True` so observation masks see true missingness.
- Expose `TimeSeriesFeatureGenerator.impute_real_covariates()` for explicit use of the previous fill policy.
- Local / MLForecast / DirectTabular `preprocess` overrides call `super().preprocess(...)`.
- Update custom-model tutorial contract and unit tests (feature generator, learner boundary, abstract model, Chronos-2 tag).