### PR TITLE
[tabular] Reuse the validation structure from `fit` in `fit_extra`

### DIFF
--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -2403,6 +2403,20 @@ class TabularPredictor:
         kwargs_orig = kwargs.copy()
         kwargs = self._validate_fit_extra_kwargs(kwargs)
 
+        if kwargs_orig.get("validation_structure") is not None:
+            # Previously accepted and silently ignored, which is the worst of the options: the
+            # caller believed their structure applied while the models were validated on plain
+            # k-fold. It cannot be honored either, because a structure has to be resolved off the
+            # raw frame before feature generation transforms or drops the columns it names, and
+            # `fit_extra` starts from the already-transformed training data. The structure from
+            # `fit` is reused automatically, so there is nothing to pass.
+            raise ValueError(
+                "`validation_structure` cannot be specified in `fit_extra`. The structure resolved "
+                "during `fit` is reused automatically, so models added here are validated on the "
+                "same splits as the existing ones. To validate with a different structure, refit "
+                "the predictor with that `validation_structure` in `fit`."
+            )
+
         verbosity = kwargs.get("verbosity", self.verbosity)
         set_logger_verbosity(verbosity)
 

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -231,6 +231,12 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         #: custom split indices
         self._groups = None
 
+        #: Explicit (train_idx, val_idx) splits a `validation_structure` resolved for this
+        #: predictor, and the row count they address. Remembered so that models added later by
+        #: `fit_extra` are validated on the same partition as the models from the original `fit`.
+        self._custom_splits: list | None = None
+        self._custom_splits_num_rows: int | None = None
+
         #: whether to treat regression predictions as class-probabilities (during distillation)
         self._regress_preds_asprobas = False
 
@@ -803,6 +809,42 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
 
         return core_models, aux_models
 
