### PR TITLE
[core] Fix EnsembleSelection crash when every candidate regret is NaN

### DIFF
--- a/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py
+++ b/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py
@@ -226,13 +226,13 @@ class EnsembleSelection(AbstractWeightedEnsemble):
         """Return sanitized regrets and the indices of the lowest finite score.
 
         Non-finite regrets (NaN / +/-inf) are treated as dead (mapped to +inf) so they
-        never beat a finite score. If every score is non-finite, fall back to index 0
-        instead of ``RandomState.choice([])`` (all-NaN + ``isclose(..., equal_nan=False)``)
-        or ``equal_nan=True`` (which later dies on ``list.index(nan)``).
+        never beat a finite score. If every score is non-finite, raise instead of
+        ``RandomState.choice([])`` or ``equal_nan=True`` (the latter later dies on
+        ``list.index(nan)`` when writing ``trajectory``).
         """
         scores = np.where(np.isfinite(scores), scores, np.inf)
         if not np.isfinite(scores).any():
-            return scores, np.array([0], dtype=int)
+            raise ValueError("all ensemble scores non-finite")
         all_best = np.argwhere(np.isclose(scores, np.nanmin(scores), atol=0, rtol=1e-12)).flatten()
         return scores, all_best
 

--- a/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py
+++ b/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py
@@ -146,7 +146,7 @@ class EnsembleSelection(AbstractWeightedEnsemble):
                 if round_scores:
                     scores[j] = scores[j].round(round_decimals)
 
-            all_best = np.argwhere(np.isclose(scores, np.nanmin(scores), atol=0, rtol=1e-12)).flatten()
+            scores, all_best = self._select_best_by_score(scores)
 
             if (len(all_best) > 1) and used_models:
                 # If tie, prioritize models already in ensemble to avoid unnecessarily large ensemble
@@ -172,9 +172,7 @@ class EnsembleSelection(AbstractWeightedEnsemble):
                             scores_tiebreak[k] = self._calculate_regret(
                                 y_true=labels, y_pred_proba=fant_ensemble_prediction, metric=secondary_metric
                             )
-                        all_best_tiebreak = np.argwhere(
-                            np.isclose(scores_tiebreak, np.nanmin(scores_tiebreak), atol=0, rtol=1e-12)
-                        ).flatten()
+                        scores_tiebreak, all_best_tiebreak = self._select_best_by_score(scores_tiebreak)
                         all_best = [index_map[index] for index in all_best_tiebreak]
 
             best = self.random_state.choice(all_best)
@@ -222,6 +220,21 @@ class EnsembleSelection(AbstractWeightedEnsemble):
             self.train_score_ = trajectory[-1]
 
         logger.debug("Ensemble indices: " + str(self.indices_))
