### PR TITLE
fix(core): include static params in grid search configs

### DIFF
--- a/core/src/autogluon/core/searcher/local_grid_searcher.py
+++ b/core/src/autogluon/core/searcher/local_grid_searcher.py
@@ -70,7 +70,7 @@ class LocalGridSearcher(LocalSearcher):
             raise AssertionError(
                 f"No configs left to get. All {self._grid_length} configs have been accessed already."
             )
-        config = self._params_grid[self._grid_index]
+        config = dict(self._params_grid[self._grid_index])
         self._grid_index += 1
         for key, val in config.items():
             # If this isn't done, warnings are spammed in XGBoost
@@ -78,4 +78,6 @@ class LocalGridSearcher(LocalSearcher):
                 config[key] = int(val)
             elif isinstance(val, np.float64):
                 config[key] = float(val)
+        # Include static parameters in every config, as in LocalRandomSearcher.
+        config.update(self._params_static)
         return config

--- a/core/tests/unittests/searcher/test_local_grid_searcher.py
+++ b/core/tests/unittests/searcher/test_local_grid_searcher.py
@@ -58,6 +58,27 @@ def test_local_grid_searcher_categorical():
         raise AssertionError("GridSearcher should error due to being out of configs")
 
 
+def test_local_grid_searcher_static_params():
+    searcher = LocalGridSearcher(search_space={"a": space.Int(0, 1), "fixed": 42})
+
+    configs = []
+    while len(searcher) > 0:
+        config = searcher.get_config()
+        configs.append(config)
+        searcher.update(config, reward=0.1)
+        assert searcher.get_reward(config) == 0.1
+
+    assert configs == [{"a": 0, "fixed": 42}, {"a": 1, "fixed": 42}]
+    assert searcher._params_static == {"fixed": 42}
+    assert len(searcher) == 0
+    try:
+        searcher.get_config()
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("GridSearcher should error due to being out of configs")
+
+
 def test_local_grid_searcher_numeric():
     search_spaces = [
         [dict(a=space.Bool()), [{"a": 0}, {"a": 1}]],


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

`LocalGridSearcher` returned only sampled parameters, so configs containing static search-space values failed validation during `update`. This change adds the static values to each returned config, matching `LocalRandomSearcher`, and adds regression coverage for enumeration, result updates, and exhaustion.

Validation: `6 passed` in the focused grid/base searcher tests; Ruff and `git diff --check` pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
