### PR TITLE
[core] Keep a zero resource request from changing HPO trial parallelism

### DIFF
--- a/core/src/autogluon/core/hpo/executors.py
+++ b/core/src/autogluon/core/hpo/executors.py
@@ -106,6 +106,7 @@ class HpoExecutor(ABC):
         minimum_model_num_cpus = minimum_model_resources.get("num_cpus", 1)
         minimum_model_num_gpus = minimum_model_resources.get("num_gpus", 0)
         initialized_model_params = initialized_model.get_params()
+        model_base = initialized_model._get_model_base()
 
         if (
             "hyperparameters" in initialized_model_params
@@ -128,31 +129,41 @@ class HpoExecutor(ABC):
                     assert user_specified_trial_num_gpus <= num_gpus, (
                         f"Detected trial level gpu requirement = {user_specified_trial_num_gpus} > total gpu granted to AG predictor = {num_gpus}"
                     )
-                num_trials_in_parallel_with_gpu = math.inf
+                # A request of 0 bounds nothing, so there is no trial count to size the
+                # other resource from. Size it as if it were unconstrained, which is what
+                # the user left it as, rather than letting the 0 change trial parallelism.
+                resources_per_trial_unconstrained = None
+                if (user_specified_trial_num_cpus is None and user_specified_trial_num_gpus == 0) or (
+                    user_specified_trial_num_gpus is None and user_specified_trial_num_cpus == 0
+                ):
+                    resources_per_trial_unconstrained = self._get_resources_per_trial_unconstrained(
+                        initialized_model=initialized_model,
+                        model_base=model_base,
+                        minimum_model_num_cpus=minimum_model_num_cpus,
+                        minimum_model_num_gpus=minimum_model_num_gpus,
+                        num_cpus=num_cpus,
+                        num_gpus=num_gpus,
+                        k_fold=k_fold,
+                        **kwargs,
+                    )
                 if user_specified_trial_num_cpus is None:
-                    # If user didn't specify cpu per trial, we find the min based on gpu.
-                    # A user-specified gpu-per-trial of 0 places no constraint on trial
-                    # parallelism, so keep num_trials_in_parallel_with_gpu unbounded
-                    # instead of dividing by zero, and let the trial use all cpus.
-                    if user_specified_trial_num_gpus:
+                    # If user didn't specify cpu per trial, we find the min based on gpu
+                    if resources_per_trial_unconstrained is not None:
+                        user_specified_trial_num_cpus = resources_per_trial_unconstrained["num_cpus"]
+                    else:
                         num_trials_in_parallel_with_gpu = num_gpus // user_specified_trial_num_gpus
                         user_specified_trial_num_cpus = (
                             num_cpus // num_trials_in_parallel_with_gpu
                         )  # keep gpus per trial int to avoid complexity
-                    else:
-                        user_specified_trial_num_cpus = num_cpus
-                num_trials_in_parallel_with_cpu = math.inf
                 if user_specified_trial_num_gpus is None:
-                    # If user didn't specify gpu per trial, we find the min based on cpu.
-                    # Symmetric guard: a user-specified cpu-per-trial of 0 must not raise
-                    # ZeroDivisionError either.
-                    if user_specified_trial_num_cpus:
+                    # If user didn't specify gpu per trial, we find the min based on cpu
+                    if resources_per_trial_unconstrained is not None:
+                        user_specified_trial_num_gpus = resources_per_trial_unconstrained["num_gpus"]
+                    else:
                         num_trials_in_parallel_with_cpu = num_cpus // user_specified_trial_num_cpus
                         user_specified_trial_num_gpus = (
                             num_gpus // num_trials_in_parallel_with_cpu
                         )  # keep gpus per trial int to avoid complexity
-                    else:
-                        user_specified_trial_num_gpus = num_gpus
                 assert user_specified_trial_num_cpus >= minimum_model_num_cpus, (
                     f"The trial requires minimum cpu {minimum_model_num_cpus}, but you only specified {user_specified_trial_num_cpus}"
                 )
@@ -166,7 +177,6 @@ class HpoExecutor(ABC):
                     "num_gpus": user_specified_trial_num_gpus,
                 }
 
