### PR TITLE
[tabular] Let predict_proba_multi and predict_multi reuse precomputed predictions

### DIFF
--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -421,9 +421,13 @@ class AbstractTabularLearner(AbstractLearner):
         use_refit_parent_oof: bool = True,
         *,
         decision_threshold: float = None,
+        model_pred_probas: dict | None = None,
     ) -> dict:
         """
         Identical to predict_proba_multi, except returns predictions instead of probabilities.
+
+        `model_pred_probas` takes prediction *probabilities* (a prior `predict_proba_multi` output;
+        for regression, predictions), never label predictions: labels cannot seed dependent models.
         """
         predict_proba_dict = self.predict_proba_multi(
             X=X,
@@ -432,6 +436,7 @@ class AbstractTabularLearner(AbstractLearner):
             transform_features=transform_features,
             inverse_transform=inverse_transform,
             use_refit_parent_oof=use_refit_parent_oof,
+            model_pred_probas=model_pred_probas,
         )
         if self.problem_type in [REGRESSION, QUANTILE]:
             return predict_proba_dict

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -282,6 +282,26 @@ class AbstractTabularLearner(AbstractLearner):
                 y_pred_proba = pd.Series(data=y_pred_proba, name=self.label, index=index)
         return y_pred_proba
 
+    def _pre_process_predict_proba(self, y_pred_proba, as_multiclass: bool = True, inverse_transform: bool = True):
+        """
+        Inverse of `_post_process_predict_proba`: convert user-facing prediction probabilities
+        back to AutoGluon's internal format. `as_multiclass` / `inverse_transform` describe the
+        format the input is in (i.e. the settings it was produced with).
+        """
+        if isinstance(y_pred_proba, DataFrame):
+            if self.problem_type == MULTICLASS or (as_multiclass and self.problem_type == BINARY):
+                # Select by class label rather than trusting column order; raises on missing classes.
+                classes = self.class_labels if inverse_transform else self.class_labels_transformed
+                y_pred_proba = y_pred_proba[classes]
+            y_pred_proba = y_pred_proba.to_numpy()
+        elif isinstance(y_pred_proba, Series):
+            y_pred_proba = y_pred_proba.to_numpy()
+        if as_multiclass and self.problem_type == BINARY:
+            y_pred_proba = y_pred_proba[:, 1]
+        if inverse_transform:
+            y_pred_proba = self.label_cleaner.transform_proba(y_pred_proba)
+        return y_pred_proba
+
     def predict_proba_multi(
         self,
         X: DataFrame = None,
@@ -291,6 +311,7 @@ class AbstractTabularLearner(AbstractLearner):
         transform_features: bool = True,
         inverse_transform: bool = True,
         use_refit_parent_oof: bool = True,
+        model_pred_probas: dict | None = None,
     ) -> dict:
         """
         Returns a dictionary of prediction probabilities where the key is
@@ -328,6 +349,12 @@ class AbstractTabularLearner(AbstractLearner):
             If False (advanced), will return prediction probabilities in AutoGluon's internal format.
         use_refit_parent_oof: bool = True
             If True and data is None and returning OOF, will return the parent model's OOF for refit models instead of raising an exception.
+        model_pred_probas : dict, optional
+            Precomputed prediction probabilities keyed by model name, in the format this method returns
+            (i.e. the output of a previous call on the same `X` with the same `as_multiclass` and
+            `inverse_transform` settings). Models present here are not predicted with again; their values
+            are converted back to the internal format and fed to any dependent models (e.g. stackers).
+            Only valid when `X` is provided.
 
         Returns
         -------
@@ -339,9 +366,26 @@ class AbstractTabularLearner(AbstractLearner):
             models = trainer.get_model_names(can_infer=True)
         if X is not None:
             X_index = copy.deepcopy(X.index) if as_pandas else None
+            seed_pred_proba_dict = None
+            if model_pred_probas:
+                seed_pred_proba_dict = {}
+                for m, pred_proba in model_pred_probas.items():
+                    pred_proba_internal = self._pre_process_predict_proba(
+                        pred_proba, as_multiclass=as_multiclass, inverse_transform=inverse_transform
+                    )
+                    if len(pred_proba_internal) != len(X):
+                        raise ValueError(
+                            f"model_pred_probas[{m!r}] has {len(pred_proba_internal)} rows but the data has "
+                            f"{len(X)} rows. Precomputed predictions must come from the same data."
+                        )
+                    seed_pred_proba_dict[m] = pred_proba_internal
             if transform_features:
                 X = self.transform_features(X)
-            predict_proba_dict = trainer.get_model_pred_proba_dict(X=X, models=models)
+            predict_proba_dict = trainer.get_model_pred_proba_dict(
+                X=X, models=models, model_pred_proba_dict=seed_pred_proba_dict
+            )
+        elif model_pred_probas:
+            raise ValueError("model_pred_probas requires X: the OOF / validation-cache paths do not predict.")
         else:
             if trainer.has_val:
                 # Return validation pred proba

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -3345,6 +3345,7 @@ class TabularPredictor:
         as_multiclass: bool = True,
         transform_features: bool = True,
         inverse_transform: bool = True,
+        model_pred_probas: dict | None = None,
     ) -> dict[str, pd.DataFrame] | dict[str, pd.Series] | dict[str, np.ndarray]:
         """
         Returns a dictionary of prediction probabilities where the key is