+
+    @staticmethod
+    def _select_best_by_score(scores: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """Return sanitized regrets and the indices of the lowest finite score.
+
+        Non-finite regrets (NaN / +/-inf) are treated as dead (mapped to +inf) so they
+        never beat a finite score. If every score is non-finite, fall back to index 0
+        instead of ``RandomState.choice([])`` (all-NaN + ``isclose(..., equal_nan=False)``)
+        or ``equal_nan=True`` (which later dies on ``list.index(nan)``).
+        """
+        scores = np.where(np.isfinite(scores), scores, np.inf)
+        if not np.isfinite(scores).any():
+            return scores, np.array([0], dtype=int)
+        all_best = np.argwhere(np.isclose(scores, np.nanmin(scores), atol=0, rtol=1e-12)).flatten()
+        return scores, all_best
 
     def _calculate_regret(
         self, y_true: np.ndarray, y_pred_proba: np.ndarray, metric: Scorer, sample_weight: np.ndarray = None

--- a/core/tests/unittests/models/test_ensemble_selection.py
+++ b/core/tests/unittests/models/test_ensemble_selection.py
@@ -21,17 +21,9 @@ def _always_nan_metric():
     return make_scorer("always_nan", lambda y_true, y_pred: np.nan, optimum=0, greater_is_better=False)
 
 
-def _assert_first_model_fallback(ensemble):
-    assert ensemble.weights_[0] == 1.0
-    assert np.count_nonzero(ensemble.weights_) == 1
-    assert np.isclose(np.sum(ensemble.weights_), 1.0)
-    assert list(ensemble.indices_) == [0]
-
-
-def test_select_best_by_score_all_nan_falls_back_to_first():
-    scores, all_best = EnsembleSelection._select_best_by_score(np.array([np.nan, np.nan, np.nan]))
-    assert np.all(np.isposinf(scores))
-    assert np.array_equal(all_best, np.array([0]))
+def test_select_best_by_score_all_nan_raises():
+    with pytest.raises(ValueError, match="all ensemble scores non-finite"):
+        EnsembleSelection._select_best_by_score(np.array([np.nan, np.nan, np.nan]))
 
 
 def test_select_best_by_score_nonfinite_lose_to_finite():
@@ -43,30 +35,30 @@ def test_select_best_by_score_nonfinite_lose_to_finite():
     assert scores[4] == 0.2
 
 
-def test_ensemble_selection_all_nan_scores_falls_back_to_first_model():
+def test_ensemble_selection_all_nan_scores_raises():
     """All-NaN regrets used to raise ValueError from RandomState.choice([])."""
     labels, predictions = _labels_and_preds()
     ensemble = _ensemble_selection(_always_nan_metric())
-    ensemble.fit(predictions=predictions, labels=labels)
-    _assert_first_model_fallback(ensemble)
+    with pytest.raises(ValueError, match="all ensemble scores non-finite"):
+        ensemble.fit(predictions=predictions, labels=labels)
 
 
-def test_ensemble_selection_all_nan_predictions_falls_back_to_first_model():
+def test_ensemble_selection_all_nan_predictions_raises():
     """All-NaN predictions produce all-NaN RMSE regrets and crashed on master."""
     labels = np.array([0.0, 1.0, 2.0, 3.0])
     predictions = [np.full_like(labels, np.nan), np.full_like(labels, np.nan)]
     ensemble = _ensemble_selection(root_mean_squared_error)
-    ensemble.fit(predictions=predictions, labels=labels)
-    _assert_first_model_fallback(ensemble)
+    with pytest.raises(ValueError, match="all ensemble scores non-finite"):
+        ensemble.fit(predictions=predictions, labels=labels)
 
 
 @pytest.mark.parametrize("dead_score", [np.nan, np.inf, -np.inf])
-def test_ensemble_selection_all_nonfinite_scores_falls_back_to_first_model(dead_score):
+def test_ensemble_selection_all_nonfinite_scores_raises(dead_score):
     labels, predictions = _labels_and_preds(n_models=3)
     ensemble = _ensemble_selection(root_mean_squared_error)
     ensemble._calculate_regret = lambda *args, **kwargs: dead_score
-    ensemble.fit(predictions=predictions, labels=labels)
-    _assert_first_model_fallback(ensemble)
+    with pytest.raises(ValueError, match="all ensemble scores non-finite"):
+        ensemble.fit(predictions=predictions, labels=labels)
 
 
 def test_ensemble_selection_nonfinite_scores_lose_to_finite():
@@ -84,9 +76,11 @@ def test_ensemble_selection_nonfinite_scores_lose_to_finite():
     ensemble.fit(predictions=predictions, labels=labels)
     assert ensemble.weights_[1] == 1.0
     assert np.count_nonzero(ensemble.weights_) == 1
+    # best_score written into trajectory is finite, so index(min) cannot miss NaN
+    assert np.isfinite(ensemble.train_score_)
 
 
-def test_ensemble_selection_second_metric_all_nan_tiebreak_does_not_crash():
+def test_ensemble_selection_second_metric_all_nan_tiebreak_raises():
     labels = np.array([0, 1, 0, 1])
     predictions = [
         np.array([0.2, 0.8, 0.3, 0.7]),
@@ -105,9 +99,8 @@ def test_ensemble_selection_second_metric_all_nan_tiebreak_does_not_crash():
         return 1.0
 
     ensemble._calculate_regret = _regret
-    ensemble.fit(predictions=predictions, labels=labels)
-    assert np.isclose(np.sum(ensemble.weights_), 1.0)
-    assert np.count_nonzero(ensemble.weights_) == 1
+    with pytest.raises(ValueError, match="all ensemble scores non-finite"):
+        ensemble.fit(predictions=predictions, labels=labels)
 
 
 def test_ensemble_selection_finite_scores_still_pick_better_model():
@@ -117,3 +110,4 @@ def test_ensemble_selection_finite_scores_still_pick_better_model():
     ensemble.fit(predictions=predictions, labels=labels)
     assert ensemble.weights_[1] > ensemble.weights_[0]
     assert np.isclose(np.sum(ensemble.weights_), 1.0)
+    assert np.isfinite(ensemble.train_score_)

--- a/core/tests/unittests/models/test_ensemble_selection.py
+++ b/core/tests/unittests/models/test_ensemble_selection.py
@@ -1,0 +1,119 @@
+import numpy as np
+import pytest
+
+from autogluon.core.metrics import log_loss, make_scorer, root_mean_squared_error
+from autogluon.core.models.greedy_ensemble.ensemble_selection import EnsembleSelection
+
+
+def _labels_and_preds(n_models=2):
+    labels = np.array([0.0, 1.0, 2.0, 3.0])
+    predictions = [np.full(labels.shape, float(i)) for i in range(n_models)]
+    return labels, predictions
+
+
+def _ensemble_selection(metric, **kwargs):
+    kwargs.setdefault("ensemble_size", 5)
+    kwargs.setdefault("problem_type", "regression")
+    return EnsembleSelection(metric=metric, **kwargs)
+
+
+def _always_nan_metric():
+    return make_scorer("always_nan", lambda y_true, y_pred: np.nan, optimum=0, greater_is_better=False)
+
+
+def _assert_first_model_fallback(ensemble):
+    assert ensemble.weights_[0] == 1.0
+    assert np.count_nonzero(ensemble.weights_) == 1
+    assert np.isclose(np.sum(ensemble.weights_), 1.0)
+    assert list(ensemble.indices_) == [0]
+
+
+def test_select_best_by_score_all_nan_falls_back_to_first():
+    scores, all_best = EnsembleSelection._select_best_by_score(np.array([np.nan, np.nan, np.nan]))
+    assert np.all(np.isposinf(scores))
+    assert np.array_equal(all_best, np.array([0]))
+
+
+def test_select_best_by_score_nonfinite_lose_to_finite():
+    scores, all_best = EnsembleSelection._select_best_by_score(np.array([np.nan, 0.4, np.inf, -np.inf, 0.2]))
+    assert np.array_equal(all_best, np.array([4]))
+    assert np.isposinf(scores[0])
+    assert np.isposinf(scores[2])
+    assert np.isposinf(scores[3])
+    assert scores[4] == 0.2
+
+
+def test_ensemble_selection_all_nan_scores_falls_back_to_first_model():
+    """All-NaN regrets used to raise ValueError from RandomState.choice([])."""
+    labels, predictions = _labels_and_preds()
+    ensemble = _ensemble_selection(_always_nan_metric())
+    ensemble.fit(predictions=predictions, labels=labels)
+    _assert_first_model_fallback(ensemble)
+
+
+def test_ensemble_selection_all_nan_predictions_falls_back_to_first_model():
+    """All-NaN predictions produce all-NaN RMSE regrets and crashed on master."""
+    labels = np.array([0.0, 1.0, 2.0, 3.0])
+    predictions = [np.full_like(labels, np.nan), np.full_like(labels, np.nan)]
+    ensemble = _ensemble_selection(root_mean_squared_error)
+    ensemble.fit(predictions=predictions, labels=labels)
+    _assert_first_model_fallback(ensemble)
+
+
+@pytest.mark.parametrize("dead_score", [np.nan, np.inf, -np.inf])
+def test_ensemble_selection_all_nonfinite_scores_falls_back_to_first_model(dead_score):
+    labels, predictions = _labels_and_preds(n_models=3)
+    ensemble = _ensemble_selection(root_mean_squared_error)
+    ensemble._calculate_regret = lambda *args, **kwargs: dead_score
+    ensemble.fit(predictions=predictions, labels=labels)
+    _assert_first_model_fallback(ensemble)
+
+
+def test_ensemble_selection_nonfinite_scores_lose_to_finite():
+    labels, predictions = _labels_and_preds(n_models=3)
+    ensemble = _ensemble_selection(root_mean_squared_error)
+    call = {"i": 0}
+    per_model = [np.nan, 0.25, np.inf]
+
+    def _regret(*args, **kwargs):
+        j = call["i"] % len(per_model)
+        call["i"] += 1
+        return per_model[j]
+
+    ensemble._calculate_regret = _regret
+    ensemble.fit(predictions=predictions, labels=labels)
+    assert ensemble.weights_[1] == 1.0
+    assert np.count_nonzero(ensemble.weights_) == 1
+
+
+def test_ensemble_selection_second_metric_all_nan_tiebreak_does_not_crash():
+    labels = np.array([0, 1, 0, 1])
+    predictions = [
+        np.array([0.2, 0.8, 0.3, 0.7]),
+        np.array([0.1, 0.9, 0.4, 0.6]),
+    ]
+    ensemble = EnsembleSelection(
+        ensemble_size=5,
+        problem_type="binary",
+        metric=make_scorer("tied", lambda y_true, y_pred: 1.0, optimum=0, greater_is_better=False),
+        tie_breaker="second_metric",
+    )
+
+    def _regret(y_true, y_pred_proba, metric, sample_weight=None):
+        if metric is log_loss or getattr(metric, "name", None) == "log_loss":
+            return np.nan
+        return 1.0
+
+    ensemble._calculate_regret = _regret
+    ensemble.fit(predictions=predictions, labels=labels)
+    assert np.isclose(np.sum(ensemble.weights_), 1.0)
+    assert np.count_nonzero(ensemble.weights_) == 1
+
+
+def test_ensemble_selection_finite_scores_still_pick_better_model():
+    labels = np.array([0.0, 1.0, 2.0, 3.0])
+    predictions = [np.zeros_like(labels), labels.copy()]
+    ensemble = _ensemble_selection(root_mean_squared_error)
+    ensemble.fit(predictions=predictions, labels=labels)
+    assert ensemble.weights_[1] > ensemble.weights_[0]
+    assert np.isclose(np.sum(ensemble.weights_), 1.0)

--- a/timeseries/tests/unittests/models/ensemble/test_greedy_nonfinite_scores.py
+++ b/timeseries/tests/unittests/models/ensemble/test_greedy_nonfinite_scores.py
@@ -1,0 +1,102 @@
+"""Greedy ensemble selection when every candidate regret is non-finite.
+
+Ordinary constant / zero-demand items make MASE (in-sample scale 0) and the
+default WQL (forecast-horizon sum 0) return NaN. On AutoGluon master,
+``EnsembleSelection`` then dies inside ``RandomState.choice([])``. After the
+core guard, ``GreedyEnsemble.fit`` / ``PerItemGreedyEnsemble.fit`` raise a
+clear ``ValueError`` instead of inventing a winner.
+
+Do not route this through ``EnsembleComposer``: its ``fit`` try/except
+swallows the error and skips the ensemble, so a predictor-level crash is not
+the user-facing behavior.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from autogluon.timeseries import TimeSeriesDataFrame
+from autogluon.timeseries.models.ensemble import GreedyEnsemble, PerItemGreedyEnsemble
+
+from ...common import get_data_frame_with_item_index
+
+
+PREDICTION_LENGTH = 2
+QUANTILE_COLUMNS = ["mean", "0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9"]
+
+
+def _zero_demand_item(length: int = 12) -> TimeSeriesDataFrame:
+    """Tiny intermittent / all-zero item (daily, longer than MASE seasonality)."""
+    data = get_data_frame_with_item_index(["SKU"], data_length=length, freq="D", start_date="2022-01-01")
+    data["target"] = 0.0
+    return data
+
+
+def _horizon_forecasts(data: TimeSeriesDataFrame, value: float = 0.0) -> TimeSeriesDataFrame:
+    """Forecast aligned with the last ``prediction_length`` rows (the val window)."""
+    horizon_index = data.slice_by_timestep(-PREDICTION_LENGTH, None).index
+    return TimeSeriesDataFrame(
+        pd.DataFrame(
+            np.full((len(horizon_index), len(QUANTILE_COLUMNS)), value),
+            index=horizon_index,
+            columns=QUANTILE_COLUMNS,
+        )
+    )
+
+
+def _zero_demand_ensemble_inputs():
+    data = _zero_demand_item()
+    # SeasonalNaive / ZeroModel on an all-zero item emit a zero forecast.
+    zero_forecast = _horizon_forecasts(data, value=0.0)
+    predictions_per_window = {
+        "Naive": [zero_forecast],
+        "SeasonalNaive": [zero_forecast.copy()],
+    }
+    return predictions_per_window, [data]
+
+
+@pytest.mark.parametrize(
+    "ensemble_cls, hyperparameters",
+    [
+        (GreedyEnsemble, {"ensemble_size": 2}),
+        (PerItemGreedyEnsemble, {"ensemble_size": 2, "n_jobs": 1}),
+    ],
+)
+@pytest.mark.parametrize("eval_metric", [None, "WQL", "MASE"])
+def test_when_all_ensemble_scores_nonfinite_then_fit_raises_clear_error(ensemble_cls, hyperparameters, eval_metric):
+    """Zero-demand item + MASE / default WQL: all regrets NaN, then a clear ValueError.
+
+    Master ``EnsembleSelection`` raised ``ValueError`` from ``RandomState.choice([])``
+    (``'a' cannot be empty unless no samples are taken``). After the guard this is
+    ``ValueError: all ensemble scores non-finite``.
+    """
+    predictions_per_window, data_per_window = _zero_demand_ensemble_inputs()
+    ensemble = ensemble_cls(
+        prediction_length=PREDICTION_LENGTH,
+        eval_metric=eval_metric,
+        hyperparameters=hyperparameters,
+        freq=data_per_window[0].freq,
+    )
+    with pytest.raises(ValueError, match="all ensemble scores non-finite"):
+        ensemble.fit(
+            predictions_per_window=predictions_per_window,
+            data_per_window=data_per_window,
+        )
+
+
+def test_when_constant_series_and_mase_then_greedy_ensemble_fit_raises_clear_error():
+    """MASE is undefined on a constant item (in-sample seasonal error 0)."""
+    data = get_data_frame_with_item_index(["SKU"], data_length=12, freq="D", start_date="2022-01-01")
+    data["target"] = 5.0
+    forecast = _horizon_forecasts(data, value=5.0)
+    ensemble = GreedyEnsemble(
+        prediction_length=PREDICTION_LENGTH,
+        eval_metric="MASE",
+        hyperparameters={"ensemble_size": 2},
+        freq=data.freq,
+    )
+    with pytest.raises(ValueError, match="all ensemble scores non-finite"):
+        ensemble.fit(
+            predictions_per_window={"Naive": [forecast], "SeasonalNaive": [forecast.copy()]},
+            data_per_window=[data],
+        )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- `EnsembleSelection._fit` crashed with `ValueError: 'a' cannot be empty unless no samples are taken` when every candidate regret was NaN. `np.nanmin` is NaN, `np.isclose(..., equal_nan=False)` yields no matches, then `RandomState.choice([])` raises. The same `isclose`/`nanmin` pattern is used for `second_metric` tie-break. A follow-on `trajectory.index(min_score)` also cannot find NaN.
- Non-finite regrets (NaN and ±inf) are now treated as dead (`+inf`). If no finite score remains, raise `ValueError("all ensemble scores non-finite")` before `choice` / writing `best_score` into `trajectory`. Do not invent a winner and do not use `equal_nan=True`.
- Note: all-inf scores used to `choice` among themselves (`isclose(inf, inf)`). They now error as non-finite. Mixed finite + NaN/inf still picks the finite model.
- Adds fast `EnsembleSelection` unit tests that fail on current master for all-NaN regrets/preds and pass after the patch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.