### PR TITLE
fix: don't crash on pd.NA in get_bool_true_val

### DIFF
--- a/common/src/autogluon/common/features/infer_types.py
+++ b/common/src/autogluon/common/features/infer_types.py
@@ -177,14 +177,16 @@ def get_bool_true_val(uniques):
     except (ValueError, TypeError):
         pass
     replace_val = uniques[1]
+    # This is to ensure that we don't map a missing value to `True` in the boolean.
+    # `pd.isna` is used instead of `np.isnan` because it handles np.nan, None and pd.NA uniformly and
+    # always returns a real bool. `np.isnan(pd.NA)` returns pd.NA rather than raising, so it was not
+    # caught by the except clause and the following `if is_nan:` raised
+    # "TypeError: boolean value of NA is ambiguous" for pandas nullable dtypes.
     try:
-        # This is to ensure that we don't map np.nan to `True` in the boolean.
-        is_nan = np.isnan(replace_val)
+        is_nan = bool(pd.isna(replace_val))
     except (ValueError, TypeError):
-        if replace_val is None:
-            is_nan = True
-        else:
-            is_nan = False
+        # Non-scalar unique value, for which pd.isna would return an array.
+        is_nan = replace_val is None
     if is_nan:
         replace_val = uniques[0]
     return replace_val

--- a/common/tests/unittests/test_infer_types.py
+++ b/common/tests/unittests/test_infer_types.py
@@ -35,3 +35,24 @@ def test_when_pandas_categorical_then_no_attribute_error(series):
     uniques = series.unique()
     result = get_bool_true_val(uniques)
     assert result in list(series.unique())
+
+
+@pytest.mark.parametrize(
+    "series,expected",
+    [
+        (pd.Series(["yes", None], dtype="string"), "yes"),
+        (pd.Series([True, None], dtype="boolean"), True),
+        (pd.Series([1, None], dtype="Int64"), 1),
+        (pd.Series([1.5, None], dtype="Float64"), 1.5),
+    ],
+)
+def test_when_nullable_dtype_with_pd_na_then_na_not_chosen_as_true(series, expected):
+    """Regression test: pd.NA must not be chosen as the True value, and must not raise.
+
+    np.isnan(pd.NA) returns pd.NA instead of raising, so `if is_nan:` raised
+    "TypeError: boolean value of NA is ambiguous" for any nullable-dtype column whose two unique
+    values include pd.NA (e.g. a `string` column holding one value plus nulls).
+    """
+    uniques = series.unique()
+    assert len(uniques) == 2
+    assert get_bool_true_val(uniques) == expected


### PR DESCRIPTION
## Issue

`get_bool_true_val` guards against mapping a missing value to `True` using `np.isnan(replace_val)`. For pandas **nullable** dtypes that guard misfires in an unusual way: `np.isnan(pd.NA)` *returns* `pd.NA` instead of raising, so it is not caught by the surrounding `except (ValueError, TypeError)`, and the next line — `if is_nan:` — raises

```
TypeError: boolean value of NA is ambiguous
```

`AsTypeFeatureGenerator` bool-encodes any column with exactly two unique values, so this is reached during `fit_transform` by any nullable-dtype column whose two uniques include a null. The most common shape is a pandas `string` column holding one real value plus nulls, where `series.unique()` is `['value', <NA>]`.

An `object` column is unaffected, because `np.isnan(np.nan)` is a real `True` — so the failure only appears once a frame uses the nullable dtypes.

### Reproduction

```python
import pandas as pd
from autogluon.features.generators import AutoMLPipelineFeatureGenerator

X = pd.DataFrame({"num": [1.0, 2.0, 3.0, 4.0]})
X["flag"] = pd.array(["ONLY", "ONLY", None, None], dtype="string")   # uniques == ['ONLY', <NA>]
y = pd.Series([0, 1, 0, 1])

AutoMLPipelineFeatureGenerator().fit_transform(X, y)
# TypeError: boolean value of NA is ambiguous
```

Traceback tail:

```
  File "autogluon/features/generators/astype.py", line 116, in _fit_transform
    feature_bool_val = get_bool_true_val(uniques=uniques)
  File "autogluon/common/features/infer_types.py", line 188, in get_bool_true_val
    if is_nan:
  File "pandas/_libs/missing.pyx", line 392, in pandas._libs.missing.NAType.__bool__
TypeError: boolean value of NA is ambiguous
```

Where that branch happens to be passed, the subsequent `(X[col] == true_val).astype(np.int8)` raises `ValueError: cannot convert NA to integer` on the masked comparison instead — same trigger, different exit.

This was found while running AutoGluon feature preprocessing over ~273 real wide tables; any mostly-empty text column with a single distinct value crashed the whole `fit_transform`.

## Fix

Use `pd.isna`, which handles `np.nan`, `None` and `pd.NA` uniformly and always returns a real bool. The `except` clause is kept for a non-scalar unique value, where `pd.isna` would return an array.

## Tests

Added `test_when_nullable_dtype_with_pd_na_then_na_not_chosen_as_true` to `common/tests/unittests/test_infer_types.py`, parametrised over `string`, `boolean`, `Int64` and `Float64`.

Verified against the unpatched function: the `string` and `boolean` cases fail with the exact `TypeError` above, and all 11 tests in the file pass with the fix. Existing behaviour for `object`/numpy dtypes and for real (non-null) values is unchanged.