### PR TITLE
[tabular] Fix DyStack holdout leakage when using groups

### DIFF
--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -160,6 +160,11 @@ class TabularPredictor:
         It is not recommended to use this option unless it is required for very specific situations.
         Bugs may arise from edge cases if the provided groups are not valid to properly train models, such as if not all classes are present during training in multiclass classification. It is up to the user to sanitize their groups.
 
+        Dynamic stacking holdouts and DyStack CV splits are group-disjoint as well (whole groups
+        are held out), so the stacked-overfitting check cannot leak across groups. That requires
+        at least 3 unique group ids. For grouped *and* repeated bagging, prefer
+        `validation_structure={"group_on": ...}` instead of `groups`.
+
         As an example, if you want your data folds to preserve adjacent rows in the table without shuffling, then for 3 fold bagging with 6 rows of data, the groups column values should be [0, 0, 1, 1, 2, 2].
     positive_class : str or int, default = None
         Used to determine the positive class in binary classification.
@@ -1672,6 +1677,14 @@ class TabularPredictor:
             enable_ray_logging=enable_ray_logging,
         )
 
+        features_X = X.drop(self.label, axis=1)
+        y = X[self.label]
+        # `validation_structure` already encodes grouped/temporal holdouts. The older
+        # `groups=` bagging channel does not: a random row holdout leaks across groups
+        # (https://github.com/autogluon/autogluon/issues/5533). Reuse the same
+        # group-disjoint splitter when `groups` is set.
+        validation_structure = self._dystack_validation_structure(X=X, ag_fit_kwargs=ag_fit_kwargs, X_val=X_val)
+
         # -- Validation Method
         if validation_procedure == "holdout":
             if holdout_data is None:
@@ -1681,13 +1694,12 @@ class TabularPredictor:
                 # train_indices/val_indices channel the CV procedure already goes through, so
                 # the sub-fit itself needs no change. `holdout_split_indices` returns None for
                 # stratify-only structures, where the default split needs no correction.
-                validation_structure = ag_fit_kwargs.get("validation_structure")
                 structure_holdout = (
                     None
                     if validation_structure is None
                     else validation_structure.holdout_split_indices(
-                        X.drop(self.label, axis=1),
-                        X[self.label],
+                        features_X,
+                        y,
                         holdout_frac=holdout_frac,
                         random_state=42,
                         problem_type=self.problem_type,
@@ -1695,6 +1707,10 @@ class TabularPredictor:
                 )
                 if structure_holdout is not None:
                     train_indices, val_indices = structure_holdout
+                    if self._learner.groups is not None:
+                        train_indices, val_indices = self._dystack_keep_logo_feasible(
+                            train_indices, val_indices, X[self._learner.groups]
+                        )
                     ds_fit_kwargs.update(dict(train_indices=train_indices, val_indices=val_indices))
                 else:
                     ds_fit_kwargs["holdout_frac"] = holdout_frac
@@ -1715,30 +1731,37 @@ class TabularPredictor:
             # Holdout is false, use (repeated) cross-validation
             is_stratified = self.problem_type in [BINARY, MULTICLASS]
             is_binned = self.problem_type in [REGRESSION, QUANTILE]
-            self._learner._validate_groups(X=X, X_val=X_val)  # Validate splits before splitting
-            validation_structure = ag_fit_kwargs.get("validation_structure")
             if validation_structure is not None:
                 # Honor the declared grouped/temporal structure here too. A random sub-fit split
                 # would leak across groups or forward in time exactly as the validation it is
                 # meant to audit, so the leakage detector would be blind on the data where
                 # structure-aware validation matters most.
                 splits, _, _ = validation_structure.custom_splits(
-                    X.drop(self.label, axis=1),
-                    X[self.label],
+                    features_X,
+                    y,
                     num_folds=n_folds,
                     num_repeats=n_repeats,
                     random_state=42,
                     problem_type=self.problem_type,
                 )
             else:
+                groups_values = None
+                if self._learner.groups is not None:
+                    # CVSplitter needs the group *vector*, not the column name.
+                    groups_values = X[self._learner.groups]
                 splits = CVSplitter(
                     n_splits=n_folds,
                     n_repeats=n_repeats,
-                    groups=self._learner.groups,
+                    groups=groups_values,
                     stratify=is_stratified,
                     bin=is_binned,
                     random_state=42,
-                ).split(X=X.drop(self.label, axis=1), y=X[self.label])
+                ).split(X=features_X, y=y)
+            if self._learner.groups is not None:
+                group_values = X[self._learner.groups]
+                splits = [
+                    self._dystack_keep_logo_feasible(train_idx, val_idx, group_values) for train_idx, val_idx in splits
+                ]
             # `splits` may hold fewer than n_folds x n_repeats entries: the structure can clamp
             # the fold count (few groups, a rare stratification value), so budget off the actual
             # number rather than the requested one.
