### PR TITLE
[Tabular] Support refit_full for fit_strategy="parallel"

### DIFF
--- a/core/src/autogluon/core/ray/distributed_jobs_managers.py
+++ b/core/src/autogluon/core/ray/distributed_jobs_managers.py
@@ -175,7 +175,10 @@ class ParallelFitManager:
     def total_num_cpus_virtual(self) -> int:
         return self.total_num_cpus + self.extra_num_cpus
 
-    def num_children_model(self, model: AbstractModel) -> int:
+    def num_children_model(self, model: AbstractModel | str) -> int:
+        if self.mode == "refit":
+            # `model` is a str. A refit_full fits a single model on all data (folds are collapsed).
+            return 1
         if (not isinstance(model, BaggedEnsembleModel)) or model._user_params.get("use_child_oof", False):
             return 1
         else:
@@ -253,19 +256,17 @@ class ParallelFitManager:
         total_models_to_fit = 0
         for i, model in enumerate(models_to_schedule):
             model_name = model if self.mode == "refit" else model.name
-            if model_name in self.model_child_mem_estimate_cache:
-                model_child_memory_estimate = self.model_child_mem_estimate_cache[model_name]
-            else:
-                try:
-                    # FIXME: DONT USE TRY/EXCEPT, this is done to handle models crashing during initialization such as KNN when `NoValidFeatures`. Instead figure this out earlier or in the worker thread
-                    model_child_memory_estimate = self.get_memory_estimate_for_model_child(model=model)
-                except Exception as e:
-                    logger.log(
-                        20,
-                        f"Ran into exception when getting memory estimate for model, skipping model {model.name}: {e.__class__.__name__}: {e}",
-                    )
-                    continue
-                self.model_child_mem_estimate_cache[model_name] = model_child_memory_estimate
+            try:
+                # FIXME: DONT USE TRY/EXCEPT, this is done to handle models crashing during initialization such as KNN when `NoValidFeatures`. Instead figure this out earlier or in the worker thread
+                model_child_memory_estimate = self.get_cached_memory_estimate_for_model_child(
+                    model=model, model_name=model_name
+                )
+            except Exception as e:
+                logger.log(
+                    20,
+                    f"Ran into exception when getting memory estimate for model, skipping model {model_name}: {e.__class__.__name__}: {e}",
+                )
+                continue
             if model_child_memory_estimate > self.max_mem:
                 logger.log(
                     20, f"Insufficient total memory to fit model for even a single fold. Skipping {model_name}..."
@@ -294,19 +295,17 @@ class ParallelFitManager:
         for i, model in enumerate(models_to_schedule):
             model_name = model if self.mode == "refit" else model.name
             # TODO: refactor memory estimate logic to be one function call with the same code below
-            if model_name in self.model_child_mem_estimate_cache:
-                model_child_memory_estimate = self.model_child_mem_estimate_cache[model_name]
-            else:
-                try:
-                    # FIXME: DONT USE TRY/EXCEPT, this is done to handle models crashing during initialization such as KNN when `NoValidFeatures`. Instead figure this out earlier or in the worker thread
-                    model_child_memory_estimate = self.get_memory_estimate_for_model_child(model=model)
-                except Exception as e:
-                    logger.log(
-                        20,
-                        f"Ran into exception when getting memory estimate for model, skipping model {model.name}: {e.__class__.__name__}: {e}",
-                    )
-                    continue
-                self.model_child_mem_estimate_cache[model_name] = model_child_memory_estimate
+            try:
+                # FIXME: DONT USE TRY/EXCEPT, this is done to handle models crashing during initialization such as KNN when `NoValidFeatures`. Instead figure this out earlier or in the worker thread
+                model_child_memory_estimate = self.get_cached_memory_estimate_for_model_child(
+                    model=model, model_name=model_name
+                )
+            except Exception as e:
+                logger.log(
+                    20,
+                    f"Ran into exception when getting memory estimate for model, skipping model {model_name}: {e.__class__.__name__}: {e}",
+                )
+                continue
             if model_child_memory_estimate > self.max_mem:
                 logger.log(
                     20, f"Insufficient total memory to fit model for even a single fold. Skipping {model_name}..."
@@ -537,6 +536,32 @@ class ParallelFitManager:
         else:
             raise ValueError(f"Unknown mode: {self.mode}")
 
+    def get_cached_memory_estimate_for_model_child(self, *, model: AbstractModel | str, model_name: str) -> int:
+        """Return the per-child memory estimate for `model`, computing it only if not already known.
+
+        In `refit` mode the model is only known by name, so the estimate cannot be (re)computed here.
+        Instead, we read the estimate that was recorded on the trainer's model graph during the
+        original parallel fit (see `AbstractTrainer._fit_level_parallel`).
+        """
+        if model_name in self.model_child_mem_estimate_cache:
+            return self.model_child_mem_estimate_cache[model_name]
+
+        if self.mode == "refit":
+            mem_usage_child = self.get_model_attribute_func(
+                model=model_name, attribute="fit_child_mem_estimate", default=None
+            )
+            if mem_usage_child is None:
+                # Models without a recorded estimate are refit by cloning the parent rather than by
+                # training (e.g. WeightedEnsemble), so they require effectively no extra memory.
+                # The trainer gates on the estimate being present for all models that actually retrain.
+                logger.log(15, f"No cached memory estimate for {model_name}, assuming refit requires no memory.")
+                mem_usage_child = 0
+        else:
+            mem_usage_child = self.get_memory_estimate_for_model_child(model=model)
+
+        self.model_child_mem_estimate_cache[model_name] = mem_usage_child
+        return mem_usage_child
+
     def get_memory_estimate_for_model_child(self, *, model: AbstractModel) -> int:
         X = self.X
         y = self.y
@@ -580,7 +605,7 @@ class ParallelFitManager:
             return mem_usage_child
 
     def get_memory_estimate_for_model(
-        self, *, model: AbstractModel, mem_usage_child: int = None, num_children: int = None
+        self, *, model: AbstractModel | str, mem_usage_child: int = None, num_children: int = None
     ) -> int:
         if num_children is None:
             num_children = self.num_children_model(model)
@@ -592,7 +617,7 @@ class ParallelFitManager:
 
         logger.log(
             15,
-            f"\t{mem_usage_bag_mb:.0f} MB (per bag)\t| {mem_usage_child_mb:.0f} MB (per child)\t| {num_children} children\t| {model.name}",
+            f"\t{mem_usage_bag_mb:.0f} MB (per bag)\t| {mem_usage_child_mb:.0f} MB (per child)\t| {num_children} children\t| {model if isinstance(model, str) else model.name}",
         )
         return mem_usage_bag
 
@@ -694,8 +719,12 @@ class ParallelFitManager:
         self.job_refs_to_model_name[job_ref] = model_name
         self.job_refs_to_model_memory_estimate[job_ref] = model_memory_estimate
 
-    def deallocate_resources(self, *, job_ref: str) -> None:
-        """Deallocate resources for a model fit."""
+    def deallocate_resources(self, *, job_ref: str) -> int | None:
+        """Deallocate resources for a model fit.
+
+        Returns the per-child memory estimate that was used to schedule the job, so that the caller
+        can persist it (e.g. on the trainer's model graph) for later reuse by `refit_full`.
+        """
 
         resources = self.job_refs_to_allocated_resources.pop(job_ref)
         model_name = self.job_refs_to_model_name.pop(job_ref)
@@ -703,7 +732,7 @@ class ParallelFitManager:
         self.available_num_gpus += resources.total_num_gpus
         model_memory_estimate = self.job_refs_to_model_memory_estimate.pop(job_ref)
         self.available_mem += model_memory_estimate
-        self.model_child_mem_estimate_cache.pop(model_name)
+        return self.model_child_mem_estimate_cache.pop(model_name, None)
 
     def clean_unfinished_job_refs(self, *, unfinished_job_refs: list[str] | None = None):
         import ray

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -1650,11 +1650,6 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         fit_strategy: Literal["sequential", "parallel"] = "sequential",
         **kwargs,
     ) -> list[str]:
-        if fit_strategy == "parallel":
-            logger.log(
-                30, f"Note: refit_full does not yet support fit_strategy='parallel', switching to 'sequential'..."
-            )
-            fit_strategy = "sequential"
         if X is None:
             X = self.load_X()
         if X_val is None:
@@ -1684,6 +1679,28 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         levels = sorted(model_levels.keys())
         models_trained_full = []
         model_refit_map = {}  # FIXME: is this even used, remove?
+
+        if fit_strategy == "parallel":
+            # Parallel refit requires a per-child memory estimate to schedule the refit jobs.
+            # The estimate is recorded on the model graph during the original parallel fit, so it is
+            # only available if the models themselves were fit with `fit_strategy="parallel"`.
+            # Only models in the "core" stack are actually retrained during refit; aux models
+            # (e.g. WeightedEnsemble) are refit by cloning the parent and need no memory estimate.
+            models_missing_mem_estimate = [
+                model
+                for model in models
+                if self.get_model_attribute(model, "stack_name", default=None) == "core"
+                and self.get_model_attribute(model, "fit_child_mem_estimate", default=None) is None
+            ]
+            if models_missing_mem_estimate:
+                logger.log(
+                    30,
+                    "Note: refit_full does not support fit_strategy='parallel' for models fit without it "
+                    f"(missing memory estimates for {len(models_missing_mem_estimate)}/{len(models)} models), "
+                    "switching to 'sequential'...",
+                )
+                logger.log(15, f"\tModels missing a memory estimate: {models_missing_mem_estimate}")
+                fit_strategy = "sequential"
 
         if fit_strategy == "sequential":
             for level in levels:
@@ -1752,6 +1769,9 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
 
                 while unfinished_job_refs:
                     finished, unfinished_job_refs = ray.wait(unfinished_job_refs, num_returns=1)
+                    # Free the resources held by the finished job, otherwise the remaining models
+                    # can never be scheduled and would be silently dropped.
+                    distributed_manager.deallocate_resources(job_ref=finished[0])
                     refit_full_parent, model_trained, model_path, model_type = ray.get(finished[0])
 
                     self._add_model(
@@ -1772,6 +1792,13 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
                     logger.log(20, f"Finished refit model for {refit_full_parent}")
                     unfinished_job_refs += distributed_manager.schedule_jobs()
 
+                if distributed_manager.models_to_schedule:
+                    logger.log(
+                        30,
+                        f"WARNING: Failed to refit {len(distributed_manager.models_to_schedule)} L{level} models, "
+                        f"they could never be scheduled with the available resources: "
+                        f"{distributed_manager.models_to_schedule}",
+                    )
                 logger.log(20, f"Finished distributed refitting for {len(models_trained_full_level)} L{level} models.")
                 models_trained_full += models_trained_full_level
                 distributed_manager.clean_job_state(unfinished_job_refs=unfinished_job_refs)
@@ -3499,7 +3526,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
                 logger.log(20, "Ran into timeout while waiting for model training to finish. Stopping now.")
                 break
 
-            distributed_manager.deallocate_resources(job_ref=finished[0])
+            model_child_mem_estimate = distributed_manager.deallocate_resources(job_ref=finished[0])
             model_name, model_path, model_type, exc, model_failure_info = ray.get(finished[0])
             assert model_name in expected_model_names, (
                 f"Unexpected model name outputted during parallel fit: {model_name}\n"
@@ -3546,6 +3573,14 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
                     stack_name=kwargs["stack_name"],
                     level=kwargs["level"],
                 ):
+                    # Persist the memory estimate on the model graph so that `refit_full` can
+                    # schedule this model with fit_strategy="parallel" without recomputing it.
+                    # Stored per-model (rather than in a single trainer-level dict) so that it is
+                    # not overwritten by subsequent stacking layers.
+                    # FIXME: The estimate is slightly off for refit, since refit trains on more rows
+                    #  than the bagged child models did (depending on the validation method).
+                    if model_child_mem_estimate is not None:
+                        self._update_model_attr(model_name, fit_child_mem_estimate=model_child_mem_estimate)
                     jobs_running = len(unfinished_job_refs)
                     if can_schedule_jobs:
                         remaining_task_word = "pending"


### PR DESCRIPTION
*Issue #, if available:*

Supersedes #4680 by @LennartPurucker, whose approach and diagnosis this builds on (credited as co-author). That branch cannot be rebased: it predates the split of `core/.../trainer/abstract_trainer.py` into a 196-line generic base in `core` plus the bulk in `tabular`, so every trainer hunk targets code that no longer lives at that path and `git rebase` produces a whole-file conflict. Re-implemented on current master instead.

*Description of changes:*

`refit_full(fit_strategy="parallel")` is currently dead code — `refit_single_full` logs *"refit_full does not yet support fit_strategy='parallel', switching to 'sequential'"* and downgrades unconditionally. The parallel path below that guard has never run, and could not: in `refit` mode `ParallelFitManager` receives models as **strings**, so `get_memory_estimate_for_model_child` cannot call `estimate_memory_usage_static_child` to size the jobs.

## Changes

**Store the per-child memory estimate on the model graph.** `_fit_level_parallel` now records it as a `fit_child_mem_estimate` model attribute as each model is added; `deallocate_resources` returns the estimate it pops instead of discarding it. This addresses both review comments on #4680: a single trainer-level dict was overwritten by each stacking layer, whereas per-model storage keeps L1 and L2 estimates side by side and persists with the trainer across save/load.

**Read the estimate from the DAG in refit mode.** New `ParallelFitManager.get_cached_memory_estimate_for_model_child` replaces two copy-pasted estimate blocks in `schedule_jobs`; in `refit` mode it reads `fit_child_mem_estimate` through the already-injected `get_model_attribute_func`. Also fixed along the way: `num_children_model` and `get_memory_estimate_for_model` both assumed an `AbstractModel` and raised `AttributeError: 'str' object has no attribute 'name'` on the refit-mode string (hit live while testing).

**Gate the fallback on estimate availability.** `refit_full` downgrades to sequential only when a *core* model lacks an estimate — i.e. the models were originally fit sequentially — and logs which ones at verbosity 15. Aux models are exempt because their refit is a clone (`convert_to_refit_full_via_copy`), not a fit.

## Pre-existing bug fixed alongside: parallel refit silently dropped models

Not part of #4680, and the feature would have shipped broken without it. The `while unfinished_job_refs` loop in `refit_single_full` never called `deallocate_resources`, so resources held by a finished refit job were never returned. Once the first model claimed the CPUs, every remaining model in the level was pushed to `models_to_schedule_later` forever and then **discarded with no error**.

Observed before the fix on a 3-model × 2-level stack: `WeightedEnsemble_L2` was allocated all 48 CPUs, and `LightGBM_BAG_L2`, `LightGBM_2_BAG_L2` and `XGBoost_BAG_L2` were never refit —

```
Scheduling distributed model-workers for refitting 4 L2 models...
Finished distributed refitting for 1 L2 models.
```

no warning either. Now the loop deallocates on each finished job, and a `WARNING` is logged if any model is still unscheduled when a level ends, so a future scheduling stall can never be silent.

## Verification

End to end on a 400-row synthetic binary task, `num_bag_folds=2`, `num_stack_levels=1`, `fit_strategy="parallel"`, `num_gpus=0`, 8 models:

- Estimates land per model and per level — `LightGBM_BAG_L1: 66122686`, `XGBoost_BAG_L1: 7252638`, `LightGBM_BAG_L2: 66718246`, … — L1 values are **not** overwritten by L2, which is the multi-layer problem raised in the #4680 review.
- `refit_full(fit_strategy="parallel")` refits all 8 models, with a refit map and leaderboard matching a sequential-refit run exactly.
- `core/tests/unittests/ray` + `core/tests/unittests/test_parallel_local_folding.py` — 32 passed.
- `tabular/tests/unittests/models/advanced` + `tabular/tests/unittests/edgecases` — 40 passed.
- `ruff format --check` and `ruff check --select I` clean on `core/` and `tabular/`.

Note for reviewers testing this: on a GPU machine `fit_strategy="parallel"` still downgrades to sequential at *fit* time unless `num_gpus=0` or `AG_PARALLEL_GPU=True`. That is pre-existing and unrelated, but it masks the whole feature if you test on a GPU box.

## Known follow-ups (not addressed here)

- **No unit test.** Nothing in the repo exercises `refit_full(fit_strategy="parallel")`; a test needs ray and ≥12 CPUs (or `AG_FORCE_PARALLEL=True`) plus `num_gpus=0`.
- **The estimate is knowingly low for refit.** A refit trains on train+val, i.e. more rows than any bagged child saw, so the cached per-child estimate is an underestimate. Carried over from #4680 as a `FIXME`; scaling by the row-count ratio would be a small, principled fix.
- **Sequentially-fit models still cannot be refit in parallel,** since estimates only exist after a parallel fit. Recomputing from the persisted model template would remove the restriction.
- `WeightedEnsemble` requests `fit_num_cpus_child` (all cores) for a clone that needs approximately none. Harmless now that deallocation works, but it serialises the level for no reason.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
