### PR TITLE
[docs] Add v1.6.0 to What's New index

### DIFF
--- a/docs/whats_new/index.md
+++ b/docs/whats_new/index.md
@@ -6,6 +6,7 @@ Here you can find the release notes for current and past releases of AutoGluon.
 :hidden: true
 :maxdepth: 1
 
+v1.6.0
 v1.5.0
 v1.4.0
 v1.3.1
@@ -30,8 +31,15 @@ v0.4.1
 v0.4.0
 ```
 
-:::{dropdown} v1.5.0
+:::{dropdown} v1.6.0
 :open:
+
+```{include} v1.6.0.md
+```
+
+:::
+
+:::{dropdown} v1.5.0
 
 ```{include} v1.5.0.md
 ```


### PR DESCRIPTION
Adds the v1.6.0 release notes to the What's New index page so they render on the docs site.

Fixes #5839