@@ -3392,6 +3393,20 @@ class TabularPredictor:
         inverse_transform : bool, default = True
             If True, will return prediction probabilities in the original format.
             If False (advanced), will return prediction probabilities in AutoGluon's internal format.
+        model_pred_probas : dict, optional
+            Precomputed prediction probabilities keyed by model name, in the format this method returns
+            (i.e. the output of a previous `predict_proba_multi` call on the same `data` with the same
+            `as_multiclass` and `inverse_transform` settings). Models present here are skipped instead of
+            predicted with again, and their values feed any models that depend on them (e.g. stack ensembles).
+            This makes repeated inference cheap when models are added after an initial prediction pass:
+            ```
+            pred_probas = predictor.predict_proba_multi(data)         # predicts every model once
+            predictor.fit_extra(..., base_model_names=...)            # adds a stacker
+            pred_probas = predictor.predict_proba_multi(data, model_pred_probas=pred_probas)
+            # only the new stacker is predicted with; base model predictions are reused
+            ```
+            Only valid when `data` is provided. The caller is responsible for the values matching `data`;
+            row counts are validated, contents cannot be.
 
         Returns
         -------
@@ -3414,6 +3429,7 @@ class TabularPredictor:
             transform_features=transform_features,
             inverse_transform=inverse_transform,
             use_refit_parent_oof=True,
+            model_pred_probas=model_pred_probas,
         )
 
     @overload

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -3441,6 +3441,7 @@ class TabularPredictor:
         transform_features: bool = True,
         inverse_transform: bool = True,
         decision_threshold: float = None,
+        model_pred_probas: dict | None = None,
     ) -> dict[str, pd.Series]: ...
 
     @overload
@@ -3453,6 +3454,7 @@ class TabularPredictor:
         transform_features: bool = True,
         inverse_transform: bool = True,
         decision_threshold: float = None,