@@ -1825,6 +1848,83 @@ class TabularPredictor:
         ag_fit_kwargs["X_unlabeled"] = X_unlabeled
 
         return num_stack_levels, time_limit_fit_full
+
+    def _dystack_validation_structure(
+        self, X: pd.DataFrame, ag_fit_kwargs: dict, X_val: pd.DataFrame | None
+    ) -> ValidationStructure | None:
+        """Structure used for DyStack sub-fit splits.
+
+        `validation_structure` already encodes grouped/temporal holdouts. The older
+        `groups=` bagging channel does not: without this, DyStack's default row-wise
+        holdout leaks across groups (https://github.com/autogluon/autogluon/issues/5533).
+        """
+        structure = ag_fit_kwargs.get("validation_structure")
+        if structure is not None:
+            return structure
+        groups_col = self._learner.groups
+        if groups_col is None:
+            return None
+        self._learner._validate_groups(X=X, X_val=X_val)
+        n_groups = int(X[groups_col].nunique())
+        # Hold out >=1 group and still leave >=2 groups so LeaveOneGroupOut bagging
+        # in the sub-fit is valid.
+        if n_groups < 3:
+            raise ValueError(
+                f"dynamic_stacking with `groups` needs at least 3 unique groups so one "
+                f"group can be held out while bagging still has 2+ groups. "
+                f"Column {groups_col!r} has {n_groups} unique value(s). "
+                f"Set `dynamic_stacking=False`, or switch to "
+                f"`validation_structure={{'group_on': {groups_col!r}}}`."
+            )
+        logger.log(
+            20,
+            f"\tDyStack: holding out whole groups from `{groups_col}` so the "
+            "stacked-overfitting check does not leak across groups.",
+        )
+        return ValidationStructure(group_on=groups_col)
+
+    def _dystack_keep_logo_feasible(
+        self,
+        train_idx: np.ndarray,
+        val_idx: np.ndarray,
+        group_values: pd.Series,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Keep a DyStack split valid for LeaveOneGroupOut bagging.
+
+        `groups=` bagging needs >=2 training groups. A coarse group holdout (few
+        groups, large ``holdout_frac``) can leave one group on the train side;
+        moving the smallest whole validation groups across restores that without
+        putting a group on both sides.
+        """
+        groups = np.asarray(group_values)
+        train_idx = np.asarray(train_idx)
+        val_idx = np.asarray(val_idx)
+
+        def n_groups(idx: np.ndarray) -> int:
+            return 0 if len(idx) == 0 else int(pd.unique(groups[idx]).size)
+
+        moved = 0
+        while n_groups(train_idx) < 2 and n_groups(val_idx) > 1:
+            val_counts = pd.Series(groups[val_idx]).value_counts().sort_values(kind="stable")
+            group = val_counts.index[0]
+            whole = np.flatnonzero(groups == group)
+            train_idx = np.union1d(train_idx, whole)
+            val_idx = np.setdiff1d(val_idx, whole)
+            moved += 1
+        if n_groups(train_idx) < 2 or n_groups(val_idx) < 1:
+            raise ValueError(
+                f"dynamic_stacking with `groups` could not hold out a group while leaving "
+                f"2+ groups for bagging (train groups={n_groups(train_idx)}, "
+                f"holdout groups={n_groups(val_idx)}). Use more groups, a smaller "
+                f"`ds_args['holdout_frac']`, or set `dynamic_stacking=False`."
+            )
+        if moved:
+            logger.log(
+                20,
+                f"\tDyStack: moved {moved} group(s) from the holdout into training so "
+                "LeaveOneGroupOut bagging still has 2+ groups.",
+            )
+        return train_idx, val_idx
 
     def _sub_fit_memory_save_wrapper(
         self,

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1631,6 +1631,10 @@ class TabularPredictor:
         time_limit_og = ag_fit_kwargs["time_limit"]
         org_num_stack_levels = ag_fit_kwargs["num_stack_levels"]
         ds_fit_context = os.path.join(self._learner.path_context_og, "ds_sub_fit")
+
+        skip_reason = self._dystack_skip_reason(ag_fit_kwargs=ag_fit_kwargs)
+        if skip_reason is not None:
+            return self._dystack_disable_stacking(reason=skip_reason), time_limit_og
         logger.info(
             "\tThis is used to identify the optimal `num_stack_levels` value. "
             "Copies of AutoGluon will be fit on subsets of the data. "
@@ -1686,6 +1690,9 @@ class TabularPredictor:
         validation_structure = self._dystack_validation_structure(X=X, ag_fit_kwargs=ag_fit_kwargs, X_val=X_val)
 
         # -- Validation Method
+        # Both branches can now decide the check cannot run (`skip_reason`), leaving the sub-fit
+        # unexecuted, so start from "no leakage observed" rather than relying on assignment below.
+        stacked_overfitting = False
         if validation_procedure == "holdout":
             if holdout_data is None:
                 ds_fit_kwargs["ds_fit_context"] = os.path.join(ds_fit_context, "sub_fit_ho")
@@ -1708,25 +1715,34 @@ class TabularPredictor:
                 if structure_holdout is not None:
                     train_indices, val_indices = structure_holdout
                     if self._learner.groups is not None:
-                        train_indices, val_indices = self._dystack_keep_logo_feasible(
+                        feasible = self._dystack_keep_logo_feasible(
                             train_indices, val_indices, X[self._learner.groups]
                         )
-                    ds_fit_kwargs.update(dict(train_indices=train_indices, val_indices=val_indices))
+                        if feasible is None:
+                            skip_reason = (
+                                "no group-disjoint holdout leaves 2+ groups for LeaveOneGroupOut "
+                                "bagging in the sub-fit"
+                            )
+                        else:
+                            train_indices, val_indices = feasible
+                    if skip_reason is None:
+                        ds_fit_kwargs.update(dict(train_indices=train_indices, val_indices=val_indices))
                 else:
                     ds_fit_kwargs["holdout_frac"] = holdout_frac
             else:
                 _, holdout_data, _, _ = self._validate_fit_data(train_data=X, tuning_data=holdout_data)
                 ds_fit_kwargs["ds_fit_context"] = os.path.join(ds_fit_context, "sub_fit_custom_ho")
 
-            stacked_overfitting = self._sub_fit_memory_save_wrapper(
-                train_data=X,
-                time_limit=time_limit,
-                time_start=time_start,
-                ds_fit_kwargs=ds_fit_kwargs,
-                ag_fit_kwargs=inner_ag_fit_kwargs,
-                ag_post_fit_kwargs=inner_ag_post_fit_kwargs,
-                holdout_data=holdout_data,
-            )
+            if skip_reason is None:
+                stacked_overfitting = self._sub_fit_memory_save_wrapper(
+                    train_data=X,
+                    time_limit=time_limit,
+                    time_start=time_start,
+                    ds_fit_kwargs=ds_fit_kwargs,
+                    ag_fit_kwargs=inner_ag_fit_kwargs,
+                    ag_post_fit_kwargs=inner_ag_post_fit_kwargs,
+                    holdout_data=holdout_data,
+                )
         else:
             # Holdout is false, use (repeated) cross-validation
             is_stratified = self.problem_type in [BINARY, MULTICLASS]
@@ -1759,9 +1775,14 @@ class TabularPredictor:
                 ).split(X=features_X, y=y)
             if self._learner.groups is not None:
                 group_values = X[self._learner.groups]
-                splits = [
+                feasible_splits = [
                     self._dystack_keep_logo_feasible(train_idx, val_idx, group_values) for train_idx, val_idx in splits
                 ]
+                splits = [split for split in feasible_splits if split is not None]
+                if not splits:
+                    skip_reason = (
+                        "no cross-validation split leaves 2+ groups for LeaveOneGroupOut bagging in the sub-fit"
+                    )
             # `splits` may hold fewer than n_folds x n_repeats entries: the structure can clamp
             # the fold count (few groups, a rare stratification value), so budget off the actual
             # number rather than the requested one.
@@ -1819,12 +1840,14 @@ class TabularPredictor:
 
         # -- Determine rest time and new num_stack_levels
         time_spend_sub_fits = time.time() - time_start
-        num_stack_levels = 0 if stacked_overfitting else org_num_stack_levels
-        self._stacked_overfitting_occurred = stacked_overfitting
-
-        logger.info(
-            f"\t{num_stack_levels}\t = Optimal   num_stack_levels (Stacked Overfitting Occurred: {self._stacked_overfitting_occurred})"
-        )
+        if skip_reason is not None:
+            num_stack_levels = self._dystack_disable_stacking(reason=skip_reason)
+        else:
+            num_stack_levels = 0 if stacked_overfitting else org_num_stack_levels
+            self._stacked_overfitting_occurred = stacked_overfitting
+            logger.info(
+                f"\t{num_stack_levels}\t = Optimal   num_stack_levels (Stacked Overfitting Occurred: {self._stacked_overfitting_occurred})"
+            )
         log_str = f"\t{round(time_spend_sub_fits)}s\t = DyStack   runtime"
         if time_limit_og is None:
             time_limit_fit_full = None
@@ -1849,6 +1872,46 @@ class TabularPredictor:
 
         return num_stack_levels, time_limit_fit_full
 
+    def _dystack_skip_reason(self, ag_fit_kwargs: dict) -> str | None:
+        """Why the DyStack check cannot run at all, or None when it can.
+
+        Returned before any sub-fit is attempted, so the caller can disable stacking and carry on
+        rather than fail the fit.
+        """
+        groups_col = self._learner.groups
+        if groups_col is None or ag_fit_kwargs.get("validation_structure") is not None:
+            return None
+        X = ag_fit_kwargs["X"]
+        if groups_col not in X.columns:
+            return None  # `_validate_groups` reports a missing column with a better message
+        n_groups = int(X[groups_col].nunique())
+        # Holding out a whole group has to leave >=2 groups behind, or LeaveOneGroupOut bagging
+        # in the sub-fit has nothing to split.
+        if n_groups < 3:
+            return (
+                f"`groups={groups_col!r}` has only {n_groups} unique value(s); holding out a whole "
+                f"group would leave fewer than the 2 groups LeaveOneGroupOut bagging needs, so the "
+                f"stacked-overfitting check cannot run on group-disjoint splits"
+            )
+        return None
+
+    def _dystack_disable_stacking(self, reason: str) -> int:
+        """Disable stacking because the DyStack check could not be run.
+
+        Not the same as the check running and finding no leakage: here the answer is unknown, and
+        the conservative response to unknown is to not stack. Recorded as ``None`` rather than
+        ``False`` so callers can tell "not measured" from "measured, clean".
+        """
+        logger.log(
+            30,
+            f"\tWarning: Skipping the DyStack stacked-overfitting check and disabling stacking "
+            f"(num_stack_levels=0), because {reason}. "
+            f"Pass `validation_structure={{'group_on': ...}}` for grouped validation that supports "
+            f"more folds, or `dynamic_stacking=False` to keep stacking without the check.",
+        )
+        self._stacked_overfitting_occurred = None
+        return 0
+
     def _dystack_validation_structure(
         self, X: pd.DataFrame, ag_fit_kwargs: dict, X_val: pd.DataFrame | None
     ) -> ValidationStructure | None:
@@ -1865,17 +1928,6 @@ class TabularPredictor:
         if groups_col is None:
             return None
         self._learner._validate_groups(X=X, X_val=X_val)
-        n_groups = int(X[groups_col].nunique())
-        # Hold out >=1 group and still leave >=2 groups so LeaveOneGroupOut bagging
-        # in the sub-fit is valid.
-        if n_groups < 3:
-            raise ValueError(
-                f"dynamic_stacking with `groups` needs at least 3 unique groups so one "
-                f"group can be held out while bagging still has 2+ groups. "
-                f"Column {groups_col!r} has {n_groups} unique value(s). "
-                f"Set `dynamic_stacking=False`, or switch to "
-                f"`validation_structure={{'group_on': {groups_col!r}}}`."
-            )
         logger.log(
             20,
             f"\tDyStack: holding out whole groups from `{groups_col}` so the "
@@ -1888,13 +1940,23 @@ class TabularPredictor:
         train_idx: np.ndarray,
         val_idx: np.ndarray,
         group_values: pd.Series,
-    ) -> tuple[np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray] | None:
         """Keep a DyStack split valid for LeaveOneGroupOut bagging.
 
         `groups=` bagging needs >=2 training groups. A coarse group holdout (few
         groups, large ``holdout_frac``) can leave one group on the train side;
         moving the smallest whole validation groups across restores that without
         putting a group on both sides.
+
+        Returns ``None`` when no such split exists, so the caller can disable stacking rather
+        than fail the fit: an unusable sub-fit split means the leakage check cannot run, and the
+        safe response to "unknown" is to not stack.
+
+        Unreachable through ``groups=`` today, because ``_dystack_skip_reason`` already rejects
+        fewer than 3 groups and the repair below always succeeds from 3 up. It becomes reachable
+        once this guard is extended to ``validation_structure={"group_on": ...}``, which can leave
+        a single training group with 2-3 groups and a large ``holdout_frac`` -- there the sub-fit
+        currently fails and DyStack proceeds *with stacking still enabled*.
         """
         groups = np.asarray(group_values)
         train_idx = np.asarray(train_idx)
@@ -1912,12 +1974,7 @@ class TabularPredictor:
             val_idx = np.setdiff1d(val_idx, whole)
             moved += 1
         if n_groups(train_idx) < 2 or n_groups(val_idx) < 1:
-            raise ValueError(
-                f"dynamic_stacking with `groups` could not hold out a group while leaving "
-                f"2+ groups for bagging (train groups={n_groups(train_idx)}, "
-                f"holdout groups={n_groups(val_idx)}). Use more groups, a smaller "
-                f"`ds_args['holdout_frac']`, or set `dynamic_stacking=False`."
-            )
+            return None
         if moved:
             logger.log(
                 20,

--- a/tabular/tests/unittests/dynamic_stacking/test_dynamic_stacking.py
+++ b/tabular/tests/unittests/dynamic_stacking/test_dynamic_stacking.py
@@ -301,21 +301,31 @@ def test_dynamic_stacking_with_groups_is_group_disjoint(validation_procedure, mo
         _assert_group_disjoint(cv_splits, groups)
 
 
-def test_dynamic_stacking_with_groups_too_few_groups_raises():
-    """Need 3+ groups: one held out, two left for LeaveOneGroupOut bagging."""
+def test_dynamic_stacking_with_groups_too_few_groups_disables_stacking():
+    """Too few groups to run the check: disable stacking, do not fail the fit.
+
+    Holding out a whole group needs 2 groups left for LeaveOneGroupOut bagging, so 2 groups
+    cannot support a group-disjoint sub-fit. The check therefore cannot run -- and because the
+    answer is unknown rather than "clean", the safe response is to not stack. Failing here would
+    turn a fit that works today into an error.
+    """
     from autogluon.tabular import TabularPredictor
 
     df = _grouped_toy_for_dystack(n=12, n_groups=2)
-    with pytest.raises(ValueError, match="at least 3 unique groups"):
-        TabularPredictor(label="label", groups="gid", verbosity=0).fit(
-            df,
-            hyperparameters={"DUMMY": {}},
-            num_bag_folds=2,
-            num_stack_levels=1,
-            dynamic_stacking=True,
-            ds_args={"enable_ray_logging": False, "memory_safe_fits": False},
-            fit_weighted_ensemble=False,
-        )
+    predictor = TabularPredictor(label="label", groups="gid", verbosity=0).fit(
+        df,
+        hyperparameters={"DUMMY": {}},
+        num_bag_folds=2,
+        num_stack_levels=1,
+        dynamic_stacking=True,
+        ds_args={"enable_ray_logging": False, "memory_safe_fits": False},
+        fit_weighted_ensemble=False,
+    )
+
+    # No L2: stacking was turned off rather than run on leaky splits.
+    assert not [m for m in predictor.model_names() if m.endswith("_L2")], predictor.model_names()
+    # `None`, not `False`: the check did not run, so "no leakage" was never established.
+    assert predictor._stacked_overfitting_occurred is None
 
 
 _DS_GROUPS = dict(enable_ray_logging=False, memory_safe_fits=False, clean_up_fits=True)

--- a/tabular/tests/unittests/dynamic_stacking/test_dynamic_stacking.py
+++ b/tabular/tests/unittests/dynamic_stacking/test_dynamic_stacking.py
@@ -1,5 +1,7 @@
 import shutil
 
+import numpy as np
+import pandas as pd
 import pytest
 
 from autogluon.core.constants import BINARY
@@ -223,3 +225,229 @@ def test_dynamic_stacking_run_twice_parallel_fold_fitting_strategy():
         lb = predictor.leaderboard(test_data, extra_info=True)
         stacked_overfitting_assert(lb, predictor, False, False)
         shutil.rmtree(predictor.path)
+
+
+def _grouped_toy_for_dystack(n: int = 60, n_groups: int = 10, seed: int = 0) -> pd.DataFrame:
+    """Grouped binary toy data: both classes in every group, 6 rows per group at n=60."""
+    rng = np.random.default_rng(seed)
+    rows_per = n // n_groups
+    return pd.DataFrame(
+        {
+            "f1": rng.normal(size=n),
+            "gid": np.repeat(np.arange(n_groups), rows_per),
+            "label": np.tile([0, 1], n // 2),
+        }
+    )
+
+
+def _assert_group_disjoint(splits: list, groups: np.ndarray) -> None:
+    for train_idx, val_idx in splits:
+        assert not (set(groups[train_idx]) & set(groups[val_idx]))
+
+
+@pytest.mark.parametrize("validation_procedure", ["holdout", "cv"])
+def test_dynamic_stacking_with_groups_is_group_disjoint(validation_procedure, monkeypatch):
+    """DyStack + `groups` must not put the same group on both sides of a sub-fit split (#5533)."""
+    from autogluon.common.utils.validation_structure import ValidationStructure
+    from autogluon.tabular import TabularPredictor
+
+    df = _grouped_toy_for_dystack()
+    groups = df["gid"].to_numpy()
+
+    holdouts: list[tuple[np.ndarray, np.ndarray]] = []
+    cv_splits: list[tuple[np.ndarray, np.ndarray]] = []
+    original_holdout = ValidationStructure.holdout_split_indices
+    original_custom = ValidationStructure.custom_splits
+
+    def holdout_spy(self, X, y, holdout_frac, random_state=0, **kwargs):
+        split = original_holdout(self, X, y, holdout_frac=holdout_frac, random_state=random_state, **kwargs)
+        if split is not None:
+            holdouts.append(split)
+        return split
+
+    def custom_spy(self, X, y, **kwargs):
+        splits, n_folds, n_repeats = original_custom(self, X, y, **kwargs)
+        if kwargs.get("random_state") == 42:
+            cv_splits.extend(splits)
+        return splits, n_folds, n_repeats
+
+    monkeypatch.setattr(ValidationStructure, "holdout_split_indices", holdout_spy)
+    monkeypatch.setattr(ValidationStructure, "custom_splits", custom_spy)
+
+    TabularPredictor(label="label", groups="gid", verbosity=0).fit(
+        df,
+        hyperparameters={"DUMMY": {}},
+        num_bag_folds=2,
+        num_bag_sets=1,
+        num_stack_levels=1,
+        dynamic_stacking=True,
+        ds_args={
+            "validation_procedure": validation_procedure,
+            "n_folds": 2,
+            "n_repeats": 1,
+            "enable_ray_logging": False,
+            "memory_safe_fits": False,
+            "clean_up_fits": True,
+        },
+        fit_weighted_ensemble=False,
+        raise_on_model_failure=True,
+    )
+
+    if validation_procedure == "holdout":
+        assert holdouts, "DyStack holdout did not go through the group-aware splitter"
+        _assert_group_disjoint(holdouts, groups)
+    else:
+        assert cv_splits, "DyStack CV did not go through the group-aware splitter"
+        _assert_group_disjoint(cv_splits, groups)
+
+
+def test_dynamic_stacking_with_groups_too_few_groups_raises():
+    """Need 3+ groups: one held out, two left for LeaveOneGroupOut bagging."""
+    from autogluon.tabular import TabularPredictor
+
+    df = _grouped_toy_for_dystack(n=12, n_groups=2)
+    with pytest.raises(ValueError, match="at least 3 unique groups"):
+        TabularPredictor(label="label", groups="gid", verbosity=0).fit(
+            df,
+            hyperparameters={"DUMMY": {}},
+            num_bag_folds=2,
+            num_stack_levels=1,
+            dynamic_stacking=True,
+            ds_args={"enable_ray_logging": False, "memory_safe_fits": False},
+            fit_weighted_ensemble=False,
+        )
+
+
+_DS_GROUPS = dict(enable_ray_logging=False, memory_safe_fits=False, clean_up_fits=True)
+
+
+def _capture_dystack_splits(monkeypatch) -> list[dict]:
+    """Record the train/val index splits `_dystack` actually receives."""
+    import autogluon.tabular.predictor.predictor as pred_mod
+
+    captured: list[dict] = []
+    original = pred_mod._dystack
+
+    def spy(predictor, train_data, time_limit, ds_fit_kwargs, ag_fit_kwargs, ag_post_fit_kwargs, holdout_data=None):
+        rec = {
+            "holdout_frac": ds_fit_kwargs.get("holdout_frac"),
+            "train_indices": ds_fit_kwargs.get("train_indices"),
+            "val_indices": ds_fit_kwargs.get("val_indices"),
+        }
+        captured.append(rec)
+        return original(
+            predictor, train_data, time_limit, ds_fit_kwargs, ag_fit_kwargs, ag_post_fit_kwargs, holdout_data
+        )
+
+    monkeypatch.setattr(pred_mod, "_dystack", spy)
+    return captured
+
+
+def _fit_dystack_groups(df, ds_args=None, groups="gid"):
+    from autogluon.tabular import TabularPredictor
+
+    args = dict(_DS_GROUPS)
+    if ds_args:
+        args.update(ds_args)
+    init = dict(label="label", verbosity=0)
+    if groups is not None:
+        init["groups"] = groups
+    return TabularPredictor(**init).fit(
+        df,
+        hyperparameters={"DUMMY": {}},
+        num_bag_folds=2,
+        num_bag_sets=1,
+        num_stack_levels=1,
+        dynamic_stacking=True,
+        ds_args=args,
+        fit_weighted_ensemble=False,
+        raise_on_model_failure=True,
+    )
+
+
+def test_dynamic_stacking_with_groups_uses_indices_not_row_frac(monkeypatch):
+    """Default DyStack + groups must take the index path, not holdout_frac (#5533)."""
+    df = _grouped_toy_for_dystack()
+    captured = _capture_dystack_splits(monkeypatch)
+    predictor = _fit_dystack_groups(df)
+    assert captured, "DyStack sub-fit did not run"
+    rec = captured[0]
+    assert rec["holdout_frac"] is None
+    assert rec["train_indices"] is not None and rec["val_indices"] is not None
+    groups = df["gid"].to_numpy()
+    _assert_group_disjoint([(rec["train_indices"], rec["val_indices"])], groups)
+    assert len(predictor.predict_oof()) == len(df), "full fit must train on all rows, not the sub-fit slice"
+    shutil.rmtree(predictor.path)
+
+
+def test_dynamic_stacking_without_groups_still_uses_holdout_frac(monkeypatch):
+    """No groups= → DyStack keep the historical row-wise holdout_frac path."""
+    df = _grouped_toy_for_dystack()
+    captured = _capture_dystack_splits(monkeypatch)
+    predictor = _fit_dystack_groups(df, groups=None)
+    rec = captured[0]
+    assert rec["holdout_frac"] is not None
+    assert rec["train_indices"] is None
+    shutil.rmtree(predictor.path)
+
+
+def test_dynamic_stacking_with_groups_exactly_3_groups_is_feasible(monkeypatch):
+    """3 groups is the minimum: 1 held out, 2 left for LeaveOneGroupOut."""
+    df = _grouped_toy_for_dystack(n=18, n_groups=3)
+    captured = _capture_dystack_splits(monkeypatch)
+    predictor = _fit_dystack_groups(df)
+    rec = captured[0]
+    train_g = set(df["gid"].to_numpy()[rec["train_indices"]])
+    val_g = set(df["gid"].to_numpy()[rec["val_indices"]])
+    assert train_g.isdisjoint(val_g)
+    assert len(train_g) >= 2
+    assert len(val_g) >= 1
+    shutil.rmtree(predictor.path)
+
+
+def test_dynamic_stacking_with_groups_large_holdout_frac_keeps_logo_feasible(monkeypatch):
+    """A 50% group holdout of 3 groups can leave 1 train group; repair must keep LOGO valid."""
+    df = _grouped_toy_for_dystack(n=18, n_groups=3)
+    captured = _capture_dystack_splits(monkeypatch)
+    predictor = _fit_dystack_groups(df, ds_args={"holdout_frac": 0.5})
+    rec = captured[0]
+    train_g = set(df["gid"].to_numpy()[rec["train_indices"]])
+    val_g = set(df["gid"].to_numpy()[rec["val_indices"]])
+    assert train_g.isdisjoint(val_g)
+    assert len(train_g) >= 2
+    assert len(val_g) >= 1
+    shutil.rmtree(predictor.path)
+
+
+def test_dynamic_stacking_with_groups_cv_three_groups_keeps_logo_feasible(monkeypatch):
+    """2-fold DyStack CV on 3 groups can produce a 1-group train fold; repair it."""
+    df = _grouped_toy_for_dystack(n=18, n_groups=3)
+    captured = _capture_dystack_splits(monkeypatch)
+    predictor = _fit_dystack_groups(df, ds_args={"validation_procedure": "cv", "n_folds": 2, "n_repeats": 1})
+    assert captured
+    groups = df["gid"].to_numpy()
+    for rec in captured:
+        train_g = set(groups[rec["train_indices"]])
+        val_g = set(groups[rec["val_indices"]])
+        assert train_g.isdisjoint(val_g)
+        assert len(train_g) >= 2
+        assert len(val_g) >= 1
+    shutil.rmtree(predictor.path)
+
+
+def test_dynamic_stacking_false_allows_two_groups():
+    """The 3-group floor is only for DyStack + groups, not for grouped bagging alone."""
+    from autogluon.tabular import TabularPredictor
+
+    df = _grouped_toy_for_dystack(n=12, n_groups=2)
+    predictor = TabularPredictor(label="label", groups="gid", verbosity=0).fit(
+        df,
+        hyperparameters={"DUMMY": {}},
+        num_bag_folds=2,
+        num_stack_levels=0,
+        dynamic_stacking=False,
+        fit_weighted_ensemble=False,
+        raise_on_model_failure=True,
+    )
+    assert len(predictor.predict_oof()) == len(df)
+    shutil.rmtree(predictor.path)


### PR DESCRIPTION
*Issue #, if available:*

Fixes #5533

*Description of changes:*

`groups=` already makes **bagging** leave-one-group-out. Dynamic stacking's default holdout did not: it used `generate_train_test_split_combined` (a row split), so the same group could sit in the DyStack sub-fit train set and the holdout. Bagged OOF (`score_val`) stayed honest; the DyStack holdout (`score_test`) could look nearly perfect — the `.8` vs `.9998` F1 in the report.

This reuses the existing `ValidationStructure(group_on=)` splitter for DyStack holdout and CV when `groups=` is set (the two APIs stay mutually exclusive for the user). The full fit after DyStack still trains on all rows.

Guards so the sub-fit can still bag:
- at least 3 unique groups (one held out, two left for leave-one-group-out)
- if a coarse split would leave only 1 train group (few groups + large `holdout_frac`), move the smallest whole holdout groups back until train has 2

`ds_args["holdout_data"]` is still the caller's split. No `groups=` is unchanged (row holdout).

---

### Also fixed here: DyStack CV + `groups` crashes on master

`CVSplitter` expects the group *vector*, but master passed the column *name*, and
`_get_splitter_cls` calls `.unique()` on it. So `ds_args={"validation_procedure": "cv"}`
together with `groups=` is unusable today, not merely leaky:

```
### master ###    DyStack CV + groups -> AttributeError: 'str' object has no attribute 'unique'
### this PR ###   DyStack CV + groups: completed
```

### When the check cannot run, stacking is disabled rather than the fit failing

Too few groups to build a group-disjoint holdout means the stacked-overfitting question is
*unanswered*, not answered "clean". Erroring would turn fits that work today into failures
(`groups` with 2 unique values plus `dynamic_stacking=True` succeeds on master), so instead
stacking is turned off and the fit continues, with `_stacked_overfitting_occurred` set to
`None` to distinguish "not measured" from "measured, clean".

### Known follow-up (not in this PR)

The infeasibility guard is gated on `groups is not None`, but the constraint belongs to
group-disjoint holdouts generally. Reached through `validation_structure={"group_on": ...}`
on master, with no `groups` involved:

| n_groups | holdout_frac | train groups left | sub-fit |
|---|---|---|---|
| 2 | any | 1 | fails -> stacking stays **enabled** |
| 3 | >=0.5 | 1 | fails -> stacking stays **enabled** |
| 3 | 0.2 | 2 | ok |
| 4+ | >=0.2 | 2+ | ok |

DyStack swallows the sub-fit failure and keeps stacking on, so the leakage check silently does
not run. Un-gating the guard would apply the same disable-stacking policy to that path.
