### PR TITLE
[tabular] Store the TabPFN in-context training set at inference precision

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
@@ -23,6 +23,16 @@ _NARROWED_INFERENCE_DTYPES = {
     np.dtype(np.float64): np.float32,
     np.dtype(np.int64): np.int32,
 }
+_NARROWED_RAW_TARGET_DTYPES = {np.dtype(np.int64): np.int32}
+"""Narrowing allowed for a target that is still preprocessed after being stored."""
+
+
+def _narrow_array(obj: object, name: str, narrowed_dtypes: dict) -> None:
+    """Replace `obj.name` with a narrower view of itself, if one is allowed."""
+    array = getattr(obj, name, None)
+    narrower = narrowed_dtypes.get(getattr(array, "dtype", None))
+    if narrower is not None:
+        setattr(obj, name, array.astype(narrower, copy=False))
 
 
 class TabPFNModel(AbstractTorchModel):
@@ -229,12 +239,18 @@ class TabPFNModel(AbstractTorchModel):
     def _narrow_inference_context(self):
         """Store the in-context training set at the precision inference uses.
 
-        TabPFN keeps a preprocessed copy of the training data per ensemble member and
+        TabPFN keeps the training data it attends over on the inference engine and
         converts it with ``torch.as_tensor(..., dtype=torch.float32)`` at predict time,
         so the float64 arrays its preprocessing produces are never read at full width.
-        Narrowing them here halves what the fitted model holds and what its pickle
-        writes, and keeps the two at the same dtype. Scales with ``n_estimators``,
-        which replicates the training set once per member.
+        Narrowing them halves what the fitted model holds and what its pickle writes.
+
+        Which arrays can narrow depends on the fit mode. With preprocessing cached, the
+        stored arrays are already preprocessed and feed that conversion directly, so
+        both narrow losslessly -- once per ensemble member, which is where the size
+        comes from. ``fit_mode="low_memory"`` instead keeps the raw training set and
+        re-runs the preprocessing on every predict: the features still narrow
+        losslessly, but a float target does not, because its transforms would then be
+        computed at the narrower precision.
 
         Skipped when ``inference_precision`` forces a wider dtype, the one case where
         the extra precision reaches the model.
@@ -243,12 +259,14 @@ class TabPFNModel(AbstractTorchModel):
         if forced_dtype is not None and forced_dtype.itemsize > _INFERENCE_DTYPE_BYTES:
             return
         executor = getattr(self.model, "executor_", None)
-        for member in getattr(executor, "ensemble_members", None) or []:
-            for name in ("X_train", "y_train"):
-                array = getattr(member, name, None)
-                narrower = _NARROWED_INFERENCE_DTYPES.get(getattr(array, "dtype", None))
-                if narrower is not None:
-                    setattr(member, name, array.astype(narrower, copy=False))
+        members = getattr(executor, "ensemble_members", None)
+        if members is not None:
+            for member in members:
+                _narrow_array(member, "X_train", _NARROWED_INFERENCE_DTYPES)
+                _narrow_array(member, "y_train", _NARROWED_INFERENCE_DTYPES)
+        else:
+            _narrow_array(executor, "X_train", _NARROWED_INFERENCE_DTYPES)
+            _narrow_array(executor, "y_train", _NARROWED_RAW_TARGET_DTYPES)
 
     def _predict_proba(self, X, **kwargs) -> np.ndarray:
         if not self.params_aux.get("model_telemetry", False):

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
@@ -18,6 +18,12 @@ _HAS_LOGGED_TABPFN_LICENSE: bool = False
 _HAS_LOGGED_TABPFN_NONCOMMERICAL: bool = False
 _HAS_LOGGED_TABPFN_CPU_WARNING: bool = False
 
+_INFERENCE_DTYPE_BYTES = 4
+_NARROWED_INFERENCE_DTYPES = {
+    np.dtype(np.float64): np.float32,
+    np.dtype(np.int64): np.int32,
+}
+
 
 class TabPFNModel(AbstractTorchModel):
     """TabPFN-2.5 is a tabular foundation model that is developed and maintained by PriorLabs: https://priorlabs.ai/.
@@ -218,6 +224,31 @@ class TabPFNModel(AbstractTorchModel):
             X=X,
             y=y,
         )
+        self._narrow_inference_context()
+
+    def _narrow_inference_context(self):
+        """Store the in-context training set at the precision inference uses.
+
+        TabPFN keeps a preprocessed copy of the training data per ensemble member and
+        converts it with ``torch.as_tensor(..., dtype=torch.float32)`` at predict time,
+        so the float64 arrays its preprocessing produces are never read at full width.
+        Narrowing them here halves what the fitted model holds and what its pickle
+        writes, and keeps the two at the same dtype. Scales with ``n_estimators``,
+        which replicates the training set once per member.
+
+        Skipped when ``inference_precision`` forces a wider dtype, the one case where
+        the extra precision reaches the model.
+        """
+        forced_dtype = getattr(self.model, "forced_inference_dtype_", None)
+        if forced_dtype is not None and forced_dtype.itemsize > _INFERENCE_DTYPE_BYTES:
+            return
+        executor = getattr(self.model, "executor_", None)
+        for member in getattr(executor, "ensemble_members", None) or []:
+            for name in ("X_train", "y_train"):
+                array = getattr(member, name, None)
+                narrower = _NARROWED_INFERENCE_DTYPES.get(getattr(array, "dtype", None))
+                if narrower is not None:
+                    setattr(member, name, array.astype(narrower, copy=False))
 
     def _predict_proba(self, X, **kwargs) -> np.ndarray:
         if not self.params_aux.get("model_telemetry", False):

--- a/tabular/tests/unittests/models/test_tabpfn3.py
+++ b/tabular/tests/unittests/models/test_tabpfn3.py
@@ -74,3 +74,64 @@ def test_tabpfn_preprocess_preserves_missing_categoricals():
         assert model._cat_indices == [X.columns.get_loc("cat")], model_cls.__name__
         # untouched numeric column
         assert processed["num"].equals(X["num"]), model_cls.__name__
+
+
+def test_tabpfn_narrows_inference_context_to_the_dtype_inference_uses():
+    """The cached in-context training set is stored at float32/int32, not float64/int64.
+
+    TabPFN builds one preprocessed copy of the training data per ensemble member and
+    converts it to float32 at predict time, so the wider arrays cost memory and disk
+    without ever being read at full width.
+    """
+    import numpy as np
+
+    from autogluon.tabular.models.tabpfnv2.tabpfnv2_5_model import TabPFNModel
+
+    model = TabPFNModel(problem_type="binary", eval_metric=None)
+    model.model = _stub_estimator(n_members=2, forced_inference_dtype=None)
+
+    model._narrow_inference_context()
+
+    for member in model.model.executor_.ensemble_members:
+        assert member.X_train.dtype == np.float32
+        assert member.y_train.dtype == np.int32
+
+
+def test_tabpfn_keeps_inference_context_when_precision_is_forced_wider():
+    """`inference_precision=torch.float64` is the case where the wider dtype is used."""
+    import numpy as np
+    import torch
+
+    from autogluon.tabular.models.tabpfnv2.tabpfnv2_5_model import TabPFNModel
+
+    model = TabPFNModel(problem_type="binary", eval_metric=None)
+    model.model = _stub_estimator(n_members=2, forced_inference_dtype=torch.float64)
+
+    model._narrow_inference_context()
+
+    for member in model.model.executor_.ensemble_members:
+        assert member.X_train.dtype == np.float64
+        assert member.y_train.dtype == np.int64
+
+
+def _stub_estimator(n_members: int, forced_inference_dtype):
+    """A stand-in for a fitted TabPFN estimator, so the test needs no checkpoint."""
+    import numpy as np
+
+    rng = np.random.default_rng(0)
+
+    class _Member:
+        def __init__(self):
+            self.X_train = rng.normal(size=(8, 3))
+            self.y_train = rng.integers(0, 2, 8)
+
+    class _Executor:
+        def __init__(self):
+            self.ensemble_members = [_Member() for _ in range(n_members)]
+
+    class _Estimator:
+        def __init__(self):
+            self.executor_ = _Executor()
+            self.forced_inference_dtype_ = forced_inference_dtype
+
+    return _Estimator()

