### PR TITLE
[timeseries] Fix test_mlforecast failures from the mocked fit's exit path

### DIFF
--- a/timeseries/tests/unittests/models/test_mlforecast.py
+++ b/timeseries/tests/unittests/models/test_mlforecast.py
@@ -167,9 +167,6 @@ def test_given_long_time_series_passed_to_model_then_preprocess_receives_shorten
         hyperparameters={"max_num_samples": max_num_samples, "differences": differences},
         prediction_length=prediction_length,
     )
-    # The mock's return value is not a real frame, so the rest of fit cannot run on it.
-    # Raise once the call has been recorded, rather than relying on whatever the mock
-    # happens to break downstream.
     with mock.patch("mlforecast.MLForecast.preprocess", side_effect=_StopAfterPreprocess) as mock_preprocess:
         with pytest.raises(_StopAfterPreprocess):
             model.fit(train_data=data)

--- a/timeseries/tests/unittests/models/test_mlforecast.py
+++ b/timeseries/tests/unittests/models/test_mlforecast.py
@@ -150,6 +150,10 @@ def test_when_eval_metric_is_changed_then_model_can_predict(temp_model_path, mlf
     assert len(predictions) == data.num_items * model.prediction_length
 
 
+class _StopAfterPreprocess(Exception):
+    """Ends fit once `MLForecast.preprocess` has recorded its call."""
+
+
 @pytest.mark.parametrize("differences", [[], [14]])
 def test_given_long_time_series_passed_to_model_then_preprocess_receives_shortened_time_series(
     temp_model_path, mlforecast_model_class, differences
@@ -163,12 +167,12 @@ def test_given_long_time_series_passed_to_model_then_preprocess_receives_shorten
         hyperparameters={"max_num_samples": max_num_samples, "differences": differences},
         prediction_length=prediction_length,
     )
-    with mock.patch("mlforecast.MLForecast.preprocess") as mock_preprocess:
-        try:
+    # The mock's return value is not a real frame, so the rest of fit cannot run on it.
+    # Raise once the call has been recorded, rather than relying on whatever the mock
+    # happens to break downstream.
+    with mock.patch("mlforecast.MLForecast.preprocess", side_effect=_StopAfterPreprocess) as mock_preprocess:
+        with pytest.raises(_StopAfterPreprocess):
             model.fit(train_data=data)
-        # using mock leads to ZeroDivisionError
-        except ZeroDivisionError:
-            pass
         received_mlforecast_df = mock_preprocess.call_args[0][0]
         assert len(received_mlforecast_df) == max_num_samples + prediction_length + sum(differences)
 


### PR DESCRIPTION
## Description

Four parametrizations of `test_given_long_time_series_passed_to_model_then_preprocess_receives_shortened_time_series` fail on master.

The test mocks `MLForecast.preprocess` and let the resulting `MagicMock` crash `fit`, catching the `ZeroDivisionError` it happened to produce. That error came from `get_approximate_df_mem_usage` computing `sample_ratio = 0 / 0` on the zero-length mock. #5863 added a `num_rows == 0` guard, so the mock now flows further and dies formatting a `MagicMock` in a log line instead:

```
TypeError: unsupported format string passed to MagicMock.__format__
features/src/autogluon/features/generators/pipeline.py:126
```

The guard is correct; the test's exit path was incidental. Give the mock a side effect that raises once the call has been recorded, so the test asserts what it means to without depending on what the mock breaks downstream.

## Testing

`pytest timeseries/tests/unittests/models/test_mlforecast.py` — 187 passed. The four failures reproduce on unmodified master and pass with this change.