+    def _resolve_custom_splits(self, ag_args_ensemble: dict | None, X) -> dict | None:
+        """Keep every model in this predictor on the same validation partition.
+
+        A `validation_structure` is resolved once, in the learner, off the raw cleaned frame -- the
+        structure columns can be transformed or dropped by feature generation, so they cannot be
+        re-read later. The resolved splits arrive here as `ag_args_ensemble["custom_splits"]`, but
+        only on the call that came through the learner: `fit_extra` builds its own `core_kwargs` and
+        so used to fall back to plain k-fold. That silently mixed group-disjoint models (from `fit`)
+        with leaky ones (from `fit_extra`) in the same predictor, and compared their `score_val`s
+        against each other.
+
+        Remembering the splits on the trainer fixes that, because both paths funnel through
+        `stack_new_level_core`. The row count is remembered with them: the splits are positional
+        indices into the training frame, so a later call that changed the row set (`fit_extra` with
+        `pseudo_data`) must not reuse them.
+        """
+        splits = None if ag_args_ensemble is None else ag_args_ensemble.get("custom_splits")
+        if splits is not None:
+            self._custom_splits = splits
+            self._custom_splits_num_rows = len(X)
+            return ag_args_ensemble
+        if self._custom_splits is None:
+            return ag_args_ensemble
+        if len(X) != self._custom_splits_num_rows:
+            logger.log(
+                30,
+                f"Warning: cannot reuse the validation splits resolved during `fit` because the "
+                f"training data now has {len(X)} rows rather than {self._custom_splits_num_rows}. "
+                f"Models fit in this call will use the default splits, so their validation scores "
+                f"are not comparable with the models fit earlier.",
+            )
+            return ag_args_ensemble
+        ag_args_ensemble = {} if ag_args_ensemble is None else ag_args_ensemble.copy()
+        ag_args_ensemble.setdefault("custom_splits", self._custom_splits)
+        return ag_args_ensemble
+
     def stack_new_level_core(
         self,
         X,
@@ -856,6 +898,8 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         ag_args_fit = ag_args_fit.copy()
         if infer_limit_batch_size is not None:
             ag_args_fit["predict_1_batch_size"] = infer_limit_batch_size
+
+        ag_args_ensemble = self._resolve_custom_splits(ag_args_ensemble=ag_args_ensemble, X=X)
 
         if isinstance(models, dict):
             get_models_kwargs = dict(
@@ -4493,6 +4537,15 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
                 os.rmdir(self.path_utils)
             except OSError:
                 pass
+            # Fit-only state, and specifically state that indexes the data just deleted:
+            # `_custom_splits` holds positional (train_idx, val_idx) pairs into the training frame
+            # and `_groups` a per-row group vector. Neither is read during inference, and without
+            # the data neither can be reused for another fit, so they are dead weight in a
+            # deployment artifact -- roughly `2 * n_rows * num_repeats` int64s, e.g. ~64 MB at 1M
+            # rows with 8 repeats.
+            self._custom_splits = None
+            self._custom_splits_num_rows = None
+            self._groups = None
         if remove_info and requires_save:
             # Remove model failure info artifacts
             self._models_failed_to_train_errors = dict()

--- a/tabular/tests/unittests/test_fit_extra_validation_structure.py
+++ b/tabular/tests/unittests/test_fit_extra_validation_structure.py
@@ -10,7 +10,7 @@ from autogluon.common.utils import cv_splitter as cvs
 from autogluon.tabular import TabularPredictor
 
 
-def _grouped_frame(n_groups: int = 6, rows_per_group: int = 30, seed: int = 0) -> pd.DataFrame:
+def _grouped_frame(n_groups: int = 3, rows_per_group: int = 8, seed: int = 0) -> pd.DataFrame:
     rng = np.random.default_rng(seed)
     n = n_groups * rows_per_group
     df = pd.DataFrame(
@@ -51,16 +51,18 @@ def test_fit_extra_reuses_the_validation_structure_from_fit(monkeypatch):
 
     predictor = TabularPredictor(label="label", verbosity=0).fit(
         df,
-        hyperparameters={"GBM": {}},
+        hyperparameters={"DUMMY": {}},
         validation_structure={"group_on": "grp"},
-        num_bag_folds=6,
+        num_bag_folds=3,
         num_bag_sets=1,
         dynamic_stacking=False,
         fit_weighted_ensemble=False,
         num_gpus=0,
     )
     phase[0] = "fit_extra"
-    predictor.fit_extra(hyperparameters={"GBM": {}}, num_bag_sets=1, fit_weighted_ensemble=False, name_suffix="_extra")
+    predictor.fit_extra(
+        hyperparameters={"DUMMY": {}}, num_bag_sets=1, fit_weighted_ensemble=False, name_suffix="_extra"
+    )
 
     assert [p for p, _, _ in seen].count("fit_extra") >= 1, "no bagged model was fit by fit_extra"
     for phase_name, has_custom, disjoint in seen:
@@ -77,9 +79,9 @@ def test_fit_extra_rejects_an_explicit_validation_structure():
     df = _grouped_frame()
     predictor = TabularPredictor(label="label", verbosity=0).fit(
         df,
-        hyperparameters={"GBM": {}},
+        hyperparameters={"DUMMY": {}},
         validation_structure={"group_on": "grp"},
-        num_bag_folds=6,
+        num_bag_folds=3,
         num_bag_sets=1,
         dynamic_stacking=False,
         fit_weighted_ensemble=False,
@@ -87,7 +89,7 @@ def test_fit_extra_rejects_an_explicit_validation_structure():
     )
     with pytest.raises(ValueError, match="cannot be specified in `fit_extra`"):
         predictor.fit_extra(
-            hyperparameters={"GBM": {}},
+            hyperparameters={"DUMMY": {}},
             fit_weighted_ensemble=False,
             validation_structure={"group_on": "grp"},
         )
@@ -126,9 +128,9 @@ def test_save_space_drops_the_fit_only_split_state():
     df = _grouped_frame()
     predictor = TabularPredictor(label="label", verbosity=0).fit(
         df,
-        hyperparameters={"GBM": {}},
+        hyperparameters={"DUMMY": {}},
         validation_structure={"group_on": "grp"},
-        num_bag_folds=6,
+        num_bag_folds=3,
         num_bag_sets=1,
         dynamic_stacking=False,
         fit_weighted_ensemble=False,

--- a/tabular/tests/unittests/test_fit_extra_validation_structure.py
+++ b/tabular/tests/unittests/test_fit_extra_validation_structure.py
@@ -1,0 +1,147 @@
+"""`fit_extra` must validate new models on the same splits as the original `fit`."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from autogluon.common.utils import cv_splitter as cvs
+from autogluon.tabular import TabularPredictor
+
+
+def _grouped_frame(n_groups: int = 6, rows_per_group: int = 30, seed: int = 0) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    n = n_groups * rows_per_group
+    df = pd.DataFrame(
+        {
+            "f1": rng.random(n),
+            "f2": rng.random(n),
+            "grp": np.repeat([f"g{i}" for i in range(n_groups)], rows_per_group),
+        }
+    )
+    df["label"] = (df["f1"] + df["f2"] > 1.0).astype(int)
+    return df
+
+
+def test_fit_extra_reuses_the_validation_structure_from_fit(monkeypatch):
+    """Models added by `fit_extra` must not be validated on leaky splits.
+
+    A `validation_structure` is resolved once, in the learner, and reaches bagging as
+    `ag_args_ensemble["custom_splits"]`. `fit_extra` builds its own `core_kwargs`, so it used to
+    fall back to plain k-fold: the same predictor then held group-disjoint models from `fit` and
+    group-leaking models from `fit_extra`, and compared their `score_val`s against each other.
+    """
+    df = _grouped_frame()
+    groups = df["grp"].to_numpy()
+    seen: list[tuple[str, bool, bool]] = []
+    phase = ["fit"]
+    original_split = cvs.CVSplitter.split
+
+    def spy(self, X, y):
+        splits = original_split(self, X, y)
+        disjoint = all(
+            set(groups[np.asarray(train_idx)]).isdisjoint(set(groups[np.asarray(val_idx)]))
+            for train_idx, val_idx in splits
+        )
+        seen.append((phase[0], self.custom_splits is not None, disjoint))
+        return splits
+
+    monkeypatch.setattr(cvs.CVSplitter, "split", spy)
+
+    predictor = TabularPredictor(label="label", verbosity=0).fit(
+        df,
+        hyperparameters={"GBM": {}},
+        validation_structure={"group_on": "grp"},
+        num_bag_folds=6,
+        num_bag_sets=1,
+        dynamic_stacking=False,
+        fit_weighted_ensemble=False,
+        num_gpus=0,
+    )
+    phase[0] = "fit_extra"
+    predictor.fit_extra(hyperparameters={"GBM": {}}, num_bag_sets=1, fit_weighted_ensemble=False, name_suffix="_extra")
+
+    assert [p for p, _, _ in seen].count("fit_extra") >= 1, "no bagged model was fit by fit_extra"
+    for phase_name, has_custom, disjoint in seen:
+        assert has_custom, f"{phase_name}: structure-resolved splits were not used"
+        assert disjoint, f"{phase_name}: a fold put the same group on both sides"
+
+
+def test_fit_extra_rejects_an_explicit_validation_structure():
+    """It was accepted and silently ignored, which is worse than refusing it.
+
+    It cannot be honored: a structure is resolved off the raw frame before feature generation
+    transforms or drops the columns it names, and `fit_extra` starts from transformed data.
+    """
+    df = _grouped_frame()
+    predictor = TabularPredictor(label="label", verbosity=0).fit(
+        df,
+        hyperparameters={"GBM": {}},
+        validation_structure={"group_on": "grp"},
+        num_bag_folds=6,
+        num_bag_sets=1,
+        dynamic_stacking=False,
+        fit_weighted_ensemble=False,
+        num_gpus=0,
+    )
+    with pytest.raises(ValueError, match="cannot be specified in `fit_extra`"):
+        predictor.fit_extra(
+            hyperparameters={"GBM": {}},
+            fit_weighted_ensemble=False,
+            validation_structure={"group_on": "grp"},
+        )
+
+
+def test_remembered_splits_are_not_reused_on_a_different_row_count():
+    """The splits are positional indices, so a changed row set must not reuse them."""
+    from autogluon.tabular.trainer.abstract_trainer import AbstractTabularTrainer
+
+    trainer = AbstractTabularTrainer.__new__(AbstractTabularTrainer)
+    splits = [(np.array([0, 1]), np.array([2])), (np.array([1, 2]), np.array([0]))]
+    trainer._custom_splits = splits
+    trainer._custom_splits_num_rows = 3
+
+    same_rows = trainer._resolve_custom_splits(ag_args_ensemble=None, X=pd.DataFrame({"a": [0, 1, 2]}))
+    assert same_rows["custom_splits"] is splits
+
+    more_rows = trainer._resolve_custom_splits(ag_args_ensemble=None, X=pd.DataFrame({"a": [0, 1, 2, 3]}))
+    assert more_rows is None, "stale positional splits must not be reused"
+
+    # An explicitly supplied set always wins, and replaces what was remembered.
+    other = [(np.array([0]), np.array([1]))]
+    out = trainer._resolve_custom_splits(ag_args_ensemble={"custom_splits": other}, X=pd.DataFrame({"a": [0, 1]}))
+    assert out["custom_splits"] is other
+    assert trainer._custom_splits is other
+    assert trainer._custom_splits_num_rows == 2
+
+
+def test_save_space_drops_the_fit_only_split_state():
+    """The splits index the training data, so they are dead weight once that data is removed.
+
+    `clone_for_deployment` goes through `save_space`, and neither the splits nor the group vector
+    is read during inference -- roughly `2 * n_rows * num_repeats` int64s of pure overhead in a
+    deployment artifact.
+    """
+    df = _grouped_frame()
+    predictor = TabularPredictor(label="label", verbosity=0).fit(
+        df,
+        hyperparameters={"GBM": {}},
+        validation_structure={"group_on": "grp"},
+        num_bag_folds=6,
+        num_bag_sets=1,
+        dynamic_stacking=False,
+        fit_weighted_ensemble=False,
+        num_gpus=0,
+    )
+    assert predictor._trainer._custom_splits is not None, "the splits should be remembered after fit"
+
+    predictor.save_space()
+
+    trainer = predictor._trainer
+    assert trainer._custom_splits is None
+    assert trainer._custom_splits_num_rows is None
+    # ...and it survives a round trip through disk, which is what a deployment clone loads.
+    reloaded = TabularPredictor.load(predictor.path)
+    assert reloaded._trainer._custom_splits is None
+    assert len(reloaded.predict(df)) == len(df)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Models added by `fit_extra` are validated on **different splits** than the models from the original `fit`, silently. A `validation_structure` is resolved once, in the learner, off the raw cleaned frame — feature generation can transform or drop the columns it names, so they cannot be read again later. The resolved splits reach bagging as `ag_args_ensemble["custom_splits"]`, but only on the call that came through the learner. `fit_extra` builds its own `core_kwargs`, so it falls back to plain k-fold.

Measured by spying on `CVSplitter.split` and checking each fold against the group vector:

| phase | n_splits | custom_splits | folds group-disjoint |
|---|---|---|---|
| `fit` | 6 | True | **True** |
| `fit_extra`, structure not re-specified | 6 | False | **False** |
| `fit_extra`, structure re-specified | 6 | False | **False** |

So one predictor ends up holding group-disjoint models from `fit` and group-**leaking** models from `fit_extra`, and compares their `score_val`s against each other for model selection and ensemble weighting — where the leaky ones will tend to look better. `n_splits=6` survives only because the fold *count* is trainer state; the partition is not.

This applies to every structure type. With `time_on` it is arguably worse: a `fit_extra` model gets folds trained on data from after the window it is scored on, while the original models do not.

## Changes

**Remember the resolved splits on the trainer and re-inject them.** Both `fit` and `fit_extra` funnel through `stack_new_level_core`, so one injection point covers both. The row count is remembered alongside, because the splits are positional indices into the training frame — a later call that changed the row set must not reuse them, and warns instead.

**`validation_structure` in `fit_extra` now raises.** It was accepted (it is in `_fit_extra_kwargs_dict`) and then silently ignored — the worst of the options, since the caller believed their structure applied while the models were validated on plain k-fold. It cannot be honored either, for the reason above, so the error says the structure from `fit` is reused automatically and that changing it means refitting.

**Drop the state in `reduce_memory_size(remove_data=True)`**, which is what `save_space` and `clone_for_deployment` call. The splits index the data being deleted, are never read during inference, and cannot be reused for another fit once the data is gone:

| rows | folds | repeats | `custom_splits` size |
|---|---|---|---|
| 100k | 8 | 1 | 0.8 MB |
| 1M | 8 | 1 | 8.0 MB |
| 1M | 8 | 8 | 64.0 MB |

Pure dead weight in a deployment artifact. `_groups` is cleared with it for the same reason.

## Tests

New `tabular/tests/unittests/test_fit_extra_validation_structure.py`:

- `fit` → `fit_extra` keeps every fold group-disjoint and structure-resolved. **Fails on master** — this is the regression test for the bug.
- An explicit `validation_structure` in `fit_extra` raises.
- Remembered splits are not reused when the row count differs, while an explicitly supplied set always wins and replaces what was remembered.
- `save_space()` clears the state, it stays cleared across a reload, and the reloaded predictor still predicts.

71 passed across the new file, `test_validation_structure.py`, and `models/advanced` (which covers `clone_for_deployment`). `ruff format --check` and `ruff check --select I` clean on `tabular/`.

## Note on ordering

Independent of #5856, but that PR inherits this defect the moment a `groups` user calls `fit_extra`, since `groups` now routes through `validation_structure`. Either order works; this one stands alone.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
