### PR TITLE
[timeseries] Fix isort lint failure on master

### DIFF
--- a/timeseries/tests/unittests/models/ensemble/test_greedy_nonfinite_scores.py
+++ b/timeseries/tests/unittests/models/ensemble/test_greedy_nonfinite_scores.py
@@ -20,7 +20,6 @@ from autogluon.timeseries.models.ensemble import GreedyEnsemble, PerItemGreedyEn
 
 from ...common import get_data_frame_with_item_index
 
-
 PREDICTION_LENGTH = 2
 QUANTILE_COLUMNS = ["mean", "0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9"]
 


### PR DESCRIPTION
## Description of changes

Master's `lint_check` CI job is currently **red**, and it gates ~10 downstream jobs (`needs: lint_check`). Most recent run: [32761952314](https://github.com/autogluon/autogluon/actions/runs/32761952314).

```
+ ruff check --select I timeseries/
I001 [*] Import block is un-sorted or un-formatted
Found 1 error.
##[error]Process completed with exit code 1.
```

The test file added in #5852 has one extra blank line after its import block. This PR removes it — the entire diff is `-1` line.

### Why it slipped through

`ruff format --check` and `ruff check` (the pyproject rule set, `E4`/`E7`/`E9`/`F`) both pass on that file. The failing step is the separate isort pass, `ruff check --select I`, which `.github/workflow_scripts/lint_check.sh` runs per package. #5852 was approved and merged before its CI run reported.

### Worth noting for follow-up (not fixed here)

`lint_check.sh` runs under `set -ex`, and `timeseries` is the **second** of six packages it checks:

```bash
function lint_check_all {
    lint_check multimodal
    lint_check timeseries   # <-- aborts here
    lint_check common
    lint_check core
    lint_check features
    lint_check tabular
}
```

So a failure in an early package means `common`, `core`, `features` and `tabular` are never linted at all in that run. Collecting failures across all packages before exiting would give the full picture in one run instead of one package per push. Happy to open a separate PR for that if it's wanted.

## Verification

Reproduced with the exact ruff version CI installs (v0.16.4, which `setup_build_env` reads from `.pre-commit-config.yaml`), running the full `lint_check.sh` ruff sequence over all six packages plus the final `ruff check timeseries/`:

- Before: 1 error, `timeseries/tests/unittests/models/ensemble/test_greedy_nonfinite_scores.py:14:1: I001`
- After: all six packages clean, `ruff check timeseries/` → `All checks passed!`

`timeseries/tests/unittests/models/ensemble/test_greedy_nonfinite_scores.py`: 7 passed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)