-        model_base = initialized_model._get_model_base()
         if model_base != initialized_model:
             # This is an ensemble model
             total_num_cpus_per_trial = num_cpus
@@ -233,55 +243,83 @@ class HpoExecutor(ABC):
                 }
         if "resources_per_trial" not in self.hyperparameter_tune_kwargs:
             # User didn't provide any requirements
-
-            num_jobs_in_parallel_with_mem = math.inf
-            model_estimate_memory_usage = initialized_model.estimate_memory_usage(**kwargs)
-            if model_estimate_memory_usage is not None:
-                total_memory_available = ResourceManager.get_available_virtual_mem()
-                num_jobs_in_parallel_with_mem = total_memory_available // model_estimate_memory_usage
-
-            num_jobs_in_parallel_with_cpu = num_cpus // minimum_model_num_cpus
-            num_jobs_in_parallel_with_gpu = math.inf
-            if minimum_model_num_gpus > 0:
-                num_jobs_in_parallel_with_gpu = num_gpus // minimum_model_num_gpus
-            num_jobs_in_parallel = min(
-                num_jobs_in_parallel_with_mem, num_jobs_in_parallel_with_cpu, num_jobs_in_parallel_with_gpu
+            self.hyperparameter_tune_kwargs["resources_per_trial"] = self._get_resources_per_trial_unconstrained(
+                initialized_model=initialized_model,
+                model_base=model_base,
+                minimum_model_num_cpus=minimum_model_num_cpus,
+                minimum_model_num_gpus=minimum_model_num_gpus,
+                num_cpus=num_cpus,
+                num_gpus=num_gpus,
+                k_fold=k_fold,
+                **kwargs,
             )
-            if k_fold is not None and k_fold > 0:
-                max_models = self.hyperparameter_tune_kwargs.get("num_trials", math.inf) * k_fold
-                num_jobs_in_parallel = min(num_jobs_in_parallel, max_models)
-            system_num_cpu = ResourceManager.get_cpu_count()
-            system_num_gpu = ResourceManager.get_gpu_count()
-            if model_base != initialized_model:
-                # bagged model
-                if num_jobs_in_parallel // k_fold < 1:
-                    # We can only train 1 trial in parallel
-                    num_trials_in_parallel = 1
-                else:
-                    num_trials_in_parallel = num_jobs_in_parallel // k_fold
-                if self.executor_type == "custom":
-                    # custom backend runs sequentially
-                    num_trials_in_parallel = 1
-                cpu_per_trial = int(num_cpus // num_trials_in_parallel)
-                gpu_per_trial = num_gpus // num_trials_in_parallel
-            else:
-                num_trials = self.hyperparameter_tune_kwargs.get("num_trials", math.inf)
-                if self.executor_type == "custom":
-                    # custom backend runs sequentially
-                    num_jobs_in_parallel = 1
-                cpu_per_trial = int(num_cpus // min(num_jobs_in_parallel, num_trials))
-                gpu_per_trial = num_gpus / min(num_jobs_in_parallel, num_trials)
-            # In distributed setting, a single trial could be scheduled with resources that's more than a single node causing hanging
-            # Force it to be less than the current node. This works under the assumption that all nodes are of the same type
-            cpu_per_trial = min(cpu_per_trial, system_num_cpu)
-            gpu_per_trial = min(gpu_per_trial, system_num_gpu)
-
-            self.hyperparameter_tune_kwargs["resources_per_trial"] = {
-                "num_cpus": cpu_per_trial,
-                "num_gpus": gpu_per_trial,
-            }
 
         self.resources = dict(num_gpus=num_gpus, num_cpus=num_cpus)
+
+    def _get_resources_per_trial_unconstrained(
+        self,
+        initialized_model: AbstractModel,
+        model_base: AbstractModel,
+        minimum_model_num_cpus: int,
+        minimum_model_num_gpus: Union[int, float],
+        num_cpus: int,
+        num_gpus: Union[int, float],
+        k_fold: Optional[int] = None,
+        **kwargs,
+    ) -> Dict[str, Union[int, float]]:
+        """
+        Resources per trial when the user placed no constraint on them, maximizing the
+        number of trials running in parallel while respecting the minimum resources
+        required, the memory estimate, and the trial/fold counts.
+        """
+        num_jobs_in_parallel_with_mem = math.inf
+        model_estimate_memory_usage = initialized_model.estimate_memory_usage(**kwargs)
+        if model_estimate_memory_usage is not None:
+            total_memory_available = ResourceManager.get_available_virtual_mem()
+            num_jobs_in_parallel_with_mem = total_memory_available // model_estimate_memory_usage
+
+        num_jobs_in_parallel_with_cpu = math.inf
+        if minimum_model_num_cpus > 0:
+            num_jobs_in_parallel_with_cpu = num_cpus // minimum_model_num_cpus
+        num_jobs_in_parallel_with_gpu = math.inf
+        if minimum_model_num_gpus > 0:
+            num_jobs_in_parallel_with_gpu = num_gpus // minimum_model_num_gpus
+        num_jobs_in_parallel = min(
+            num_jobs_in_parallel_with_mem, num_jobs_in_parallel_with_cpu, num_jobs_in_parallel_with_gpu
+        )
+        if k_fold is not None and k_fold > 0:
+            max_models = self.hyperparameter_tune_kwargs.get("num_trials", math.inf) * k_fold
+            num_jobs_in_parallel = min(num_jobs_in_parallel, max_models)
+        system_num_cpu = ResourceManager.get_cpu_count()
+        system_num_gpu = ResourceManager.get_gpu_count()
+        if model_base != initialized_model:
+            # bagged model
+            if num_jobs_in_parallel // k_fold < 1:
+                # We can only train 1 trial in parallel
+                num_trials_in_parallel = 1
+            else:
+                num_trials_in_parallel = num_jobs_in_parallel // k_fold
+            if self.executor_type == "custom":
+                # custom backend runs sequentially
+                num_trials_in_parallel = 1
+            cpu_per_trial = int(num_cpus // num_trials_in_parallel)
+            gpu_per_trial = num_gpus // num_trials_in_parallel
+        else:
+            num_trials = self.hyperparameter_tune_kwargs.get("num_trials", math.inf)
+            if self.executor_type == "custom":
+                # custom backend runs sequentially
+                num_jobs_in_parallel = 1
+            cpu_per_trial = int(num_cpus // min(num_jobs_in_parallel, num_trials))
+            gpu_per_trial = num_gpus / min(num_jobs_in_parallel, num_trials)
+        # In distributed setting, a single trial could be scheduled with resources that's more than a single node causing hanging
+        # Force it to be less than the current node. This works under the assumption that all nodes are of the same type
+        cpu_per_trial = min(cpu_per_trial, system_num_cpu)
+        gpu_per_trial = min(gpu_per_trial, system_num_gpu)
+
+        return {
+            "num_cpus": cpu_per_trial,
+            "num_gpus": gpu_per_trial,
+        }
 
     @abstractmethod
     def validate_search_space(

--- a/tabular/tests/unittests/resource_allocation/test_hpo_resource_allocation.py
+++ b/tabular/tests/unittests/resource_allocation/test_hpo_resource_allocation.py
@@ -257,44 +257,62 @@ def test_hpo_without_bagging_valid_resources_per_trial(mock_system_resources_ctx
         assert executor.hyperparameter_tune_kwargs["resources_per_trial"] == {"num_cpus": 1, "num_gpus": 0.2}
 
 
+def _resources_per_trial(executor_cls, hyperparameters, minimum_resources, total_resources):
+    """`resources_per_trial` that `executor_cls` allocates for a model with these hyperparameters."""
+    executor = _initialize_executor(executor_cls, {"scheduler": "local", "searcher": "random", "num_trials": 4})
+    model = DummyModel(minimum_resources=minimum_resources, hyperparameters=hyperparameters)
+    model.initialize()
+    executor.register_resources(model, X=dummy_x, **total_resources)
+    return executor.hyperparameter_tune_kwargs["resources_per_trial"]
+
+
 @pytest.mark.parametrize("executor_cls", [RayHpoExecutor, CustomHpoExecutor])
 def test_hpo_without_bagging_zero_gpus_per_trial_no_cpus_specified(mock_system_resources_ctx_mgr, executor_cls):
-    """Regression test for a ZeroDivisionError: specifying only `num_gpus: 0` in
-    `ag_args_fit` (a common way to pin a model to CPU, e.g. to keep it off the GPU
-    while other models use it) used to crash `register_resources`, which
-    unconditionally computed `num_gpus // user_specified_trial_num_gpus` when cpus
-    per trial weren't specified. A gpu-per-trial request of 0 places no constraint
-    on parallelism, so the fix gives the trial all available cpus instead.
+    """Specifying only `num_gpus: 0` in `ag_args_fit` (a common way to pin a model to
+    cpu, e.g. to keep it off the gpu while other models use it) pins gpus per trial
+    without changing anything else.
+
+    A request of 0 bounds nothing, so there is no trial count to size cpus from, and
+    cpus stay at what an unconstrained request would get. Also a regression test for
+    issue #5552, where this case computed `num_gpus // 0`.
     """
-    hyperparameter_tune_kwargs = {"scheduler": "local", "searcher": "random", "num_trials": 4}
-    executor = _initialize_executor(executor_cls, hyperparameter_tune_kwargs)
     total_resources = {"num_cpus": 8, "num_gpus": 1}
+    minimum_resources = {"num_cpus": 1, "num_gpus": 0}
     with mock_system_resources_ctx_mgr(num_cpus=total_resources["num_cpus"], num_gpus=total_resources["num_gpus"]):
-        model = DummyModel(
-            minimum_resources={"num_cpus": 1, "num_gpus": 0},
-            hyperparameters={"ag_args_fit": {"num_gpus": 0}},
+        unconstrained = _resources_per_trial(executor_cls, {}, minimum_resources, total_resources)
+        pinned = _resources_per_trial(
+            executor_cls, {"ag_args_fit": {"num_gpus": 0}}, minimum_resources, total_resources
         )
-        model.initialize()
-        executor.register_resources(model, X=dummy_x, **total_resources)
-        assert executor.hyperparameter_tune_kwargs["resources_per_trial"] == {"num_cpus": 8, "num_gpus": 0}
+    assert pinned == {**unconstrained, "num_gpus": 0}
 
 
 @pytest.mark.parametrize("executor_cls", [RayHpoExecutor, CustomHpoExecutor])
 def test_hpo_without_bagging_zero_cpus_per_trial_no_gpus_specified(mock_system_resources_ctx_mgr, executor_cls):
-    """Symmetric regression test for the `num_cpus: 0`-only case, which hit the same
-    ZeroDivisionError pattern on the other branch of `register_resources`.
-    """
-    hyperparameter_tune_kwargs = {"scheduler": "local", "searcher": "random", "num_trials": 4}
-    executor = _initialize_executor(executor_cls, hyperparameter_tune_kwargs)
+    """Symmetric case: `num_cpus: 0` pins cpus per trial and leaves gpus unchanged."""
     total_resources = {"num_cpus": 8, "num_gpus": 2}
+    minimum_resources = {"num_cpus": 0, "num_gpus": 0.1}
     with mock_system_resources_ctx_mgr(num_cpus=total_resources["num_cpus"], num_gpus=total_resources["num_gpus"]):
-        model = DummyModel(
-            minimum_resources={"num_cpus": 0, "num_gpus": 0.1},
-            hyperparameters={"ag_args_fit": {"num_cpus": 0}},
+        unconstrained = _resources_per_trial(executor_cls, {}, minimum_resources, total_resources)
+        pinned = _resources_per_trial(
+            executor_cls, {"ag_args_fit": {"num_cpus": 0}}, minimum_resources, total_resources
         )
-        model.initialize()
-        executor.register_resources(model, X=dummy_x, **total_resources)
-        assert executor.hyperparameter_tune_kwargs["resources_per_trial"] == {"num_cpus": 0, "num_gpus": 2}
+    assert pinned == {**unconstrained, "num_cpus": 0}
+
+
+@pytest.mark.parametrize("executor_cls", [RayHpoExecutor, CustomHpoExecutor])
+def test_hpo_without_bagging_positive_gpus_per_trial_still_sizes_cpus(mock_system_resources_ctx_mgr, executor_cls):
+    """A positive gpu request does bound trial parallelism, so cpus are still derived from it.
+
+    With 2 gpus and 1 gpu per trial, 2 trials fit, so each gets half the cpus rather
+    than the smaller share an unconstrained request would receive.
+    """
+    total_resources = {"num_cpus": 8, "num_gpus": 2}
+    minimum_resources = {"num_cpus": 1, "num_gpus": 0}
+    with mock_system_resources_ctx_mgr(num_cpus=total_resources["num_cpus"], num_gpus=total_resources["num_gpus"]):
+        derived = _resources_per_trial(
+            executor_cls, {"ag_args_fit": {"num_gpus": 1}}, minimum_resources, total_resources
+        )
+    assert derived == {"num_cpus": 4, "num_gpus": 1}
 
 
 @pytest.mark.parametrize("executor_cls", [RayHpoExecutor, CustomHpoExecutor])


### PR DESCRIPTION
Follow-up to #5832, which fixed the `ZeroDivisionError` from `ag_args_fit={"num_gpus": 0}` but left the resulting allocation changing trial parallelism.

## The behavior

`register_resources` derives the trial-level resource the user did not specify from the one they did. That coupling is right when the specified resource bounds how many trials fit: with 2 gpus and 1 gpu per trial, 2 trials run at once, so each should get half the cpus, and Ray keeps both gpus busy.

A request of **0** bounds nothing, so there is no trial count to derive from. The fallback gave the trial every cpu, which serializes the run:

| `ag_args_fit` (Ray, 8 cpus / 1 gpu, 4 trials) | before | after |
|---|---|---|
| nothing specified | `{'num_cpus': 2, 'num_gpus': 0.25}` | unchanged |
| `{'num_gpus': 0}` | `{'num_cpus': 8, 'num_gpus': 0}` (1 trial at a time) | `{'num_cpus': 2, 'num_gpus': 0}` (4 trials) |
| `{'num_gpus': 1}` (2 gpus total) | `{'num_cpus': 4, 'num_gpus': 1}` | unchanged |

Pinning a model to cpu is a statement about gpus. It should not also decide how many trials run at once.

## The change

A resource the user never mentioned is sized the way it is sized when the user specifies nothing at all, so a 0 pins only what it names. The sizing that ran when no resources were requested moves into `_get_resources_per_trial_unconstrained`, so both callers share one implementation instead of agreeing by construction.

That path divided by `minimum_model_num_cpus` unguarded. A model with no cpu minimum now reaches it, so it is guarded the same way the gpu minimum beside it already was.

The two tests added with the `ZeroDivisionError` fix asserted the old fallback (all cpus, and all gpus for the symmetric `num_cpus: 0` case). They now assert the property this change is about: the allocation matches the unconstrained one except for the resource the user pinned. A third test covers a positive request still deriving the other resource.

## Verification

Across both executors, with a probe over resource combinations and an end-to-end `TabularPredictor.fit`:

- `num_gpus: 0` now matches the unspecified allocation with gpus pinned to 0, on a gpu box and a cpu-only box
- positive requests, contradictory requests, and requests below the model minimum are unchanged, including the messages added in #5832
- bagged HPO composes: `{'num_cpus': 4, 'num_gpus': 0}` per trial with per-fold resources derived from it
- `tabular/tests/unittests/resource_allocation/test_hpo_resource_allocation.py` goes 32 to 34 passing

`test_gpu_assignment.py::TestRayGpuAssignmentIntegration::test_ray_gpu_assignment_no_gpu_integration` fails in a full-directory run and passes in isolation, identically on master. Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi