### PR TITLE
[features] Fix DatetimeFeatureGenerator IndexError on non-RangeIndex

### DIFF
--- a/features/src/autogluon/features/generators/datetime.py
+++ b/features/src/autogluon/features/generators/datetime.py
@@ -56,7 +56,7 @@ class DatetimeFeatureGenerator(AbstractFeatureGenerator):
         #   The runtime is approximately 0.08 seconds per 1000 rows in worst case.
         series = pd.to_datetime(X[feature].copy(), utc=True, errors="coerce", format="mixed")
         broken_idx = series[(series == "NaT") | series.isna() | series.isnull()].index
-        bad_rows = series.iloc[broken_idx]
+        bad_rows = series.loc[broken_idx]
         if is_fit:
             good_rows = series[~series.isin(bad_rows)].astype(np.int64)
             self._fillna_map[feature] = pd.to_datetime(int(good_rows.mean()), utc=True, format="mixed")

--- a/features/src/autogluon/features/generators/datetime.py
+++ b/features/src/autogluon/features/generators/datetime.py
@@ -55,12 +55,21 @@ class DatetimeFeatureGenerator(AbstractFeatureGenerator):
         #   Alternatives like Polars do not offer the same datetime conversion logic, and thus aren't valid to use.
         #   The runtime is approximately 0.08 seconds per 1000 rows in worst case.
         series = pd.to_datetime(X[feature].copy(), utc=True, errors="coerce", format="mixed")
-        broken_idx = series[(series == "NaT") | series.isna() | series.isnull()].index
-        bad_rows = series.loc[broken_idx]
+        # A boolean mask rather than an index of labels. The invalid rows were only ever needed to
+        # exclude them from the mean, which `isin` did by *value* -- so neither label nor positional
+        # indexing was required, and mixing the two is what broke here: `broken_idx` holds labels,
+        # and indexing with them positionally either raises (labels beyond the row count) or picks
+        # the wrong rows, which silently poisons the fill value because `NaT.astype(np.int64)` is a
+        # large negative sentinel. A mask is correct for any index, including a duplicated one,
+        # where the label-based assignment below used to raise `InvalidIndexError`.
+        # `isna()` alone matches what the previous `(series == "NaT") | isna() | isnull()` matched:
+        # `isnull` is an alias of `isna`, and comparing a tz-aware datetime64 series to the string
+        # "NaT" is always False.
+        bad_mask = series.isna()
         if is_fit:
-            good_rows = series[~series.isin(bad_rows)].astype(np.int64)
+            good_rows = series[~bad_mask].astype(np.int64)
             self._fillna_map[feature] = pd.to_datetime(int(good_rows.mean()), utc=True, format="mixed")
-        series[broken_idx] = self._fillna_map[feature]
+        series[bad_mask] = self._fillna_map[feature]
         return series
 
     # TODO: Improve handling of missing datetimes

--- a/features/tests/features/generators/test_datetime.py
+++ b/features/tests/features/generators/test_datetime.py
@@ -128,3 +128,65 @@ def test_datetime_feature_generator_advanced(generator_helper, data_helper):
     )
 
     assert expected_output_data_feat_datetime == list(output_data["datetime_as_object"].values)
+
+
+def test_datetime_feature_generator_non_range_index(generator_helper, data_helper):
+    # Given
+    # Same datetime values as test_datetime_feature_generator, but a non-contiguous index.
+    # broken_idx is label-based; series.iloc[broken_idx] raises IndexError.
+    # Existing tests stay on RangeIndex, so they do not catch this.
+    input_data = data_helper.generate_datetime_feature().to_frame(name="datetime")
+    input_data.index = [10, 20, 30, 40, 50, 60, 70, 80, 90]
+
+    generator = DatetimeFeatureGenerator()
+
+    expected_feature_metadata_in_full = {
+        ("datetime", ()): ["datetime"],
+    }
+
+    expected_feature_metadata_full = {
+        ("int", ("datetime_as_int",)): [
+            "datetime",
+            "datetime.year",
+            "datetime.month",
+            "datetime.day",
+            "datetime.dayofweek",
+        ]
+    }
+
+    # Mean-fill of invalid rows is unchanged vs the RangeIndex test.
+    expected_output_data_feat_datetime = [
+        1533140820000000000,
+        1301322000000000000,
+        1301322000000000000,
+        1524238620000000000,
+        1524238620000000000,
+        -5364662400000000000,
+        7289654340000000000,
+        1301322000000000000,
+        1301322000000000000,
+    ]
+
+    expected_output_data_feat_datetime_year = [
+        2018,
+        2011,  # blank and nan values are set to the mean of good values = 2011
+        2011,
+        2018,
+        2018,
+        1800,
+        2200,
+        2011,  # 2700 and 1000 are out of range for a pandas datetime so they are set to the mean
+        2011,  # see limits at https://pandas.pydata.org/docs/reference/api/pandas.Timestamp.max.html
+    ]
+
+    # When
+    output_data = generator_helper.fit_transform_assert(
+        input_data=input_data,
+        generator=generator,
+        expected_feature_metadata_in_full=expected_feature_metadata_in_full,
+        expected_feature_metadata_full=expected_feature_metadata_full,
+    )
+
+    assert expected_output_data_feat_datetime == list(output_data["datetime"].values)
+    assert expected_output_data_feat_datetime_year == list(output_data["datetime.year"].values)
+    assert list(output_data.index) == [10, 20, 30, 40, 50, 60, 70, 80, 90]

