### PR TITLE
[common] Correct the `uncovered_rows` docstring and record why splits are derived

### DIFF
--- a/common/src/autogluon/common/utils/validation_structure.py
+++ b/common/src/autogluon/common/utils/validation_structure.py
@@ -47,6 +47,14 @@ class ValidationStructure:
         are simultaneously group-disjoint and forward in time, and the non-bagged holdout is
         the latest groups. Use this for data that is both grouped and temporal; combining
         ``group_on`` with ``time_on`` is not supported, as their semantics would be ambiguous.
+    Pre-computed splits are deliberately not accepted here. A single instance is asked to split
+    several different row sets during one fit -- measured at three (the full frame for the dynamic
+    stacking sub-fit, the frame after the DyStack holdout is carved, and the frame after a
+    ``use_bag_holdout`` carve) -- so it has to *derive* splits per frame rather than replay a fixed
+    list of positional indices, which would be valid for at most one of them. Pass explicit splits
+    through ``fit(..., ag_args_ensemble={"custom_splits": ...})`` instead; those apply at the
+    bagging layer only, and the holdout and DyStack splits are unaffected.
+
     temporal_forward_only : bool, default False
         Restrict temporal validation to forward-chaining (an expanding window): fold *i*
         validates time block *i+1* and trains only on the blocks before it, so a model is never
@@ -339,9 +347,13 @@ class ValidationStructure:
         """Positional indices of rows no fold validates, i.e. rows that get no out-of-fold prediction.
 
         Empty for every configuration except ``temporal_forward_only``, whose earliest time block
-        is training data only. Callers that consume out-of-fold predictions should exclude these
-        rows: a bagged model leaves them at the accumulator's initial value rather than marking
-        them missing, so downstream they read as a prediction of 0 rather than as absent.
+        is training data only.
+
+        AutoGluon already accounts for these rows: a bagged model emits NaN for them rather than a
+        fabricated 0 (see ``BaggedEnsembleModel._predict_proba_oof``), and ``score_with_oof`` masks
+        them out, so validation scores and the weighted ensemble cover only validated rows. This
+        method is for callers doing their own arithmetic on out-of-fold predictions, which need to
+        know which rows to exclude without inferring it from NaNs.
 
         ``**kwargs`` are forwarded to :meth:`custom_splits` (``num_folds``, ``random_state``, ...)
         so the answer matches the splits that call produces.

--- a/tabular/tests/unittests/test_validation_structure.py
+++ b/tabular/tests/unittests/test_validation_structure.py
@@ -640,7 +640,7 @@ def test__temporal_forward_only__weighted_ensemble_is_scored_on_covered_rows():
     from autogluon.tabular import TabularPredictor
 
     rng = np.random.default_rng(0)
-    n = 300
+    n = 80
     data = pd.DataFrame(
         {
             "num": rng.normal(size=n),
@@ -651,7 +651,7 @@ def test__temporal_forward_only__weighted_ensemble_is_scored_on_covered_rows():
 
     predictor = TabularPredictor(label="y", problem_type="regression", verbosity=0).fit(
         data,
-        hyperparameters={"GBM": [{"num_boost_round": 20}]},
+        hyperparameters={"DUMMY": {}},
         num_bag_folds=4,
         num_bag_sets=1,
         num_stack_levels=0,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Follow-ups noticed while closing #4492.

## `uncovered_rows` documented the wrong behaviour

It told callers:

> a bagged model leaves them at the accumulator's initial value rather than marking them missing, so downstream they read as a prediction of 0 rather than as absent

That is the pre-fix behaviour. `BaggedEnsembleModel._predict_proba_oof` emits **NaN** for rows no fold validated, and `score_with_oof` masks them out, so validation scores and the weighted ensemble already cover only validated rows. Someone fixed the bagged model and this docstring was left behind, telling readers AutoGluon has a bug it does not have.

Rewritten to say what the code does, point at the mechanism, and state what the method is *for*: callers doing their own arithmetic on out-of-fold predictions, who need the row set without inferring it from NaNs. (It has direct unit tests but no production caller, which is why the drift went unnoticed.)

## Why `ValidationStructure` derives splits instead of accepting them

Recorded on the class, because it is a reasonable thing to want and worth not re-litigating. A single instance is asked to split **several different row sets during one fit** — measured at three:

```
total rows in train_data: 240
  holdout_split_indices    on a frame of 240 rows     <- DyStack
  custom_splits            on a frame of 240 rows
  holdout_split_indices    on a frame of 200 rows     <- after the DyStack holdout is carved
  custom_splits            on a frame of 200 rows
  custom_splits            on a frame of 160 rows     <- after the use_bag_holdout carve
  ...
distinct frame sizes: [160, 200, 240]
```

So it has to *derive* splits per frame. A fixed list of positional indices would be valid for at most one of the three and silently wrong or out of bounds for the others — the same hazard #5857 guards with a row-count check. The docstring points at `ag_args_ensemble={"custom_splits": ...}` for explicit splits and is explicit that those apply at the bagging layer only, leaving the holdout and DyStack splits untouched.

**This is why I did not add a custom-splits field.** A *splitter object* (`splitter.split(X, y)`) would satisfy the derive-per-frame contract and is the shape worth considering if we want a first-class entry point — but that is a new public API surface and a design decision, not a docstring fix, so it belongs in its own change rather than being slipped into a cleanup.

## Test runtime

`test__temporal_forward_only__weighted_ensemble_is_scored_on_covered_rows`: **9.2s → under 2s** (DUMMY and 80 rows instead of GBM and 300). Its teeth are the row set the scores cover, not a model that learns anything — verified by disabling the NaN marking in `_predict_proba_oof`, where it still fails.

`test__holdout_coverage__weighted_ensemble_oof_stays_row_aligned` is **left alone**. Shrinking it made it slower (4.3s → 11.1s), and re-measuring showed the 4.3s baseline was a fluke — it is ~11s at its original size too. `calibrate=True` needs real probabilities, so DUMMY is not an option there. Flagging it as the slowest test in the file rather than pretending otherwise.

## Tests

`tabular/tests/unittests/test_validation_structure.py` — 48 passed (file total 44s, down from 46s). `common/tests` — 161 passed (the one failure, `test_check_style`, also fails on clean master locally: ruff-version skew). `ruff format --check` and `ruff check --select I` clean.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
