### PR TITLE
[tests] Keep predictor artifacts out of the working directory

### DIFF
--- a/common/src/autogluon/common/utils/utils.py
+++ b/common/src/autogluon/common/utils/utils.py
@@ -19,6 +19,20 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_BASE_PATH = "AutogluonModels"
 
+#: Env var overriding the directory that auto-generated predictor paths are created under when the
+#: user does not specify `path`. Set this to a temporary directory (e.g. in a test fixture) so that
+#: predictors created without an explicit path do not leave artifacts in the working directory.
+DEFAULT_BASE_PATH_ENV_VAR = "AG_DEFAULT_BASE_PATH"
+
+
+def get_default_base_path() -> str:
+    """Return the base directory used for auto-generated predictor paths.
+
+    Honors the `AG_DEFAULT_BASE_PATH` env var, falling back to `AutogluonModels` in the working
+    directory.
+    """
+    return os.environ.get(DEFAULT_BASE_PATH_ENV_VAR) or DEFAULT_BASE_PATH
+
 
 def setup_outputdir(
     path: str | Path | None,
@@ -59,7 +73,7 @@ def setup_outputdir(
         if isinstance(default_base_path, Path):
             default_base_path = str(default_base_path)
     else:
-        default_base_path = DEFAULT_BASE_PATH
+        default_base_path = get_default_base_path()
 
     is_s3_path = False
     if path:

--- a/common/tests/unittests/test_setup_outputdir.py
+++ b/common/tests/unittests/test_setup_outputdir.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import os.path
 import tempfile
 import unittest
@@ -8,7 +9,12 @@ from unittest.mock import patch
 
 import pytest
 
-from autogluon.common.utils.utils import DEFAULT_BASE_PATH, setup_outputdir
+from autogluon.common.utils.utils import (
+    DEFAULT_BASE_PATH,
+    DEFAULT_BASE_PATH_ENV_VAR,
+    get_default_base_path,
+    setup_outputdir,
+)
 
 
 class SetupOutputDirTestCase(unittest.TestCase):
@@ -50,6 +56,46 @@ class SetupOutputDirTestCase(unittest.TestCase):
         returned_path = setup_outputdir(path, warn_if_exist=True, create_dir=False, path_suffix=path_suffix)
         assert not returned_path.endswith(os.path.sep)
         assert "my_subdir" in returned_path
+
+    def test_default_base_path_env_var(self):
+        # `AG_DEFAULT_BASE_PATH` redirects auto-generated paths, so callers (e.g. test suites) can
+        # keep predictor artifacts out of the working directory without passing `path` everywhere.
+        prev = os.environ.get(DEFAULT_BASE_PATH_ENV_VAR)
+        try:
+            os.environ.pop(DEFAULT_BASE_PATH_ENV_VAR, None)
+            assert get_default_base_path() == DEFAULT_BASE_PATH
+
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                os.environ[DEFAULT_BASE_PATH_ENV_VAR] = tmp_dir
+                assert get_default_base_path() == tmp_dir
+
+                returned_path = setup_outputdir(None, warn_if_exist=True, create_dir=False, path_suffix=None)
+                assert returned_path.startswith(os.path.realpath(tmp_dir))
+                assert os.path.join(tmp_dir, "ag") in returned_path
+
+                # an explicit `default_base_path` still wins over the env var
+                returned_path = setup_outputdir(
+                    None,
+                    warn_if_exist=True,
+                    create_dir=False,
+                    path_suffix=None,
+                    default_base_path="CustomPath",
+                )
+                assert os.path.join("CustomPath", "ag") in returned_path
+
+                # an explicit `path` is unaffected by the env var
+                explicit = os.path.join(tmp_dir, "explicit")
+                returned_path = setup_outputdir(explicit, warn_if_exist=True, create_dir=False, path_suffix=None)
+                assert str(Path(returned_path)) == explicit
+
+            # an empty value falls back to the default rather than resolving to ""
+            os.environ[DEFAULT_BASE_PATH_ENV_VAR] = ""
+            assert get_default_base_path() == DEFAULT_BASE_PATH
+        finally:
+            if prev is None:
+                os.environ.pop(DEFAULT_BASE_PATH_ENV_VAR, None)
+            else:
+                os.environ[DEFAULT_BASE_PATH_ENV_VAR] = prev
 
     def test_s3_path(self):
         path = "s3://test-bucket/test-folder"

--- a/tabular/src/autogluon/tabular/testing/fit_helper.py
+++ b/tabular/src/autogluon/tabular/testing/fit_helper.py
@@ -14,6 +14,7 @@ import pandas as pd
 import pandas.testing as pdt
 
 from autogluon.common.utils.path_converter import PathConverter
+from autogluon.common.utils.utils import get_default_base_path
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION
 from autogluon.core.metrics import METRICS
 from autogluon.core.models import AbstractModel, AuxiliaryParams, BaggedEnsembleModel
@@ -213,7 +214,7 @@ class FitHelper:
             _init_args.update(init_args)
             init_args = _init_args
         if "path" not in init_args:
-            init_args["path"] = os.path.join(directory_prefix, dataset_name, f"AutogluonOutput_{uuid.uuid4()}")
+            init_args["path"] = os.path.join(get_default_base_path(), dataset_name, f"AutogluonOutput_{uuid.uuid4()}")
         if path_as_absolute:
             init_args["path"] = PathConverter.to_absolute(path=init_args["path"])
             assert PathConverter._is_absolute(path=init_args["path"])
@@ -232,143 +233,149 @@ class FitHelper:
                 expected_model_count -= 1
             fit_args["fit_weighted_ensemble"] = fit_weighted_ensemble
 
-        ctx_before = GlobalContextSnapshot.capture()
+        try:
+            ctx_before = GlobalContextSnapshot.capture()
 
-        predictor: TabularPredictor = FitHelper.fit_dataset(
-            train_data=train_data,
-            init_args=init_args,
-            fit_args=fit_args,
-            sample_size=sample_size,
-            scikit_api=scikit_api,
-            min_cls_count_train=min_cls_count_train,
-        )
+            predictor: TabularPredictor = FitHelper.fit_dataset(
+                train_data=train_data,
+                init_args=init_args,
+                fit_args=fit_args,
+                sample_size=sample_size,
+                scikit_api=scikit_api,
+                min_cls_count_train=min_cls_count_train,
+            )
 
-        ctx_after_fit = GlobalContextSnapshot.capture()
-        ctx_before.assert_unchanged(ctx_after_fit)
+            ctx_after_fit = GlobalContextSnapshot.capture()
+            ctx_before.assert_unchanged(ctx_after_fit)
 
-        if compile:
-            predictor.compile(models="all", compiler_configs=compiler_configs)
-            predictor.persist(models="all")
+            if compile:
+                predictor.compile(models="all", compiler_configs=compiler_configs)
+                predictor.persist(models="all")
 
-        model_names = predictor.model_names()
-        model_name = model_names[0]
-        if expected_model_count is not None:
-            assert len(model_names) == expected_model_count
+            model_names = predictor.model_names()
+            model_name = model_names[0]
+            if expected_model_count is not None:
+                assert len(model_names) == expected_model_count
 
-        predictor.predict(test_data)
+            predictor.predict(test_data)
 
-        ctx_after_predict = GlobalContextSnapshot.capture()
-        ctx_after_fit.assert_unchanged(ctx_after_predict)
+            ctx_after_predict = GlobalContextSnapshot.capture()
+            ctx_after_fit.assert_unchanged(ctx_after_predict)
 
-        predictor.evaluate(test_data)
+            predictor.evaluate(test_data)
 
-        test_data_transform = predictor.transform_features(data=test_data, model=model_name)
-        test_data_transform_before = test_data_transform.copy(deep=True)
-        model = predictor._trainer.load_model(model_name=model_name)
-        model.predict(X=test_data_transform)
-        pdt.assert_frame_equal(test_data_transform, test_data_transform_before, check_dtype=True)
+            test_data_transform = predictor.transform_features(data=test_data, model=model_name)
+            test_data_transform_before = test_data_transform.copy(deep=True)
+            model = predictor._trainer.load_model(model_name=model_name)
+            model.predict(X=test_data_transform)
+            pdt.assert_frame_equal(test_data_transform, test_data_transform_before, check_dtype=True)
 
-        if predictor.can_predict_proba:
-            pred_proba = predictor.predict_proba(test_data)
-            predictor.evaluate_predictions(y_true=test_data[label], y_pred=pred_proba)
+            if predictor.can_predict_proba:
+                pred_proba = predictor.predict_proba(test_data)
+                predictor.evaluate_predictions(y_true=test_data[label], y_pred=pred_proba)
 
-            pred_proba_repeat = predictor.predict_proba(test_data)
-            are_close = np.allclose(pred_proba, pred_proba_repeat, atol=1e-5)
-            if not are_close:
-                raise AssertionError(
-                    "Predictions differ when predicting on the same data multiple times\n"
-                    f"First Predict:\n{pred_proba}\n"
-                    f"Second Predict:\n{pred_proba_repeat}\n"
-                )
-
-            pred_proba_1 = predictor.predict_proba(test_data.head(1))  # Verify model can predict on a single sample
-            if verify_single_prediction_equivalent_to_multi:
-                pred_proba_1_from_multi = pred_proba.head(1)
-                are_close = np.allclose(pred_proba_1, pred_proba_1_from_multi, atol=1e-5)
+                pred_proba_repeat = predictor.predict_proba(test_data)
+                are_close = np.allclose(pred_proba, pred_proba_repeat, atol=1e-5)
                 if not are_close:
                     raise AssertionError(
-                        "Predictions differ when predicting a single sample vs predicting multiple samples\n"
-                        f"Single Sample:\n{pred_proba_1}\n"
-                        f"Multi Sample:\n{pred_proba_1_from_multi}\n"
+                        "Predictions differ when predicting on the same data multiple times\n"
+                        f"First Predict:\n{pred_proba}\n"
+                        f"Second Predict:\n{pred_proba_repeat}\n"
                     )
-        else:
-            try:
-                predictor.predict_proba(test_data)
-            except AssertionError:
-                pass  # expected
+
+                pred_proba_1 = predictor.predict_proba(
+                    test_data.head(1)
+                )  # Verify model can predict on a single sample
+                if verify_single_prediction_equivalent_to_multi:
+                    pred_proba_1_from_multi = pred_proba.head(1)
+                    are_close = np.allclose(pred_proba_1, pred_proba_1_from_multi, atol=1e-5)
+                    if not are_close:
+                        raise AssertionError(
+                            "Predictions differ when predicting a single sample vs predicting multiple samples\n"
+                            f"Single Sample:\n{pred_proba_1}\n"
+                            f"Multi Sample:\n{pred_proba_1_from_multi}\n"
+                        )
             else:
-                raise AssertionError("Expected `predict_proba` to raise AssertionError, but it didn't!")
+                try:
+                    predictor.predict_proba(test_data)
+                except AssertionError:
+                    pass  # expected
+                else:
+                    raise AssertionError("Expected `predict_proba` to raise AssertionError, but it didn't!")
 
-        if refit_full:
-            refit_model_names = predictor.refit_full()
-            if expected_model_count is not None:
-                assert len(refit_model_names) == expected_model_count
-            refit_model_name = refit_model_names[model_name]
-            assert "_FULL" in refit_model_name
-            predictor.predict(test_data, model=refit_model_name)
-            if predictor.can_predict_proba:
-                predictor.predict_proba(test_data, model=refit_model_name)
+            if refit_full:
+                refit_model_names = predictor.refit_full()
+                if expected_model_count is not None:
+                    assert len(refit_model_names) == expected_model_count
+                refit_model_name = refit_model_names[model_name]
+                assert "_FULL" in refit_model_name
+                predictor.predict(test_data, model=refit_model_name)
+                if predictor.can_predict_proba:
+                    predictor.predict_proba(test_data, model=refit_model_name)
 
-            # verify that val_in_fit is False if the model supports refit_full
-            model = predictor._trainer.load_model(refit_model_name)
-            if isinstance(model, BaggedEnsembleModel):
-                model = model.load_child(model.models[0])
-            model_info = model.get_info()
-            can_refit_full = model._get_tags()["can_refit_full"]
-            if can_refit_full:
-                assert not model_info["val_in_fit"], (
-                    f"val data must not be present in refit model if `can_refit_full=True`. Maybe an exception occurred?"
-                )
-            else:
-                assert model_info["val_in_fit"], f"val data must be present in refit model if `can_refit_full=False`"
-        if verify_model_seed:
-            names = predictor.model_names()
-            for name in names:
-                model = predictor._trainer.load_model(name)
-                _verify_model_seed(model=model)
+                # verify that val_in_fit is False if the model supports refit_full
+                model = predictor._trainer.load_model(refit_model_name)
+                if isinstance(model, BaggedEnsembleModel):
+                    model = model.load_child(model.models[0])
+                model_info = model.get_info()
+                can_refit_full = model._get_tags()["can_refit_full"]
+                if can_refit_full:
+                    assert not model_info["val_in_fit"], (
+                        f"val data must not be present in refit model if `can_refit_full=True`. Maybe an exception occurred?"
+                    )
+                else:
+                    assert model_info["val_in_fit"], (
+                        f"val data must be present in refit model if `can_refit_full=False`"
+                    )
+            if verify_model_seed:
+                names = predictor.model_names()
+                for name in names:
+                    model = predictor._trainer.load_model(name)
+                    _verify_model_seed(model=model)
 
-        if predictor_info:
-            predictor.info()
-        lb_kwargs = {}
-        if extra_info:
-            lb_kwargs["extra_info"] = True
-        lb = predictor.leaderboard(test_data, extra_metrics=extra_metrics, **lb_kwargs)
-        stacked_overfitting_assert(
-            lb, predictor, expected_stacked_overfitting_at_val, expected_stacked_overfitting_at_test
-        )
+            if predictor_info:
+                predictor.info()
+            lb_kwargs = {}
+            if extra_info:
+                lb_kwargs["extra_info"] = True
+            lb = predictor.leaderboard(test_data, extra_metrics=extra_metrics, **lb_kwargs)
+            stacked_overfitting_assert(
+                lb, predictor, expected_stacked_overfitting_at_val, expected_stacked_overfitting_at_test
+            )
 
-        predictor_load = predictor.load(path=predictor.path)
-        predictor_load.predict(test_data)
+            predictor_load = predictor.load(path=predictor.path)
+            predictor_load.predict(test_data)
 
-        # TODO: This is expensive, only do this sparingly.
-        if verify_load_wo_cuda:
-            import torch
+            # TODO: This is expensive, only do this sparingly.
+            if verify_load_wo_cuda:
+                import torch
 
-            if torch.cuda.is_available():
-                # Checks if the model is able to predict w/o CUDA.
-                # This verifies that a model artifact works on a CPU machine.
-                predictor_path = predictor.path
+                if torch.cuda.is_available():
+                    # Checks if the model is able to predict w/o CUDA.
+                    # This verifies that a model artifact works on a CPU machine.
+                    predictor_path = predictor.path
 
-                code = textwrap.dedent(f"""
-                        import os
-                        os.environ["CUDA_VISIBLE_DEVICES"] = ""
-                        from autogluon.tabular import TabularPredictor
+                    code = textwrap.dedent(f"""
+                            import os
+                            os.environ["CUDA_VISIBLE_DEVICES"] = ""
+                            from autogluon.tabular import TabularPredictor
 
-                        import torch
-                        assert torch.cuda.is_available() is False
-                        predictor = TabularPredictor.load(r"{predictor_path}")
-                        X, y = predictor.load_data_internal()
-                        predictor.persist("all")
-                        predictor.predict_multi(X, transform_features=False)
-                    """)
-                subprocess.run([sys.executable, "-c", code], check=True)
+                            import torch
+                            assert torch.cuda.is_available() is False
+                            predictor = TabularPredictor.load(r"{predictor_path}")
+                            X, y = predictor.load_data_internal()
+                            predictor.persist("all")
+                            predictor.predict_multi(X, transform_features=False)
+                        """)
+                    subprocess.run([sys.executable, "-c", code], check=True)
 
-        assert os.path.realpath(save_path) == os.path.realpath(predictor.path)
-        if delete_directory:
-            shutil.rmtree(
-                save_path, ignore_errors=True
-            )  # Delete AutoGluon output directory to ensure runs' information has been removed.
-        return predictor
+            assert os.path.realpath(save_path) == os.path.realpath(predictor.path)
+            return predictor
+        finally:
+            if delete_directory:
+                # Always remove the AutoGluon output directory, including when an assertion above
+                # fails -- otherwise failing tests are exactly the ones that leak artifacts.
+                shutil.rmtree(save_path, ignore_errors=True)
 
     @staticmethod
     def load_dataset(name: str, directory_prefix: str = "./datasets/") -> tuple[pd.DataFrame, pd.DataFrame, dict]:

--- a/tabular/tests/conftest.py
+++ b/tabular/tests/conftest.py
@@ -96,3 +96,22 @@ def mock_num_gpus():
 @pytest.fixture
 def k_fold():
     return 2
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _ag_default_base_path(tmp_path_factory):
+    """Redirect auto-generated predictor paths into pytest's temporary directory.
+
+    Without this, every `TabularPredictor(...)` created without an explicit `path` leaves an
+    `AutogluonModels/ag-<timestamp>` directory behind in the working directory, and `FitHelper`
+    writes its predictors under `./datasets/`. pytest reclaims its own tmp dirs (keeping only the
+    last few sessions), so nothing accumulates in the repo.
+    """
+    base_path = tmp_path_factory.mktemp("ag_models")
+    prev = os.environ.get("AG_DEFAULT_BASE_PATH")
+    os.environ["AG_DEFAULT_BASE_PATH"] = str(base_path)
+    yield str(base_path)
+    if prev is None:
+        os.environ.pop("AG_DEFAULT_BASE_PATH", None)
+    else:
+        os.environ["AG_DEFAULT_BASE_PATH"] = prev


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Test runs leave predictor artifacts behind in the working directory. Two independent causes:

1. **`setup_outputdir` reserves a directory on construction.** `TabularPredictor.__init__` calls it with `create_dir=True`, so merely *constructing* a predictor without `path=` creates `./AutogluonModels/ag-<timestamp>[-NNN]/` relative to the CWD and nothing ever removes it. Only 8 of the 40 `TabularPredictor(...)` calls in `tabular/tests` pass `path=`.
2. **`FitHelper.fit_and_validate_dataset` cleans up only on the success path.** Its `shutil.rmtree(save_path, ignore_errors=True)` sits at the end of the function body, so any assertion failure earlier skips it — meaning **failing tests are exactly the ones that leak**. Its output also landed under `./datasets/<dataset_name>/`, mixed in with the cached dataset downloads.

Both are gitignored, so they never show up in `git status` and accumulate unnoticed. My working copy had 105 `AutogluonModels/ag-*` directories before I looked.

## Changes

- **`common/utils/utils.py`** — new `AG_DEFAULT_BASE_PATH` env var and `get_default_base_path()`, consulted by `setup_outputdir` when neither `path` nor `default_base_path` is given. `default_base_path` was already a `setup_outputdir` parameter and already forwarded from `TabularPredictor.__init__`; this just adds a process-wide default underneath it. An explicit `default_base_path` still wins, and an explicit `path` is unaffected.
- **`tabular/tests/conftest.py`** — session-scoped autouse fixture pointing `AG_DEFAULT_BASE_PATH` at `tmp_path_factory`. pytest reclaims its own tmp root (keeping only the last few sessions), so nothing accumulates and no test needs an explicit delete call.
- **`FitHelper.fit_and_validate_dataset`** — body wrapped in `try`/`finally` so the `rmtree` also runs when an assertion fails, and the default output path moved from `./datasets/<name>/` to `<get_default_base_path()>/<name>/`.
- **`common/tests/unittests/test_setup_outputdir.py`** — covers the env var, precedence vs. an explicit `default_base_path`, that an explicit `path` is unaffected, and that an empty value falls back to `AutogluonModels` rather than resolving to `""`.

The `fit_helper.py` diff looks large because of the `try:` indentation; `git diff -w` shows it as 15 lines. Two nearby lines were reformatted by `ruff format` as a consequence of the added indentation level.

## Effect

Running `tabular/tests/unittests/registry/` + `models/test_dummy.py` + `models/test_lightgbm.py` (211 tests) from a clean checkout:

| | `AutogluonModels/ag-*` left behind | `datasets/**/AutogluonOutput_*` left behind |
|---|---|---|
| master | 34 | 3 |
| this branch | **0** | **0** |

## Tests

- `common/tests/unittests/test_setup_outputdir.py` — 3 passed (the 2 existing cases plus the new one).
- The 211 tests above — all pass, runtime unchanged (57.1s master vs 48.1s here, i.e. noise).
- A probe test that forces an assertion failure inside `FitHelper.fit_and_validate_dataset` and asserts nothing is left behind: **fails on master, passes here.** Not included in the diff, since asserting on a deliberately-failing helper call is awkward to express as a permanent test — happy to add it if you'd prefer it pinned.
- `ruff format --check` and `ruff check --select I` clean on `common/` and `tabular/`.

`AG_DEFAULT_BASE_PATH` is also useful outside tests — on shared machines or a read-only working directory — so it may be worth documenting publicly in a follow-up.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