+        model_pred_probas: dict | None = None,
     ) -> dict[str, np.ndarray]: ...
 
     def predict_multi(
@@ -3464,6 +3466,7 @@ class TabularPredictor:
         inverse_transform: bool = True,
         *,
         decision_threshold: float = None,
+        model_pred_probas: dict | None = None,
     ) -> dict[str, pd.Series] | dict[str, np.ndarray]:
         """
         Returns a dictionary of predictions where the key is
@@ -3511,6 +3514,15 @@ class TabularPredictor:
             You can obtain an optimized `decision_threshold` by first calling :meth:`TabularPredictor.calibrate_decision_threshold`.
             Useful to set for metrics such as `balanced_accuracy` and `f1` as `0.5` is often not an optimal threshold.
             Predictions are calculated via the following logic on the positive class: `1 if pred > decision_threshold else 0`
+        model_pred_probas : dict, optional
+            Precomputed prediction *probabilities* keyed by model name: the output of a previous
+            :meth:`TabularPredictor.predict_proba_multi` call on the same `data` (for regression, a previous
+            `predict_multi` output). Models present here are skipped instead of predicted with again, and their
+            values feed any models that depend on them (e.g. stack ensembles). Probabilities are required
+            because label predictions cannot seed dependent models; the predictions returned for seeded models
+            are derived from the provided probabilities (respecting `decision_threshold`).
+            Only valid when `data` is provided. The caller is responsible for the values matching `data`;
+            row counts are validated, contents cannot be.
 
         Returns
         -------
@@ -3528,6 +3540,7 @@ class TabularPredictor:
             transform_features=transform_features,
             inverse_transform=inverse_transform,
             decision_threshold=decision_threshold,
+            model_pred_probas=model_pred_probas,
         )
 
     def fit_summary(self, verbosity: int = 3, show_plot: bool = False) -> dict:

--- a/tabular/tests/unittests/edgecases/test_predict_proba_multi_seed.py
+++ b/tabular/tests/unittests/edgecases/test_predict_proba_multi_seed.py
@@ -1,0 +1,80 @@
+"""Tests for `predict_proba_multi(model_pred_probas=...)`: seeding precomputed predictions."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from autogluon.tabular import TabularPredictor
+
+
+def _fit_bagged_predictor(path, problem_type: str) -> tuple[TabularPredictor, pd.DataFrame]:
+    rng = np.random.default_rng(0)
+    n = 400
+    df = pd.DataFrame({"x1": rng.normal(size=n), "x2": rng.normal(size=n)})
+    if problem_type == "binary":
+        df["label"] = (df["x1"] + rng.normal(scale=0.5, size=n) > 0).astype(int)
+    else:
+        df["label"] = rng.choice(["u", "v", "w"], size=n, p=[0.5, 0.3, 0.2])
+    train, test = df.iloc[:300], df.iloc[300:].drop(columns=["label"])
+    predictor = TabularPredictor(label="label", problem_type=problem_type, path=str(path), verbosity=0).fit(
+        train,
+        hyperparameters={"GBM": {}, "RF": {}},
+        num_bag_folds=2,
+    )
+    return predictor, test
+
+
+@pytest.mark.parametrize("problem_type", ["binary", "multiclass"])
+@pytest.mark.parametrize("as_pandas", [True, False])
+@pytest.mark.parametrize("as_multiclass", [True, False])
+def test_seeded_ensemble_prediction_matches_full(tmp_path, problem_type, as_pandas, as_multiclass):
+    """Seeding base model predictions reproduces the dependent ensemble's predictions exactly."""
+    predictor, test = _fit_bagged_predictor(tmp_path, problem_type)
+    base_models = [m for m in predictor.model_names() if "WeightedEnsemble" not in m]
+    ensemble = next(m for m in predictor.model_names() if "WeightedEnsemble" in m)
+
+    full = predictor.predict_proba_multi(test, as_pandas=as_pandas, as_multiclass=as_multiclass)
+    seeded = predictor.predict_proba_multi(
+        test,
+        models=[ensemble],
+        as_pandas=as_pandas,
+        as_multiclass=as_multiclass,
+        model_pred_probas={m: full[m] for m in base_models},
+    )
+    assert np.allclose(np.asarray(full[ensemble]), np.asarray(seeded[ensemble]))
+
+
+def test_seeds_are_used_not_recomputed(tmp_path):
+    """A corrupted seed must change the dependent ensemble's output."""
+    predictor, test = _fit_bagged_predictor(tmp_path, "multiclass")
+    base_models = [m for m in predictor.model_names() if "WeightedEnsemble" not in m]
+    ensemble = next(m for m in predictor.model_names() if "WeightedEnsemble" in m)
+
+    full = predictor.predict_proba_multi(test)
+    corrupted = {m: full[m] for m in base_models}
+    flipped = full[base_models[0]].iloc[::-1].reset_index(drop=True)
+    flipped.index = full[base_models[0]].index
+    corrupted[base_models[0]] = flipped
+    seeded = predictor.predict_proba_multi(test, models=[ensemble], model_pred_probas=corrupted)
+    assert not np.allclose(full[ensemble].to_numpy(), seeded[ensemble].to_numpy())
+
+
+def test_row_count_mismatch_raises(tmp_path):
+    predictor, test = _fit_bagged_predictor(tmp_path, "multiclass")
+    base_models = [m for m in predictor.model_names() if "WeightedEnsemble" not in m]
+    ensemble = next(m for m in predictor.model_names() if "WeightedEnsemble" in m)
+
+    full = predictor.predict_proba_multi(test)
+    with pytest.raises(ValueError, match="rows"):
+        predictor.predict_proba_multi(
+            test, models=[ensemble], model_pred_probas={base_models[0]: full[base_models[0]].iloc[:10]}
+        )
+
+
+def test_seeding_without_data_raises(tmp_path):
+    predictor, _ = _fit_bagged_predictor(tmp_path, "multiclass")
+    model = predictor.model_names()[0]
+    with pytest.raises(ValueError, match="requires"):
+        predictor.predict_proba_multi(model_pred_probas={model: np.zeros((10, 3))})

