### PR TITLE
[common] Add `ValidationStructure.splitter` for custom cross-validators

### DIFF
--- a/common/src/autogluon/common/utils/validation_structure.py
+++ b/common/src/autogluon/common/utils/validation_structure.py
@@ -47,13 +47,26 @@ class ValidationStructure:
         are simultaneously group-disjoint and forward in time, and the non-bagged holdout is
         the latest groups. Use this for data that is both grouped and temporal; combining
         ``group_on`` with ``time_on`` is not supported, as their semantics would be ambiguous.
-    Pre-computed splits are deliberately not accepted here. A single instance is asked to split
-    several different row sets during one fit -- measured at three (the full frame for the dynamic
-    stacking sub-fit, the frame after the DyStack holdout is carved, and the frame after a
-    ``use_bag_holdout`` carve) -- so it has to *derive* splits per frame rather than replay a fixed
-    list of positional indices, which would be valid for at most one of them. Pass explicit splits
-    through ``fit(..., ag_args_ensemble={"custom_splits": ...})`` instead; those apply at the
-    bagging layer only, and the holdout and DyStack splits are unaffected.
+    splitter : sklearn-style cross-validator, optional
+        A splitter whose ``split(X, y)`` yields ``(train_idx, val_idx)`` pairs, e.g.
+        ``sklearn.model_selection.TimeSeriesSplit(n_splits=5)``. Use it for a validation scheme the
+        declarative fields above cannot express; prefer those fields where they can, because they
+        describe the data rather than the mechanics and so keep working as the surrounding logic
+        changes.
+
+        A splitter rather than a fixed list of splits, because one structure is asked to split
+        several different row sets during a single fit (the full frame for the dynamic-stacking
+        sub-fit, the frame after the DyStack holdout is carved, the frame after a
+        ``use_bag_holdout`` carve). Splits must therefore be *derived* per frame; a fixed list of
+        positional indices would be valid for at most one of them. That is also what this buys over
+        ``fit(..., ag_args_ensemble={"custom_splits": ...})``, which only reaches bagging: a
+        splitter is consulted for the non-bagged holdout and the DyStack splits as well, so those
+        do not fall back to a random split of data the splitter is meant to keep ordered.
+
+        The fold count comes from the splitter, so ``num_bag_folds`` is adopted from it rather than
+        honored, and repeats are always 1 (re-running a deterministic splitter would only duplicate
+        work). Mutually exclusive with every other field: it replaces fold derivation rather than
+        refining it.
 
     temporal_forward_only : bool, default False
         Restrict temporal validation to forward-chaining (an expanding window): fold *i*
@@ -79,6 +92,7 @@ class ValidationStructure:
     group_time_on: str | None = None
     size_validation_on_groups: bool = False
     temporal_forward_only: bool = False
+    splitter: Any = None
 
     def __post_init__(self):
         if self.group_on is not None and self.time_on is not None:
@@ -88,9 +102,36 @@ class ValidationStructure:
             )
         if self.group_time_on is not None and (self.group_on is not None or self.time_on is not None):
             raise ValueError("`group_time_on` is mutually exclusive with `group_on` / `time_on`.")
-        if all(v is None for v in (self.group_on, self.time_on, self.stratify_on, self.group_time_on)):
+        if self.splitter is not None:
+            others = {
+                "group_on": self.group_on,
+                "time_on": self.time_on,
+                "stratify_on": self.stratify_on,
+                "group_time_on": self.group_time_on,
+            }
+            set_others = sorted(name for name, value in others.items() if value is not None)
+            if self.size_validation_on_groups:
+                set_others.append("size_validation_on_groups")
+            if self.temporal_forward_only:
+                set_others.append("temporal_forward_only")
+            if set_others:
+                raise ValueError(
+                    f"`splitter` replaces fold derivation, so it cannot be combined with "
+                    f"{set_others}. Drop those, or drop `splitter` and let the declared structure "
+                    f"derive the splits."
+                )
+            # `str` is excluded explicitly: `str.split` is callable, so a bare column name passes a
+            # plain duck-type check and then fails deep inside fold resolution.
+            if isinstance(self.splitter, (str, bytes)) or not callable(getattr(self.splitter, "split", None)):
+                raise ValueError(
+                    f"`splitter` must be a cross-validator with a `split(X, y)` method, e.g. "
+                    f"`sklearn.model_selection.TimeSeriesSplit`. Got: {type(self.splitter)}. "
+                    f"To name a column, use `group_on` or `time_on` instead."
+                )
+        elif all(v is None for v in (self.group_on, self.time_on, self.stratify_on, self.group_time_on)):
             raise ValueError(
-                "ValidationStructure requires at least one of `group_on`, `time_on`, `stratify_on`, `group_time_on`."
+                "ValidationStructure requires at least one of `group_on`, `time_on`, `stratify_on`, "
+                "`group_time_on`, `splitter`."
             )
         if self.temporal_forward_only and self.time_on is None and self.group_time_on is None:
             raise ValueError(
@@ -230,6 +271,22 @@ class ValidationStructure:
         * fewer groups than folds: folds drop to the group count;
         * a stratification value rarer than the fold count: folds drop to that count.
         """
+        if self.splitter is not None:
+            splits = self._splitter_splits(X, y)
+            if num_repeats is not None and num_repeats > 1:
+                logger.log(
+                    20,
+                    f"validation_structure: `splitter` produces a fixed partition, so repeats add "
+                    f"nothing; num_repeats reduced from {num_repeats} to 1.",
+                )
+            if num_folds is not None and num_folds != len(splits):
+                logger.log(
+                    20,
+                    f"validation_structure: `splitter` produced {len(splits)} folds "
+                    f"(requested {num_folds}); adopting the splitter's count.",
+                )
+            return splits, len(splits), 1
+
         num_folds = max(2, num_folds if num_folds is not None else 8)
         num_repeats = max(1, num_repeats if num_repeats is not None else 1)
 
@@ -342,6 +399,30 @@ class ValidationStructure:
             splits.extend(repeat_splits)
         _validate_splits(splits, n_rows=len(X), stratify=self._stratify_values(X, y))
         return splits, num_folds, num_repeats
+
+    def _splitter_splits(self, X: pd.DataFrame, y: pd.Series) -> list[tuple[np.ndarray, np.ndarray]]:
+        """Positional splits from `self.splitter`, validated enough to fail clearly rather than late.
+
+        A splitter that yields fewer than 2 folds cannot bag, and one that yields an empty
+        validation fold produces a model with no score. Both are far easier to diagnose here than
+        as a downstream shape error.
+        """
+        splits = [
+            (np.asarray(train_idx, dtype=int), np.asarray(val_idx, dtype=int))
+            for train_idx, val_idx in self.splitter.split(X, y)
+        ]
+        if len(splits) < 2:
+            raise ValueError(
+                f"`splitter` produced {len(splits)} fold(s) for {len(X)} rows; bagging needs at "
+                f"least 2. Check the splitter's configuration against the training data size."
+            )
+        for fold, (train_idx, val_idx) in enumerate(splits):
+            if len(train_idx) == 0 or len(val_idx) == 0:
+                raise ValueError(
+                    f"`splitter` produced fold {fold} with {len(train_idx)} training and "
+                    f"{len(val_idx)} validation rows; both must be non-empty."
+                )
+        return splits
 
     def uncovered_rows(self, X: pd.DataFrame, y: pd.Series, **kwargs) -> np.ndarray:
         """Positional indices of rows no fold validates, i.e. rows that get no out-of-fold prediction.
@@ -496,8 +577,10 @@ class ValidationStructure:
 
         Group structure yields a group-disjoint split; time structure yields a
         *forward* holdout (the latest contiguous block — a random fold would leak
-        future information into training). Returns None when only ``stratify_on`` is
-        set: AutoGluon's default label-stratified holdout needs no correction.
+        future information into training); a ``splitter`` yields its last fold, and
+        ``holdout_frac`` is ignored because the splitter sets its own sizes. Returns None when
+        only ``stratify_on`` is set: AutoGluon's default label-stratified holdout needs no
+        correction.
 
         ``min_cls_count_train`` is the per-class row count the training side must keep, the
         same guarantee ``generate_train_test_split`` enforces on the unstructured path. It is
@@ -505,6 +588,14 @@ class ValidationStructure:
         stays group-disjoint; a forward holdout cannot be repaired that way and is reported
         instead (moving validation rows into training would move the time boundary).
         """
+        if self.splitter is not None:
+            # The splitter's last fold. For a forward-chaining splitter that is the most recent
+            # block trained on everything before it, which is the holdout such a user wants; for an
+            # unordered splitter it is one fold, which is no worse than the default random holdout
+            # and at least honours whatever the splitter is enforcing. `holdout_frac` is ignored --
+            # the splitter decides its own sizes.
+            train_idx, val_idx = self._splitter_splits(X, y)[-1]
+            return train_idx, val_idx
         if self.time_on is None and self.group_on is None and self.group_time_on is None:
             return None
         if self.time_on is not None or self.group_time_on is not None:

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -916,6 +916,17 @@ class TabularPredictor:
                 (`num_stack_levels > 0`, `dynamic_stacking`). The weighted ensemble is supported: it
                 excludes the unvalidated rows, so its validation score stays comparable to the base
                 models'.
+                `splitter` (sklearn-style cross-validator, default None) is the escape hatch for a
+                scheme the fields above cannot express, e.g. `{"splitter": TimeSeriesSplit(n_splits=5)}`.
+                Its `split(X, y)` is consulted for the bagging folds, the non-bagged holdout (its last
+                fold) and the dynamic-stacking splits, so a splitter that keeps data ordered is not
+                undone by a random holdout elsewhere. The fold count comes from the splitter, so
+                `num_bag_folds` is adopted from it rather than honored, and repeats are always 1.
+                Mutually exclusive with the other keys. Prefer the declarative fields where they fit:
+                they describe the data rather than the mechanics. Stacking is refused if the splitter
+                leaves rows unvalidated (as `TimeSeriesSplit` does), for the same reason as
+                `temporal_forward_only`; a splitter that validates every row (e.g. `KFold`) stacks
+                normally.
             validation_size_curves : dict | ValidationSizeCurves, default = None
                 [EXPERIMENTAL] Overrides for how the automatically selected validation method scales
                 with data size, as a `ValidationSizeCurves` or an equivalent dict. The curve format
@@ -1469,7 +1480,20 @@ class TabularPredictor:
             dynamic_stacking_was_auto=dynamic_stacking_was_auto,
         )
 
-        if validation_structure is not None and validation_structure.temporal_forward_only:
+        if validation_structure is not None and validation_structure.splitter is not None:
+            # A splitter can leave rows unvalidated exactly as forward-chaining does -- a
+            # `TimeSeriesSplit` never validates its earliest block -- so the same restriction
+            # applies, keyed on the property rather than on which field produced it. Determined by
+            # asking the splitter: `KFold` covers every row and stacks fine, so refusing every
+            # splitter would be wrong. The raw frame is close enough for a yes/no answer, since
+            # cleaning only removes rows.
+            structure_leaves_gaps = (
+                len(validation_structure.uncovered_rows(train_data.drop(columns=[self.label]), train_data[self.label]))
+                > 0
+            )
+        else:
+            structure_leaves_gaps = validation_structure is not None and validation_structure.temporal_forward_only
+        if structure_leaves_gaps:
             # Forward-chaining leaves the earliest time block unvalidated, so those rows have no
             # out-of-fold prediction. A bagged model leaves them at the OOF accumulator's initial
             # value, which reads downstream as a prediction of 0 rather than as missing. Validation
@@ -1488,12 +1512,18 @@ class TabularPredictor:
             if dynamic_stacking:
                 unsupported.append("dynamic_stacking=True")
             if unsupported:
+                source = (
+                    "`validation_structure.splitter`"
+                    if validation_structure.splitter is not None
+                    else "`validation_structure.temporal_forward_only=True`"
+                )
                 raise ValueError(
-                    "`validation_structure.temporal_forward_only=True` cannot be combined with "
-                    f"{', '.join(unsupported)}. Forward-chaining leaves the earliest time block "
-                    "without out-of-fold predictions, so a higher stacking layer would have no real "
-                    "features for those rows. Set num_stack_levels=0 and dynamic_stacking=False, or "
-                    "use the default leave-one-block-out temporal splits."
+                    f"{source} leaves some rows without out-of-fold predictions, which cannot be "
+                    f"combined with {', '.join(unsupported)}: a higher stacking layer would have no "
+                    f"real features for those rows. Set num_stack_levels=0 and "
+                    f"dynamic_stacking=False, or use a validation scheme that validates every row "
+                    f"(the default leave-one-block-out temporal splits, or a splitter such as "
+                    f"KFold)."
                 )
         if auto_stack:
             logger.log(

--- a/tabular/tests/unittests/test_validation_structure.py
+++ b/tabular/tests/unittests/test_validation_structure.py
@@ -1159,3 +1159,172 @@ def test_deprecated_groups_warning_names_ignored_columns():
 
     with pytest.warns(DeprecationWarning, match=r"ignored_columns"):
         TabularPredictor(label="label", groups="grp", verbosity=0)
+
+
+# ── splitter escape hatch ─────────────────────────────────────────────────────────
+
+
+def _splitter_frame(n: int = 60) -> pd.DataFrame:
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame({"t": np.arange(float(n)), "x": rng.normal(size=n)})
+    df["y"] = (df["x"] > 0).astype(int)
+    return df
+
+
+def test__splitter__folds_come_from_the_splitter():
+    """The splitter decides the partition, the fold count and the repeats."""
+    from sklearn.model_selection import TimeSeriesSplit
+
+    df = _splitter_frame()
+    X, y = df.drop(columns="y"), df["y"]
+    vs = ValidationStructure(splitter=TimeSeriesSplit(n_splits=5))
+
+    # requested counts are adopted from the splitter, not honored
+    splits, num_folds, num_repeats = vs.custom_splits(X, y, num_folds=8, num_repeats=3, problem_type="binary")
+    assert (num_folds, num_repeats) == (5, 1)
+    assert len(splits) == 5
+
+    t = X["t"].to_numpy()
+    for train_idx, val_idx in splits:
+        assert t[train_idx].max() < t[val_idx].min(), "forward-chaining was not preserved"
+
+
+def test__splitter__holdout_is_the_last_fold():
+    """For a forward-chaining splitter that is the most recent window; `holdout_frac` is ignored."""
+    from sklearn.model_selection import TimeSeriesSplit
+
+    df = _splitter_frame()
+    X, y = df.drop(columns="y"), df["y"]
+    vs = ValidationStructure(splitter=TimeSeriesSplit(n_splits=5))
+
+    train_idx, val_idx = vs.holdout_split_indices(X, y, holdout_frac=0.01, problem_type="binary")
+    last_train, last_val = vs.custom_splits(X, y, problem_type="binary")[0][-1]
+    assert np.array_equal(train_idx, last_train)
+    assert np.array_equal(val_idx, last_val)
+    assert X["t"].to_numpy()[train_idx].max() < X["t"].to_numpy()[val_idx].min()
+
+
+def test__splitter__uncovered_rows_reports_the_gap():
+    from sklearn.model_selection import KFold, TimeSeriesSplit
+
+    df = _splitter_frame()
+    X, y = df.drop(columns="y"), df["y"]
+    # TimeSeriesSplit never validates its earliest block
+    assert len(ValidationStructure(splitter=TimeSeriesSplit(n_splits=5)).uncovered_rows(X, y)) == 10
+    # KFold validates every row
+    assert len(ValidationStructure(splitter=KFold(n_splits=5)).uncovered_rows(X, y)) == 0
+
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        ({"splitter": "not-a-splitter"}, "must be a cross-validator"),
+        ({"splitter": None}, "requires at least one of"),
+    ],
+)
+def test__splitter__rejects_bad_input(kwargs, match):
+    from sklearn.model_selection import KFold  # noqa: F401 - imported for symmetry with other cases
+
+    with pytest.raises(ValueError, match=match):
+        ValidationStructure(**kwargs)
+
+
+@pytest.mark.parametrize("other", [{"group_on": "t"}, {"time_on": "t"}, {"temporal_forward_only": True}])
+def test__splitter__is_mutually_exclusive_with_the_declarative_fields(other):
+    """It replaces fold derivation rather than refining it, so combining is ambiguous."""
+    from sklearn.model_selection import KFold
+
+    with pytest.raises(ValueError, match="replaces fold derivation"):
+        ValidationStructure(splitter=KFold(n_splits=3), **other)
+
+
+@pytest.mark.parametrize(
+    "splits, match",
+    [
+        ([(np.arange(10), np.arange(10, 12))], "needs at least 2"),
+        ([(np.arange(10), np.array([], dtype=int))] * 2, "must be non-empty"),
+    ],
+)
+def test__splitter__rejects_unusable_partitions(splits, match):
+    """Fails where it is diagnosable, rather than as a downstream shape error."""
+
+    class _Fixed:
+        def split(self, X, y=None):
+            yield from splits
+
+    df = _splitter_frame(n=20)
+    with pytest.raises(ValueError, match=match):
+        ValidationStructure(splitter=_Fixed()).custom_splits(df.drop(columns="y"), df["y"])
+
+
+def test__predictor_fit__splitter__reaches_bagging_and_dystack(monkeypatch):
+    """The point of the field: a splitter is honored everywhere splits are chosen.
+
+    `ag_args_ensemble={"custom_splits": ...}` only reaches bagging, so the DyStack sub-fit would
+    split randomly and audit an ordered scheme with an unordered one.
+    """
+    from sklearn.model_selection import KFold
+
+    from autogluon.common.utils import cv_splitter as cvs
+    from autogluon.tabular import TabularPredictor
+
+    # KFold rather than TimeSeriesSplit: DyStack needs `num_stack_levels > 0`, which is refused for
+    # a splitter that leaves rows unvalidated. Forward-chaining is asserted in the bagging test.
+    df = _splitter_frame(n=120)
+    seen: list[tuple[int, bool]] = []
+    original = cvs.CVSplitter.split
+
+    def spy(self, X, y):
+        splits = original(self, X, y)
+        seen.append((len(splits), self.custom_splits is not None))
+        return splits
+
+    monkeypatch.setattr(cvs.CVSplitter, "split", spy)
+    TabularPredictor(label="y", verbosity=0).fit(
+        df,
+        hyperparameters={"DUMMY": {}},
+        num_bag_folds=8,  # overridden by the splitter's 4
+        num_bag_sets=1,
+        validation_structure={"splitter": KFold(n_splits=4)},
+        dynamic_stacking=True,
+        ds_args={"validation_procedure": "holdout", "enable_ray_logging": False, "memory_safe_fits": False},
+        num_stack_levels=1,
+        fit_weighted_ensemble=False,
+        num_gpus=0,
+    )
+
+    assert len(seen) >= 2, "the DyStack sub-fit did not bag"
+    for n_folds, has_custom in seen:
+        assert has_custom, "the splitter's splits did not reach bagging"
+        assert n_folds == 4, f"expected the splitter's fold count, got {n_folds}"
+
+
+@pytest.mark.parametrize(
+    "splitter_name, n_stack_levels, expect_l2",
+    [("TimeSeriesSplit", 1, False), ("KFold", 1, True)],
+)
+def test__predictor_fit__splitter__stacking_refused_only_when_rows_are_unvalidated(
+    splitter_name, n_stack_levels, expect_l2
+):
+    """Keyed on the property, not the field: `KFold` covers every row and stacks fine."""
+    import sklearn.model_selection as skms
+
+    from autogluon.tabular import TabularPredictor
+
+    df = _splitter_frame(n=120)
+    fit_kwargs = dict(
+        hyperparameters={"DUMMY": {}},
+        num_bag_folds=4,
+        num_bag_sets=1,
+        validation_structure={"splitter": getattr(skms, splitter_name)(n_splits=4)},
+        num_stack_levels=n_stack_levels,
+        dynamic_stacking=False,
+        fit_weighted_ensemble=False,
+        num_gpus=0,
+    )
+    if expect_l2:
+        predictor = TabularPredictor(label="y", verbosity=0).fit(df, **fit_kwargs)
+        assert any(m.endswith("_L2") for m in predictor.model_names())
+    else:
+        with pytest.raises(ValueError, match="without out-of-fold predictions"):
+            TabularPredictor(label="y", verbosity=0).fit(df, **fit_kwargs)


### PR DESCRIPTION
*Issue #, if available:*

Follow-up to #5858, and the constructive half of the #5628 / #4492 discussion.

*Description of changes:*

An escape hatch for validation schemes the declarative fields cannot describe:

```python
from sklearn.model_selection import TimeSeriesSplit

predictor.fit(..., validation_structure={"splitter": TimeSeriesSplit(n_splits=5)})
```

## Why a splitter object and not a list of splits

One `ValidationStructure` is asked to split **several different row sets during a single fit** — measured at three: the full frame for the dynamic-stacking sub-fit, the frame after the DyStack holdout is carved, and the frame after a `use_bag_holdout` carve (240, 200 and 160 rows on a 240-row input). So splits must be *derived* per frame. A fixed list of positional indices would be valid for at most one of them and silently wrong or out of bounds for the others — the hazard #5857 guards with a row-count check. A splitter re-derives, so it fits the contract; #5858 records the reasoning on the class.

## Why not just `ag_args_ensemble={"custom_splits": ...}`

That only reaches bagging. A splitter is consulted for the **non-bagged holdout** (its last fold — for a forward-chaining splitter, the most recent window) and for the **DyStack splits** too, so an ordered scheme is not undone by a random split elsewhere. That was my main objection to #5628's `cv_splitter` parameter, so it would be poor form to reproduce it here.

Verified end to end — every `CVSplitter` call in the fit *and* the DyStack sub-fit:

```
KFold(n_splits=4), num_bag_folds=8:
  CVSplitter: folds=4 custom_splits=True     <- main fit
  CVSplitter: folds=4 custom_splits=True     <- DyStack sub-fit

TimeSeriesSplit(n_splits=4):
  every bagged fold trains only on rows earlier than its validation window
```

## Semantics

- The fold count comes from the splitter: `num_bag_folds` is **adopted** from it, not honored (logged when they differ), and repeats are forced to 1 since re-running a deterministic splitter only duplicates work.
- Mutually exclusive with `group_on` / `time_on` / `group_time_on` / `stratify_on` / `temporal_forward_only` / `size_validation_on_groups` — it replaces fold derivation rather than refining it.
- Prefer the declarative fields where they fit; they describe the data rather than the mechanics, and so keep working as the surrounding logic changes. The docstring says so.

## The stacking guard is now keyed on the property, not the field

The existing refusal was `temporal_forward_only and num_stack_levels > 0`, but the *reason* is "leaves rows without out-of-fold predictions" — and a splitter can do that too. `TimeSeriesSplit` never validates its earliest block, so a stacker would train on NaN features for those rows. Generalised to ask the structure:

| splitter | `num_stack_levels=1` |
|---|---|
| `TimeSeriesSplit` (leaves a gap) | refused, with the reason |
| `KFold` (covers every row) | fits `Dummy_BAG_L1`, `Dummy_BAG_L2` |

Refusing every splitter would have been wrong; keying on coverage is the honest condition. This also gives `uncovered_rows` its first production caller — #5858 noted it had none.

## Input validation

`str` is rejected explicitly, because `str.split` is callable: a bare column name passed as `splitter` passes a plain duck-type check and then fails deep inside fold resolution. The error points at `group_on` / `time_on` instead. (My own test caught this — the first version of the guard accepted `"not-a-splitter"`.)

A splitter yielding fewer than 2 folds, or any fold with an empty training or validation set, is rejected where it is diagnosable rather than as a downstream shape error.

## Tests

Fold and repeat adoption, forward-chaining preserved, the holdout being the last fold with `holdout_frac` ignored, `uncovered_rows` reporting the gap for `TimeSeriesSplit` and none for `KFold`, mutual exclusivity, the bad-input and unusable-partition guards, splits reaching both bagging and DyStack, and stacking refused only when rows go unvalidated.

`test_validation_structure.py` — 61 passed. `common/tests/unittests` — 161 passed. `dynamic_stacking` + `test_fit_extra_validation_structure.py` — 19 passed. `ruff format --check` and `ruff check --select I` clean.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