--- a/features/tests/features/generators/test_datetime.py
+++ b/features/tests/features/generators/test_datetime.py
@@ -190,3 +190,42 @@ def test_datetime_feature_generator_non_range_index(generator_helper, data_helpe
     assert expected_output_data_feat_datetime == list(output_data["datetime"].values)
     assert expected_output_data_feat_datetime_year == list(output_data["datetime.year"].values)
     assert list(output_data.index) == [10, 20, 30, 40, 50, 60, 70, 80, 90]
+
+
+def test_datetime_feature_generator_transform_non_range_index(data_helper):
+    # Fit on RangeIndex (default pipeline), then transform a held-out frame that
+    # kept leftover labels — the bag/split crash path. .iloc[broken_idx] IndexErrors.
+    train = data_helper.generate_datetime_feature().to_frame(name="datetime")
+    generator = DatetimeFeatureGenerator()
+    generator.fit_transform(train)
+
+    held_out = train.copy()
+    held_out.index = [10, 20, 30, 40, 50, 60, 70, 80, 90]
+    output = generator.transform(held_out)
+
+    expected_output_data_feat_datetime = [
+        1533140820000000000,
+        1301322000000000000,
+        1301322000000000000,
+        1524238620000000000,
+        1524238620000000000,
+        -5364662400000000000,
+        7289654340000000000,
+        1301322000000000000,
+        1301322000000000000,
+    ]
+    expected_output_data_feat_datetime_year = [
+        2018,
+        2011,
+        2011,
+        2018,
+        2018,
+        1800,
+        2200,
+        2011,
+        2011,
+    ]
+    assert expected_output_data_feat_datetime == list(output["datetime"].values)
+    assert expected_output_data_feat_datetime_year == list(output["datetime.year"].values)
+    assert list(output.index) == [10, 20, 30, 40, 50, 60, 70, 80, 90]
+

--- a/features/tests/features/generators/test_datetime.py
+++ b/features/tests/features/generators/test_datetime.py
@@ -229,3 +229,47 @@ def test_datetime_feature_generator_transform_non_range_index(data_helper):
     assert expected_output_data_feat_datetime_year == list(output["datetime.year"].values)
     assert list(output.index) == [10, 20, 30, 40, 50, 60, 70, 80, 90]
 
+
+def test_datetime_feature_generator_permuted_index_fill_value(data_helper):
+    """A permuted index must not change the fill value.
+
+    The invalid rows used to be selected positionally from an index of *labels*. With labels beyond
+    the row count that raises, which is loud; with labels inside it -- any permuted index, as
+    `sort_values`, `groupby` or `sample` produce -- it silently picks the wrong rows, and the
+    invalid rows then survive into the mean as `NaT.astype(np.int64)`, a large negative sentinel.
+    The fill value came out decades early with no error.
+    """
+    import numpy as np
+    import pandas as pd
+
+    values = ["2020-01-01", "2020-02-01", "not-a-date", "2020-04-01"]
+    permuted = pd.DataFrame({"datetime_as_object": values}, index=[3, 2, 1, 0])
+
+    generator = DatetimeFeatureGenerator()
+    generator.fit_transform(permuted)
+
+    good = pd.to_datetime(pd.Series([v for v in values if v != "not-a-date"]), utc=True).astype(np.int64)
+    assert generator._fillna_map["datetime_as_object"] == pd.to_datetime(int(good.mean()), utc=True)
+
+
+def test_datetime_feature_generator_duplicate_index(data_helper):
+    """A duplicated index is now handled rather than raising.
+
+    The label-based assignment that filled the invalid rows raised
+    `InvalidIndexError: Reindexing only valid with uniquely valued Index objects`; a boolean mask
+    does not need a unique index.
+    """
+    import numpy as np
+    import pandas as pd
+
+    values = ["not-a-date", "2020-02-01", "2020-03-01", "2020-04-01", "2020-05-01", "2020-06-01"]
+    duplicated = pd.DataFrame({"datetime_as_object": values}, index=[0, 1, 0, 1, 0, 1])
+
+    generator = DatetimeFeatureGenerator()
+    output = generator.fit_transform(duplicated)
+
+    good = pd.to_datetime(pd.Series(values[1:]), utc=True).astype(np.int64)
+    expected_fill = pd.to_datetime(int(good.mean()), utc=True)
+    assert generator._fillna_map["datetime_as_object"] == expected_fill
+    # the invalid row was filled with the mean rather than left as NaT
+    assert output["datetime_as_object"].iloc[0] == expected_fill.value


### PR DESCRIPTION
*Issue #, if available:*
Related to #3401 / #3507 (same `.iloc` vs `.loc` bug class). Those fixed AutoGluon EDA; `DatetimeFeatureGenerator.normalize_timeseries` was not updated.

*Description of changes:*
- In `normalize_timeseries`, select invalid rows with `series.loc[broken_idx]` instead of `series.iloc[broken_idx]`. `broken_idx` is taken from `series.index` (labels). Assignment `series[broken_idx] = fill` is already label-based; `.iloc` treats those labels as positions and raises `IndexError: positional indexers are out-of-bounds` when the index is not a RangeIndex (bag/split leftover labels).
- Tests: `fit_transform` on a non-contiguous index, and `fit` on RangeIndex then `transform` a held-out frame that kept leftover labels. Mean-fill values are unchanged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.