--- a/tabular/tests/unittests/edgecases/test_predict_proba_multi_seed.py
+++ b/tabular/tests/unittests/edgecases/test_predict_proba_multi_seed.py
@@ -78,3 +78,49 @@ def test_seeding_without_data_raises(tmp_path):
     model = predictor.model_names()[0]
     with pytest.raises(ValueError, match="requires"):
         predictor.predict_proba_multi(model_pred_probas={model: np.zeros((10, 3))})
+
+
+@pytest.mark.parametrize("problem_type", ["binary", "multiclass"])
+def test_predict_multi_seeded_matches_full(tmp_path, problem_type):
+    """predict_multi seeded with predict_proba_multi output reproduces unseeded predictions."""
+    predictor, test = _fit_bagged_predictor(tmp_path, problem_type)
+    base_models = [m for m in predictor.model_names() if "WeightedEnsemble" not in m]
+
+    pred_probas = predictor.predict_proba_multi(test)
+    full = predictor.predict_multi(test)
+    seeded = predictor.predict_multi(test, model_pred_probas={m: pred_probas[m] for m in base_models})
+    for m in full:
+        assert full[m].equals(seeded[m]), m
+
+
+def test_predict_multi_seeded_respects_decision_threshold(tmp_path):
+    """Seeded models' predictions are derived from the seeds with the requested threshold."""
+    predictor, test = _fit_bagged_predictor(tmp_path, "binary")
+    base_models = [m for m in predictor.model_names() if "WeightedEnsemble" not in m]
+
+    pred_probas = predictor.predict_proba_multi(test)
+    seeds = {m: pred_probas[m] for m in base_models}
+    low = predictor.predict_multi(test, model_pred_probas=seeds, decision_threshold=0.01)
+    high = predictor.predict_multi(test, model_pred_probas=seeds, decision_threshold=0.99)
+    m = base_models[0]
+    assert low[m].mean() > high[m].mean()
+
+
+def test_predict_multi_seeded_regression(tmp_path):
+    """For regression, predict_multi seeds are predictions and pass through unchanged."""
+    rng = np.random.default_rng(0)
+    n = 400
+    df = pd.DataFrame({"x1": rng.normal(size=n), "x2": rng.normal(size=n)})
+    df["label"] = df["x1"] * 2 + rng.normal(scale=0.1, size=n)
+    train, test = df.iloc[:300], df.iloc[300:].drop(columns=["label"])
+    predictor = TabularPredictor(label="label", problem_type="regression", path=str(tmp_path), verbosity=0).fit(
+        train,
+        hyperparameters={"GBM": {}, "RF": {}},
+        num_bag_folds=2,
+    )
+    base_models = [m for m in predictor.model_names() if "WeightedEnsemble" not in m]
+
+    full = predictor.predict_multi(test)
+    seeded = predictor.predict_multi(test, model_pred_probas={m: full[m] for m in base_models})
+    for m in full:
+        assert np.allclose(full[m].to_numpy(), seeded[m].to_numpy()), m


### PR DESCRIPTION
## Description

Adds a `model_pred_probas` parameter to `predict_proba_multi` and `predict_multi`: a dict of precomputed prediction probabilities (a previous `predict_proba_multi` output on the same data). Models present in the dict are skipped instead of predicted with again, and their values feed any dependent models (stack ensembles) through the trainer's existing `model_pred_proba_dict` mechanism.

This makes repeated inference cheap when models are added after an initial prediction pass:

```python
pred_probas = predictor.predict_proba_multi(data)      # predicts every model once
predictor.fit_extra(..., base_model_names=...)         # adds a stacker
pred_probas = predictor.predict_proba_multi(data, model_pred_probas=pred_probas)
# only the new stacker predicts; base model predictions are reused
```

## Implementation notes

- A new learner-level `_pre_process_predict_proba` inverts `_post_process_predict_proba`: column-order-robust class selection (selects by class label, raises on missing classes), binary `as_multiclass` reduction, and `label_cleaner.transform_proba` back to internal format.
- Row counts are validated against the data; seeding without `data` raises (the OOF/val-cache paths do not predict).
- `predict_multi` seeds take *probabilities*, never label predictions (labels cannot feed dependent models); seeded models' returned predictions are derived from the provided probabilities, respecting `decision_threshold`. For regression the seeds are predictions and pass through unchanged.
- 15 tests in `tabular/tests/unittests/edgecases/test_predict_proba_multi_seed.py`: exact-match seeded vs unseeded (binary/multiclass × pandas/numpy × as_multiclass), corrupted-seed sensitivity, row-count and no-data errors, predict_multi parity, decision-threshold behavior, regression passthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi