### PR TITLE
Fix ZeroDivisionError in HPO resource allocation when num_gpus=0

### DIFF
--- a/core/src/autogluon/core/hpo/executors.py
+++ b/core/src/autogluon/core/hpo/executors.py
@@ -118,6 +118,16 @@ class HpoExecutor(ABC):
                 "num_gpus", None
             )
             if user_specified_trial_num_cpus is not None or user_specified_trial_num_gpus is not None:
+                # Validate what the user asked for before deriving the other resource from it:
+                # a request larger than the total makes the trial count 0 further down.
+                if user_specified_trial_num_cpus is not None:
+                    assert user_specified_trial_num_cpus <= num_cpus, (
+                        f"Detected trial level cpu requirement = {user_specified_trial_num_cpus} > total cpu granted to AG predictor = {num_cpus}"
+                    )
+                if user_specified_trial_num_gpus is not None:
+                    assert user_specified_trial_num_gpus <= num_gpus, (
+                        f"Detected trial level gpu requirement = {user_specified_trial_num_gpus} > total gpu granted to AG predictor = {num_gpus}"
+                    )
                 num_trials_in_parallel_with_gpu = math.inf
                 if user_specified_trial_num_cpus is None:
                     # If user didn't specify cpu per trial, we find the min based on gpu.
@@ -143,14 +153,8 @@ class HpoExecutor(ABC):
                         )  # keep gpus per trial int to avoid complexity
                     else:
                         user_specified_trial_num_gpus = num_gpus
-                assert user_specified_trial_num_cpus <= num_cpus, (
-                    f"Detected trial level cpu requirement = {user_specified_trial_num_cpus} > total cpu granted to AG predictor = {num_cpus}"
-                )
                 assert user_specified_trial_num_cpus >= minimum_model_num_cpus, (
                     f"The trial requires minimum cpu {minimum_model_num_cpus}, but you only specified {user_specified_trial_num_cpus}"
-                )
-                assert user_specified_trial_num_gpus <= num_gpus, (
-                    f"Detected trial level gpu requirement = {user_specified_trial_num_gpus} > total gpu granted to AG predictor = {num_gpus}"
                 )
                 assert user_specified_trial_num_gpus >= minimum_model_num_gpus, (
                     f"The trial requires minimum gpu {minimum_model_num_gpus}, but you only specified {user_specified_trial_num_gpus}"

--- a/core/src/autogluon/core/hpo/executors.py
+++ b/core/src/autogluon/core/hpo/executors.py
@@ -120,18 +120,29 @@ class HpoExecutor(ABC):
             if user_specified_trial_num_cpus is not None or user_specified_trial_num_gpus is not None:
                 num_trials_in_parallel_with_gpu = math.inf
                 if user_specified_trial_num_cpus is None:
-                    # If user didn't specify cpu per trial, we find the min based on gpu
-                    num_trials_in_parallel_with_gpu = num_gpus // user_specified_trial_num_gpus
-                    user_specified_trial_num_cpus = (
-                        num_cpus // num_trials_in_parallel_with_gpu
-                    )  # keep gpus per trial int to avoid complexity
+                    # If user didn't specify cpu per trial, we find the min based on gpu.
+                    # A user-specified gpu-per-trial of 0 places no constraint on trial
+                    # parallelism, so keep num_trials_in_parallel_with_gpu unbounded
+                    # instead of dividing by zero, and let the trial use all cpus.
+                    if user_specified_trial_num_gpus:
+                        num_trials_in_parallel_with_gpu = num_gpus // user_specified_trial_num_gpus
+                        user_specified_trial_num_cpus = (
+                            num_cpus // num_trials_in_parallel_with_gpu
+                        )  # keep gpus per trial int to avoid complexity
+                    else:
+                        user_specified_trial_num_cpus = num_cpus
                 num_trials_in_parallel_with_cpu = math.inf
                 if user_specified_trial_num_gpus is None:
-                    # If user didn't specify gpu per trial, we find the min based on cpu
-                    num_trials_in_parallel_with_cpu = num_cpus // user_specified_trial_num_cpus
-                    user_specified_trial_num_gpus = (
-                        num_gpus // num_trials_in_parallel_with_cpu
-                    )  # keep gpus per trial int to avoid complexity
+                    # If user didn't specify gpu per trial, we find the min based on cpu.
+                    # Symmetric guard: a user-specified cpu-per-trial of 0 must not raise
+                    # ZeroDivisionError either.
+                    if user_specified_trial_num_cpus:
+                        num_trials_in_parallel_with_cpu = num_cpus // user_specified_trial_num_cpus
+                        user_specified_trial_num_gpus = (
+                            num_gpus // num_trials_in_parallel_with_cpu
+                        )  # keep gpus per trial int to avoid complexity
+                    else:
+                        user_specified_trial_num_gpus = num_gpus
                 assert user_specified_trial_num_cpus <= num_cpus, (
                     f"Detected trial level cpu requirement = {user_specified_trial_num_cpus} > total cpu granted to AG predictor = {num_cpus}"
                 )

--- a/tabular/tests/unittests/resource_allocation/test_hpo_resource_allocation.py
+++ b/tabular/tests/unittests/resource_allocation/test_hpo_resource_allocation.py
@@ -258,6 +258,46 @@ def test_hpo_without_bagging_valid_resources_per_trial(mock_system_resources_ctx
 
 
 @pytest.mark.parametrize("executor_cls", [RayHpoExecutor, CustomHpoExecutor])
+def test_hpo_without_bagging_zero_gpus_per_trial_no_cpus_specified(mock_system_resources_ctx_mgr, executor_cls):
+    """Regression test for a ZeroDivisionError: specifying only `num_gpus: 0` in
+    `ag_args_fit` (a common way to pin a model to CPU, e.g. to keep it off the GPU
+    while other models use it) used to crash `register_resources`, which
+    unconditionally computed `num_gpus // user_specified_trial_num_gpus` when cpus
+    per trial weren't specified. A gpu-per-trial request of 0 places no constraint
+    on parallelism, so the fix gives the trial all available cpus instead.
+    """
+    hyperparameter_tune_kwargs = {"scheduler": "local", "searcher": "random", "num_trials": 4}
+    executor = _initialize_executor(executor_cls, hyperparameter_tune_kwargs)
+    total_resources = {"num_cpus": 8, "num_gpus": 1}
+    with mock_system_resources_ctx_mgr(num_cpus=total_resources["num_cpus"], num_gpus=total_resources["num_gpus"]):
+        model = DummyModel(
+            minimum_resources={"num_cpus": 1, "num_gpus": 0},
+            hyperparameters={"ag_args_fit": {"num_gpus": 0}},
+        )
+        model.initialize()
+        executor.register_resources(model, X=dummy_x, **total_resources)
+        assert executor.hyperparameter_tune_kwargs["resources_per_trial"] == {"num_cpus": 8, "num_gpus": 0}
+
+
+@pytest.mark.parametrize("executor_cls", [RayHpoExecutor, CustomHpoExecutor])
+def test_hpo_without_bagging_zero_cpus_per_trial_no_gpus_specified(mock_system_resources_ctx_mgr, executor_cls):
+    """Symmetric regression test for the `num_cpus: 0`-only case, which hit the same
+    ZeroDivisionError pattern on the other branch of `register_resources`.
+    """
+    hyperparameter_tune_kwargs = {"scheduler": "local", "searcher": "random", "num_trials": 4}
+    executor = _initialize_executor(executor_cls, hyperparameter_tune_kwargs)
+    total_resources = {"num_cpus": 8, "num_gpus": 2}
+    with mock_system_resources_ctx_mgr(num_cpus=total_resources["num_cpus"], num_gpus=total_resources["num_gpus"]):
+        model = DummyModel(
+            minimum_resources={"num_cpus": 0, "num_gpus": 0.1},
+            hyperparameters={"ag_args_fit": {"num_cpus": 0}},
+        )
+        model.initialize()
+        executor.register_resources(model, X=dummy_x, **total_resources)
+        assert executor.hyperparameter_tune_kwargs["resources_per_trial"] == {"num_cpus": 0, "num_gpus": 2}
+
+
+@pytest.mark.parametrize("executor_cls", [RayHpoExecutor, CustomHpoExecutor])
 def test_hpo_without_bagging_no_resources_per_trial(mock_system_resources_ctx_mgr, executor_cls):
     hyperparameter_tune_kwargs = {"scheduler": "local", "searcher": "random", "num_trials": 4}
     executor = _initialize_executor(executor_cls, hyperparameter_tune_kwargs)

--- a/tabular/tests/unittests/resource_allocation/test_hpo_resource_allocation.py
+++ b/tabular/tests/unittests/resource_allocation/test_hpo_resource_allocation.py
@@ -298,6 +298,42 @@ def test_hpo_without_bagging_zero_cpus_per_trial_no_gpus_specified(mock_system_r
 
 
 @pytest.mark.parametrize("executor_cls", [RayHpoExecutor, CustomHpoExecutor])
+def test_hpo_without_bagging_more_cpus_per_trial_than_total(mock_system_resources_ctx_mgr, executor_cls):
+    """Requesting more cpus per trial than the predictor was granted reports what is wrong.
+
+    The requested value is validated before the unspecified gpu count is derived from it,
+    which would otherwise divide by a trial count of `num_cpus // 100 == 0`.
+    """
+    hyperparameter_tune_kwargs = {"scheduler": "local", "searcher": "random", "num_trials": 4}
+    executor = _initialize_executor(executor_cls, hyperparameter_tune_kwargs)
+    total_resources = {"num_cpus": 8, "num_gpus": 2}
+    with mock_system_resources_ctx_mgr(num_cpus=total_resources["num_cpus"], num_gpus=total_resources["num_gpus"]):
+        model = DummyModel(
+            minimum_resources={"num_cpus": 1, "num_gpus": 0},
+            hyperparameters={"ag_args_fit": {"num_cpus": 100}},
+        )
+        model.initialize()
+        with pytest.raises(AssertionError, match="Detected trial level cpu requirement = 100"):
+            executor.register_resources(model, X=dummy_x, **total_resources)
+
+
+@pytest.mark.parametrize("executor_cls", [RayHpoExecutor, CustomHpoExecutor])
+def test_hpo_without_bagging_more_gpus_per_trial_than_total(mock_system_resources_ctx_mgr, executor_cls):
+    """Requesting gpus per trial on a predictor granted no gpus reports what is wrong."""
+    hyperparameter_tune_kwargs = {"scheduler": "local", "searcher": "random", "num_trials": 4}
+    executor = _initialize_executor(executor_cls, hyperparameter_tune_kwargs)
+    total_resources = {"num_cpus": 8, "num_gpus": 0}
+    with mock_system_resources_ctx_mgr(num_cpus=total_resources["num_cpus"], num_gpus=total_resources["num_gpus"]):
+        model = DummyModel(
+            minimum_resources={"num_cpus": 1, "num_gpus": 0},
+            hyperparameters={"ag_args_fit": {"num_gpus": 1}},
+        )
+        model.initialize()
+        with pytest.raises(AssertionError, match="Detected trial level gpu requirement = 1"):
+            executor.register_resources(model, X=dummy_x, **total_resources)
+
+
+@pytest.mark.parametrize("executor_cls", [RayHpoExecutor, CustomHpoExecutor])
 def test_hpo_without_bagging_no_resources_per_trial(mock_system_resources_ctx_mgr, executor_cls):
     hyperparameter_tune_kwargs = {"scheduler": "local", "searcher": "random", "num_trials": 4}
     executor = _initialize_executor(executor_cls, hyperparameter_tune_kwargs)


### PR DESCRIPTION
`HpoExecutor.register_resources()` divides `num_gpus // user_specified_trial_num_gpus` without checking for zero. Setting `ag_args_fit={"num_gpus": 0}` crashes with `ZeroDivisionError`.

This is the trial-level counterpart to #4384, which fixed the same issue in the per-fold block further down. That fix didn't cover this block, which runs for every model regardless of bagging.

Fix: when the unspecified resource would divide by zero, skip the division and give the trial all of that resource instead. Symmetric for `num_cpus=0`.

Repro:
```python
from autogluon.tabular import TabularPredictor
TabularPredictor(label="class").fit(
    train_data=train_data,
    hyperparameters={"CAT": {"ag_args_fit": {"num_gpus": 0}}},
    hyperparameter_tune_kwargs="auto",
)
```

Adds two regression tests to `test_hpo_resource_allocation.py`, parametrized over both executors like their neighbors.
