### PR TITLE
[ci] Gate fork PR CI behind maintainer approval

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -34,8 +34,17 @@ jobs:
         run: |
           echo This is a restricted branch reserved for certain modules. Please use another branch instead
           exit 1
-  lint_check:
+  approval_gate:
+    # Gate CI for external fork PRs behind maintainer approval. Non-fork events
+    # get an empty environment string, so pushes and in-repo PRs are not gated.
     needs: branch_check
+    runs-on: ubuntu-latest
+    environment: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork) && 'integration-tests' || '' }}
+    steps:
+      - name: Approved
+        run: echo "Approved - running CI"
+  lint_check:
+    needs: approval_gate
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Adds an `approval_gate` job so that CI for pull requests from forks runs after a maintainer approves it. `lint_check` and the rest of the job graph now depend on this gate.

The gate is attached via a GitHub Environment only for fork PRs:

```yaml
environment: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork) && 'integration-tests' || '' }}
```

Pushes and in-repo pull requests get an empty environment string and run as before.

Setup: the `integration-tests` environment (with required reviewers) should be created in repo Settings → Environments before this is merged.
