### PR TITLE
[core] Reference pretrained weights by default instead of copying them

### DIFF
--- a/core/src/autogluon/core/models/abstract/_auxiliary_params.py
+++ b/core/src/autogluon/core/models/abstract/_auxiliary_params.py
@@ -127,13 +127,22 @@ class AuxiliaryParams:
     Models may declare the sentinel "auto" and resolve it to an int during `_fit`."""
     drop_unique: bool = field(default=True, metadata=_WRAPPER_ONLY)
     """Whether to drop features that have only 1 unique value."""
-    save_pretrained_weights: bool = field(default=True, metadata=_WRAPPER_ONLY)
+    save_pretrained_weights: bool = field(default=False, metadata=_WRAPPER_ONLY)
     """Whether a fitted model's pretrained weights are written into its pickle.
 
-    If False, the weights are referenced instead and reloaded from their source when the
-    model is loaded, which requires that source to still be resolvable. Trades a
-    self-contained save for a much smaller one. Only honored by models that carry
-    pretrained weights; ignored by every other model."""
+    Default False: the weights are referenced and reloaded from their source when the model is
+    loaded. They are identical for every model of a given checkpoint, so embedding them stores one
+    copy many times over -- once per distinct model in a portfolio, and again in every saved
+    predictor -- for hundreds of MB each. (Not once per bagged fold: models carrying pretrained
+    weights set ``refit_folds``, so a bag keeps a single copy.) Referencing them is also no slower
+    overall; skipping the write can more than pay for the re-read.
+
+    Set True for a self-contained artifact that needs neither the checkpoint nor a network at
+    inference. That is the right choice when the artifact will be moved to a host whose cache is
+    not provisioned, and it pairs with ``fetch_pretrained_weights=False`` to guarantee no fetch
+    can occur.
+
+    Only honored by models that carry pretrained weights; ignored by every other model."""
 
     fetch_pretrained_weights: bool | str = field(default=True, metadata=_WRAPPER_ONLY)
     """Whether pretrained weights may be fetched from a remote source when absent from the local cache.

--- a/tabular/src/autogluon/tabular/models/nori/nori_model.py
+++ b/tabular/src/autogluon/tabular/models/nori/nori_model.py
@@ -73,12 +73,6 @@ class NoriModel(AbstractTorchModel):
         # ~21 GB at 10k x 100, and ~58 GB at the 50k-row cap (100 features),
         # so the cap only fits on high-memory GPUs.
         "max_rows": 50000,
-        # Keep current behaviour: NoriRegressor never holds the pretrained module, so
-        # AutoGluon has always saved Nori without weights (~0.2 MB). Defaulting to True
-        # would copy the 45 MB checkpoint into every model directory and every bagged
-        # fold. Set `ag.save_pretrained_weights=True` for an artifact that needs no
-        # checkpoint at inference.
-        "save_pretrained_weights": False,
         # No feature cap: the model sees at most `_INTERNAL_MAX_FEATURES` columns whatever the
         # input width (see that attribute), so a wide fit costs no more memory than a 256-feature
         # one -- measured 8.8 GB at both 256 and 5000 features.

--- a/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
+++ b/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
@@ -68,13 +68,6 @@ class TabICLModel(AbstractTorchModel):
         # context (kv_cache is off by default) — a 1024-row cap made a 100k-row
         # predict ~100x slower while saving no VRAM.
         "max_batch_size": None,
-        # Keep tabicl's own default: its __getstate__ drops `model_` from the pickle and
-        # __setstate__ rebuilds it from the checkpoint, so AutoGluon has always saved TabICL
-        # without weights. Defaulting to True here would silently turn a 0.02 MB artifact into
-        # ~105 MB per model (and per bagged fold). The trade is the same one the option names:
-        # a small artifact that needs the checkpoint resolvable at load, versus a self-contained
-        # one. Set `ag.save_pretrained_weights=True` for the latter.
-        "save_pretrained_weights": False,
     }
     _default_ag_args_ensemble_extra = {
         "fold_fitting_strategy": "sequential_local",

--- a/tabular/tests/unittests/models/test_tabpfn3.py
+++ b/tabular/tests/unittests/models/test_tabpfn3.py
@@ -246,11 +246,31 @@ def test_tabpfn_save_keeps_foundation_weights_out_of_the_pickle(tmp_path, monkey
     assert loaded.model is estimator
 
 
-def test_tabpfn_save_pretrained_weights_default_keeps_the_estimator_in_the_pickle(tmp_path):
-    """The default is a self-contained save: the estimator stays in the pickle."""
+def test_tabpfn_references_pretrained_weights_by_default(tmp_path):
+    """The default is to reference the weights, not to write a copy per model.
+
+    The behaviour that follows from this default is covered by
+    `test_tabpfn_save_keeps_foundation_weights_out_of_the_pickle`, which stubs tabpfn's
+    save/load pair; this pins the default itself so a schema change cannot flip it silently.
+    """
     from autogluon.tabular.models.tabpfnv2.tabpfnv2_5_model import TabPFNModel
 
     model = TabPFNModel(problem_type="binary", eval_metric=None, path=str(tmp_path))
+    model.initialize()
+
+    assert model.aux_params.save_pretrained_weights is False
+
+
+def test_tabpfn_save_pretrained_weights_true_keeps_the_estimator_in_the_pickle(tmp_path):
+    """Opting in gives a self-contained save: the estimator stays in the pickle."""
+    from autogluon.tabular.models.tabpfnv2.tabpfnv2_5_model import TabPFNModel
+
+    model = TabPFNModel(
+        problem_type="binary",
+        eval_metric=None,
+        path=str(tmp_path),
+        hyperparameters={"ag.save_pretrained_weights": True},
+    )
     model.initialize()
     model.model = _stub_estimator(n_members=1, forced_inference_dtype=None)
     model.device = "cpu"  # normally set during fit; this test does not fit


### PR DESCRIPTION
> **Stacked on #5869.** Base is `remote-weights-policy`; review that one first. This PR is only the default flip — retarget to `master` once #5869 merges.

## Description of changes

#5869 wires `ag.save_pretrained_weights` across all five foundation models but deliberately keeps each model's existing default, leaving the family inconsistent: TabPFN v2.5, TabPFN-3 and TabDPT embed weights; TabICL and Nori reference them. That split follows each backend's own behaviour rather than a decision.

This PR makes the decision: flip the schema default to `False`, so every model carrying pretrained weights references its checkpoint. The per-model overrides TabICL and Nori needed are removed, since the schema now says it.

The weights are identical for every model of a given checkpoint, so embedding them stores one copy many times over a portfolio and over saved predictors.

## Effect

Default artifact size, regression on 2000x20:

| model | before | after |
|---|---|---|
| TabPFN v2.5 | 39.59 MB | **0.10 MB** |
| TabPFN-3 | 222.78 MB | **0.06 MB** |
| TabDPT | 242.54 MB | **0.02 MB** |
| TabICL | 0.07 MB | 0.07 MB *(already referenced)* |
| Nori | 0.01 MB | 0.01 MB *(already referenced)* |

Whole-predictor, 8-fold bag:

| model | before | after |
|---|---|---|
| TabDPT | 242.67 MB | **0.15 MB** |
| TabPFN-3 | 223.05 MB | **0.18 MB** |

**Referencing is not slower overall.** Skipping the write offsets the re-read, and for TabDPT it is a net **74 ms faster** per save+load cycle. Fit and inference times are unchanged for every model. Round-trips are bit-identical (`max|delta| = 0.0`) for all six classes, including TabDPTTurbo.

### A correction carried over from #5869

Several commit messages in #5869 say embedding costs a copy "per model **and per bagged fold**". That is wrong, and this PR's measurements are what showed it: these models set `refit_folds: True`, so an 8-fold TabDPT bag stores **one** 242 MB copy, not eight — `S1F1/model.pkl` is 242.57 MB while `S1F2..S1F8` are each ~0 MB. The multiplication is across distinct models in a portfolio and across saved predictors, not across folds.

#5869's description does not repeat the error, so nothing needs editing there; the corrected wording is in this PR's `save_pretrained_weights` docstring.

## This is a behaviour change

An artifact saved with the new default needs its checkpoint resolvable at load. Moving one to a host with an unprovisioned cache now requires a fetch where it previously did not.

The escape hatch is per-model or global:

```python
predictor.fit(..., hyperparameters={TabDPTModel: {"ag.save_pretrained_weights": True}})
```

and pairing it with `ag.fetch_pretrained_weights=False` (from #5869) guarantees a self-contained artifact that cannot reach the network at all.

Worth weighing against the alternative reading: the previous default silently wrote hundreds of MB per model, which is its own surprise, and one that scales with the number of foundation models in a portfolio.

## Tests

`test_tabpfn_save_pretrained_weights_default_keeps_the_estimator_in_the_pickle` asserted the old default and is replaced by two tests:

- `test_tabpfn_references_pretrained_weights_by_default` — pins the default itself, so a schema change cannot flip it silently. The behaviour it implies is already covered by `test_tabpfn_save_keeps_foundation_weights_out_of_the_pickle`, which stubs tabpfn's save/load pair.
- `test_tabpfn_save_pretrained_weights_true_keeps_the_estimator_in_the_pickle` — the opt-in path, previously untested as an explicit choice.

Suites: `test_tabdpt`, `test_tabdpt_turbo`, `test_nori`, `test_tabicl`, `test_tabpfn3` — 23 passed / 2 skipped; `core/tests/unittests/models` 61 passed. `ruff format` and `ruff check --select I` clean.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

