### PR TITLE
[common] Count each distinct object once in get_approximate_df_mem_usage

### DIFF
--- a/common/src/autogluon/common/utils/pandas_utils.py
+++ b/common/src/autogluon/common/utils/pandas_utils.py
@@ -1,5 +1,6 @@
 import logging
 import math
+import sys
 from functools import wraps
 
 from pandas import DataFrame
@@ -29,18 +30,43 @@ def _suspend_logging_for_package(package_name):
     return _suspend_logging
 
 
+def _object_column_mem_usage(values, num_rows: int, sample_ratio: float) -> int:
+    """Memory of one object column, counting each distinct Python object once.
+
+    ``memory_usage(deep=True)`` adds ``sys.getsizeof(obj)`` for every cell, so a value shared by
+    many cells is charged once per cell instead of once. Sharing is the common case rather than a
+    corner case: pandas' C ``read_csv`` parser reuses a single ``str`` object for every repeat of a
+    value, so a low-cardinality string column read from disk is fully shared. The overstatement is
+    ``sys.getsizeof(value) / 8`` per column, which is a few-fold for short strings and unbounded
+    for long ones.
+
+    Shaped like the category branch above: fixed-width storage for every row, plus the distinct
+    values, extrapolated from the sample.
+    """
+    unique_objects = {id(obj): obj for obj in values}
+    unique_bytes = sum(map(sys.getsizeof, unique_objects.values()))
+    return int(values.itemsize * num_rows + unique_bytes / sample_ratio)
+
+
 # suspend_logging to hide the Pandas log of NumExpr initialization
 @_suspend_logging_for_package("pandas")
 def get_approximate_df_mem_usage(df: DataFrame, sample_ratio=0.2):
-    if sample_ratio >= 1:
-        return df.memory_usage(deep=True)
+    num_rows = len(df)
+    if sample_ratio >= 1 or num_rows == 0:
+        memory_usage = df.memory_usage(deep=True)
+        for column in df:
+            if df[column].dtype == object:
+                memory_usage[column] = _object_column_mem_usage(df[column].to_numpy(), num_rows, 1.0)
+        return memory_usage
     else:
-        num_rows = len(df)
         num_rows_sample = math.ceil(sample_ratio * num_rows)
         sample_ratio = num_rows_sample / num_rows
         dtypes_raw = get_type_map_raw(df)
         columns_category = [column for column in df if dtypes_raw[column] == R_CATEGORY]
         columns_inexact = [column for column in df if dtypes_raw[column] not in [R_INT, R_FLOAT, R_CATEGORY]]
+        # Object columns need per-object accounting, the rest extrapolate from a deep sample.
+        columns_object = [column for column in columns_inexact if df[column].dtype == object]
+        columns_inexact = [column for column in columns_inexact if df[column].dtype != object]
         memory_usage = df.memory_usage()
         if columns_category:
             for column in columns_category:
@@ -50,6 +76,11 @@ def get_approximate_df_mem_usage(df: DataFrame, sample_ratio=0.2):
                 memory_usage[column] = int(
                     df[column].cat.codes.dtype.itemsize * num_rows
                     + df[column].cat.categories[:num_categories_sample].memory_usage(deep=True) / sample_ratio_cat
+                )
+        if columns_object:
+            for column in columns_object:
+                memory_usage[column] = _object_column_mem_usage(
+                    df[column].to_numpy()[:num_rows_sample], num_rows, sample_ratio
                 )
         if columns_inexact:
             # this line causes NumExpr log, suspend_logging is used to hide the log.

--- a/common/tests/unittests/utils/test_pandas_utils.py
+++ b/common/tests/unittests/utils/test_pandas_utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 import numpy as np
 import pandas as pd
 
@@ -77,9 +79,36 @@ def test_category_column_estimate_matches_formula(monkeypatch):
     pd.testing.assert_series_equal(got, expected)
 
 
