### PR TITLE
[tabular] Implement `groups` via `validation_structure` and deprecate it

### DIFF
--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -111,6 +111,11 @@ class DefaultLearner(AbstractTabularLearner):
             # Ensure that the eval_metric is valid for the problem_type
             self._verify_metric(eval_metric=self.eval_metric, problem_type=self.problem_type)
         if self.groups is not None:
+            # `groups` is the deprecated spelling of `validation_structure={"group_on": ...}`; the
+            # structure itself is built in `TabularPredictor.fit` (DyStack needs it earlier than
+            # here). What remains is reproducing the fold arithmetic the `groups` channel implied:
+            # `CVSplitter` swapped in `LeaveOneGroupOut`, whose partition is exactly grouped k-fold
+            # at k == n_groups with a single repeat (verified for binary, multiclass and regression).
             num_bag_sets = 1
             num_bag_folds = len(X[self.groups].unique())
         X_og = None if infer_limit_batch_size is None else X
@@ -221,7 +226,6 @@ class DefaultLearner(AbstractTabularLearner):
             time_limit=time_limit_trainer,
             infer_limit=infer_limit,
             infer_limit_batch_size=infer_limit_batch_size,
-            groups=groups,
             validation_structure=validation_structure,
             label_cleaner=copy.deepcopy(self.label_cleaner),
             **trainer_fit_kwargs,
@@ -351,11 +355,8 @@ class DefaultLearner(AbstractTabularLearner):
         y = self.label_cleaner.transform(y)
         X = self.set_predefined_weights(X, y)
         X, w = extract_column(X, self.sample_weight)
-        X, groups = extract_column(X, self.groups)
         structure_splits = None
         structure_holdout = None
-        if validation_structure is not None and groups is not None:
-            raise ValueError("Specify either `groups` or `validation_structure`, not both.")
         if validation_structure is not None and num_bag_folds < 2 and X_val is None:
             # Non-bagged holdout, resolved here for the same reason the bagged path below is:
             # feature transformation can drop the very columns the structure names (TabArena's
@@ -422,6 +423,11 @@ class DefaultLearner(AbstractTabularLearner):
                 problem_type=self.problem_type,
             )
             structure_splits = custom_splits
+        # After the splits are resolved, not before: the structure reads the group/time columns off
+        # `X`, while `groups` additionally requires its column not to be trained on. Dropping it
+        # here satisfies both -- the splits are already computed, and the column never reaches
+        # feature generation.
+        X, groups = extract_column(X, self.groups)
         if self.label_cleaner.num_classes is not None and self.problem_type != BINARY:
             logger.log(20, f"Train Data Class Count: {self.label_cleaner.num_classes}")
 

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -158,13 +158,21 @@ class TabularPredictor:
         The data will be split via `sklearn.model_selection.LeaveOneGroupOut`.
         Use this option to control the exact split indices AutoGluon uses.
         .. deprecated:: 1.6.0
-            Use `fit(..., validation_structure={"group_on": <column>})` instead; `groups` will be
-            removed in AutoGluon 2.0. The replacement produces the same group-disjoint splits and
-            additionally supports repeated bagging, a group-aware non-bagged holdout, combining
-            groups with time (`group_time_on`), and sizing the validation method by group count
-            rather than row count (`size_validation_on_groups`). `groups` is now implemented as
-            `validation_structure={"group_on": ...}` with the fold count pinned to the number of
-            groups and a single repeat, which is what it always did implicitly.
+            Use `TabularPredictor(..., learner_kwargs={"ignored_columns": [<column>]})` together with
+            `fit(..., validation_structure={"group_on": <column>})` instead; `groups` will be removed
+            in AutoGluon 2.0. The replacement produces the same
+            group-disjoint splits and additionally supports repeated bagging, a group-aware
+            non-bagged holdout, combining groups with time (`group_time_on`), and sizing the
+            validation method by group count rather than row count (`size_validation_on_groups`).
+            `groups` is now implemented as `validation_structure={"group_on": ...}` with the fold
+            count pinned to the number of groups and a single repeat, which is what it always did
+            implicitly.
+
+            `ignored_columns` is required for an exact migration: `groups` excludes its column from
+            the features, while `validation_structure` leaves the columns it names in place. Whether
+            keeping the group id helps is model-dependent -- it can act as a fixed effect that
+            improves tree models and can hurt neural nets -- so neither behavior is imposed, but the
+            two spellings do differ and migrating without `ignored_columns` changes the model inputs.
 
         It is not recommended to use this option unless it is required for very specific situations.
         Bugs may arise from edge cases if the provided groups are not valid to properly train models, such as if not all classes are present during training in multiclass classification. It is up to the user to sanitize their groups.
