### PR TITLE
fix: Remove unsupported force_int_remainder_cols from ColumnTransformer (closes #5289)

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabular_nn/utils/data_preprocessor.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/utils/data_preprocessor.py
@@ -49,20 +49,12 @@ def create_preprocessor(
             steps=[("ordinal", OrdinalMergeRaresHandleUnknownEncoder(max_levels=max_category_levels))]
         )  # returns 0-n when max_category_levels = n-1. category n is reserved for unknown test-time categories.
         transformers.append(("ordinal", ordinal_transformer, embed_features))
-    try:
-        out = ColumnTransformer(
-            transformers=transformers,
-            remainder="passthrough",
-            force_int_remainder_cols=False,
-        )  # numeric features are processed in the same order as in numeric_features vector, so feature-names remain the same.
-    except:
-        # TODO: Avoid try/except once scikit-learn 1.5 is minimum
-        # Needed for scikit-learn 1.4 and 1.9+, force_int_remainder_cols is deprecated in 1.7 and introduced in 1.5
-        # ref: https://github.com/autogluon/autogluon/issues/5289
-        out = ColumnTransformer(
-            transformers=transformers,
-            remainder="passthrough",
-        )  # numeric features are processed in the same order as in numeric_features vector, so feature-names remain the same.
+    # ColumnTransformer does not accept force_int_remainder_cols in all supported scikit-learn versions.
+    # We omit it to maintain compatibility; the default behavior (keep numeric remainder columns as numeric) is what we want.
+    out = ColumnTransformer(
+        transformers=transformers,
+        remainder="passthrough",
+    )  # numeric features are processed in the same order as in numeric_features vector, so feature-names remain the same.
     return out
 
 


### PR DESCRIPTION
## What
The TabularNeuralNetTorch training failed with `TypeError` because `create_preprocessor` passed the `force_int_remainder_cols` parameter to `ColumnTransformer` in scikit-learn. This parameter is not supported in all versions (introduced in 1.5, deprecated in 1.7, and removed in 1.9+). The try/except fallback was intended to handle compatibility but still introduced complexity and potential silent failures.

## Fix
The fix simply removes the unsupported parameter and always uses the default behavior. The remainder column dtype behavior is unchanged (numeric columns remain numeric), and compatibility is restored across all supported scikit-learn versions.

Closes #5289