--- a/tabular/tests/unittests/models/test_tabpfn3.py
+++ b/tabular/tests/unittests/models/test_tabpfn3.py
@@ -114,6 +114,28 @@ def test_tabpfn_keeps_inference_context_when_precision_is_forced_wider():
         assert member.y_train.dtype == np.int64
 
 
+class _StubOnDemandExecutor:
+    """`InferenceEngineOnDemand` keeps the raw arrays, with no ensemble members."""
+
+    def __init__(self, y_dtype, rng):
+        import numpy as np
+
+        self.X_train = rng.normal(size=(8, 3))
+        self.y_train = rng.integers(0, 2, 8).astype(y_dtype)
+
+
+class _StubOnDemandEstimator:
+    def __init__(self, y_dtype, rng):
+        self.executor_ = _StubOnDemandExecutor(y_dtype, rng)
+        self.forced_inference_dtype_ = None
+
+
+def _stub_on_demand_estimator(y_dtype):
+    import numpy as np
+
+    return _StubOnDemandEstimator(y_dtype, np.random.default_rng(0))
+
+
 def _stub_estimator(n_members: int, forced_inference_dtype):
     """A stand-in for a fitted TabPFN estimator, so the test needs no checkpoint."""
     import numpy as np
@@ -135,3 +157,24 @@ def _stub_estimator(n_members: int, forced_inference_dtype):
             self.forced_inference_dtype_ = forced_inference_dtype
 
     return _Estimator()
+
+
+def test_tabpfn_narrows_low_memory_features_but_not_a_float_target():
+    """`fit_mode="low_memory"` keeps the raw training set and re-preprocesses per predict.
+
+    Narrowing the features there is still lossless, but narrowing a float target is
+    not: its transforms would then be computed at the narrower precision. An integer
+    target (classification) is exact either way.
+    """
+    import numpy as np
+
+    from autogluon.tabular.models.tabpfnv2.tabpfnv2_5_model import TabPFNModel
+
+    for y_dtype, expected in ((np.int64, np.int32), (np.float64, np.float64)):
+        model = TabPFNModel(problem_type="binary", eval_metric=None)
+        model.model = _stub_on_demand_estimator(y_dtype=y_dtype)
+
+        model._narrow_inference_context()
+
+        assert model.model.executor_.X_train.dtype == np.float32
+        assert model.model.executor_.y_train.dtype == expected


### PR DESCRIPTION
## Description

TabPFN keeps the training data it attends over on the inference engine. Those arrays are float64, but TabPFN converts them with `torch.as_tensor(..., dtype=torch.float32)` at predict time, so the extra width is never read. This narrows them after fit.

With preprocessing cached (the default `fit_mode`), the stored arrays are already preprocessed and feed that conversion directly, so both features and target narrow losslessly — once per ensemble member, which is where the size comes from. `n_estimators` defaults to 8, replicating the training set 8 times.

`fit_mode="low_memory"` instead keeps the raw training set and re-runs the preprocessing on every predict. The features still narrow losslessly there, but a float target does not — its transforms would then be computed at the narrower precision — so it is left alone. An integer target is exact either way.

On 20k rows x 30 features at the default `n_estimators=8`:

| | held by fitted model | pickled |
|---|---|---|
| before | 39.7 MB | 252.6 MB |
| after | 19.8 MB | 232.8 MB |

Under `fit_mode="low_memory"`, 4.0 MB -> 2.0 MB held.

Predictions are bit-identical, verified end to end on `TabPFN3Model` for classification and regression, in both fit modes.

Skipped when `inference_precision` forces a wider dtype, the one case where the extra precision reaches the model.

## Testing

Three unit tests covering the narrowing, the forced-precision skip, and the low-memory engine. All use a stub estimator, so they need no checkpoint and no GPU.