@@ -252,18 +260,26 @@ class TabularPredictor:
             learner_kwargs["positive_class"] = positive_class
 
         if groups is not None:
+            replacement = (
+                f"TabularPredictor(..., learner_kwargs={{'ignored_columns': [{groups!r}]}})"
+                f".fit(..., validation_structure={{'group_on': {groups!r}}})"
+            )
             warnings.warn(
                 "`groups` is deprecated and will be removed in AutoGluon 2.0. Use "
-                f"`predictor.fit(..., validation_structure={{'group_on': {groups!r}}})` instead, which "
-                "produces the same group-disjoint splits and additionally supports repeated bagging, "
-                "a group-aware non-bagged holdout, and combining groups with time via `group_time_on`.",
+                f"`{replacement}` instead, which produces the same group-disjoint splits and "
+                "additionally supports repeated bagging, a group-aware non-bagged holdout, and "
+                "combining groups with time via `group_time_on`. "
+                f"`ignored_columns` is the second half of the replacement: `groups` excludes "
+                f"{groups!r} from the features, whereas `validation_structure` on its own leaves its "
+                "columns in place, so migrating without it silently starts training on the group id.",
                 DeprecationWarning,
                 stacklevel=2,
             )
             logger.log(
                 30,
                 f"Warning: `groups` is deprecated and will be removed in AutoGluon 2.0. "
-                f"Use `fit(..., validation_structure={{'group_on': {groups!r}}})` instead.",
+                f"Use `{replacement}` instead -- `ignored_columns` is needed to keep {groups!r} out "
+                f"of the features, which `groups` does implicitly.",
             )
         self._learner: AbstractTabularLearner = learner_type(
             path_context=path,

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -157,13 +157,22 @@ class TabularPredictor:
         This parameter is ignored if bagging is not enabled. To instead specify a custom validation set with bagging disabled, specify `tuning_data` in `.fit`.
         The data will be split via `sklearn.model_selection.LeaveOneGroupOut`.
         Use this option to control the exact split indices AutoGluon uses.
+        .. deprecated:: 1.6.0
+            Use `fit(..., validation_structure={"group_on": <column>})` instead; `groups` will be
+            removed in AutoGluon 2.0. The replacement produces the same group-disjoint splits and
+            additionally supports repeated bagging, a group-aware non-bagged holdout, combining
+            groups with time (`group_time_on`), and sizing the validation method by group count
+            rather than row count (`size_validation_on_groups`). `groups` is now implemented as
+            `validation_structure={"group_on": ...}` with the fold count pinned to the number of
+            groups and a single repeat, which is what it always did implicitly.
+
         It is not recommended to use this option unless it is required for very specific situations.
         Bugs may arise from edge cases if the provided groups are not valid to properly train models, such as if not all classes are present during training in multiclass classification. It is up to the user to sanitize their groups.
 
         Dynamic stacking holdouts and DyStack CV splits are group-disjoint as well (whole groups
-        are held out), so the stacked-overfitting check cannot leak across groups. That requires
-        at least 3 unique group ids. For grouped *and* repeated bagging, prefer
-        `validation_structure={"group_on": ...}` instead of `groups`.
+        are held out), so the stacked-overfitting check cannot leak across groups. That needs at
+        least 3 unique group ids; with fewer, stacking is disabled rather than the fit failing,
+        because the check cannot be run and "unknown" is not the same as "no leakage".
 
         As an example, if you want your data folds to preserve adjacent rows in the table without shuffling, then for 3 fold bagging with 6 rows of data, the groups column values should be [0, 0, 1, 1, 2, 2].
     positive_class : str or int, default = None
@@ -242,6 +251,20 @@ class TabularPredictor:
         if positive_class is not None:
             learner_kwargs["positive_class"] = positive_class
 
+        if groups is not None:
+            warnings.warn(
+                "`groups` is deprecated and will be removed in AutoGluon 2.0. Use "
+                f"`predictor.fit(..., validation_structure={{'group_on': {groups!r}}})` instead, which "
+                "produces the same group-disjoint splits and additionally supports repeated bagging, "
+                "a group-aware non-bagged holdout, and combining groups with time via `group_time_on`.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            logger.log(
+                30,
+                f"Warning: `groups` is deprecated and will be removed in AutoGluon 2.0. "
+                f"Use `fit(..., validation_structure={{'group_on': {groups!r}}})` instead.",
+            )
         self._learner: AbstractTabularLearner = learner_type(
             path_context=path,
             label=label,
@@ -1384,6 +1407,11 @@ class TabularPredictor:
             raise ValueError(
                 "Specify either `groups` (TabularPredictor init) or `validation_structure` (fit), not both."
             )
+        if self._learner.groups is not None:
+            # Resolve the deprecated `groups` into the structure here rather than in the learner:
+            # DyStack runs before the learner, so a structure created further down would leave the
+            # sub-fit splits ungrouped -- which is the leak #5533 reported.
+            validation_structure = ValidationStructure(group_on=self._learner.groups)
         num_group_instances = (
             None if validation_structure is None else validation_structure.num_group_instances(train_data)
         )
@@ -1688,6 +1716,7 @@ class TabularPredictor:
         # (https://github.com/autogluon/autogluon/issues/5533). Reuse the same
         # group-disjoint splitter when `groups` is set.
         validation_structure = self._dystack_validation_structure(X=X, ag_fit_kwargs=ag_fit_kwargs, X_val=X_val)
+        dystack_group_col = self._dystack_group_column(ag_fit_kwargs=ag_fit_kwargs)
 
         # -- Validation Method
         # Both branches can now decide the check cannot run (`skip_reason`), leaving the sub-fit
@@ -1714,10 +1743,8 @@ class TabularPredictor:
                 )
                 if structure_holdout is not None:
                     train_indices, val_indices = structure_holdout
-                    if self._learner.groups is not None:
-                        feasible = self._dystack_keep_logo_feasible(
-                            train_indices, val_indices, X[self._learner.groups]
-                        )
+                    if dystack_group_col is not None:
+                        feasible = self._dystack_keep_logo_feasible(train_indices, val_indices, X[dystack_group_col])
                         if feasible is None:
                             skip_reason = (
                                 "no group-disjoint holdout leaves 2+ groups for LeaveOneGroupOut "
@@ -1761,20 +1788,17 @@ class TabularPredictor:
                     problem_type=self.problem_type,
                 )
             else:
-                groups_values = None
-                if self._learner.groups is not None:
-                    # CVSplitter needs the group *vector*, not the column name.
-                    groups_values = X[self._learner.groups]
+                # Unreachable with grouping: `groups` and `validation_structure` both arrive as a
+                # structure and take the branch above, so this is the ungrouped default.
                 splits = CVSplitter(
                     n_splits=n_folds,
                     n_repeats=n_repeats,
-                    groups=groups_values,
                     stratify=is_stratified,
                     bin=is_binned,
                     random_state=42,
                 ).split(X=features_X, y=y)
-            if self._learner.groups is not None:
-                group_values = X[self._learner.groups]
+            if dystack_group_col is not None:
+                group_values = X[dystack_group_col]
                 feasible_splits = [
                     self._dystack_keep_logo_feasible(train_idx, val_idx, group_values) for train_idx, val_idx in splits
                 ]
