### PR TITLE
[tabular] Document holdout_frac as rows, validate it, and size refit_full

### DIFF
--- a/tabular/src/autogluon/tabular/configs/pipeline_presets.py
+++ b/tabular/src/autogluon/tabular/configs/pipeline_presets.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import numbers
 import warnings
 from dataclasses import dataclass, fields
 
@@ -63,10 +64,12 @@ class ValidationSizeCurves:
         ValidationSizeCurves(num_bag_sets=[[2_000, 5], 1])
         ValidationSizeCurves.from_input({"num_bag_sets": [[2_000, 5], 1]})  # equivalent
 
-    ``holdout_frac`` and ``dynamic_stacking`` have no default curve, because neither built-in
-    policy is a step function of size: ``holdout_frac`` is a continuous function of the row count,
-    and ``dynamic_stacking`` is derived from another knob (it defaults to ``not use_bag_holdout``).
-    A curve given here replaces that policy.
+    ``holdout_frac``, ``dynamic_stacking`` and ``refit_full`` have no default curve, because no
+    built-in policy for them is a step function of size: ``holdout_frac`` is a continuous function
+    of the row count, ``dynamic_stacking`` is derived from another knob (it defaults to ``not
+    use_bag_holdout``), and ``refit_full`` is a fixed ``False``. A curve given here replaces that
+    policy, which is how refitting can be asked for only above the size where bagging stops --
+    ``{"num_bag_folds": [[50_000, 8], 0], "refit_full": [[50_000, False], True]}``.
     """
 
     num_bag_folds: SizeCurve = None
@@ -75,6 +78,7 @@ class ValidationSizeCurves:
     num_stack_levels: SizeCurve = None
     holdout_frac: SizeCurve = None
     dynamic_stacking: SizeCurve = None
+    refit_full: SizeCurve = None
 
     @classmethod
     def from_input(cls, value: ValidationSizeCurves | dict | None) -> ValidationSizeCurves | None:
@@ -181,6 +185,53 @@ def _get_validation_preset(
     return resolved
 
 
+def _validate_holdout_frac(holdout_frac: float | int | None, num_train_rows: int, is_used: bool) -> None:
+    """Reject a `holdout_frac` that cannot produce a usable train/validation split.
+
+    An int is an absolute row count and a float is a fraction of the rows, matching
+    `sklearn.model_selection.train_test_split`'s `test_size`. The form is always checked; the
+    row arithmetic only when the value will actually be used, so a size that a bagged fit
+    ignores stays as harmless as it is today. Called only for a caller-supplied value.
+    """
+    if holdout_frac is None:
+        return
+    if isinstance(holdout_frac, bool):
+        raise ValueError(
+            f"`holdout_frac={holdout_frac}` is a bool, which is not a holdout size. Pass an int "
+            "for a number of rows, or a float between 0 and 1 for a fraction of them."
+        )
+    if isinstance(holdout_frac, numbers.Integral):
+        holdout_rows = int(holdout_frac)
+        reading = f"read as {holdout_rows} validation rows"
+        if holdout_rows < 1:
+            raise ValueError(
+                f"`holdout_frac={holdout_frac}` is an int, read as a number of validation rows, "
+                "so it must be at least 1. Pass a float between 0 and 1 for a fraction instead."
+            )
+    elif isinstance(holdout_frac, numbers.Real):
+        if not 0 < float(holdout_frac) < 1:
+            raise ValueError(
+                f"`holdout_frac={holdout_frac}` is a float, read as the fraction of rows to hold "
+                "out, so it must be between 0 and 1 (exclusive). Pass an int for an absolute "
+                "number of validation rows instead."
+            )
+        holdout_rows = int(num_train_rows * float(holdout_frac))
+        reading = f"a fraction of {num_train_rows} rows, read as {holdout_rows} validation rows"
+    else:
+        raise ValueError(
+            f"`holdout_frac` must be an int (rows) or a float between 0 and 1 (fraction), got: {holdout_frac!r}"
+        )
+
+    if not is_used:
+        return
+    train_rows = num_train_rows - holdout_rows
+    if holdout_rows < 1 or train_rows < 1:
+        raise ValueError(
+            f"`holdout_frac={holdout_frac}` is {reading}, leaving {train_rows} to train on out of "
+            f"{num_train_rows}; both sides of the split need at least 1 row."
+        )
+
+
 # TODO(refactor): use a data class for the config of the validation method.
 # TODO(improvement): Implement a more sophisticated solution.
 #   Could also use more metadata such as  num_features, num_models,
@@ -195,7 +246,7 @@ def get_validation_and_stacking_method(
     num_bag_folds: int | None,
     num_bag_sets: int | None,
     use_bag_holdout: bool | None,
-    holdout_frac: float | None,
+    holdout_frac: float | int | None,
     # Stacking/Pipeline parameters
     auto_stack: bool,
     num_stack_levels: int | None,
@@ -222,8 +273,9 @@ def get_validation_and_stacking_method(
         The number of repeats for cross-validation.
     use_bag_holdout: bool | None
         Whether to use (additional) holdout validation.
-    holdout_frac: float | None
-        The fraction of data to holdout for validation.
+    holdout_frac: float | int | None
+        How much data to hold out for validation: an int is a number of rows, a float between 0
+        and 1 is a fraction of them.
     auto_stack: bool
         Whether to automatically determine the stacking method.
     num_stack_levels: int | None
@@ -266,6 +318,9 @@ def get_validation_and_stacking_method(
     # `auto_stack` or derived from another knob.
     curve_overrides = ValidationSizeCurves.from_input(validation_size_curves)
     specified = set(curve_overrides.as_overrides()) if curve_overrides is not None else set()
+    # Only a caller-supplied value is validated below; the built-in policy is AutoGluon's own
+    # and must keep resolving for any size, however small.
+    holdout_frac_from_caller = holdout_frac is not None
 
     # Independent of `auto_stack`
     if use_bag_holdout is None:
@@ -277,7 +332,9 @@ def get_validation_and_stacking_method(
         # that derivation, so it can be sized independently.
         dynamic_stacking = cv_preset["dynamic_stacking"] if "dynamic_stacking" in specified else not use_bag_holdout
     if refit_full is None:
-        refit_full = False
+        # Like `dynamic_stacking`, `refit_full` has no size-based default; a curve replaces the
+        # fixed `False`, so refitting can be asked for only in the size regime that needs it.
+        refit_full = cv_preset["refit_full"] if "refit_full" in specified else False
 
     # Changed by `auto_stack` -- except where the caller gave a curve for the knob. Supplying a
     # curve is itself a request for size-driven selection of that knob, so `auto_stack` does not
@@ -354,6 +411,16 @@ def get_validation_and_stacking_method(
             )
             num_bag_folds = supported_num_bag_folds
             num_stack_levels = supported_num_stack_levels
+
+    if holdout_frac_from_caller:
+        _validate_holdout_frac(
+            holdout_frac=holdout_frac,
+            num_train_rows=num_train_rows,
+            # `holdout_frac` is only consulted for a non-bagged holdout or an explicit
+            # bag-holdout; bagging otherwise ignores it, and a size that could not be split is
+            # then as harmless as it has always been.
+            is_used=num_bag_folds < 2 or bool(use_bag_holdout),
+        )
 
     return (
         num_bag_folds,

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1127,7 +1127,7 @@ class TabularPredictor:
                 Final disk usage of predictor will be identical regardless of the setting after `predictor.delete_models(models_to_keep="best")` is called post-fit.
             set_best_to_refit_full : bool, default = False
                 If True, will change the default model that Predictor uses for prediction when model is not specified to the refit_full version of the model that exhibited the highest validation score.
-                Only valid if `refit_full` is set, or if `validation_size_curves` gives `refit_full` a curve.
+                Requires `refit_full` to be set, or `validation_size_curves` to give `refit_full` a curve; otherwise it is disabled with a warning, since no refit model would exist to select.
                 With a curve it means "serve the refit when the size regime produces one", and is inert in the regimes that do not refit, so it needs no curve of its own.
             keep_only_best : bool, default = False
                 If True, only the best model and its ancestor models are saved in the outputted `predictor`. All other models are deleted.
@@ -6086,10 +6086,15 @@ class TabularPredictor:
                 "`refit_full=True` is only available when `cache_data=True`. Set `cache_data=True` to utilize `refit_full`."
             )
         if set_best_to_refit_full and not refit_full and not _has_refit_full_curve(kwargs_sanitized):
-            raise ValueError(
-                "`set_best_to_refit_full=True` is only available when `refit_full=True`, or when "
-                "`validation_size_curves` gives `refit_full` a curve. Set `refit_full=True` to utilize `set_best_to_refit_full`."
+            # Not fatal: there is simply no refit model to promote, so the flag has nothing to do.
+            refit_state = "is not set" if refit_full is None else f"is {refit_full}"
+            logger.log(
+                30,
+                f"Warning: `set_best_to_refit_full={set_best_to_refit_full}` is disabled because "
+                f"`refit_full` {refit_state}, so no refit model will exist to select. Set "
+                "`refit_full=True`, or give `refit_full` a curve in `validation_size_curves`, to use it.",
             )
+            kwargs_sanitized["set_best_to_refit_full"] = False
         valid_calibrate_options = [True, False, "auto"]
         calibrate = kwargs_sanitized["calibrate"]
         if calibrate not in valid_calibrate_options:

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -932,15 +932,17 @@ class TabularPredictor:
                 with data size, as a `ValidationSizeCurves` or an equivalent dict. The curve format
                 and the set of tunable knobs may change in a future release.
                 Each entry maps one knob -- `num_bag_folds`, `num_bag_sets`, `use_bag_holdout`,
-                `num_stack_levels`, `holdout_frac`, `dynamic_stacking` -- to either a fixed value or a size curve
+                `num_stack_levels`, `holdout_frac`, `dynamic_stacking`, `refit_full` -- to either a fixed value or a size curve
                 `[[rows, value], ..., fallback]`, read as "use `value` at or below `rows`", with the
                 trailing entry applying above every anchor. Only the entries given are overridden;
                 the rest keep their defaults, and an explicit `num_bag_folds` / `num_bag_sets` /
-                `use_bag_holdout` / `num_stack_levels` / `dynamic_stacking` argument still wins over any
+                `use_bag_holdout` / `num_stack_levels` / `dynamic_stacking` / `refit_full` argument still wins over any
                 curve. A knob given a curve is not overridden by `auto_stack`, since supplying the curve
                 is itself a request for size-driven selection of it.
                     `validation_size_curves={'num_bag_sets': [[2000, 5], 1]}` -> 5 repeats at or below
                     2000 rows and 1 above, i.e. repeated cross-validation on small data.
+                    `validation_size_curves={'num_bag_folds': [[50000, 8], 0], 'refit_full': [[50000, False], True]}`
+                    -> bag below 50000 rows, and above it validate on a holdout and refit on all the data.
                 Read at the number of groups instead of rows when `validation_structure` sets
                 `size_validation_on_groups`.
             num_stack_levels : int, default = None
@@ -956,8 +958,9 @@ class TabularPredictor:
                         more overfitting.
                     If False, AutoGluon repeats kfold bagging immediately after evaluating each model.
                         Thus, AutoGluon might evaluate fewer models with less overfitting.
-            holdout_frac : float, default = None
-                Fraction of train_data to holdout as tuning data for optimizing hyperparameters (ignored unless `tuning_data = None`, ignored if `num_bag_folds != 0` unless `use_bag_holdout == True`).
+            holdout_frac : float | int, default = None
+                How much of train_data to holdout as tuning data for optimizing hyperparameters (ignored unless `tuning_data = None`, ignored if `num_bag_folds != 0` unless `use_bag_holdout == True`).
+                A float between 0 and 1 is a fraction of the rows; an int is an absolute number of rows, which keeps the validation set a fixed size as the data grows.
                 Default value (if None) is selected based on the number of rows in the training data. Default values range from 0.2 at 2,500 rows to 0.01 at 250,000 rows.
                 Default value is doubled if `hyperparameter_tune_kwargs` is set, up to a maximum of 0.2.
                 Disabled if `num_bag_folds >= 2` unless `use_bag_holdout == True`.
@@ -1083,8 +1086,9 @@ class TabularPredictor:
                 Reference `hyperparameters` documentation for what models correspond to each value.
                 Useful when a particular model type such as 'KNN' or 'custom' is not desired but altering the `hyperparameters` dictionary is difficult or time-consuming.
                     Example: To exclude both 'KNN' and 'custom' models, specify `excluded_model_types=['KNN', 'custom']`.
-            refit_full : bool or str, default = False
+            refit_full : bool or str, default = None
                 Whether to retrain all models on all of the data (training + validation) after the normal training procedure.
+                If None, refitting does not occur unless `validation_size_curves` gives `refit_full` a curve.
                 This is equivalent to calling `predictor.refit_full(model=refit_full)` after fit.
                 If `refit_full=True`, it will be treated as `refit_full='all'`.
                 If `refit_full=False`, refitting will not occur.
@@ -2223,7 +2227,7 @@ class TabularPredictor:
     def _post_fit(
         self,
         keep_only_best=False,
-        refit_full=False,
+        refit_full=None,
         set_best_to_refit_full=False,
         save_space=False,
         calibrate=False,
@@ -2247,6 +2251,11 @@ class TabularPredictor:
 
             logger.log(30, "Warning: No models found, skipping post_fit logic...")
             return
+
+        if refit_full is None:
+            # Unspecified. `fit` resolves this before calling, but `fit_extra` passes the raw
+            # argument, and the `is not False` check below would read None as a request.
+            refit_full = False
 
         if refit_full is True:
             if keep_only_best is True:
@@ -5954,7 +5963,7 @@ class TabularPredictor:
             set_best_to_refit_full=False,
             keep_only_best=False,
             save_space=False,
-            refit_full=False,
+            refit_full=None,
             save_bag_folds=None,
             # other
             verbosity=self.verbosity,

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -72,6 +72,7 @@ from ..configs.feature_generator_presets import get_default_feature_generator
 from ..configs.hyperparameter_configs import get_hyperparameter_config
 from ..configs.pipeline_presets import (
     USE_BAG_HOLDOUT_AUTO_THRESHOLD,
+    ValidationSizeCurves,
     get_validation_and_stacking_method,
 )
 from ..configs.presets_configs import tabular_presets_alias, tabular_presets_dict
@@ -1126,7 +1127,8 @@ class TabularPredictor:
                 Final disk usage of predictor will be identical regardless of the setting after `predictor.delete_models(models_to_keep="best")` is called post-fit.
             set_best_to_refit_full : bool, default = False
                 If True, will change the default model that Predictor uses for prediction when model is not specified to the refit_full version of the model that exhibited the highest validation score.
-                Only valid if `refit_full` is set.
+                Only valid if `refit_full` is set, or if `validation_size_curves` gives `refit_full` a curve.
+                With a curve it means "serve the refit when the size regime produces one", and is inert in the regimes that do not refit, so it needs no curve of its own.
             keep_only_best : bool, default = False
                 If True, only the best model and its ancestor models are saved in the outputted `predictor`. All other models are deleted.
                     If you only care about deploying the most accurate predictor with the smallest file-size and no longer need any of the other trained models or functionality beyond prediction on new data, then set: `keep_only_best=True`, `save_space=True`.
@@ -6083,9 +6085,10 @@ class TabularPredictor:
             raise ValueError(
                 "`refit_full=True` is only available when `cache_data=True`. Set `cache_data=True` to utilize `refit_full`."
             )
-        if set_best_to_refit_full and not refit_full:
+        if set_best_to_refit_full and not refit_full and not _has_refit_full_curve(kwargs_sanitized):
             raise ValueError(
-                "`set_best_to_refit_full=True` is only available when `refit_full=True`. Set `refit_full=True` to utilize `set_best_to_refit_full`."
+                "`set_best_to_refit_full=True` is only available when `refit_full=True`, or when "
+                "`validation_size_curves` gives `refit_full` a curve. Set `refit_full=True` to utilize `set_best_to_refit_full`."
             )
         valid_calibrate_options = [True, False, "auto"]
         calibrate = kwargs_sanitized["calibrate"]
@@ -6878,3 +6881,13 @@ def _dystack(
         predictor._sub_fits.append(ds_fit_context)
 
     return stacked_overfitting, ho_leaderboard, None
+
+
+def _has_refit_full_curve(kwargs: dict) -> bool:
+    """Whether `validation_size_curves` decides `refit_full` from the row count.
+
+    The curve is read during `fit`, after the kwargs are validated, so an unset `refit_full`
+    at validation time is not yet an answer.
+    """
+    curves = ValidationSizeCurves.from_input(kwargs.get("validation_size_curves"))
+    return curves is not None and "refit_full" in curves.as_overrides()

--- a/tabular/tests/unittests/configs/test_validation_size_curves.py
+++ b/tabular/tests/unittests/configs/test_validation_size_curves.py
@@ -354,3 +354,92 @@ def test__dynamic_stacking_curve_is_read_at_the_sample_size():
 def test__explicit_dynamic_stacking_argument_beats_its_curve():
     """As for every other knob, an explicit argument wins over the curve."""
     assert _resolve_dynamic_stacking({"dynamic_stacking": True}, dynamic_stacking=False)[0] is False
+
+
+def _resolve_method(num_train_rows: int, **kwargs):
+    """Resolve the validation method, returning it as a dict of knob -> value."""
+    kwargs.setdefault("num_bag_folds", None)
+    kwargs.setdefault("holdout_frac", None)
+    kwargs.setdefault("refit_full", None)
+    kwargs.setdefault("validation_size_curves", None)
+    resolved = get_validation_and_stacking_method(
+        num_bag_sets=None,
+        use_bag_holdout=None,
+        auto_stack=False,
+        num_stack_levels=None,
+        dynamic_stacking=None,
+        num_train_rows=num_train_rows,
+        problem_type="binary",
+        hpo_enabled=False,
+        n_samples_minority_class=None,
+        **kwargs,
+    )
+    keys = [
+        "num_bag_folds",
+        "num_bag_sets",
+        "num_stack_levels",
+        "dynamic_stacking",
+        "use_bag_holdout",
+        "holdout_frac",
+        "refit_full",
+    ]
+    return dict(zip(keys, resolved))
+
+
+def test__refit_full__has_no_default_curve():
+    """Without a curve `refit_full` stays False, whatever the size."""
+    assert _resolve_method(1_000)["refit_full"] is False
+    assert _resolve_method(1_000_000)["refit_full"] is False
+
+
+def test__refit_full__curve_sizes_it_like_any_other_knob():
+    """Refit only in the regime where bagging has stopped, without a caller-side size check."""
+    curves = {"num_bag_folds": [[50_000, 8], 0], "refit_full": [[50_000, False], True]}
+    below = _resolve_method(10_000, validation_size_curves=curves)
+    above = _resolve_method(60_000, validation_size_curves=curves)
+    assert (below["num_bag_folds"], below["refit_full"]) == (8, False)
+    assert (above["num_bag_folds"], above["refit_full"]) == (0, True)
+
+
+def test__explicit_refit_full_argument_beats_its_curve():
+    """As for every other knob, an explicit argument wins over the curve."""
+    resolved = _resolve_method(60_000, validation_size_curves={"refit_full": True}, refit_full=False)
+    assert resolved["refit_full"] is False
+
+
+def test__holdout_frac__int_is_an_absolute_row_count():
+    """An int passes through as rows; sklearn's `test_size` reads it that way."""
+    assert _resolve_method(60_000, holdout_frac=10_000, num_bag_folds=0)["holdout_frac"] == 10_000
+
+
+@pytest.mark.parametrize(
+    "holdout_frac,message",
+    [
+        (1.5, "must be between 0 and 1"),
+        (0.0, "must be between 0 and 1"),
+        (0, "must be at least 1"),
+        (True, "is a bool"),
+        ("0.2", "must be an int .rows. or a float"),
+    ],
+)
+def test__holdout_frac__rejects_values_that_are_not_a_size(holdout_frac, message):
+    with pytest.raises(ValueError, match=message):
+        _resolve_method(1_000, holdout_frac=holdout_frac, num_bag_folds=0)
+
+
+@pytest.mark.parametrize("holdout_frac", [1_000, 2_000])
+def test__holdout_frac__rejects_a_split_with_an_empty_side(holdout_frac):
+    """Both sides need a row: the error says how the value was read and what it left."""
+    with pytest.raises(ValueError, match="both sides of the split need at least 1 row"):
+        _resolve_method(1_000, holdout_frac=holdout_frac, num_bag_folds=0)
+
+
+def test__holdout_frac__is_not_validated_when_bagging_ignores_it():
+    """Bagging ignores `holdout_frac`, so an unusable size stays as harmless as it was."""
+    resolved = _resolve_method(5_000, holdout_frac=10_000, validation_size_curves={"num_bag_folds": 8})
+    assert resolved["num_bag_folds"] == 8
+
+
+def test__holdout_frac__built_in_policy_is_never_rejected():
+    """The default is AutoGluon's own and must resolve at any size, however small."""
+    assert _resolve_method(1, num_bag_folds=0)["holdout_frac"] > 0

--- a/tabular/tests/unittests/configs/test_validation_size_curves.py
+++ b/tabular/tests/unittests/configs/test_validation_size_curves.py
@@ -8,6 +8,7 @@ import pytest
 
 from autogluon.tabular.configs.pipeline_presets import (
     USE_BAG_HOLDOUT_AUTO_THRESHOLD,
+    ValidationSizeCurves,
     _get_validation_preset,
     get_validation_and_stacking_method,
     resolve_size_curve,
@@ -443,3 +444,19 @@ def test__holdout_frac__is_not_validated_when_bagging_ignores_it():
 def test__holdout_frac__built_in_policy_is_never_rejected():
     """The default is AutoGluon's own and must resolve at any size, however small."""
     assert _resolve_method(1, num_bag_folds=0)["holdout_frac"] > 0
+
+
+def test__set_best_to_refit_full__is_allowed_alongside_a_refit_full_curve():
+    """The curve decides refitting from the row count, after the kwargs are validated.
+
+    `set_best_to_refit_full` needs no curve of its own: paired with a `refit_full` curve it
+    says "serve the refit when there is one", and is inert in the sizes that do not refit.
+    """
+    from autogluon.tabular.predictor.predictor import _has_refit_full_curve
+
+    assert _has_refit_full_curve({"validation_size_curves": {"refit_full": [[50_000, False], True]}})
+    assert _has_refit_full_curve({"validation_size_curves": ValidationSizeCurves(refit_full=True)})
+    # A curve for some other knob says nothing about refitting.
+    assert not _has_refit_full_curve({"validation_size_curves": {"num_bag_folds": 8}})
+    assert not _has_refit_full_curve({"validation_size_curves": None})
+    assert not _has_refit_full_curve({})

--- a/tabular/tests/unittests/configs/test_validation_size_curves.py
+++ b/tabular/tests/unittests/configs/test_validation_size_curves.py
@@ -460,3 +460,34 @@ def test__set_best_to_refit_full__is_allowed_alongside_a_refit_full_curve():
     assert not _has_refit_full_curve({"validation_size_curves": {"num_bag_folds": 8}})
     assert not _has_refit_full_curve({"validation_size_curves": None})
     assert not _has_refit_full_curve({})
+
+
+@pytest.mark.parametrize("refit_full", [None, False])
+def test__set_best_to_refit_full__is_disabled_with_a_warning_not_an_error(refit_full, caplog, monkeypatch):
+    """Nothing to promote is not a fit-stopping problem; say so and carry on."""
+    import logging
+
+    import pandas as pd
+    from sklearn.datasets import make_classification
+
+    from autogluon.tabular import TabularPredictor
+
+    X, y = make_classification(n_samples=200, n_features=4, random_state=0)
+    train_data = pd.DataFrame(X).rename(columns=str)
+    train_data["label"] = y
+
+    # AutoGluon's logger does not propagate, so caplog's root handler never sees its records.
+    monkeypatch.setattr(logging.getLogger("autogluon"), "propagate", True)
+
+    predictor = TabularPredictor(label="label", eval_metric="roc_auc", verbosity=2)
+    with caplog.at_level(logging.WARNING, logger="autogluon"):
+        predictor.fit(
+            train_data=train_data,
+            hyperparameters={"GBM": [{}]},
+            set_best_to_refit_full=True,
+            refit_full=refit_full,
+        )
+
+    assert "`set_best_to_refit_full=True` is disabled" in caplog.text
+    # The fit still produced a usable predictor, and nothing was promoted.
+    assert not any(name.endswith("_FULL") for name in predictor.model_names())


### PR DESCRIPTION
## Description

Changes to how the validation method is specified.

**`holdout_frac` accepts an int.** It always has — the value reaches `sklearn.model_selection.train_test_split`, whose `test_size` reads an int as an absolute row count — but it was typed and documented as a float only. A fixed-size validation set is usually what large-data configs want, so this documents it and widens the annotations.

**Invalid values are rejected with a message that says how they were read.**

```
`holdout_frac=1000` is read as 1000 validation rows, leaving 0 to train on out of 1000; both sides of the split need at least 1 row.
`holdout_frac=0.1` is a fraction of 4 rows, read as 0 validation rows, leaving 4 to train on out of 4; both sides of the split need at least 1 row.
`holdout_frac=0` is an int, read as a number of validation rows, so it must be at least 1. Pass a float between 0 and 1 for a fraction instead.
`holdout_frac=True` is a bool, which is not a holdout size. Pass an int for a number of rows, or a float between 0 and 1 for a fraction of them.
```

Two things are deliberately *not* validated: the built-in default policy, which is AutoGluon's own and must keep resolving at any size however small; and any value in a fit where bagging ignores `holdout_frac`, so a size that is inert today stays inert.

**`refit_full` becomes a `validation_size_curves` knob**, so refitting can be asked for only in the size regime that needs it:

```python
validation_size_curves={"num_bag_folds": [[50_000, 8], 0], "refit_full": [[50_000, False], True]}
```

Bag below 50k rows; above it, validate on a holdout and refit on all the data — with no size branch in the caller. Its fit default becomes `None` so an unspecified value can reach the curve; `_post_fit` normalizes `None`, which `fit_extra` needs since it passes the raw argument to a `refit_full is not False` check.

**`set_best_to_refit_full` no longer raises when there is nothing to promote.** It gets no curve of its own and does not need one, but its guard had two problems. It ran before the curve was read, so it refused the pairing even at sizes where the curve resolves to `True`; it now accepts a `refit_full` curve, where it means "serve the refit when the size regime produces one" and is inert in the regimes that do not refit. And having no refit model to select is not a reason to stop a fit, so it is now disabled with a warning rather than a `ValueError`:

```
Warning: `set_best_to_refit_full=True` is disabled because `refit_full` is not set, so no refit model will exist to select. Set `refit_full=True`, or give `refit_full` a curve in `validation_size_curves`, to use it.
```

The message distinguishes an unset `refit_full` from an explicit `False`.

## Testing

Twelve unit tests covering the int form, each rejection, the two non-validated cases, the `refit_full` curve, the `set_best_to_refit_full` pairing, and the disable-with-warning path. Verified end to end with real fits: the curve produces `LightGBM_FULL` above the threshold and no refit below it; `set_best_to_refit_full=True` promotes `LightGBM_FULL` to best above the threshold and changes nothing below; a fit with `set_best_to_refit_full=True` and no refit now warns and completes; and `fit_extra` does not refit under the new default.