### PR TITLE
[tabular] Fix TypeError in get_model_best for refit_full models

### DIFF
--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -1942,6 +1942,8 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
                 raise AssertionError(
                     "No fit models that can infer exist with a validation score to choose the best model, but refit_full models exist. Set `allow_full=True` to get the best refit_full model."
                 )
+        # refit_full models have val_score=None and often predict_time=None
+        perfs = [(m, -np.inf if s is None else s, np.inf if t is None else t) for m, s, t in perfs]
         return max(perfs, key=lambda i: (i[1], -i[2]))[0]
 
     def save_model(self, model, reduce_memory=True):

--- a/tabular/tests/unittests/models/advanced/test_refit_full.py
+++ b/tabular/tests/unittests/models/advanced/test_refit_full.py
@@ -79,3 +79,65 @@ def test_refit_full_train_data_extra_bag():
     predictor.predict(test_data, model=refit_model_name)
 
     shutil.rmtree(predictor.path, ignore_errors=True)
+
+
+def _fit_bagged_dummy_with_refit_full() -> TabularPredictor:
+    fit_args = dict(
+        hyperparameters={"DUMMY": {}},
+        num_bag_folds=2,
+        num_bag_sets=1,
+        ag_args_ensemble={"fold_fitting_strategy": "sequential_local"},
+    )
+    return FitHelper.fit_and_validate_dataset(
+        dataset_name="toy_binary",
+        fit_args=fit_args,
+        expected_model_count=2,
+        refit_full=True,
+        delete_directory=False,
+    )
+
+
+def _simulate_refit_without_predict_time(predictor: TabularPredictor) -> None:
+    """Dummy refit_full clones the parent and copies predict_time; real refits leave it None."""
+    for full_model in predictor.model_refit_map().values():
+        predictor._trainer._update_model_attr(full_model, predict_time=None)
+    predictor._trainer.save()
+
+
+def test_get_model_best_when_only_refit_full_models_remain():
+    """get_model_best() must work when only `_FULL` models remain (issue #5552)."""
+    predictor = _fit_bagged_dummy_with_refit_full()
+    _, test_data, _ = FitHelper.load_dataset(name="toy_binary")
+    _simulate_refit_without_predict_time(predictor)
+
+    full_models = list(predictor.model_refit_map().values())
+    assert full_models
+    for full_model in full_models:
+        assert predictor._trainer.get_model_attribute(full_model, "val_score") is None
+        assert predictor._trainer.get_model_attribute_full(full_model, "predict_time") is None
+
+    predictor.delete_models(models_to_keep=full_models, dry_run=False)
+    assert set(predictor.model_names()) == set(full_models)
+    assert predictor._trainer.get_model_best() in full_models
+    predictor.predict(test_data)
+    shutil.rmtree(predictor.path, ignore_errors=True)
+
+
+def test_clone_for_deployment_non_best_refit_full_model():
+    """clone_for_deployment of a non-best `_FULL` model (issue #5552)."""
+    predictor = _fit_bagged_dummy_with_refit_full()
+    _, test_data, _ = FitHelper.load_dataset(name="toy_binary")
+    _simulate_refit_without_predict_time(predictor)
+
+    refit_map = predictor.model_refit_map()
+    assert len(refit_map) >= 2
+    non_best_full = next(full for full in refit_map.values() if full != predictor.model_best)
+    assert predictor._trainer.get_model_attribute(non_best_full, "val_score") is None
+    assert predictor._trainer.get_model_attribute_full(non_best_full, "predict_time") is None
+
+    clone_path = predictor.path + "_clone_for_deployment_full"
+    clone = predictor.clone_for_deployment(path=clone_path, model=non_best_full, return_clone=True)
+    assert clone.model_best == non_best_full
+    clone.predict(test_data)
+    shutil.rmtree(predictor.path, ignore_errors=True)
+    shutil.rmtree(clone_path, ignore_errors=True)


### PR DESCRIPTION
*Issue #, if available:*

Fixes #5552

*Description of changes:*

`clone_for_deployment(model="<non-best>_*_FULL")` after `refit_full()` crashes with:

```
TypeError: bad operand type for unary -: 'NoneType'
```

in `get_model_best`:

```python
return max(perfs, key=lambda i: (i[1], -i[2]))[0]
```

`delete_models` calls `get_model_best()` after the previous `model_best` is removed. Only `_FULL` models remain. Those have `val_score=None` (trained on all data) and usually `predict_time=None` (never timed on holdout), so the sort does `-None`.

Cloning a bagged parent works because those models have numeric scores/times. Cloning `model="best"` after `refit_full()` often works too, because that `_FULL` model is already `model_best` and is kept.

This fills missing score/time with `-inf` / `inf` so the existing `(score, -time)` sort stays numeric. Same path also covers a direct `delete_models(models_to_keep=...)` that leaves only `_FULL` models.

Tests (Dummy + bagging, `FitHelper`, toy data):
- `get_model_best()` after only `_FULL` models remain
- `clone_for_deployment` of a non-best `_FULL` model

Dummy `refit_full` clones the parent and copies `predict_time`, so the tests zero it to match models that actually refit (e.g. XGBoost, the original report).