@@ -1872,14 +1896,29 @@ class TabularPredictor:
 
         return num_stack_levels, time_limit_fit_full
 
+    @staticmethod
+    def _dystack_group_column(ag_fit_kwargs: dict) -> str | None:
+        """The single group column DyStack must keep whole, or None when there is no grouping.
+
+        Grouped validation reaches DyStack only as a `ValidationStructure` now, whether the user
+        spelled it `validation_structure={"group_on": ...}` or via the deprecated `groups`. A
+        composite `group_on` (a list of columns) is left alone: the feasibility repair below moves
+        whole groups by value, which a multi-column key does not express as one column.
+        """
+        structure = ag_fit_kwargs.get("validation_structure")
+        if structure is None:
+            return None
+        group_on = structure.group_on if structure.group_on is not None else structure.group_time_on
+        return group_on if isinstance(group_on, str) else None
+
     def _dystack_skip_reason(self, ag_fit_kwargs: dict) -> str | None:
         """Why the DyStack check cannot run at all, or None when it can.
 
         Returned before any sub-fit is attempted, so the caller can disable stacking and carry on
         rather than fail the fit.
         """
-        groups_col = self._learner.groups
-        if groups_col is None or ag_fit_kwargs.get("validation_structure") is not None:
+        groups_col = self._dystack_group_column(ag_fit_kwargs=ag_fit_kwargs)
+        if groups_col is None:
             return None
         X = ag_fit_kwargs["X"]
         if groups_col not in X.columns:
@@ -1921,19 +1960,9 @@ class TabularPredictor:
         `groups=` bagging channel does not: without this, DyStack's default row-wise
         holdout leaks across groups (https://github.com/autogluon/autogluon/issues/5533).
         """
-        structure = ag_fit_kwargs.get("validation_structure")
-        if structure is not None:
-            return structure
-        groups_col = self._learner.groups
-        if groups_col is None:
-            return None
-        self._learner._validate_groups(X=X, X_val=X_val)
-        logger.log(
-            20,
-            f"\tDyStack: holding out whole groups from `{groups_col}` so the "
-            "stacked-overfitting check does not leak across groups.",
-        )
-        return ValidationStructure(group_on=groups_col)
+        if self._learner.groups is not None:
+            self._learner._validate_groups(X=X, X_val=X_val)
+        return ag_fit_kwargs.get("validation_structure")
 
     def _dystack_keep_logo_feasible(
         self,

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -3723,7 +3723,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         X_unlabeled=None,
         num_stack_levels=0,
         time_limit=None,
-        groups=None,
+        groups=None,  # deprecated with `TabularPredictor(groups=...)`; unused by the tabular path
         **kwargs,
     ) -> list[str]:
         """Identical to self.train_multi_levels, but also saves the data to disk. This should only ever be called once."""
@@ -3744,6 +3744,9 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
                     self.save_y_test(y_test)
             self.is_data_saved = True
         if self._groups is None:
+            # Only a direct trainer caller can set this now. The tabular path routes grouped
+            # validation through `validation_structure`, which reaches bagging as explicit
+            # `custom_splits` instead of a per-row group vector.
             self._groups = groups
         self._num_rows_train = len(X)
         if X_val is not None:

--- a/tabular/src/autogluon/tabular/trainer/auto_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/auto_trainer.py
@@ -57,7 +57,6 @@ class AutoTrainer(AbstractTabularTrainer):
         infer_limit=None,
         infer_limit_batch_size=None,
         use_bag_holdout=False,
-        groups=None,
         validation_structure=None,
         callbacks: list[callable] = None,
         label_cleaner=None,
@@ -79,10 +78,11 @@ class AutoTrainer(AbstractTabularTrainer):
 
         if (y_val is None) or (X_val is None):
             if not self.bagged_mode or use_bag_holdout:
-                if groups is not None:
-                    raise AssertionError(
-                        f"Validation data must be manually specified if use_bag_holdout and groups are both specified."
-                    )
+                # `groups` used to be rejected here: it had no say in the holdout, so
+                # use_bag_holdout without explicit validation data would have split rows at random
+                # and put the same group on both sides. It now arrives as a `ValidationStructure`,
+                # whose `holdout_split_indices` carves the holdout group-disjointly below, so the
+                # combination is supported rather than refused.
                 if self.bagged_mode:
                     # Need at least 2 samples of each class in train data after split for downstream k-fold splits
                     # to ensure each k-fold has at least 1 sample of each class in training data
@@ -185,7 +185,6 @@ class AutoTrainer(AbstractTabularTrainer):
             aux_kwargs=aux_kwargs,
             infer_limit=infer_limit,
             infer_limit_batch_size=infer_limit_batch_size,
-            groups=groups,
             callbacks=callbacks,
         )
 

--- a/tabular/tests/unittests/test_validation_structure.py
+++ b/tabular/tests/unittests/test_validation_structure.py
@@ -1010,18 +1010,26 @@ def test__fold_ids__binary__ungrouped_fold_count_respects_scorability():
 # ── deprecated `groups` channel ───────────────────────────────────────────────────
 
 
-def _toy_groups_frame(n_groups: int = 6, rows_per_group: int = 20, seed: int = 0) -> pd.DataFrame:
+#: Kept small on purpose: these tests assert on which rows land in which fold, not on accuracy, so
+#: the group count is the only thing that has to be realistic (`groups` pins folds to it).
+_N_GROUPS = 3
+_ROWS_PER_GROUP = 8
+
+
+def _toy_groups_frame(n_groups: int = _N_GROUPS, rows_per_group: int = _ROWS_PER_GROUP, seed: int = 0) -> pd.DataFrame:
     rng = np.random.default_rng(seed)
     n = n_groups * rows_per_group
-    df = pd.DataFrame(
+    return pd.DataFrame(
         {
             "f1": rng.random(n),
             "f2": rng.random(n),
             "grp": np.repeat(np.arange(n_groups), rows_per_group),
+            # Deterministic rather than derived from the features: every group must carry both
+            # classes, or a fold becomes unscorable and the fold count gets clamped, which would
+            # make the leave-one-group-out assertions flaky at this size.
+            "label": np.tile([0, 1], n // 2),
         }
     )
-    df["label"] = (df["f1"] + df["f2"] > 1.0).astype(int)
-    return df
 
 
 def _fit_with_groups(df: pd.DataFrame, **fit_kwargs):
@@ -1029,7 +1037,7 @@ def _fit_with_groups(df: pd.DataFrame, **fit_kwargs):
 
     return TabularPredictor(label="label", groups="grp", verbosity=0).fit(
         df,
-        hyperparameters={"GBM": {}},
+        hyperparameters={"DUMMY": {}},
         dynamic_stacking=False,
         fit_weighted_ensemble=False,
         num_gpus=0,
@@ -1067,7 +1075,7 @@ def test_groups_routes_through_validation_structure_as_leave_one_group_out(monke
     assert seen, "`groups` did not reach ValidationStructure.custom_splits"
     group_on, num_folds, num_repeats, splits = seen[0]
     assert group_on == "grp"
-    assert (num_folds, num_repeats) == (6, 1)
+    assert (num_folds, num_repeats) == (_N_GROUPS, 1)
 
     groups = df["grp"].to_numpy()
     for train_idx, val_idx in splits:
@@ -1076,7 +1084,7 @@ def test_groups_routes_through_validation_structure_as_leave_one_group_out(monke
         assert len(set(groups[val_idx])) == 1
 
     model_name = predictor.model_names()[0]
-    assert predictor._trainer.get_model_attribute(model_name, "num_children") == 6
+    assert predictor._trainer.get_model_attribute(model_name, "num_children") == _N_GROUPS
 
 
 def test_groups_column_is_not_a_feature():
@@ -1127,9 +1135,9 @@ def test_ignored_columns_may_name_a_structure_column(monkeypatch):
     monkeypatch.setattr(ValidationStructure, "custom_splits", spy)
     predictor = TabularPredictor(label="label", verbosity=0, learner_kwargs={"ignored_columns": ["grp"]}).fit(
         df,
-        hyperparameters={"GBM": {}},
+        hyperparameters={"DUMMY": {}},
         validation_structure={"group_on": "grp"},
-        num_bag_folds=6,
+        num_bag_folds=_N_GROUPS,
         num_bag_sets=1,
         dynamic_stacking=False,
         fit_weighted_ensemble=False,

--- a/tabular/tests/unittests/test_validation_structure.py
+++ b/tabular/tests/unittests/test_validation_structure.py
@@ -1005,3 +1005,97 @@ def test__fold_ids__binary__ungrouped_fold_count_respects_scorability():
     values = np.asarray(y)
     for fold in fold_ids.unique():
         assert len(set(pd.unique(values[fold_ids.to_numpy() == fold]))) == 2
+
+
+# ── deprecated `groups` channel ───────────────────────────────────────────────────
+
+
+def _toy_groups_frame(n_groups: int = 6, rows_per_group: int = 20, seed: int = 0) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    n = n_groups * rows_per_group
+    df = pd.DataFrame(
+        {
+            "f1": rng.random(n),
+            "f2": rng.random(n),
+            "grp": np.repeat(np.arange(n_groups), rows_per_group),
+        }
+    )
+    df["label"] = (df["f1"] + df["f2"] > 1.0).astype(int)
+    return df
+
+
+def _fit_with_groups(df: pd.DataFrame, **fit_kwargs):
+    from autogluon.tabular import TabularPredictor
+
+    return TabularPredictor(label="label", groups="grp", verbosity=0).fit(
+        df,
+        hyperparameters={"GBM": {}},
+        dynamic_stacking=False,
+        fit_weighted_ensemble=False,
+        num_gpus=0,
+        **fit_kwargs,
+    )
+
+
+def test_groups_is_deprecated():
+    """`groups` warns and names its replacement and removal version."""
+    from autogluon.tabular import TabularPredictor
+
+    with pytest.warns(DeprecationWarning, match=r"AutoGluon 2\.0"):
+        predictor = TabularPredictor(label="label", groups="grp", verbosity=0)
+    assert predictor._learner.groups == "grp"
+
+
+def test_groups_routes_through_validation_structure_as_leave_one_group_out(monkeypatch):
+    """`groups` must keep its semantics now that it is a `ValidationStructure` underneath.
+
+    `CVSplitter` used to swap in `LeaveOneGroupOut`; grouped k-fold at k == n_groups is the same
+    partition, so the observable contract is: one fold per group, one repeat, group-disjoint.
+    """
+    df = _toy_groups_frame()
+    seen: list[tuple] = []
+    original = ValidationStructure.custom_splits
+
+    def spy(self, X, y, **kwargs):
+        splits, num_folds, num_repeats = original(self, X, y, **kwargs)
+        seen.append((self.group_on, num_folds, num_repeats, [(np.asarray(t), np.asarray(v)) for t, v in splits]))
+        return splits, num_folds, num_repeats
+
+    monkeypatch.setattr(ValidationStructure, "custom_splits", spy)
+    predictor = _fit_with_groups(df)
+
+    assert seen, "`groups` did not reach ValidationStructure.custom_splits"
+    group_on, num_folds, num_repeats, splits = seen[0]
+    assert group_on == "grp"
+    assert (num_folds, num_repeats) == (6, 1)
+
+    groups = df["grp"].to_numpy()
+    for train_idx, val_idx in splits:
+        assert set(groups[train_idx]).isdisjoint(set(groups[val_idx]))
+        # leave-one-group-out: each fold validates exactly one whole group
+        assert len(set(groups[val_idx])) == 1
+
+    model_name = predictor.model_names()[0]
+    assert predictor._trainer.get_model_attribute(model_name, "num_children") == 6
+
+
+def test_groups_column_is_not_a_feature():
+    """The group column must stay out of the features.
+
+    This is the one place the two channels genuinely differed: `validation_structure` leaves its
+    columns in place, while `groups` extracts its column. Translating without preserving that
+    would silently start training on the group id.
+    """
+    df = _toy_groups_frame()
+    predictor = _fit_with_groups(df)
+    assert "grp" not in predictor.feature_metadata.get_features()
+
+
+def test_groups_supports_use_bag_holdout():
+    """Previously an AssertionError: `groups` had no say in the holdout, so it was refused.
+
+    The structure carves a group-disjoint bag-holdout, so the combination is now supported.
+    """
+    df = _toy_groups_frame()
+    predictor = _fit_with_groups(df, use_bag_holdout=True)
+    assert predictor.model_names()

--- a/tabular/tests/unittests/test_validation_structure.py
+++ b/tabular/tests/unittests/test_validation_structure.py
@@ -1099,3 +1099,55 @@ def test_groups_supports_use_bag_holdout():
     df = _toy_groups_frame()
     predictor = _fit_with_groups(df, use_bag_holdout=True)
     assert predictor.model_names()
+
+
+def test_ignored_columns_may_name_a_structure_column(monkeypatch):
+    """`ignored_columns` naming the `group_on` column must still produce group-disjoint splits.
+
+    Note the spelling: `ignored_columns` is a key of the predictor's `learner_kwargs`, not a `fit`
+    argument -- which is most of why this migration is awkward enough to want a first-class
+    `ValidationStructure` field instead.
+
+    This is the documented migration off `groups`, and it only works because of an ordering that
+    nothing else enforces: the learner resolves the splits (which read the column off `X`) before
+    feature generation applies `ignored_columns` (which drops it). Move the drop earlier and grouped
+    validation breaks with a confusing "column not found", so the invariant is pinned here.
+    """
+    from autogluon.tabular import TabularPredictor
+
+    df = _toy_groups_frame()
+    seen: list[list] = []
+    original = ValidationStructure.custom_splits
+
+    def spy(self, X, y, **kwargs):
+        splits, num_folds, num_repeats = original(self, X, y, **kwargs)
+        seen.append([(np.asarray(t), np.asarray(v)) for t, v in splits])
+        return splits, num_folds, num_repeats
+
+    monkeypatch.setattr(ValidationStructure, "custom_splits", spy)
+    predictor = TabularPredictor(label="label", verbosity=0, learner_kwargs={"ignored_columns": ["grp"]}).fit(
+        df,
+        hyperparameters={"GBM": {}},
+        validation_structure={"group_on": "grp"},
+        num_bag_folds=6,
+        num_bag_sets=1,
+        dynamic_stacking=False,
+        fit_weighted_ensemble=False,
+        num_gpus=0,
+    )
+
+    assert seen, "splits were not resolved while the group column was still present"
+    groups = df["grp"].to_numpy()
+    for train_idx, val_idx in seen[0]:
+        assert set(groups[train_idx]).isdisjoint(set(groups[val_idx]))
+
+    # ...and the column is still kept out of the features, matching `groups`.
+    assert "grp" not in predictor.feature_metadata.get_features()
+
+
+def test_deprecated_groups_warning_names_ignored_columns():
+    """The migration advice has to mention both halves, or migrating changes the model inputs."""
+    from autogluon.tabular import TabularPredictor
+
+    with pytest.warns(DeprecationWarning, match=r"ignored_columns"):
+        TabularPredictor(label="label", groups="grp", verbosity=0)


### PR DESCRIPTION
*Issue #, if available:*

Follow-up to #5853.

*Description of changes:*

`groups` and `validation_structure` were two implementations of grouped validation. Every fix had to be applied to both — #5853 had to add a `groups`-specific group-disjoint DyStack holdout that `validation_structure` already had — and only one of them was ever protected. This makes `groups` a thin deprecated alias for the other:

```python
validation_structure = ValidationStructure(group_on=groups)
num_bag_folds, num_bag_sets = X[groups].nunique(), 1
```

`CVSplitter` swapped in `LeaveOneGroupOut` for `groups`, and grouped k-fold at `k == n_groups` is the same partition — verified identical for binary, multiclass and regression at 4 and 6 groups — so pinning the fold count and repeats reproduces what `groups` always did implicitly. `groups` now emits a `DeprecationWarning` naming AutoGluon 2.0 and the replacement.

## Two properties preserved deliberately

**The group column must not become a feature.** This is the one place the channels genuinely differed:

```
groups=grp     features = ['f1', 'f2']            'grp' used as a feature: False
group_on=grp   features = ['f1', 'f2', 'grp']     'grp' used as a feature: True
```

A naive translation would silently start training on the group id. `extract_column` now runs *after* the splits are resolved: the structure needs the column present, and feature generation must not see it.

**The structure is built in `TabularPredictor.fit`, not in the learner.** DyStack runs before the learner, so a structure created further down leaves the sub-fit splits ungrouped — exactly the leak #5533 reported. I hit this: 7 DyStack tests failed with "did not go through the group-aware splitter" before moving it up.

## Removed, now that grouped validation arrives by one route

- `_dystack_validation_structure` no longer synthesizes a structure from `groups`.
- **The DyStack feasibility repair is no longer gated on `groups is not None`.** It keys off the resolved structure, so it now also covers `validation_structure={"group_on": ...}` — the follow-up flagged in #5853. On master that path fails its sub-fit and leaves stacking **enabled**:

  | n_groups | holdout_frac | train groups left | before | after |
  |---|---|---|---|---|
  | 2 | any | 1 | sub-fit fails, stacking **on** | stacking disabled |
  | 3 | ≥0.5 | 1 | sub-fit fails, stacking **on** | stacking disabled |
  | 3 | 0.2 | 2 | ok | ok |
  | 4+ | ≥0.2 | 2+ | ok | ok |

- The `groups` vector no longer threads predictor → learner → trainer; bagging receives explicit `custom_splits`. `CVSplitter(groups=)` and `BaggedEnsembleModel(groups=)` are **untouched** — they are lower-level primitives with their own callers, and deleting them is a wider API change than this deprecation warrants.
- `AutoTrainer.fit` drops its `groups` parameter, and with it the assertion that `use_bag_holdout` plus `groups` required explicit validation data. That existed because `groups` had no say in the holdout; the structure now carves it group-disjointly, so the combination works.

## Verification

With `groups="grp"` over 6 groups:

```
routed through ValidationStructure: group_on='grp' folds=6 repeats=1
  all folds group-disjoint: True
  each fold validates exactly one whole group (LOGO): True
model=LightGBM_BAG_L1 num_children=6
features=['f1', 'f2']  'grp' excluded from features: True
use_bag_holdout + groups: OK
```

Four new cases in `test_validation_structure.py` cover the warning, the leave-one-group-out contract, the feature exclusion, and `use_bag_holdout`.

`test_validation_structure.py` — 46 passed. Plus `dynamic_stacking` and `configs/test_validation_size_curves.py` — 136 passed. Plus `edgecases` and `models/advanced` — 55 passed. `ruff format --check` and `ruff check --select I` clean on `tabular/`.

## Behavior changes to be aware of

1. `groups` now warns. Nothing else about a `groups` fit changes: same partition, same fold count, same feature set.
2. Fold **order** differs from `LeaveOneGroupOut` — same partition, but `GroupKFold` balances rather than iterating groups in sorted order, so which fold-model sees which group changes. OOF predictions are identical row-wise; per-fold models are not bit-identical.
3. `use_bag_holdout` with `groups` used to raise and now works.
4. Too few groups for a group-disjoint DyStack holdout disables stacking rather than failing, for `validation_structure` as well as `groups` (per the policy set in #5853).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