-def test_inexact_object_column_uses_head_deep_scaled(monkeypatch):
-    # Choose n where ceil(sample_ratio*n) changes the effective ratio.
-    # n=6, sample_ratio=0.2 -> ceil(1.2)=2 -> sample_ratio_adj=2/6=0.333...
+def test_inexact_non_object_column_uses_head_deep_scaled(monkeypatch):
+    # Non-object "inexact" columns still extrapolate a deep sample. Choose n where
+    # ceil(sample_ratio*n) changes the effective ratio: n=6, 0.2 -> ceil(1.2)=2 -> 2/6.
+    df = pd.DataFrame(
+        {
+            "dt": pd.to_datetime(["2020-01-0%d" % i for i in range(1, 7)]),
+            "i": pd.Series([1, 2, 3, 4, 5, 6], dtype="int64"),
+        }
+    )
+    num_rows = len(df)
+    sample_ratio_in = 0.2
+    num_rows_sample = int(np.ceil(sample_ratio_in * num_rows))
+    sample_ratio_adj = num_rows_sample / num_rows
+
+    monkeypatch.setattr(
+        pandas_utils,
+        "get_type_map_raw",
+        lambda _df: {"dt": "datetime", "i": pandas_utils.R_INT},
+    )
+
+    got = get_approximate_df_mem_usage(df, sample_ratio=sample_ratio_in)
+
+    base = df.memory_usage()  # shallow
+    inexact = df[["dt"]].head(num_rows_sample).memory_usage(deep=True)[["dt"]] / sample_ratio_adj
+    expected = inexact.combine_first(base)
+
+    pd.testing.assert_series_equal(got, expected)
+
+
+def test_object_column_counts_each_distinct_object_once(monkeypatch):
     df = pd.DataFrame(
         {
             "obj": ["a", "bb", "ccc", "dddd", "eeeee", "ffffff"],
@@ -91,7 +120,6 @@ def test_inexact_object_column_uses_head_deep_scaled(monkeypatch):
     num_rows_sample = int(np.ceil(sample_ratio_in * num_rows))
     sample_ratio_adj = num_rows_sample / num_rows
 
-    # Mark "obj" as inexact by returning something not in {R_INT, R_FLOAT, R_CATEGORY}
     monkeypatch.setattr(
         pandas_utils,
         "get_type_map_raw",
@@ -100,8 +128,41 @@ def test_inexact_object_column_uses_head_deep_scaled(monkeypatch):
 
     got = get_approximate_df_mem_usage(df, sample_ratio=sample_ratio_in)
 
-    base = df.memory_usage()  # shallow
-    inexact = df[["obj"]].head(num_rows_sample).memory_usage(deep=True)[["obj"]] / sample_ratio_adj
-    expected = inexact.combine_first(base)
+    sample = df["obj"].to_numpy()[:num_rows_sample]
+    unique_bytes = sum(sys.getsizeof(obj) for obj in {id(o): o for o in sample}.values())
+    expected = df.memory_usage()  # shallow base
+    expected["obj"] = int(sample.itemsize * num_rows + unique_bytes / sample_ratio_adj)
 
     pd.testing.assert_series_equal(got, expected)
+
+
+def test_object_column_shared_values_are_not_charged_per_cell():
+    """Regression test for #5433.
+
+    ``memory_usage(deep=True)`` charges ``sys.getsizeof(value)`` once per cell, so a column whose
+    cells all reference one large string is reported as if each cell held its own copy. pandas'
+    C ``read_csv`` parser reuses one object per distinct value, so this is the ordinary case for a
+    low-cardinality string column loaded from disk.
+    """
+    num_rows = 10_000
+    shared = "x" * 50_000  # one object, referenced by every cell
+    df = pd.DataFrame({"obj": [shared] * num_rows})
+
+    estimate = get_approximate_df_mem_usage(df)["obj"]
+    real_upper_bound = df["obj"].to_numpy().itemsize * num_rows + sys.getsizeof(shared) * 8
+
+    assert estimate < real_upper_bound, f"{estimate} not below {real_upper_bound}"
+    # The buggy formula charged the 50 KB string to all 10k cells: ~500 MB.
+    assert df.memory_usage(deep=True)["obj"] > 100 * estimate
+
+
+def test_object_column_distinct_values_are_not_undercounted():
+    """The shared-object fix must not make high-cardinality columns look free."""
+    num_rows = 10_000
+    df = pd.DataFrame({"obj": [f"{i}_{'p' * 200}" for i in range(num_rows)]})
+
+    estimate = get_approximate_df_mem_usage(df)["obj"]
+    deep = df.memory_usage(deep=True)["obj"]
+
+    # Every value is a distinct object, so the estimate should track deep accounting closely.
+    assert 0.9 * deep <= estimate <= 1.1 * deep, f"{estimate} vs {deep}"


### PR DESCRIPTION
## Description of changes

Root-cause fix for #5433, where an 85k x 1097 training frame was reported as **3.04 TiB**.

`get_approximate_df_mem_usage` leans on `memory_usage(deep=True)` for object columns. That adds `sys.getsizeof(obj)` for **every cell**, so a value shared by many cells is charged once per cell instead of once. Object columns now use the same shape the category branch alongside them already used: fixed-width storage for every row, plus the distinct values extrapolated from the sample.

```python
unique_objects = {id(obj): obj for obj in values}
unique_bytes = sum(map(sys.getsizeof, unique_objects.values()))
return int(values.itemsize * num_rows + unique_bytes / sample_ratio)
```

Dedup is by **identity, not value** — equal-but-distinct strings really do occupy separate memory, so value-dedup would trade the overestimate for an underestimate.

### Why this is the common path, not a corner case

pandas' C `read_csv` parser reuses a single `str` object for every repeat of a value, so any low-cardinality string column loaded from disk is fully shared. Measured share of cells pointing at one object (5000 rows, 3 distinct values):

| How data reaches `fit` | shared | distinct objects |
|---|---|---|
| `fit(train_data="train.csv")` / `pd.read_csv` | 99.9% | 3 |
| `pd.read_parquet` | 99.9% | 3 |
| `df[col] = "constant"` | 100% | 1 |
| `df[col].map({...})` | 99.9% | 3 |
| DataFrame built from Python lists | 0% | 5000 |
| `.fillna("missing")`, `.astype(str)` | 0% | 5000 |

The overstatement per object column is `sys.getsizeof(value) / 8` — a few-fold for short category strings, unbounded for long text. It only becomes *visible* when the inflated figure approaches system RAM, which is why the issue reads as rare.

### Why it matters beyond the log line

`get_approximate_df_mem_usage` also feeds per-model memory estimates that gate whether a model is skipped as too large: `lr_model.py:338` (15x), `tabular_nn_torch.py:891` (5x), `rf_model.py:162` (4x), `tabicl_model.py:220` (3x), plus `catboost_model.py:134` and `xgboost_model.py:318`. An inflated estimate silently skips models on object-heavy frames.

## Verification

Estimate vs **real process memory**, each case measured in an isolated subprocess (RSS delta around `pd.read_csv`, 200k rows x 5 columns):

| case | real | before | after |
|---|---|---|---|
| `read_csv`, 20 B strings | 7.9 MiB | 66.8 MiB (**8.5x**) | 7.6 MiB (0.97x) |
| `read_csv`, 2 KB strings | 8.8 MiB | 1955 MiB (**223x**) | 8.0 MiB (0.91x) |
| `read_csv`, all values distinct | 84.7 MiB | 83.4 MiB (0.98x) | 82.7 MiB (0.98x) |

The third row is the guard that matters: high-cardinality columns are unchanged.

End-to-end at `TabularPredictor.fit` level, a frame occupying 2.0 MiB with one long repeated-string column:

```
before:  Train Data (Original) Memory Usage: 77.38 MB
after:   Train Data (Original) Memory Usage:  0.40 MB
```

**No performance cost** (min of 5 runs) — slightly faster, because the shared case calls `getsizeof` a handful of times instead of once per sampled cell:

| workload | before | after |
|---|---|---|
| numeric 200k x 50 | 0.5 ms | 0.5 ms |
| object 200k x 20, 8 shared values | 95.9 ms | 87.9 ms |
| object 200k x 20, **all distinct** (worst case) | 94.3 ms | 86.3 ms |
| category 200k x 20 | 0.7 ms | 0.7 ms |

### Tests

`test_inexact_object_column_uses_head_deep_scaled` asserted the buggy formula verbatim, so it is replaced by:

- `test_inexact_non_object_column_uses_head_deep_scaled` — keeps the head-deep-scaled path covered via a datetime column
- `test_object_column_counts_each_distinct_object_once` — the new formula
- `test_object_column_shared_values_are_not_charged_per_cell` — regression test for #5433
- `test_object_column_distinct_values_are_not_undercounted` — guards against the opposite error

Suites run locally: `common` 164 passed; `features` 93 passed (1 pre-existing `test_check_style` failure, also fails on master); `test_lightgbm` / `test_rf` / `test_linear` / `test_catboost` 25 passed. `ruff format --diff`, `ruff check --select I` and `ruff check` clean on `common/` with the version CI pins (v0.16.4).

## Related

This supersedes the diagnosis in #5470, which attributes #5433 to `psutil` misreporting memory on Windows. The two log lines in the issue show otherwise — `Available Memory` at `features/generators/pipeline.py:126` is a **sum** of available memory and the estimated frame size, so psutil's own value is `3203341.44 - 3185574.16 = 17767.28 MB = 17.35 GiB`, which is correct for that 32 GB machine. Feeding it back through the percentage formula reproduces the issue's reported 99.4% exactly.

That also suggests the Linux/Kubernetes report from @benhoumine-Abdelkhalek on #5470 may be this same bug rather than a separate one, since nothing here is platform-specific.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)