### PR TITLE
[core][tabular] Add ag.fetch_pretrained_weights; extend ag.save_pretrained_weights to all foundation models

### DIFF
--- a/common/src/autogluon/common/utils/pretrained_weights.py
+++ b/common/src/autogluon/common/utils/pretrained_weights.py
@@ -1,0 +1,82 @@
+"""Policy for fetching pretrained weights that are absent from the local cache.
+
+Models carrying pretrained weights download them on demand. That is convenient on a workstation
+and unwanted in places where a fit must not reach the network: an air-gapped or VPC-isolated host,
+a benchmark run that must not vary with what a remote registry serves, or a serving container whose
+image was built with the weights baked in and should fail loudly rather than silently re-download.
+
+The policy is expressed by the ``ag.fetch_pretrained_weights`` auxiliary parameter and can be
+overridden per-process by :data:`FETCH_ENV_VAR`. Enforcement is per-package, because each
+foundation-model library reaches the network differently; this module only decides *whether* a
+fetch is allowed.
+"""
+
+from __future__ import annotations
+
+import os
+
+__all__ = [
+    "FETCH_ENV_VAR",
+    "FIT_ONLY",
+    "PretrainedWeightsUnavailableError",
+    "fetch_allowed",
+    "resolve_policy",
+]
+
+#: Deployment-level override, mirroring ``AG_ALLOW_PICKLE_FROM_URL``. A serving host sets this to
+#: constrain fetches regardless of what a fitted artifact was pickled with.
+FETCH_ENV_VAR = "AG_FETCH_PRETRAINED_WEIGHTS"
+
+#: Fetch while fitting, never when loading a saved model.
+FIT_ONLY = "fit_only"
+
+_VALID = (True, False, FIT_ONLY)
+
+
+class PretrainedWeightsUnavailableError(RuntimeError):
+    """Weights are absent from the local cache and the active policy forbids fetching them."""
+
+
+def resolve_policy(aux_value: bool | str) -> bool | str:
+    """Resolve the effective policy, letting the environment override the fitted artifact.
+
+    The environment wins because an inference-time policy belongs to the deployment rather than to
+    the model: a serving host must be able to forbid fetches without re-fitting.
+    """
+    raw = os.environ.get(FETCH_ENV_VAR)
+    if raw is not None:
+        lowered = raw.strip().lower()
+        if lowered in ("true", "1"):
+            return True
+        if lowered in ("false", "0"):
+            return False
+        if lowered == FIT_ONLY:
+            return FIT_ONLY
+        raise ValueError(f"{FETCH_ENV_VAR}={raw!r} is not understood; expected True, False, or {FIT_ONLY!r}.")
+    if aux_value not in _VALID:
+        raise ValueError(
+            f"ag.fetch_pretrained_weights={aux_value!r} is not understood; expected True, False, or {FIT_ONLY!r}."
+        )
+    return aux_value
+
+
+def fetch_allowed(aux_value: bool | str, *, stage: str) -> bool:
+    """Whether a remote fetch is permitted at ``stage``, one of ``"fit"`` or ``"load"``."""
+    if stage not in ("fit", "load"):
+        raise ValueError(f"stage must be 'fit' or 'load', got {stage!r}")
+    policy = resolve_policy(aux_value)
+    if policy is True:
+        return True
+    if policy is False:
+        return False
+    return stage == "fit"
+
+
+def unavailable_message(*, model_name: str, stage: str, location: object = None) -> str:
+    """A consistent error message across packages."""
+    where = f"\nExpected location: {location}" if location is not None else ""
+    return (
+        f"{model_name} needs pretrained weights that are not in the local cache, and fetching them "
+        f"is disabled at {stage} time (ag.fetch_pretrained_weights / {FETCH_ENV_VAR}).{where}\n"
+        f"Either pre-populate the cache on this machine, or allow fetching."
+    )

--- a/core/src/autogluon/core/models/abstract/_auxiliary_params.py
+++ b/core/src/autogluon/core/models/abstract/_auxiliary_params.py
@@ -135,6 +135,21 @@ class AuxiliaryParams:
     self-contained save for a much smaller one. Only honored by models that carry
     pretrained weights; ignored by every other model."""
 
+    fetch_pretrained_weights: bool | str = field(default=True, metadata=_WRAPPER_ONLY)
+    """Whether pretrained weights may be fetched from a remote source when absent from the local cache.
+
+    One of:
+
+    * ``True`` (default): fetch whenever the weights are not cached locally.
+    * ``False``: never fetch. If the weights are missing, raise instead of reaching the network.
+    * ``"fit_only"``: fetch during `fit`, but never when loading a saved model. Use this to keep a
+      serving host offline while still allowing a training host to populate its cache.
+
+    ``"fit_only"`` exists because `save_pretrained_weights=False` makes a saved model depend on the
+    weight source still being reachable at load time; the two options together decide whether that
+    dependency is allowed to become a network call. Only honored by models that carry pretrained
+    weights; ignored by every other model."""
+
     extra: dict[str, Any] = field(default_factory=dict, metadata=_WRAPPER_ONLY)
     """Keys of `params_aux` that are not fields above: model-private params (registered via
     the model's `_ag_params()`, e.g. TabPFN's `model_telemetry`) and any user-supplied extras."""

--- a/tabular/src/autogluon/tabular/models/nori/_weight_fetch.py
+++ b/tabular/src/autogluon/tabular/models/nori/_weight_fetch.py
@@ -1,0 +1,49 @@
+"""Enforcement of ``ag.fetch_pretrained_weights`` for Nori at inference time.
+
+``NoriRegressor`` does not hold the pretrained module: it builds its predictor lazily on the first
+``predict``, resolving the checkpoint then. So unlike the other foundation models, gating ``fit``
+alone leaves the inference-time fetch open -- a model loaded on a cold serving host would download
+weights on its first prediction.
+
+``synthefy_nori.hf.download_checkpoint`` is the single resolution point, and the library imports it
+inside the calling function, so replacing the module attribute is enough.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Iterator
+
+from autogluon.common.utils.pretrained_weights import (
+    PretrainedWeightsUnavailableError,
+    unavailable_message,
+)
+
+__all__ = ["local_weights_only"]
+
+
+@contextlib.contextmanager
+def local_weights_only(*, stage: str, model_name: str) -> Iterator[None]:
+    """Restrict Nori's checkpoint resolution to the local cache."""
+    import synthefy_nori.hf as nori_hf
+
+    original = nori_hf.download_checkpoint
+
+    def _cached_only(repo_id=None, filename=None, *, model=None, **kwargs):
+        from huggingface_hub import hf_hub_download
+        from huggingface_hub.errors import LocalEntryNotFoundError
+
+        repo = nori_hf.resolve_model_repo(model) if model is not None else (repo_id or nori_hf.DEFAULT_MODEL_REPO_ID)
+        name = filename or nori_hf.DEFAULT_CHECKPOINT_FILENAME
+        try:
+            return hf_hub_download(repo_id=repo, filename=name, local_files_only=True)
+        except LocalEntryNotFoundError as err:
+            raise PretrainedWeightsUnavailableError(
+                unavailable_message(model_name=model_name, stage=stage, location=f"{repo}/{name}")
+            ) from err
+
+    nori_hf.download_checkpoint = _cached_only
+    try:
+        yield
+    finally:
+        nori_hf.download_checkpoint = original

--- a/tabular/src/autogluon/tabular/models/nori/nori_model.py
+++ b/tabular/src/autogluon/tabular/models/nori/nori_model.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import logging
 from typing import TYPE_CHECKING
 
@@ -150,6 +151,20 @@ class NoriModel(AbstractTorchModel):
             ) from None
 
     def _predict_proba(self, X, **kwargs) -> np.ndarray:
+        # Nori builds its predictor lazily on first predict and resolves the checkpoint then, so
+        # unlike the other foundation models the inference-time fetch is not covered by gating
+        # `_fit`. The load-stage policy governs here.
+        with self._inference_fetch_policy():
+            return self._predict_proba_inner(X, **kwargs)
+
+    def _inference_fetch_policy(self):
+        if fetch_allowed(self.aux_params.fetch_pretrained_weights, stage="load"):
+            return contextlib.nullcontext()
+        from ._weight_fetch import local_weights_only
+
+        return local_weights_only(stage="load", model_name=type(self).__name__)
+
+    def _predict_proba_inner(self, X, **kwargs) -> np.ndarray:
         X = self.preprocess(X, **kwargs)
         # Nori is regression-only: `predict` returns point estimates directly.
         return self.model.predict(X)

--- a/tabular/src/autogluon/tabular/models/nori/nori_model.py
+++ b/tabular/src/autogluon/tabular/models/nori/nori_model.py
@@ -6,6 +6,11 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
+from autogluon.common.utils.pretrained_weights import (
+    PretrainedWeightsUnavailableError,
+    fetch_allowed,
+    unavailable_message,
+)
 from autogluon.tabular import __version__
 from autogluon.tabular.models.abstract.abstract_torch_model import AbstractTorchModel
 
@@ -109,8 +114,40 @@ class NoriModel(AbstractTorchModel):
 
         X = self.preprocess(X, y=y)
         y = y.to_numpy()
+        # Only take over checkpoint resolution when the policy forbids fetching. Left alone,
+        # NoriRegressor resolves its own checkpoint exactly as before, so the default path is
+        # untouched -- including for callers who supply `model_path` themselves.
+        if "model_path" not in hyp and not fetch_allowed(self.aux_params.fetch_pretrained_weights, stage="fit"):
+            hyp["model_path"] = self._resolve_cached_checkpoint(model=hyp.get("model"))
         self.model = NoriRegressor(device=device, **hyp)
         self.model.fit(X=X, y=y)
+
+    @classmethod
+    def _resolve_cached_checkpoint(cls, model: str | None) -> str:
+        """Resolve this variant's checkpoint from the local cache, or raise.
+
+        Called only when fetching is disabled. Resolving the path ourselves and handing it to
+        ``NoriRegressor`` as ``model_path`` is what keeps a disabled fetch from breaking an
+        already-provisioned machine: a cached checkpoint still resolves, and only a real
+        download is refused.
+        """
+        from huggingface_hub import hf_hub_download
+        from huggingface_hub.errors import LocalEntryNotFoundError
+        from synthefy_nori.hf import (
+            DEFAULT_CHECKPOINT_FILENAME,
+            DEFAULT_MODEL_REPO_ID,
+            resolve_model_repo,
+        )
+
+        repo_id = resolve_model_repo(model) if model is not None else DEFAULT_MODEL_REPO_ID
+        try:
+            return hf_hub_download(repo_id=repo_id, filename=DEFAULT_CHECKPOINT_FILENAME, local_files_only=True)
+        except LocalEntryNotFoundError:
+            raise PretrainedWeightsUnavailableError(
+                unavailable_message(
+                    model_name=cls.__name__, stage="fit", location=f"{repo_id}/{DEFAULT_CHECKPOINT_FILENAME}"
+                )
+            ) from None
 
     def _predict_proba(self, X, **kwargs) -> np.ndarray:
         X = self.preprocess(X, **kwargs)

--- a/tabular/src/autogluon/tabular/models/nori/nori_model.py
+++ b/tabular/src/autogluon/tabular/models/nori/nori_model.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import os
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -72,6 +73,12 @@ class NoriModel(AbstractTorchModel):
         # ~21 GB at 10k x 100, and ~58 GB at the 50k-row cap (100 features),
         # so the cap only fits on high-memory GPUs.
         "max_rows": 50000,
+        # Keep current behaviour: NoriRegressor never holds the pretrained module, so
+        # AutoGluon has always saved Nori without weights (~0.2 MB). Defaulting to True
+        # would copy the 45 MB checkpoint into every model directory and every bagged
+        # fold. Set `ag.save_pretrained_weights=True` for an artifact that needs no
+        # checkpoint at inference.
+        "save_pretrained_weights": False,
         # No feature cap: the model sees at most `_INTERNAL_MAX_FEATURES` columns whatever the
         # input width (see that attribute), so a wide fit costs no more memory than a 256-feature
         # one -- measured 8.8 GB at both 256 and 5000 features.
@@ -149,6 +156,49 @@ class NoriModel(AbstractTorchModel):
                     model_name=cls.__name__, stage="fit", location=f"{repo_id}/{DEFAULT_CHECKPOINT_FILENAME}"
                 )
             ) from None
+
+    pretrained_weights_file_name = "nori_checkpoint.pt"
+    """Filename of the embedded checkpoint under ``ag.save_pretrained_weights=True``."""
+
+    def save(self, path: str | None = None, verbose: bool = True) -> str:
+        """Save the fitted estimator, embedding the checkpoint only when asked.
+
+        ``NoriRegressor`` never holds the pretrained module -- it builds its predictor lazily on
+        the first ``predict`` and resolves the checkpoint then -- so the *unflagged* behaviour
+        already matches ``ag.save_pretrained_weights=False``, and inference depends on the
+        checkpoint still being resolvable. Honoring ``True`` therefore means copying the
+        checkpoint into the artifact and pointing the estimator at that copy, which is what makes
+        the artifact self-contained.
+        """
+        if not self.is_fit() or not self.aux_params.save_pretrained_weights:
+            return super().save(path=path, verbose=verbose)
+
+        import shutil
+
+        path = path if path is not None else self.path
+        os.makedirs(path, exist_ok=True)
+        embedded = os.path.join(path, self.pretrained_weights_file_name)
+        if not os.path.exists(embedded):
+            source = self._resolve_cached_checkpoint(model=self._get_model_params().get("model"))
+            shutil.copyfile(source, embedded)
+
+        # Point the estimator at the copy, relative to the model directory so the artifact stays
+        # movable; `load` resolves it back to an absolute path.
+        previous = getattr(self.model, "model_path", None)
+        self.model.model_path = self.pretrained_weights_file_name
+        try:
+            return super().save(path=path, verbose=verbose)
+        finally:
+            self.model.model_path = previous
+
+    @classmethod
+    def load(cls, path: str, reset_paths: bool = True, verbose: bool = True):
+        """Load the pickle, pointing the estimator at an embedded checkpoint if one is present."""
+        model = super().load(path=path, reset_paths=reset_paths, verbose=verbose)
+        embedded = os.path.join(path, cls.pretrained_weights_file_name)
+        if model.model is not None and os.path.exists(embedded):
+            model.model.model_path = embedded
+        return model
 
     def _predict_proba(self, X, **kwargs) -> np.ndarray:
         # Nori builds its predictor lazily on first predict and resolves the checkpoint then, so

--- a/tabular/src/autogluon/tabular/models/tabdpt/_weight_fetch.py
+++ b/tabular/src/autogluon/tabular/models/tabdpt/_weight_fetch.py
@@ -1,0 +1,45 @@
+"""Enforcement of ``ag.fetch_pretrained_weights`` for TabDPT.
+
+:class:`TabDPTModel` pins a checkpoint only when ``_checkpoint_filename`` is set; otherwise it
+lets the library resolve its own default through ``TabDPTEstimator.download_weights``, which calls
+``hf_hub_download`` with no cache probe. Blanket-blocking that call would break an already
+provisioned machine, so the guard instead forces ``local_files_only=True``: a cached checkpoint
+still resolves, and only a real fetch is refused.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Iterator
+
+from autogluon.common.utils.pretrained_weights import (
+    PretrainedWeightsUnavailableError,
+    unavailable_message,
+)
+
+__all__ = ["local_weights_only"]
+
+
+@contextlib.contextmanager
+def local_weights_only(*, stage: str, model_name: str) -> Iterator[None]:
+    """Restrict ``tabdpt``'s checkpoint resolution to the local cache."""
+    import tabdpt.estimator as estimator
+
+    original = estimator.hf_hub_download
+
+    def _local_only(*args, **kwargs):
+        from huggingface_hub.errors import LocalEntryNotFoundError
+
+        kwargs["local_files_only"] = True
+        try:
+            return original(*args, **kwargs)
+        except LocalEntryNotFoundError as err:
+            raise PretrainedWeightsUnavailableError(
+                unavailable_message(model_name=model_name, stage=stage, location=kwargs.get("filename"))
+            ) from err
+
+    estimator.hf_hub_download = _local_only
+    try:
+        yield
+    finally:
+        estimator.hf_hub_download = original

--- a/tabular/src/autogluon/tabular/models/tabdpt/_weights.py
+++ b/tabular/src/autogluon/tabular/models/tabdpt/_weights.py
@@ -1,0 +1,53 @@
+"""Detach and rebuild TabDPT's pretrained module for ``ag.save_pretrained_weights=False``.
+
+``TabDPTEstimator`` loads its safetensors checkpoint inline in ``__init__`` and keeps the resulting
+``nn.Module`` on ``.model``; there is no reload entry point to call, so rebuilding reproduces those
+few lines. Two constructor arguments needed for the rebuild (``clip_sigma``, ``use_flash``) are not
+kept on the estimator, only on the module itself, so they are recorded before it is dropped.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: Attribute on the estimator holding what the rebuild needs. Pickled with the model.
+REBUILD_ATTR = "_ag_pretrained_rebuild"
+
+
+def capture_rebuild_args(estimator: Any) -> None:
+    """Record what ``rebuild_pretrained`` will need, before the module is dropped."""
+    module = estimator.model
+    setattr(
+        estimator,
+        REBUILD_ATTR,
+        {
+            "clip_sigma": getattr(module, "clip_sigma", 8.0),
+            "use_flash": getattr(module, "use_flash", getattr(estimator, "use_flash", True)),
+        },
+    )
+
+
+def rebuild_pretrained(estimator: Any, checkpoint_path: str) -> None:
+    """Reload the pretrained module from ``checkpoint_path`` onto ``estimator.model``."""
+    import json
+
+    from omegaconf import OmegaConf
+    from safetensors import safe_open
+    from tabdpt.model import TabDPTModel as _TabDPTNet
+
+    args = getattr(estimator, REBUILD_ATTR, {}) or {}
+    device = estimator.device
+
+    with safe_open(checkpoint_path, framework="pt", device=device) as f:
+        cfg = OmegaConf.create(json.loads(f.metadata()["cfg"]))
+        model_state = {k: f.get_tensor(k) for k in f.keys()}
+
+    cfg.env.device = device
+    estimator.path = checkpoint_path
+    estimator.model = _TabDPTNet.load(
+        model_state=model_state,
+        config=cfg,
+        use_flash=args.get("use_flash", True),
+        clip_sigma=args.get("clip_sigma", 8.0),
+    )
+    estimator.model.eval()

--- a/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_model.py
+++ b/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_model.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import os
 from typing import TYPE_CHECKING, ClassVar
 
 from autogluon.common.utils.pretrained_weights import (
@@ -12,6 +13,7 @@ from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION
 from autogluon.tabular.models.abstract.abstract_torch_model import AbstractTorchModel
 
 from ._weight_fetch import local_weights_only
+from ._weights import capture_rebuild_args, rebuild_pretrained
 
 if TYPE_CHECKING:
     import numpy as np
@@ -211,10 +213,59 @@ class TabDPTModel(AbstractTorchModel):
         self._use_flash_og = self.model.use_flash
         return self
 
+    def save(self, path: str | None = None, verbose: bool = True) -> str:
+        """Save the fitted estimator, optionally without the foundation model weights.
+
+        Under ``ag.save_pretrained_weights=False`` the pretrained module is dropped from the
+        pickle and rebuilt from its checkpoint on load. The weights are identical for every
+        TabDPT model of a given checkpoint, so the default keeps a copy per model.
+        """
+        if not self.is_fit() or self.aux_params.save_pretrained_weights or self.model.model is None:
+            return super().save(path=path, verbose=verbose)
+
+        capture_rebuild_args(self.model)
+        pretrained = self.model.model
+        self.model.model = None
+        try:
+            return super().save(path=path, verbose=verbose)
+        finally:
+            self.model.model = pretrained
+
+    @classmethod
+    def load(cls, path: str, reset_paths: bool = True, verbose: bool = True):
+        """Load the pickle, rebuilding the pretrained module if it was left out of the save."""
+        model = super().load(path=path, reset_paths=reset_paths, verbose=verbose)
+        estimator = model.model
+        if estimator is not None and getattr(estimator, "model", "missing") is None:
+            checkpoint = getattr(estimator, "path", None)
+            if not checkpoint or not os.path.exists(checkpoint):
+                # The fit-time cache path does not exist here; re-resolve it, which is where the
+                # load-stage fetch policy applies.
+                allow = fetch_allowed(model.aux_params.fetch_pretrained_weights, stage="load")
+                with cls._weight_fetch_policy(allow, stage="load"):
+                    checkpoint = cls._resolve_any_checkpoint(allow)
+            rebuild_pretrained(estimator, checkpoint)
+            model._set_device(model.suggest_device_infer(verbose=verbose))
+        return model
+
+    @classmethod
+    def _resolve_any_checkpoint(cls, allow_fetch: bool) -> str:
+        """Resolve this class's checkpoint, whether or not a filename is pinned."""
+        if cls._checkpoint_filename is not None:
+            return cls._download_checkpoint(allow_fetch)
+        from tabdpt.estimator import TabDPTEstimator
+
+        return TabDPTEstimator.download_weights()
+
     def get_device(self) -> str:
         return self.model.device
 
     def _set_device(self, device: str):
+        if getattr(self.model, "model", "missing") is None:
+            # Pretrained module detached for an `ag.save_pretrained_weights=False` save; there is
+            # nothing to move, and `load` places the rebuilt module itself.
+            self.model.device = device
+            return
         self.model.to(device)
         if device == "cpu":
             self.model.use_flash = False

--- a/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_model.py
+++ b/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_model.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+import contextlib
 from typing import TYPE_CHECKING, ClassVar
 
+from autogluon.common.utils.pretrained_weights import (
+    PretrainedWeightsUnavailableError,
+    fetch_allowed,
+    unavailable_message,
+)
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION
 from autogluon.tabular.models.abstract.abstract_torch_model import AbstractTorchModel
+
+from ._weight_fetch import local_weights_only
 
 if TYPE_CHECKING:
     import numpy as np
@@ -102,20 +110,33 @@ class TabDPTModel(AbstractTorchModel):
 
         X = self.preprocess(X, y=y)
         y = y.to_numpy()
+        allow_fetch = fetch_allowed(self.aux_params.fetch_pretrained_weights, stage="fit")
         if self._checkpoint_filename is not None:
-            fit_params["model_weight_path"] = self._download_checkpoint()
-        self.model = model_cls(
-            device=device,
-            **fit_params,
-        )
+            fit_params["model_weight_path"] = self._download_checkpoint(allow_fetch)
+        # With no pinned checkpoint the library resolves its own default in `TabDPTEstimator
+        # .__init__` (not in `fit`), so the policy has to be in force around construction rather
+        # than applied to a path we resolved ourselves.
+        with self._weight_fetch_policy(allow_fetch):
+            self.model = model_cls(
+                device=device,
+                **fit_params,
+            )
         self.model.fit(X=X, y=y)
 
     @classmethod
-    def _download_checkpoint(cls) -> str:
+    def _weight_fetch_policy(cls, allow_fetch: bool):
+        if allow_fetch or cls._checkpoint_filename is not None:
+            return contextlib.nullcontext()
+        return local_weights_only(stage="fit", model_name=cls.__name__)
+
+    @classmethod
+    def _download_checkpoint(cls, allow_fetch: bool = True) -> str:
         """Resolve this version's checkpoint to a local path (from cache, else download).
 
         Tries the local cache first so prefetched / offline compute nodes skip the etag
-        HEAD-request that ``hf_hub_download`` makes by default.
+        HEAD-request that ``hf_hub_download`` makes by default. That probe is also what lets
+        ``ag.fetch_pretrained_weights`` be honored without intercepting anything: a cached
+        checkpoint still resolves when fetching is disabled, and only the fallback is gated.
         """
         from huggingface_hub import hf_hub_download
         from huggingface_hub.errors import LocalEntryNotFoundError
@@ -127,6 +148,10 @@ class TabDPTModel(AbstractTorchModel):
                 local_files_only=True,
             )
         except LocalEntryNotFoundError:
+            if not allow_fetch:
+                raise PretrainedWeightsUnavailableError(
+                    unavailable_message(model_name=cls.__name__, stage="fit", location=cls._checkpoint_filename)
+                ) from None
             return hf_hub_download(repo_id=cls._hf_repo_id, filename=cls._checkpoint_filename)
 
     def _get_tabdpt_params(self, num_gpus: float) -> tuple[dict, dict]:

--- a/tabular/src/autogluon/tabular/models/tabicl/_weight_fetch.py
+++ b/tabular/src/autogluon/tabular/models/tabicl/_weight_fetch.py
@@ -1,0 +1,64 @@
+"""Enforcement of ``ag.fetch_pretrained_weights`` for TabICL at load time.
+
+At *fit* time the policy is simply passed to the estimator's ``allow_auto_download`` parameter.
+Load is different: tabicl's ``__setstate__`` reloads the checkpoint during unpickling, so the fetch
+happens before the AutoGluon model object -- and therefore its ``aux_params`` -- exists. The only
+policy source available at that moment is the environment, which is also the right scope: an
+inference-time policy belongs to the deployment rather than to the artifact.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Iterator
+
+from autogluon.common.utils.pretrained_weights import (
+    PretrainedWeightsUnavailableError,
+    fetch_allowed,
+    unavailable_message,
+)
+
+__all__ = ["weight_fetch_policy"]
+
+_PATCH_TARGETS = ("tabicl._sklearn.classifier", "tabicl._sklearn.regressor")
+
+
+@contextlib.contextmanager
+def weight_fetch_policy(*, stage: str, model_name: str) -> Iterator[None]:
+    """Block remote checkpoint fetches for the duration when the environment forbids them.
+
+    ``aux_value`` defaults to True because the fitted artifact cannot be consulted here; only
+    ``AG_FETCH_PRETRAINED_WEIGHTS`` can tighten this.
+    """
+    if fetch_allowed(True, stage=stage):
+        yield
+        return
+
+    import importlib
+
+    modules = []
+    for name in _PATCH_TARGETS:
+        try:
+            modules.append(importlib.import_module(name))
+        except ImportError:  # pragma: no cover - layout differs across tabicl versions
+            continue
+
+    originals = [(m, m.hf_hub_download) for m in modules if hasattr(m, "hf_hub_download")]
+
+    def _guarded(*args, **kwargs):
+        # tabicl probes the cache with local_files_only=True first; that call touches no network.
+        if kwargs.get("local_files_only"):
+            for module, original in originals:
+                if module.hf_hub_download is _guarded:
+                    return original(*args, **kwargs)
+        raise PretrainedWeightsUnavailableError(
+            unavailable_message(model_name=model_name, stage=stage, location=kwargs.get("filename"))
+        )
+
+    for module, _ in originals:
+        module.hf_hub_download = _guarded
+    try:
+        yield
+    finally:
+        for module, original in originals:
+            module.hf_hub_download = original

--- a/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
+++ b/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
@@ -66,6 +66,13 @@ class TabICLModel(AbstractTorchModel):
         # context (kv_cache is off by default) — a 1024-row cap made a 100k-row
         # predict ~100x slower while saving no VRAM.
         "max_batch_size": None,
+        # Keep tabicl's own default: its __getstate__ drops `model_` from the pickle and
+        # __setstate__ rebuilds it from the checkpoint, so AutoGluon has always saved TabICL
+        # without weights. Defaulting to True here would silently turn a 0.02 MB artifact into
+        # ~105 MB per model (and per bagged fold). The trade is the same one the option names:
+        # a small artifact that needs the checkpoint resolvable at load, versus a self-contained
+        # one. Set `ag.save_pretrained_weights=True` for the latter.
+        "save_pretrained_weights": False,
     }
     _default_ag_args_ensemble_extra = {
         "fold_fitting_strategy": "sequential_local",
@@ -208,6 +215,38 @@ class TabICLModel(AbstractTorchModel):
             X = self.preprocess(X, **kwargs)
             return np.asarray(self.model.predict(X, output_type="quantiles", alphas=self.quantile_levels))
         return super()._predict_proba(X=X, **kwargs)
+
+    def save(self, path: str | None = None, verbose: bool = True) -> str:
+        """Save the fitted estimator, embedding the foundation weights only when asked.
+
+        tabicl's own ``__getstate__`` drops ``model_`` from a plain pickle and its ``__setstate__``
+        rebuilds it from the checkpoint, so the *unflagged* behaviour already matches
+        ``ag.save_pretrained_weights=False`` -- and makes loading depend on the checkpoint still
+        being resolvable. The library exposes ``_save_model_weights`` to opt back in to a
+        self-contained artifact, so honoring ``ag.save_pretrained_weights=True`` means setting it.
+        """
+        if not self.is_fit() or not self.aux_params.save_pretrained_weights:
+            return super().save(path=path, verbose=verbose)
+
+        # Consumed by tabicl's __getstate__ during the pickle below, then removed.
+        self.model._save_model_weights = True
+        try:
+            return super().save(path=path, verbose=verbose)
+        finally:
+            del self.model._save_model_weights
+
+    @classmethod
+    def load(cls, path: str, reset_paths: bool = True, verbose: bool = True):
+        """Load the pickle, applying the load-stage weight-fetch policy.
+
+        When the weights were not embedded, tabicl's ``__setstate__`` reloads them from the
+        checkpoint -- a network fetch on a host with a cold cache. That unpickling happens inside
+        ``super().load``, so the policy has to be in force around it.
+        """
+        from ._weight_fetch import weight_fetch_policy
+
+        with weight_fetch_policy(stage="load", model_name=cls.__name__):
+            return super().load(path=path, reset_paths=reset_paths, verbose=verbose)
 
     def get_device(self) -> str:
         return self.model.device_.type

--- a/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
+++ b/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
@@ -10,6 +10,11 @@ import numpy as np
 import pandas as pd
 
 from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
+from autogluon.common.utils.pretrained_weights import (
+    PretrainedWeightsUnavailableError,
+    fetch_allowed,
+    unavailable_message,
+)
 from autogluon.tabular import __version__
 from autogluon.tabular.models.abstract.abstract_torch_model import AbstractTorchModel
 
@@ -172,16 +177,31 @@ class TabICLModel(AbstractTorchModel):
         # resolve the per-problem-type form of the `checkpoint_version` hyperparameter (a bare
         # string, or a `(classification, regression)` tuple) that the library itself does not accept.
         hyp["checkpoint_version"] = self.get_checkpoint_version(hyperparameter=hyp)
+        # tabicl exposes the fetch decision on the estimator itself, so `ag.fetch_pretrained_weights`
+        # needs no interception here. The guard only ever tightens: it can force fetching off, but a
+        # user who explicitly set `allow_auto_download=False` keeps that.
+        fetch_blocked_by_policy = not fetch_allowed(self.aux_params.fetch_pretrained_weights, stage="fit")
+        if fetch_blocked_by_policy:
+            hyp["allow_auto_download"] = False
         self.model = model_cls(
             **hyp,
             device=device,
             n_jobs=num_cpus,
         )
         X = self.preprocess(X, y=y, is_train=True)
-        self.model = self.model.fit(
-            X=X,
-            y=y,
-        )
+        try:
+            self.model = self.model.fit(
+                X=X,
+                y=y,
+            )
+        except ValueError as err:
+            # Re-raise tabicl's "not cached and automatic download is disabled" as the shared error,
+            # so the message names the option that caused it rather than the library's own flag.
+            if fetch_blocked_by_policy and "download is disabled" in str(err):
+                raise PretrainedWeightsUnavailableError(
+                    unavailable_message(model_name=self.name, stage="fit")
+                ) from err
+            raise
 
     def _predict_proba(self, X, **kwargs) -> np.ndarray:
         if self.problem_type == "quantile":

--- a/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
+++ b/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
@@ -18,6 +18,8 @@ from autogluon.common.utils.pretrained_weights import (
 from autogluon.tabular import __version__
 from autogluon.tabular.models.abstract.abstract_torch_model import AbstractTorchModel
 
+from ._weight_fetch import weight_fetch_policy
+
 logger = logging.getLogger(__name__)
 
 
@@ -243,8 +245,6 @@ class TabICLModel(AbstractTorchModel):
         checkpoint -- a network fetch on a host with a cold cache. That unpickling happens inside
         ``super().load``, so the policy has to be in force around it.
         """
-        from ._weight_fetch import weight_fetch_policy
-
         with weight_fetch_policy(stage="load", model_name=cls.__name__):
             return super().load(path=path, reset_paths=reset_paths, verbose=verbose)
 

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/_weight_fetch.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/_weight_fetch.py
@@ -1,11 +1,11 @@
-"""Policy gate for fetching TabPFN's pretrained weights from a remote source.
+"""Enforcement of ``ag.fetch_pretrained_weights`` for TabPFN.
 
 ``tabpfn`` already has the right primitive -- ``load_model_criterion_config(...,
-download_if_not_exists=...)`` -- but ``tabpfn.base`` hardcodes it to ``True`` (see
-``tabpfn/base.py``), so the estimator API offers no way to turn fetching off. Until that is
-exposed upstream, gate the single function that performs the fetch.
+download_if_not_exists=...)`` -- but ``tabpfn/base.py`` hardcodes it to ``True``, so the estimator
+API offers no way to turn fetching off. Until that is exposed upstream, gate the single function
+that performs the fetch.
 
-``HF_HUB_OFFLINE`` is not sufficient: ``download_model`` falls back to
+``HF_HUB_OFFLINE`` is not sufficient here: ``download_model`` falls back to
 ``urllib.request.urlopen`` against huggingface.co when the ``huggingface_hub`` path fails, so an
 HF-level switch only changes *which* code path reaches the network.
 """
@@ -13,80 +13,33 @@ HF-level switch only changes *which* code path reaches the network.
 from __future__ import annotations
 
 import contextlib
-import logging
-import os
 from typing import Iterator
 
-logger = logging.getLogger(__name__)
+from autogluon.common.utils.pretrained_weights import (
+    PretrainedWeightsUnavailableError,
+    fetch_allowed,
+    unavailable_message,
+)
 
-#: Deployment-level override, mirroring ``AG_ALLOW_PICKLE_FROM_URL``. A serving host sets this to
-#: forbid fetches regardless of what the fitted artifact was pickled with.
-FETCH_ENV_VAR = "AG_FETCH_PRETRAINED_WEIGHTS"
-
-FIT_ONLY = "fit_only"
-
-
-class PretrainedWeightsUnavailableError(RuntimeError):
-    """Weights are absent locally and the active policy forbids fetching them."""
-
-
-def resolve_policy(aux_value: bool | str) -> bool | str:
-    """Environment beats the fitted artifact, matching the ``AG_ALLOW_PICKLE_FROM_URL`` precedent."""
-    raw = os.environ.get(FETCH_ENV_VAR)
-    if raw is None:
-        return aux_value
-    lowered = raw.strip().lower()
-    if lowered in ("true", "1"):
-        return True
-    if lowered in ("false", "0"):
-        return False
-    if lowered == FIT_ONLY:
-        return FIT_ONLY
-    raise ValueError(f"{FETCH_ENV_VAR}={raw!r} is not understood; expected one of True, False, {FIT_ONLY!r}.")
-
-
-def fetch_allowed(aux_value: bool | str, *, stage: str) -> bool:
-    """Whether a remote fetch is permitted at ``stage`` ("fit" or "load")."""
-    policy = resolve_policy(aux_value)
-    if policy is True:
-        return True
-    if policy is False:
-        return False
-    if policy == FIT_ONLY:
-        return stage == "fit"
-    raise ValueError(
-        f"ag.fetch_pretrained_weights={policy!r} is not understood; expected True, False, or {FIT_ONLY!r}."
-    )
+__all__ = ["weight_fetch_policy"]
 
 
 @contextlib.contextmanager
-def no_remote_fetch(*, stage: str, model_name: str) -> Iterator[None]:
-    """Make a missing checkpoint raise instead of silently reaching the network."""
+def weight_fetch_policy(aux_value: bool | str, *, stage: str, model_name: str) -> Iterator[None]:
+    """No-op when fetching is allowed; otherwise make a missing checkpoint raise."""
+    if fetch_allowed(aux_value, stage=stage):
+        yield
+        return
+
     import tabpfn.model_loading as model_loading
 
     original = model_loading.download_model
 
     def _blocked(to, *args, **kwargs):
-        raise PretrainedWeightsUnavailableError(
-            f"{model_name} needs pretrained weights that are not in the local cache, and "
-            f"fetching them is disabled at {stage} time "
-            f"(ag.fetch_pretrained_weights / {FETCH_ENV_VAR}).\n"
-            f"Expected location: {to}\n"
-            f"Either pre-populate the cache on this machine, or allow fetching."
-        )
+        raise PretrainedWeightsUnavailableError(unavailable_message(model_name=model_name, stage=stage, location=to))
 
     model_loading.download_model = _blocked
     try:
         yield
     finally:
         model_loading.download_model = original
-
-
-@contextlib.contextmanager
-def weight_fetch_policy(aux_value: bool | str, *, stage: str, model_name: str) -> Iterator[None]:
-    """No-op when fetching is allowed; otherwise block it for the duration."""
-    if fetch_allowed(aux_value, stage=stage):
-        yield
-    else:
-        with no_remote_fetch(stage=stage, model_name=model_name):
-            yield

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/_weight_fetch.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/_weight_fetch.py
@@ -1,0 +1,92 @@
+"""Policy gate for fetching TabPFN's pretrained weights from a remote source.
+
+``tabpfn`` already has the right primitive -- ``load_model_criterion_config(...,
+download_if_not_exists=...)`` -- but ``tabpfn.base`` hardcodes it to ``True`` (see
+``tabpfn/base.py``), so the estimator API offers no way to turn fetching off. Until that is
+exposed upstream, gate the single function that performs the fetch.
+
+``HF_HUB_OFFLINE`` is not sufficient: ``download_model`` falls back to
+``urllib.request.urlopen`` against huggingface.co when the ``huggingface_hub`` path fails, so an
+HF-level switch only changes *which* code path reaches the network.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+from typing import Iterator
+
+logger = logging.getLogger(__name__)
+
+#: Deployment-level override, mirroring ``AG_ALLOW_PICKLE_FROM_URL``. A serving host sets this to
+#: forbid fetches regardless of what the fitted artifact was pickled with.
+FETCH_ENV_VAR = "AG_FETCH_PRETRAINED_WEIGHTS"
+
+FIT_ONLY = "fit_only"
+
+
+class PretrainedWeightsUnavailableError(RuntimeError):
+    """Weights are absent locally and the active policy forbids fetching them."""
+
+
+def resolve_policy(aux_value: bool | str) -> bool | str:
+    """Environment beats the fitted artifact, matching the ``AG_ALLOW_PICKLE_FROM_URL`` precedent."""
+    raw = os.environ.get(FETCH_ENV_VAR)
+    if raw is None:
+        return aux_value
+    lowered = raw.strip().lower()
+    if lowered in ("true", "1"):
+        return True
+    if lowered in ("false", "0"):
+        return False
+    if lowered == FIT_ONLY:
+        return FIT_ONLY
+    raise ValueError(f"{FETCH_ENV_VAR}={raw!r} is not understood; expected one of True, False, {FIT_ONLY!r}.")
+
+
+def fetch_allowed(aux_value: bool | str, *, stage: str) -> bool:
+    """Whether a remote fetch is permitted at ``stage`` ("fit" or "load")."""
+    policy = resolve_policy(aux_value)
+    if policy is True:
+        return True
+    if policy is False:
+        return False
+    if policy == FIT_ONLY:
+        return stage == "fit"
+    raise ValueError(
+        f"ag.fetch_pretrained_weights={policy!r} is not understood; expected True, False, or {FIT_ONLY!r}."
+    )
+
+
+@contextlib.contextmanager
+def no_remote_fetch(*, stage: str, model_name: str) -> Iterator[None]:
+    """Make a missing checkpoint raise instead of silently reaching the network."""
+    import tabpfn.model_loading as model_loading
+
+    original = model_loading.download_model
+
+    def _blocked(to, *args, **kwargs):
+        raise PretrainedWeightsUnavailableError(
+            f"{model_name} needs pretrained weights that are not in the local cache, and "
+            f"fetching them is disabled at {stage} time "
+            f"(ag.fetch_pretrained_weights / {FETCH_ENV_VAR}).\n"
+            f"Expected location: {to}\n"
+            f"Either pre-populate the cache on this machine, or allow fetching."
+        )
+
+    model_loading.download_model = _blocked
+    try:
+        yield
+    finally:
+        model_loading.download_model = original
+
+
+@contextlib.contextmanager
+def weight_fetch_policy(aux_value: bool | str, *, stage: str, model_name: str) -> Iterator[None]:
+    """No-op when fetching is allowed; otherwise block it for the duration."""
+    if fetch_allowed(aux_value, stage=stage):
+        yield
+    else:
+        with no_remote_fetch(stage=stage, model_name=model_name):
+            yield

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
@@ -234,11 +234,14 @@ class TabPFNModel(AbstractTorchModel):
                 del hps[k]
 
         # Model and fit
+        from ._weight_fetch import weight_fetch_policy
+
         self.model = model_base(**hps)
-        self.model = self.model.fit(
-            X=X,
-            y=y,
-        )
+        with weight_fetch_policy(self.aux_params.fetch_pretrained_weights, stage="fit", model_name=self.name):
+            self.model = self.model.fit(
+                X=X,
+                y=y,
+            )
         self._narrow_inference_context()
 
     def _narrow_inference_context(self):
@@ -307,7 +310,12 @@ class TabPFNModel(AbstractTorchModel):
         if model.model is None and os.path.exists(fit_path):
             from tabpfn import load_fitted_tabpfn_model
 
-            model.model = load_fitted_tabpfn_model(fit_path, device=model.suggest_device_infer(verbose=verbose))
+            from ._weight_fetch import weight_fetch_policy
+
+            # The sidecar carries no weights, so this reload can reach the network. That is the
+            # dependency `ag.save_pretrained_weights=False` trades the artifact size for.
+            with weight_fetch_policy(model.aux_params.fetch_pretrained_weights, stage="load", model_name=model.name):
+                model.model = load_fitted_tabpfn_model(fit_path, device=model.suggest_device_infer(verbose=verbose))
         return model
 
     def _predict_proba(self, X, **kwargs) -> np.ndarray:

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
@@ -9,6 +9,8 @@ import numpy as np
 
 from autogluon.tabular.models.abstract.abstract_torch_model import AbstractTorchModel
 
+from ._weight_fetch import weight_fetch_policy
+
 if TYPE_CHECKING:
     import pandas as pd
 
@@ -234,8 +236,6 @@ class TabPFNModel(AbstractTorchModel):
                 del hps[k]
 
         # Model and fit
-        from ._weight_fetch import weight_fetch_policy
-
         self.model = model_base(**hps)
         with weight_fetch_policy(self.aux_params.fetch_pretrained_weights, stage="fit", model_name=self.name):
             self.model = self.model.fit(
@@ -309,8 +309,6 @@ class TabPFNModel(AbstractTorchModel):
         fit_path = os.path.join(path, cls.tabpfn_fit_file_name)
         if model.model is None and os.path.exists(fit_path):
             from tabpfn import load_fitted_tabpfn_model
-
-            from ._weight_fetch import weight_fetch_policy
 
             # The sidecar carries no weights, so this reload can reach the network. That is the
             # dependency `ag.save_pretrained_weights=False` trades the artifact size for.


### PR DESCRIPTION
## Description of changes

Two related auxiliary parameters for models that carry pretrained weights, wired across **TabPFN v2.5, TabPFN-3, TabICL, TabDPT and Nori**:

- **`ag.fetch_pretrained_weights`** (new) — may a model fetch weights from a remote source when they are absent from the local cache?
- **`ag.save_pretrained_weights`** (from #5865, previously TabPFN-only) — are the weights written into the artifact, or referenced?

Motivating cases: an air-gapped or VPC-isolated host, a benchmark run that must not vary with what a remote registry serves, and a serving container built with weights baked in that should fail loudly rather than silently re-download.

## `ag.fetch_pretrained_weights`: three-valued, not boolean

| value | fit | load |
|---|---|---|
| `True` (default) | fetch | fetch |
| `False` | raise | raise |
| `"fit_only"` | fetch | raise |

The middle state is not hypothetical. `ag.save_pretrained_weights=False` buys a small artifact by making inference reload weights from source — a network call on a host with a cold cache. **TabICL and Nori have always behaved that way by default**, so this exposure already exists in AutoGluon today. A boolean forces a choice between "inference may phone home" and "give up the artifact-size win"; `fit_only` matches how people deploy — a training host that may populate its cache, a serving host that must not reach out.

`AG_FETCH_PRETRAINED_WEIGHTS` overrides the value pickled into a fitted artifact, following the `AG_ALLOW_PICKLE_FROM_URL` precedent. An inference-time policy belongs to the deployment, not the model. For TabICL this is required rather than merely preferable: its reload happens inside `__setstate__` during unpickling, before the AutoGluon model object exists.

### Enforcement is per-package

Policy resolution lives in `autogluon.common.utils.pretrained_weights`; enforcement sits with each model, because the seam differs everywhere. The shared principle is **restrict resolution to the local cache rather than block the call**, so a provisioned machine keeps working with fetching disabled and only a real download is refused.

| model | seam |
|---|---|
| TabICL | `allow_auto_download` on the estimator — passed through, no interception |
| TabDPT (pinned ckpt) | AutoGluon's `_download_checkpoint`, which already probed the cache; only its fallback is gated |
| TabDPT (unpinned) | `TabDPTEstimator.__init__` resolves the library default — in `__init__`, not `fit` |
| Nori | `model_path` on `NoriRegressor` at fit; `synthefy_nori.hf.download_checkpoint` at predict |
| TabPFN | `download_model` interception — the only monkeypatch |

**TabPFN is the awkward one.** It already has the right primitive, `load_model_criterion_config(..., download_if_not_exists=...)`, but `tabpfn/base.py:183` hardcodes it to `True`, so the estimator API cannot express this. **`HF_HUB_OFFLINE` is not sufficient** either: `download_model` falls back to `urllib.request.urlopen` against huggingface.co when the `huggingface_hub` path fails, so an HF-level switch only changes *which* path reaches the network.

**Nori needed gating at predict, not fit.** It never holds the pretrained module — it builds its predictor lazily on the first `predict` and resolves the checkpoint then — so gating `_fit` alone left a model loaded on a cold serving host downloading weights on its first prediction, with `fit_only` in force.

## `ag.save_pretrained_weights`: measured

Median of 3 reps, fresh process per cell, regression on 2000x20, one GPU, warm HuggingFace cache. **Bold = each model's default, which is what it already did — no artifact changes size on this branch.**

| model | flag | fit s | save s | load s | infer s | disk MB |
|---|---|---|---|---|---|---|
| TabPFN v2.5 | **True** | **0.94** | **0.046** | **0.030** | **0.264** | **41.71** |
| TabPFN v2.5 | False | 0.95 | 0.109 | 0.079 | 0.260 | 2.24 |
| TabPFN-3 | **True** | **1.12** | **0.177** | **0.107** | **0.377** | **224.57** |
| TabPFN-3 | False | 1.13 | 0.106 | 0.246 | 0.372 | 1.80 |
| TabICL | True | 0.87 | 0.072 | 0.185 | 0.120 | 109.94 |
| TabICL | **False** | **0.93** | **0.021** | **0.175** | **0.119** | **0.94** |
| TabDPT | **True** | **1.09** | **0.185** | **0.129** | **0.137** | **242.84** |
| TabDPT | False | 1.11 | 0.000 | 0.240 | 0.139 | 0.33 |
| Nori | True | 0.32 | 0.133 | 0.000 | 0.762 | 45.29 |
| Nori | **False** | **0.33** | **0.000** | **0.000** | **0.770** | **0.17** |

Predictions are identical across flags and reps for every model.

**Fit and inference are unaffected everywhere.** The trade is disk against a few tens of ms of save/load, and it does not always run the same way:

| model | referencing weights costs / saves | disk |
|---|---|---|
| TabDPT | **saves 74 ms** per save+load cycle | 242.84 -> 0.33 MB (747x) |
| TabPFN-3 | costs 68 ms | 224.57 -> 1.80 MB (124x) |
| TabPFN v2.5 | costs 112 ms | 41.71 -> 2.24 MB (19x) |
| TabICL | saves 51 ms | 109.94 -> 0.94 MB (117x) |
| Nori | saves 133 ms | 45.29 -> 0.17 MB (264x) |

TabDPT is the clearest win: 242 MB smaller *and* faster, because skipping a 242 MB write more than pays for re-reading the checkpoint.

### Two caveats on the table

**`load_s` is not comparable across models.** Four of the five load weights eagerly, so their `load_s` includes it — TabDPT's rises 0.129 -> 0.240 s when referencing, which is exactly its checkpoint read. **Nori is lazy**: `load()` unpickles a ~10 KB file and sets a path string, so its `load_s` is genuinely ~0 and its weight loading is reported nowhere in this table. Instrumented separately, on first predict:

```
                          save=False (HF cache)   save=True (embedded)
first predict                    1.983 s                1.221 s
  predictor build                0.843 s (42%)          0.085 s (7%)
    of which 45 MB read          0.084 s                0.084 s
  inference proper               1.141 s                1.135 s
steady predict                   0.763 s                0.764 s
```

The 45 MB read is only 84 ms. The other **0.758 s is HuggingFace Hub path resolution on an already-warm cache** — so for Nori, `save_pretrained_weights=True` also makes the first prediction ~0.76 s faster, which matters for a serving process that loads a model and answers one request.

**`load_s` reflects a warm page cache.** On a cold serving host the referencing rows also carry the download, which is what `ag.fetch_pretrained_weights` governs.

## Verification

All fetch-policy checks use a genuinely cold HuggingFace cache. `HF_HOME` must be set **before interpreter start**; setting it in-process is too late, as `huggingface_hub` resolves the path at import — my first attempt did the latter and silently passed every case.

TabICL / TabDPT / TabDPTTurbo / Nori, fit stage:

```
warm cache + fetch=False    -> fit OK                            (provisioned machine unaffected)
cold cache + fetch=False    -> PretrainedWeightsUnavailableError (no network access)
cold cache + fetch=fit_only -> fit OK                            (fit stage permits it)
```

TabICL and Nori, load/inference stage, saved without weights then cache wiped:

```
unset                                -> OK, weights fetched
AG_FETCH_PRETRAINED_WEIGHTS=fit_only -> PretrainedWeightsUnavailableError
```

Nori self-containment, fitted on a warm cache and served from a cold host with fetching disabled:

```
save_pretrained_weights=True  (45.13 MB) -> predict OK, no fetch needed
save_pretrained_weights=False ( 0.01 MB) -> PretrainedWeightsUnavailableError
```

Round-tripping under `save_pretrained_weights=False` is bit-identical for every model (`max|delta| = 0.0`).

Suites: `test_tabdpt`, `test_tabdpt_turbo`, `test_nori`, `test_tabicl`, `test_tabpfn3` — 22 passed / 2 skipped; `common` 164 passed; `core/tests/unittests/models` 61 passed. `ruff format` and `ruff check --select I` clean. (`tabicl_model.py` has one pre-existing `F401` on master, outside CI's full-`ruff check` scope.)

## Open question for maintainers

Each model keeps the default it already had, so nothing changes size for existing users — but that leaves the family inconsistent: TabPFN v2.5 / TabPFN-3 / TabDPT default to self-contained, TabICL / Nori to referenced. That split follows each backend's own behaviour rather than a decision. If a single default across foundation models is preferred, it is a small change either way; flipping toward `False` would shrink TabPFN-3 and TabDPT artifacts by >100x but is a behaviour change for existing users.

## Follow-ups not in this PR

- Expose `download_if_not_exists` on the TabPFN estimator upstream, which would let the TabPFN gate drop its interception.
- **Mitra** and **TabPFNMix** also carry pretrained weights and are not wired up. Mitra already has `download_default_weights` with a docstring citing this exact use case ("useful to call when building a docker image").

Benchmark script: `bench_save_pretrained_weights.py` (available on request; kept out of the repo).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)