### PR TITLE
[tabular] Add ag.save_pretrained_weights to reference the TabPFN checkpoint on load

### DIFF
--- a/core/src/autogluon/core/models/abstract/_auxiliary_params.py
+++ b/core/src/autogluon/core/models/abstract/_auxiliary_params.py
@@ -127,6 +127,13 @@ class AuxiliaryParams:
     Models may declare the sentinel "auto" and resolve it to an int during `_fit`."""
     drop_unique: bool = field(default=True, metadata=_WRAPPER_ONLY)
     """Whether to drop features that have only 1 unique value."""
+    save_pretrained_weights: bool = field(default=True, metadata=_WRAPPER_ONLY)
+    """Whether a fitted model's pretrained weights are written into its pickle.
+
+    If False, the weights are referenced instead and reloaded from their source when the
+    model is loaded, which requires that source to still be resolvable. Trades a
+    self-contained save for a much smaller one. Only honored by models that carry
+    pretrained weights; ignored by every other model."""
 
     extra: dict[str, Any] = field(default_factory=dict, metadata=_WRAPPER_ONLY)
     """Keys of `params_aux` that are not fields above: model-private params (registered via

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
@@ -274,17 +274,14 @@ class TabPFNModel(AbstractTorchModel):
             _narrow_array(executor, "y_train", _NARROWED_RAW_TARGET_DTYPES)
 
     def save(self, path: str | None = None, verbose: bool = True) -> str:
-        """Save the fitted estimator beside the pickle, without the foundation weights.
+        """Save the fitted estimator, optionally without the foundation model weights.
 
-        The weights are the same for every model of a given TabPFN version, so
-        pickling them into each fitted model writes a copy of the checkpoint per
-        model. ``save_fitted_tabpfn_model`` persists only the fitted state;
-        :meth:`load` reloads the weights from ``model_path``.
-
-        This makes a saved model depend on its checkpoint still being resolvable
-        when it is loaded, rather than being self-contained.
+        Under ``ag.save_pretrained_weights=False`` the fitted state goes to a sidecar
+        via ``save_fitted_tabpfn_model``, which omits the weights, and :meth:`load`
+        reloads them from ``model_path``. The weights are the same for every model of a
+        given TabPFN version, so the default pickles a copy of the checkpoint per model.
         """
-        if not self.is_fit():
+        if not self.is_fit() or self.aux_params.save_pretrained_weights:
             return super().save(path=path, verbose=verbose)
 
         from tabpfn import save_fitted_tabpfn_model

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
@@ -100,6 +100,9 @@ class TabPFNModel(AbstractTorchModel):
     default_resources_physical_cores_only = True
     default_num_gpus = max_gpus
 
+    tabpfn_fit_file_name = "fitted_estimator.tabpfn_fit"
+    """Sidecar holding the fitted state, written next to `model_file_name`."""
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._cat_indices = None
@@ -216,7 +219,9 @@ class TabPFNModel(AbstractTorchModel):
             hps=hps, is_classification=is_classification, custom_model_dir=custom_model_dir
         )
         if model_path is not None:
-            hps["model_path"] = model_path
+            # str, not Path: `save_fitted_tabpfn_model` writes the estimator's params
+            # to JSON, which has no encoder for Path.
+            hps["model_path"] = str(model_path)
 
         # Resolve inference_config
         inference_config = {
@@ -267,6 +272,46 @@ class TabPFNModel(AbstractTorchModel):
         else:
             _narrow_array(executor, "X_train", _NARROWED_INFERENCE_DTYPES)
             _narrow_array(executor, "y_train", _NARROWED_RAW_TARGET_DTYPES)
+
+    def save(self, path: str | None = None, verbose: bool = True) -> str:
+        """Save the fitted estimator beside the pickle, without the foundation weights.
+
+        The weights are the same for every model of a given TabPFN version, so
+        pickling them into each fitted model writes a copy of the checkpoint per
+        model. ``save_fitted_tabpfn_model`` persists only the fitted state;
+        :meth:`load` reloads the weights from ``model_path``.
+
+        This makes a saved model depend on its checkpoint still being resolvable
+        when it is loaded, rather than being self-contained.
+        """
+        if not self.is_fit():
+            return super().save(path=path, verbose=verbose)
+
+        from tabpfn import save_fitted_tabpfn_model
+
+        path = path if path is not None else self.path
+        os.makedirs(path, exist_ok=True)
+        save_fitted_tabpfn_model(self.model, os.path.join(path, self.tabpfn_fit_file_name))
+
+        # Detaching before `super().save()` is what keeps the weights out of the
+        # pickle, and skips the torch device round-trip it would otherwise do.
+        estimator = self.model
+        self.model = None
+        try:
+            return super().save(path=path, verbose=verbose)
+        finally:
+            self.model = estimator
+
+    @classmethod
+    def load(cls, path: str, reset_paths: bool = True, verbose: bool = True):
+        """Load the pickle, then reattach the fitted estimator and its weights."""
+        model = super().load(path=path, reset_paths=reset_paths, verbose=verbose)
+        fit_path = os.path.join(path, cls.tabpfn_fit_file_name)
+        if model.model is None and os.path.exists(fit_path):
+            from tabpfn import load_fitted_tabpfn_model
+
+            model.model = load_fitted_tabpfn_model(fit_path, device=model.suggest_device_infer(verbose=verbose))
+        return model
 
     def _predict_proba(self, X, **kwargs) -> np.ndarray:
         if not self.params_aux.get("model_telemetry", False):

--- a/tabular/tests/unittests/models/test_tabpfn3.py
+++ b/tabular/tests/unittests/models/test_tabpfn3.py
@@ -138,27 +138,40 @@ def _stub_on_demand_estimator(y_dtype):
     return _StubOnDemandEstimator(y_dtype, np.random.default_rng(0))
 
 
+class _StubEnsembleMember:
+    """Holds the in-context arrays the real ensemble members carry."""
+
+    def __init__(self, rng):
+        self.X_train = rng.normal(size=(8, 3))
+        self.y_train = rng.integers(0, 2, 8)
+
+
+class _StubExecutor:
+    def __init__(self, n_members, rng):
+        self.ensemble_members = [_StubEnsembleMember(rng) for _ in range(n_members)]
+
+
+class _StubEstimator:
+    """A stand-in for a fitted TabPFN estimator, so the tests need no checkpoint."""
+
+    def __init__(self, n_members, forced_inference_dtype, rng):
+        import torch
+
+        self.executor_ = _StubExecutor(n_members, rng)
+        self.forced_inference_dtype_ = forced_inference_dtype
+        self.devices_ = [torch.device("cpu")]
+
+    def to(self, device):
+        import torch
+
+        self.devices_ = [torch.device(device)]
+        return self
+
+
 def _stub_estimator(n_members: int, forced_inference_dtype):
-    """A stand-in for a fitted TabPFN estimator, so the test needs no checkpoint."""
     import numpy as np
 
-    rng = np.random.default_rng(0)
-
-    class _Member:
-        def __init__(self):
-            self.X_train = rng.normal(size=(8, 3))
-            self.y_train = rng.integers(0, 2, 8)
-
-    class _Executor:
-        def __init__(self):
-            self.ensemble_members = [_Member() for _ in range(n_members)]
-
-    class _Estimator:
-        def __init__(self):
-            self.executor_ = _Executor()
-            self.forced_inference_dtype_ = forced_inference_dtype
-
-    return _Estimator()
+    return _StubEstimator(n_members, forced_inference_dtype, np.random.default_rng(0))
 
 
 def test_tabpfn_narrows_low_memory_features_but_not_a_float_target():
@@ -180,8 +193,11 @@ def test_tabpfn_narrows_low_memory_features_but_not_a_float_target():
 
         assert model.model.executor_.X_train.dtype == np.float32
         assert model.model.executor_.y_train.dtype == expected
+
+
 def test_tabpfn_save_keeps_foundation_weights_out_of_the_pickle(tmp_path, monkeypatch):
-    """`save` writes the fitted state to a sidecar and `load` reattaches it.
+    """Under `ag.save_pretrained_weights=False`, `save` writes the fitted state to a
+    sidecar and `load` reattaches it.
 
     The weights are identical for every model of a TabPFN version, so pickling them
     per model writes a copy of the checkpoint each time. This covers AutoGluon's
@@ -208,7 +224,13 @@ def test_tabpfn_save_keeps_foundation_weights_out_of_the_pickle(tmp_path, monkey
     monkeypatch.setattr(tabpfn, "save_fitted_tabpfn_model", _fake_save, raising=False)
     monkeypatch.setattr(tabpfn, "load_fitted_tabpfn_model", _fake_load, raising=False)
 
-    model = TabPFNModel(problem_type="binary", eval_metric=None, path=str(tmp_path))
+    model = TabPFNModel(
+        problem_type="binary",
+        eval_metric=None,
+        path=str(tmp_path),
+        hyperparameters={"ag.save_pretrained_weights": False},
+    )
+    model.initialize()
     model.model = estimator
     saved_path = model.save()
 
@@ -224,11 +246,31 @@ def test_tabpfn_save_keeps_foundation_weights_out_of_the_pickle(tmp_path, monkey
     assert loaded.model is estimator
 
 
+def test_tabpfn_save_pretrained_weights_default_keeps_the_estimator_in_the_pickle(tmp_path):
+    """The default is a self-contained save: the estimator stays in the pickle."""
+    from autogluon.tabular.models.tabpfnv2.tabpfnv2_5_model import TabPFNModel
+
+    model = TabPFNModel(problem_type="binary", eval_metric=None, path=str(tmp_path))
+    model.initialize()
+    model.model = _stub_estimator(n_members=1, forced_inference_dtype=None)
+    model.device = "cpu"  # normally set during fit; this test does not fit
+    saved_path = model.save()
+
+    assert not os.path.exists(os.path.join(saved_path, TabPFNModel.tabpfn_fit_file_name))
+    assert TabPFNModel.load(saved_path).is_fit()
+
+
 def test_tabpfn_save_without_fit_writes_no_sidecar(tmp_path):
     """An unfit model has no fitted state to put in a sidecar."""
     from autogluon.tabular.models.tabpfnv2.tabpfnv2_5_model import TabPFNModel
 
-    model = TabPFNModel(problem_type="binary", eval_metric=None, path=str(tmp_path))
+    model = TabPFNModel(
+        problem_type="binary",
+        eval_metric=None,
+        path=str(tmp_path),
+        hyperparameters={"ag.save_pretrained_weights": False},
+    )
+    model.initialize()
     saved_path = model.save()
 
     assert not os.path.exists(os.path.join(saved_path, TabPFNModel.tabpfn_fit_file_name))

--- a/tabular/tests/unittests/models/test_tabpfn3.py
+++ b/tabular/tests/unittests/models/test_tabpfn3.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from autogluon.tabular.models.tabpfnv2.tabpfn3_model import TabPFN3Model
@@ -178,3 +180,56 @@ def test_tabpfn_narrows_low_memory_features_but_not_a_float_target():
 
         assert model.model.executor_.X_train.dtype == np.float32
         assert model.model.executor_.y_train.dtype == expected
+def test_tabpfn_save_keeps_foundation_weights_out_of_the_pickle(tmp_path, monkeypatch):
+    """`save` writes the fitted state to a sidecar and `load` reattaches it.
+
+    The weights are identical for every model of a TabPFN version, so pickling them
+    per model writes a copy of the checkpoint each time. This covers AutoGluon's
+    wiring with a stubbed tabpfn save/load pair, so it needs no checkpoint.
+    """
+    import pickle
+
+    import tabpfn
+
+    from autogluon.tabular.models.tabpfnv2.tabpfnv2_5_model import TabPFNModel
+
+    estimator = _stub_estimator(n_members=1, forced_inference_dtype=None)
+    sidecar = {}
+
+    def _fake_save(est, path):
+        sidecar["path"] = path
+        sidecar["estimator"] = est
+        open(path, "wb").close()
+
+    def _fake_load(path, *, device):
+        sidecar["device"] = device
+        return sidecar["estimator"]
+
+    monkeypatch.setattr(tabpfn, "save_fitted_tabpfn_model", _fake_save, raising=False)
+    monkeypatch.setattr(tabpfn, "load_fitted_tabpfn_model", _fake_load, raising=False)
+
+    model = TabPFNModel(problem_type="binary", eval_metric=None, path=str(tmp_path))
+    model.model = estimator
+    saved_path = model.save()
+
+    assert sidecar["path"].endswith(TabPFNModel.tabpfn_fit_file_name)
+    # The pickle no longer carries the estimator, so it cannot carry the weights.
+    with open(os.path.join(saved_path, TabPFNModel.model_file_name), "rb") as f:
+        assert pickle.load(f).model is None
+    # ... while the live model is left fit.
+    assert model.model is estimator
+
+    loaded = TabPFNModel.load(saved_path)
+    assert loaded.is_fit()
+    assert loaded.model is estimator
+
+
+def test_tabpfn_save_without_fit_writes_no_sidecar(tmp_path):
+    """An unfit model has no fitted state to put in a sidecar."""
+    from autogluon.tabular.models.tabpfnv2.tabpfnv2_5_model import TabPFNModel
+
+    model = TabPFNModel(problem_type="binary", eval_metric=None, path=str(tmp_path))
+    saved_path = model.save()
+
+    assert not os.path.exists(os.path.join(saved_path, TabPFNModel.tabpfn_fit_file_name))
+    assert not TabPFNModel.load(saved_path).is_fit()


### PR DESCRIPTION
Stacked on #5864.

## Description

A fitted TabPFN estimator carries the foundation model weights, so pickling it writes a copy of the checkpoint into every fitted model. tabpfn exports `save_fitted_tabpfn_model` / `load_fitted_tabpfn_model`, which persist the fitted state and omit the weights, reloading them from `model_path`. Available across the supported `tabpfn>=8.0,<8.5` range.

Gated behind a new auxiliary param, default `True`, so the self-contained save stays the default:

```python
predictor.fit(..., ag_args_fit={"save_pretrained_weights": False})
hyperparameters={TabPFN3Model: [{"ag.save_pretrained_weights": False}]}
```

It is generic rather than TabPFN-specific because `mitra`, `tabdpt` and `tabicl` pickle their pretrained weights the same way and can honor the same flag.

**Trade-off:** with `False`, a saved model depends on its checkpoint being resolvable at load time rather than being self-contained.

`model_path` is passed as `str` because `save_fitted_tabpfn_model` writes the estimator's params to JSON, which has no encoder for `Path`.

## Benchmark

`TabPFN3Model`, 20k rows x 30 features, `n_estimators=8`, median of 5 runs after warming fit, save, load and predict separately:

| save_pretrained_weights | fit_mode | disk MB | fit s | save s | load s | predict s |
|---|---|---|---|---|---|---|
| True | fit_preprocessors (defaults) | 232.8 | 0.29 | 1.08 | 0.11 | 1.59 |
| False | fit_preprocessors | 17.9 | 0.31 | 0.56 | 0.32 | 1.59 |
| True | low_memory | 215.4 | 0.23 | 0.96 | 0.10 | 1.62 |
| False | low_memory | 2.2 | 0.24 | 0.09 | 0.23 | 1.63 |

Predictions identical across all four. Save gets faster; load costs ~0.2s more for the checkpoint reconstruction; predict is unaffected.

Load times are warm-page-cache, which favors `True` (it re-reads 232.8 MB). `False` reads a small sidecar plus the shared checkpoint. The load penalty is per model, since each load re-initializes independently.

## Testing

Three unit tests covering the sidecar path, the default path, and the unfit case, using a stubbed tabpfn save/load pair so they need no checkpoint and no GPU.