### PR TITLE
[tabular] Add validation_mode="none" with fixed ensemble weights, size-curve driven

### DIFF
--- a/tabular/src/autogluon/tabular/configs/pipeline_presets.py
+++ b/tabular/src/autogluon/tabular/configs/pipeline_presets.py
@@ -74,6 +74,20 @@ class ValidationSizeCurves:
     use_bag_holdout``), and ``refit_full`` is a fixed ``False``. A curve given here replaces that
     policy, which is how refitting can be asked for only above the size where bagging stops --
     ``{"num_bag_folds": [[50_000, 8], 0], "refit_full": [[50_000, False], True]}``.
+
+    ``validation_mode`` and ``ensemble_weights`` have no default curve either, and are the one
+    place where curves must agree with each other: ``validation_mode="none"`` is only valid with
+    no bagging and no stacking, so a curve that switches it must switch those at the same
+    threshold. :func:`get_validation_and_stacking_method` checks the resolved combination and
+    names the knobs that disagree, rather than letting the contradiction surface as a fit-time
+    error at only some data sizes::
+
+        {
+            "validation_mode": [[100, "none"], "auto"],
+            "num_bag_folds": [[100, 0], 8],
+            "num_stack_levels": [[100, 0], 1],
+            "ensemble_weights": [[100, {"TabPFN-3": 0.5, "TabICL": 0.5}], None],
+        }
     """
 
     num_bag_folds: SizeCurve = None
@@ -83,6 +97,8 @@ class ValidationSizeCurves:
     holdout_frac: SizeCurve = None
     dynamic_stacking: SizeCurve = None
     refit_full: SizeCurve = None
+    validation_mode: SizeCurve = None
+    ensemble_weights: SizeCurve = None
 
     @classmethod
     def from_input(cls, value: ValidationSizeCurves | dict | None) -> ValidationSizeCurves | None:
@@ -195,6 +211,84 @@ def _get_validation_preset(
             default_holdout_frac(num_train_rows=num_train_rows, hyperparameter_tune=hpo_enabled), 4
         )
     return resolved
+
+
+def resolve_validation_mode(
+    validation_mode: str | None,
+    ensemble_weights: dict | None,
+    num_bag_folds: int,
+    num_stack_levels: int,
+    num_train_rows: int,
+    validation_size_curves: ValidationSizeCurves | dict[str, SizeCurve] | None = None,
+    num_group_instances: int | None = None,
+    size_on_groups: bool = False,
+) -> tuple[str, dict | None]:
+    """Resolve ``validation_mode`` and ``ensemble_weights``, then check the combination.
+
+    Separate from :func:`get_validation_and_stacking_method` because the check needs that
+    function's *output*: whether ``validation_mode="none"`` is legal depends on the bagging and
+    stacking counts it settled. A caller-supplied value wins over its curve, as everywhere else.
+    """
+    overrides = ValidationSizeCurves.from_input(validation_size_curves)
+    specified = set(overrides.as_overrides()) if overrides is not None else set()
+    effective_size = resolve_effective_sample_size(
+        num_train_rows=num_train_rows,
+        num_group_instances=num_group_instances,
+        size_on_groups=size_on_groups,
+    )
+    if validation_mode is None:
+        validation_mode = (
+            resolve_size_curve(overrides.validation_mode, effective_size) if "validation_mode" in specified else "auto"
+        )
+        if validation_mode is None:
+            validation_mode = "auto"
+    if ensemble_weights is None and "ensemble_weights" in specified:
+        ensemble_weights = resolve_size_curve(overrides.ensemble_weights, effective_size)
+
+    if validation_mode not in ("auto", "none"):
+        raise ValueError(f"validation_mode must be 'auto' or 'none', got {validation_mode!r}.")
+
+    _validate_validation_mode_bundle(
+        validation_mode=validation_mode,
+        num_bag_folds=num_bag_folds,
+        num_stack_levels=num_stack_levels,
+        from_curves=specified,
+    )
+    return validation_mode, ensemble_weights
+
+
+def _validate_validation_mode_bundle(
+    validation_mode: str,
+    num_bag_folds: int,
+    num_stack_levels: int,
+    from_curves: set[str],
+) -> None:
+    """Reject a resolved combination that `validation_mode="none"` cannot support.
+
+    Curves resolve one knob at a time, so a threshold written into three of them and mistyped in
+    the fourth produces a band of data sizes where the knobs disagree -- and only that band fails.
+    Checking the resolved set turns that into one error naming the knobs, at the size where they
+    actually conflict.
+    """
+    if validation_mode != "none":
+        return
+    conflicts = []
+    if num_bag_folds:
+        conflicts.append(f"num_bag_folds={num_bag_folds}")
+    if num_stack_levels:
+        conflicts.append(f"num_stack_levels={num_stack_levels}")
+    if not conflicts:
+        return
+    source = (
+        "The size curves resolved to this combination at this data size; check that every curve "
+        "switches at the same threshold."
+        if "validation_mode" in from_curves
+        else "Set them to 0, or drop validation_mode='none'."
+    )
+    raise ValueError(
+        f"validation_mode='none' holds nothing out, so it cannot be combined with "
+        f"{' and '.join(conflicts)}. Both are defined by out-of-fold predictions. {source}"
+    )
 
 
 def _validate_holdout_frac(holdout_frac: float | int | None, num_train_rows: int, is_used: bool) -> None:

--- a/tabular/src/autogluon/tabular/configs/pipeline_presets.py
+++ b/tabular/src/autogluon/tabular/configs/pipeline_presets.py
@@ -87,7 +87,14 @@ class ValidationSizeCurves:
             "num_bag_folds": [[100, 0], 8],
             "num_stack_levels": [[100, 0], 1],
             "ensemble_weights": [[100, {"TabPFN-3": 0.5, "TabICL": 0.5}], None],
+            "hyperparameters": [[100, {"TABPFN-3": {}, "TABICL": {}}], "default"],
         }
+
+    ``hyperparameters`` is a curve for the same reason: ``ensemble_weights`` must name exactly the
+    models that were fit, so the two have to switch together or the weights are unusable below the
+    threshold and fine above it. It is resolved earlier than the rest -- the model portfolio decides
+    whether raw text features are enabled, and so shapes the feature generator -- which means it is
+    always read at the row count, never at the group count.
     """
 
     num_bag_folds: SizeCurve = None
@@ -99,6 +106,7 @@ class ValidationSizeCurves:
     refit_full: SizeCurve = None
     validation_mode: SizeCurve = None
     ensemble_weights: SizeCurve = None
+    hyperparameters: SizeCurve = None
 
     @classmethod
     def from_input(cls, value: ValidationSizeCurves | dict | None) -> ValidationSizeCurves | None:
@@ -211,6 +219,27 @@ def _get_validation_preset(
             default_holdout_frac(num_train_rows=num_train_rows, hyperparameter_tune=hpo_enabled), 4
         )
     return resolved
+
+
+def resolve_hyperparameters_curve(
+    hyperparameters,
+    num_train_rows: int,
+    validation_size_curves: ValidationSizeCurves | dict[str, SizeCurve] | None = None,
+):
+    """Resolve a ``hyperparameters`` size curve, if one was given.
+
+    Read at the row count rather than the effective size: this runs before ``validation_structure``
+    is resolved, so the group count is not yet known. The built-in ``holdout_frac`` policy is sized
+    on rows for its own reasons, so this is not a new exception in kind.
+
+    A caller-supplied ``hyperparameters`` wins over the curve, matching every other knob.
+    """
+    if hyperparameters is not None:
+        return hyperparameters
+    overrides = ValidationSizeCurves.from_input(validation_size_curves)
+    if overrides is None or overrides.hyperparameters is None:
+        return hyperparameters
+    return resolve_size_curve(overrides.hyperparameters, num_train_rows)
 
 
 def resolve_validation_mode(

--- a/tabular/src/autogluon/tabular/configs/pipeline_presets.py
+++ b/tabular/src/autogluon/tabular/configs/pipeline_presets.py
@@ -24,6 +24,10 @@ USE_BAG_HOLDOUT_AUTO_THRESHOLD = 1_000_000
 #:     [[1_000, 0.2], 0.1]          # hold out 20% up to 1k rows, 10% above
 SizeCurve = "int | float | bool | None | list"
 
+#: Marks "this curve supplied no trailing fallback", which `None` cannot: `None` is itself a
+#: legal curve value.
+_NO_FALLBACK = object()
+
 #: Defaults for the auto-selected validation method. Numerically identical to the arithmetic
 #: they replaced, so behavior is unchanged until a curve is overridden.
 #:
@@ -112,7 +116,7 @@ def resolve_size_curve(curve: SizeCurve, num_train_rows: int) -> int | float | b
     if not curve:
         raise ValueError("A size curve must not be empty.")
 
-    fallback = None
+    fallback = _NO_FALLBACK
     anchors: list[tuple[int, object]] = []
     for entry in curve:
         if isinstance(entry, (list, tuple)):
@@ -128,7 +132,13 @@ def resolve_size_curve(curve: SizeCurve, num_train_rows: int) -> int | float | b
     for rows, value in anchors:
         if num_train_rows <= rows:
             return value
-    return fallback if fallback is not None or not anchors else anchors[-1][1]
+    if fallback is not _NO_FALLBACK:
+        return fallback
+    # No trailing value: clamp to the top rung of the ladder. A sentinel rather than `None`
+    # distinguishes this from a curve that ends in an explicit `None`, which is a real value for
+    # several knobs ("no fixed weights", "use the built-in default") and is the natural way to
+    # write "on below X, off above X".
+    return anchors[-1][1] if anchors else None
 
 
 def resolve_effective_sample_size(
@@ -164,8 +174,10 @@ def _get_validation_preset(
     of :data:`DEFAULT_VALIDATION_SIZE_CURVES`,
     so a caller can retune one knob (e.g. repeats on small data) without restating the rest.
     ``size_on_groups`` reads the curves at the group count instead of the row count -- see
-    :func:`resolve_effective_sample_size`. ``holdout_frac`` is always sized on rows, since it
-    is a fraction of the rows actually held out.
+    :func:`resolve_effective_sample_size`. The *built-in* ``holdout_frac`` policy is always sized
+    on rows, since it is a fraction of the rows actually held out; a caller-supplied
+    ``holdout_frac`` curve is read at the effective size like every other curve, so under
+    ``size_on_groups`` it is read at the group count.
     """
     overrides = ValidationSizeCurves.from_input(validation_size_curves)
     curves = {**DEFAULT_VALIDATION_SIZE_CURVES, **(overrides.as_overrides() if overrides is not None else {})}

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -56,6 +56,8 @@ class DefaultLearner(AbstractTabularLearner):
         raise_on_model_failure: bool = False,
         time_limit_preprocessing: float | None = None,
         validation_structure=None,
+        no_validation: bool = False,
+        ensemble_weights: dict | None = None,
         **trainer_fit_kwargs,
     ):
         """Arguments:
@@ -162,6 +164,7 @@ class DefaultLearner(AbstractTabularLearner):
             use_bag_holdout=trainer_fit_kwargs.get("use_bag_holdout", False),
             time_limit=time_limit_for_preprocessing,
             validation_structure=validation_structure,
+            no_validation=no_validation,
         )
         if structure_splits is not None:
             # Every bagged model consumes the same structure-aware splits (CVSplitter reads
@@ -227,6 +230,8 @@ class DefaultLearner(AbstractTabularLearner):
             infer_limit=infer_limit,
             infer_limit_batch_size=infer_limit_batch_size,
             validation_structure=validation_structure,
+            no_validation=no_validation,
+            ensemble_weights=ensemble_weights,
             label_cleaner=copy.deepcopy(self.label_cleaner),
             **trainer_fit_kwargs,
         )
@@ -301,6 +306,7 @@ class DefaultLearner(AbstractTabularLearner):
         use_bag_holdout: bool = False,
         time_limit: float | None = None,
         validation_structure=None,
+        no_validation: bool = False,
     ):
         """General data processing steps used for all models."""
         X = self._check_for_non_finite_values(X, name="train", is_train=True)

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -58,6 +58,7 @@ class DefaultLearner(AbstractTabularLearner):
         validation_structure=None,
         no_validation: bool = False,
         ensemble_weights: dict | None = None,
+        ensemble_weights_missing: str = "error",
         **trainer_fit_kwargs,
     ):
         """Arguments:
@@ -232,6 +233,7 @@ class DefaultLearner(AbstractTabularLearner):
             validation_structure=validation_structure,
             no_validation=no_validation,
             ensemble_weights=ensemble_weights,
+            ensemble_weights_missing=ensemble_weights_missing,
             label_cleaner=copy.deepcopy(self.label_cleaner),
             **trainer_fit_kwargs,
         )

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -4558,17 +4558,28 @@ class TabularPredictor:
         return refit_full_dict
 
     @property
-    def model_best(self) -> str:
+    def model_best(self) -> str | None:
         """
         Returns the string model name of the best model by validation score that can infer.
         This is the same model used during inference when `predictor.predict` is called without specifying a model.
         This can be updated to be a model other than the model with best validation score by methods such as refit_full and set_model_best.
 
+        Returns None when several models are fit, none has a validation score
+        (`validation_mode="none"`), and no combination was given -- there is then no basis for a
+        best model. `predict` raises in that state rather than answering from an arbitrary one;
+        name a model per call, or combine them with `fit(..., ensemble_weights={...})`.
+
         Returns
         -------
-        String model name of the best model
+        String model name of the best model, or None if there is no basis to choose one.
         """
-        return self._model_best(can_infer=True)
+        from ..trainer.abstract_trainer import AmbiguousModelBestError
+
+        try:
+            return self._model_best(can_infer=True)
+        except AmbiguousModelBestError:
+            # Introspection should report the absence, not raise; `predict` is where it matters.
+            return None
 
     def _model_best(self, can_infer=None) -> str:
         self._assert_is_fit("model_best")

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1478,6 +1478,15 @@ class TabularPredictor:
         if validation_mode not in ("auto", "none"):
             raise ValueError(f"validation_mode must be 'auto' or 'none', got {validation_mode!r}.")
         no_validation = validation_mode == "none"
+        if no_validation and kwargs["holdout_frac"] is not None:
+            # Checked here rather than with the other `validation_mode="none"` guards below,
+            # because `_validate_holdout_frac` runs before those and would otherwise report a
+            # contradiction as a malformed size -- `holdout_frac=0` in particular becomes "an int,
+            # read as a number of validation rows, so it must be at least 1".
+            raise ValueError(
+                f"validation_mode='none' holds nothing out, so `holdout_frac={kwargs['holdout_frac']}` "
+                "cannot also apply. Drop one of the two."
+            )
         ensemble_weights = kwargs["ensemble_weights"]
         ensemble_weights_missing = kwargs["ensemble_weights_missing"]
         if ensemble_weights_missing not in ("error", "renormalize"):

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1541,6 +1541,11 @@ class TabularPredictor:
                     "validation_mode='none' cannot be combined with `validation_structure`, which describes how to "
                     "split validation data off. Specify one or the other."
                 )
+            if ensemble_weights is not None:
+                # Check the names before fitting anything. The trainer checks them again against
+                # the models that actually fitted, but that is after every base model has been
+                # trained -- a typo would otherwise cost the whole fit.
+                self._validate_ensemble_weight_names(ensemble_weights, hyperparameters)
             if ensemble_weights is None and fit_weighted_ensemble:
                 raise ValueError(
                     "validation_mode='none' leaves no data to learn ensemble weights from. Pass explicit weights, "
@@ -6018,6 +6023,66 @@ class TabularPredictor:
         valid_values = ["sequential", "parallel"]
         if fit_strategy not in valid_values:
             raise ValueError(f"fit_strategy must be one of {valid_values}. Value: {fit_strategy}")
+
+    @staticmethod
+    def _validate_ensemble_weight_names(ensemble_weights: dict, hyperparameters: dict) -> None:
+        """Reject `ensemble_weights` names that no requested model could produce, before fitting.
+
+        Names are the model names shown in `leaderboard()` (e.g. "LightGBM"), not the
+        `hyperparameters` keys (e.g. "GBM"). Those keys are the natural thing to reach for, so
+        say which is which rather than only listing what was unmatched.
+        """
+        from ..registry import ag_model_registry
+
+        if not isinstance(hyperparameters, dict):
+            return
+        # `hyperparameters` may be keyed by stack level; flatten one level if so.
+        keys: set = set()
+        for key, value in hyperparameters.items():
+            if isinstance(key, int) and isinstance(value, dict):
+                keys.update(value.keys())
+            else:
+                keys.add(key)
+
+        expected_names: set[str] = set()
+        key_for_name: dict[str, str] = {}
+        for key in keys:
+            model_cls = None
+            if isinstance(key, str):
+                try:
+                    model_cls = ag_model_registry.key_to_cls(key)
+                except (KeyError, ValueError, AssertionError):
+                    model_cls = None
+            elif isinstance(key, type):
+                model_cls = key
+            name = getattr(model_cls, "ag_name", None)
+            if name:
+                expected_names.add(name)
+                key_for_name[name] = key if isinstance(key, str) else getattr(model_cls, "ag_key", name)
+
+        if not expected_names:
+            return  # custom classes without ag_name; leave it to the trainer's check
+        unmatched = [n for n in ensemble_weights if n not in expected_names]
+        if unmatched:
+            # One key can produce several names: extra configs (`LightGBM_2`) and `name_suffix`,
+            # which concatenates directly (`LightGBMCustom`). There is no separator to key on, so
+            # any name extending a requested one might be legitimate and is left to the trainer's
+            # exact check. Only names that match nothing at all are rejected here -- a false
+            # rejection before fitting would be worse than a precise error after it.
+            unmatched = [n for n in unmatched if not any(n.startswith(e) for e in expected_names)]
+        if unmatched:
+            hint = ""
+            used_keys = [n for n in unmatched if n in keys]
+            if used_keys:
+                renames = {k: n for n, k in key_for_name.items() if k in used_keys}
+                hint = (
+                    f" {sorted(used_keys)} look like `hyperparameters` keys; "
+                    f"ensemble_weights uses model names, e.g. {renames}."
+                )
+            raise ValueError(
+                f"ensemble_weights names {sorted(unmatched)} do not match any requested model. "
+                f"Expected names from: {sorted(expected_names)}.{hint}"
+            )
 
     def _fit_extra_kwargs_dict(self) -> dict:
         """

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -74,6 +74,7 @@ from ..configs.pipeline_presets import (
     USE_BAG_HOLDOUT_AUTO_THRESHOLD,
     ValidationSizeCurves,
     get_validation_and_stacking_method,
+    resolve_validation_mode,
 )
 from ..configs.presets_configs import tabular_presets_alias, tabular_presets_dict
 from ..learner import AbstractTabularLearner, DefaultLearner
@@ -926,6 +927,18 @@ class TabularPredictor:
                 cannot be combined with bagging, stacking, `tuning_data` or `validation_structure`,
                 each of which is defined by holding rows out.
 
+                Can also be set by a size curve, to switch modes with the data size. Because
+                `validation_mode="none"` requires no bagging and no stacking, a curve that
+                switches it must switch those at the same threshold; the resolved combination is
+                checked, so a mismatch is reported rather than failing at only some sizes::
+
+                    validation_size_curves={
+                        "validation_mode": [[100, "none"], "auto"],
+                        "num_bag_folds": [[100, 0], 8],
+                        "num_stack_levels": [[100, 0], 1],
+                        "ensemble_weights": [[100, {"TabPFN-3": 0.5, "TabICL": 0.5}], None],
+                    }
+
                 Note that with no validation score, `leaderboard()` reports `score_val` as None for
                 every model, and anything that ranks models by validation performance -- model
                 selection, `predictor.fit_weighted_ensemble()`, calibration -- has nothing to rank.
@@ -1475,7 +1488,7 @@ class TabularPredictor:
         # validation method is chosen, because a grouped structure can supply the sample size
         # that method is chosen from (`size_validation_on_groups`).
         validation_mode = kwargs["validation_mode"]
-        if validation_mode not in ("auto", "none"):
+        if validation_mode is not None and validation_mode not in ("auto", "none"):
             raise ValueError(f"validation_mode must be 'auto' or 'none', got {validation_mode!r}.")
         no_validation = validation_mode == "none"
         if no_validation and kwargs["holdout_frac"] is not None:
@@ -1534,6 +1547,20 @@ class TabularPredictor:
             validation_size_curves=kwargs["validation_size_curves"],
         )
 
+        # Resolved after the knobs above, because whether `validation_mode="none"` is legal
+        # depends on the bagging and stacking counts they settled.
+        validation_mode, ensemble_weights = resolve_validation_mode(
+            validation_mode=validation_mode,
+            ensemble_weights=ensemble_weights,
+            num_bag_folds=num_bag_folds,
+            num_stack_levels=num_stack_levels,
+            num_train_rows=len(train_data),
+            validation_size_curves=kwargs["validation_size_curves"],
+            num_group_instances=num_group_instances,
+            size_on_groups=(validation_structure is not None and validation_structure.size_validation_on_groups),
+        )
+        no_validation = validation_mode == "none"
+
         num_bag_folds, num_bag_sets, num_stack_levels, dynamic_stacking, use_bag_holdout = self._sanitize_stack_args(
             num_bag_folds=num_bag_folds,
             num_bag_sets=num_bag_sets,
@@ -1546,19 +1573,9 @@ class TabularPredictor:
         )
 
         if no_validation:
-            # `validation_mode="none"` trains on every row and scores nothing. Stacking and bagging
-            # are defined by out-of-fold predictions, so they cannot coexist with it; refuse rather
-            # than silently produce a stack whose inputs are the training data.
-            if num_bag_folds:
-                raise ValueError(
-                    f"validation_mode='none' cannot be combined with bagging (num_bag_folds={num_bag_folds}). "
-                    "Bagging derives its validation from out-of-fold predictions, which requires holding rows out."
-                )
-            if num_stack_levels:
-                raise ValueError(
-                    f"validation_mode='none' cannot be combined with stacking (num_stack_levels={num_stack_levels}). "
-                    "Stacking is trained on out-of-fold predictions, which requires holding rows out."
-                )
+            # Bagging and stacking are rejected by `resolve_validation_mode` above, which sees the
+            # resolved counts and so catches a curve-driven combination too. What remains here is
+            # what that resolver cannot see: the data and ensemble arguments.
             if tuning_data is not None:
                 raise ValueError(
                     "validation_mode='none' cannot be combined with `tuning_data`. Pass the tuning rows as part of "
@@ -6138,7 +6155,7 @@ class TabularPredictor:
             num_bag_sets=None,
             delay_bag_sets=False,
             num_stack_levels=None,
-            validation_mode="auto",
+            validation_mode=None,
             validation_structure=None,
             validation_size_curves=None,
             ensemble_weights=None,

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -898,6 +898,20 @@ class TabularPredictor:
                 Values greater than 1 will result in superior predictive performance, especially on smaller problems and with stacking enabled (reduces overall variance).
                 Be warned: This will drastically increase overall runtime, and if using a time limit, can very commonly lead to worse performance.
                 It is recommended to increase this value only as a last resort, as it is the least computationally efficient method to improve performance.
+            ensemble_weights_missing : {"error", "renormalize"}, default = "error"
+                What to do when `ensemble_weights` names a model that was not fit -- because it
+                failed, was constrained out, or the name was wrong.
+
+                "error" (default): raise. Names that no requested model could produce are rejected
+                before any model is trained.
+
+                "renormalize": drop those names and rescale the remaining weights over the models
+                that did fit, preserving their relative proportions, with a warning naming what was
+                dropped. Raises only if *none* of the named models were fit. Use this when losing
+                one model should degrade the ensemble rather than fail the run.
+
+                A fitted model with no weight remains an error under both settings: this option is
+                about named models that are absent, not the reverse.
             validation_mode : {"auto", "none"}, default = "auto"
                 How validation data is obtained.
 
@@ -1465,6 +1479,11 @@ class TabularPredictor:
             raise ValueError(f"validation_mode must be 'auto' or 'none', got {validation_mode!r}.")
         no_validation = validation_mode == "none"
         ensemble_weights = kwargs["ensemble_weights"]
+        ensemble_weights_missing = kwargs["ensemble_weights_missing"]
+        if ensemble_weights_missing not in ("error", "renormalize"):
+            raise ValueError(
+                f"ensemble_weights_missing must be 'error' or 'renormalize', got {ensemble_weights_missing!r}."
+            )
 
         validation_structure = ValidationStructure.from_input(kwargs["validation_structure"])
         if validation_structure is not None and self._learner.groups is not None:
@@ -1545,7 +1564,9 @@ class TabularPredictor:
                 # Check the names before fitting anything. The trainer checks them again against
                 # the models that actually fitted, but that is after every base model has been
                 # trained -- a typo would otherwise cost the whole fit.
-                self._validate_ensemble_weight_names(ensemble_weights, hyperparameters)
+                self._validate_ensemble_weight_names(
+                    ensemble_weights, hyperparameters, on_unmatched=ensemble_weights_missing
+                )
             if ensemble_weights is None and fit_weighted_ensemble:
                 raise ValueError(
                     "validation_mode='none' leaves no data to learn ensemble weights from. Pass explicit weights, "
@@ -1714,6 +1735,7 @@ class TabularPredictor:
             validation_structure=validation_structure,
             no_validation=no_validation,
             ensemble_weights=ensemble_weights,
+            ensemble_weights_missing=ensemble_weights_missing,
         )
         ag_post_fit_kwargs = dict(
             keep_only_best=kwargs["keep_only_best"],
@@ -6025,7 +6047,9 @@ class TabularPredictor:
             raise ValueError(f"fit_strategy must be one of {valid_values}. Value: {fit_strategy}")
 
     @staticmethod
-    def _validate_ensemble_weight_names(ensemble_weights: dict, hyperparameters: dict) -> None:
+    def _validate_ensemble_weight_names(
+        ensemble_weights: dict, hyperparameters: dict, on_unmatched: str = "error"
+    ) -> None:
         """Reject `ensemble_weights` names that no requested model could produce, before fitting.
 
         Names are the model names shown in `leaderboard()` (e.g. "LightGBM"), not the
@@ -6079,10 +6103,16 @@ class TabularPredictor:
                     f" {sorted(used_keys)} look like `hyperparameters` keys; "
                     f"ensemble_weights uses model names, e.g. {renames}."
                 )
-            raise ValueError(
+            message = (
                 f"ensemble_weights names {sorted(unmatched)} do not match any requested model. "
                 f"Expected names from: {sorted(expected_names)}.{hint}"
             )
+            if on_unmatched == "error":
+                raise ValueError(message)
+            # Under "renormalize" the caller has said missing models are acceptable, so this is a
+            # warning -- but it is still almost certainly a mistake, and it is detectable now
+            # rather than after fitting, so say so before the compute is spent.
+            logger.log(30, f"\tWARNING: {message} They will contribute nothing to the ensemble.")
 
     def _fit_extra_kwargs_dict(self) -> dict:
         """
@@ -6103,6 +6133,7 @@ class TabularPredictor:
             validation_structure=None,
             validation_size_curves=None,
             ensemble_weights=None,
+            ensemble_weights_missing="error",
             hyperparameter_tune_kwargs=None,
             ag_args=None,
             ag_args_fit=None,

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -74,6 +74,7 @@ from ..configs.pipeline_presets import (
     USE_BAG_HOLDOUT_AUTO_THRESHOLD,
     ValidationSizeCurves,
     get_validation_and_stacking_method,
+    resolve_hyperparameters_curve,
     resolve_validation_mode,
 )
 from ..configs.presets_configs import tabular_presets_alias, tabular_presets_dict
@@ -1429,6 +1430,14 @@ class TabularPredictor:
                 )
                 hyperparameters = "zeroshot_2025_tabfm"
 
+        # Resolved here, before the portfolio is validated and before it decides whether raw text
+        # features are enabled: a curve has to be read before anything consumes the value.
+        hyperparameters = resolve_hyperparameters_curve(
+            hyperparameters=hyperparameters,
+            num_train_rows=len(train_data),
+            validation_size_curves=kwargs["validation_size_curves"],
+        )
+
         if hyperparameters is None:
             hyperparameters = "default"
         if isinstance(hyperparameters, str):
@@ -1589,7 +1598,9 @@ class TabularPredictor:
             if ensemble_weights is not None:
                 # Check the names before fitting anything. The trainer checks them again against
                 # the models that actually fitted, but that is after every base model has been
-                # trained -- a typo would otherwise cost the whole fit.
+                # trained -- a typo would otherwise cost the whole fit. Under curves this is also
+                # what catches a weights/hyperparameters pair that only agrees above the
+                # threshold, which would otherwise fail at small sizes and pass at large ones.
                 self._validate_ensemble_weight_names(
                     ensemble_weights, hyperparameters, on_unmatched=ensemble_weights_missing
                 )
@@ -6139,6 +6150,22 @@ class TabularPredictor:
             # warning -- but it is still almost certainly a mistake, and it is detectable now
             # rather than after fitting, so say so before the compute is spent.
             logger.log(30, f"\tWARNING: {message} They will contribute nothing to the ensemble.")
+
+        # The reverse direction, checked second because an unmatched name is usually the cause and
+        # the better message: a requested model with no weight at all. The trainer rejects this too,
+        # but only after fitting -- and under curves it is the pairing that agrees above a threshold
+        # and not below it, so catching it here is what stops a config failing at only some sizes.
+        uncovered = sorted(
+            name for name in expected_names if not any(w == name or w.startswith(name) for w in ensemble_weights)
+        )
+        if uncovered:
+            message = (
+                f"ensemble_weights gives no weight to {uncovered}, which `hyperparameters` will fit. "
+                f"Give every model a weight (use 0 to exclude one), or drop it from `hyperparameters`."
+            )
+            if on_unmatched == "error":
+                raise ValueError(message)
+            logger.log(30, f"\tWARNING: {message} They will be excluded from the ensemble.")
 
     def _fit_extra_kwargs_dict(self) -> dict:
         """

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -898,6 +898,31 @@ class TabularPredictor:
                 Values greater than 1 will result in superior predictive performance, especially on smaller problems and with stacking enabled (reduces overall variance).
                 Be warned: This will drastically increase overall runtime, and if using a time limit, can very commonly lead to worse performance.
                 It is recommended to increase this value only as a last resort, as it is the least computationally efficient method to improve performance.
+            validation_mode : {"auto", "none"}, default = "auto"
+                How validation data is obtained.
+
+                "auto" (default): AutoGluon holds rows out, or uses out-of-fold predictions when
+                bagging, and scores every model against them.
+
+                "none": no rows are held out. Every model trains on all of `train_data` and no
+                model gets a validation score. Use this for models that need no validation set --
+                in-context learners such as TabPFN, TabICL or TabDPT -- when the ensemble
+                combination is already known and does not have to be learned from held-out
+                predictions. Requires `ensemble_weights` (or `fit_weighted_ensemble=False`), and
+                cannot be combined with bagging, stacking, `tuning_data` or `validation_structure`,
+                each of which is defined by holding rows out.
+
+                Note that with no validation score, `leaderboard()` reports `score_val` as None for
+                every model, and anything that ranks models by validation performance -- model
+                selection, `predictor.fit_weighted_ensemble()`, calibration -- has nothing to rank.
+            ensemble_weights : dict[str, float], default = None
+                Fixed weights for the weighted ensemble, keyed by fitted model name as it appears
+                in `leaderboard()`, e.g. `{"TabPFN-3": 0.5, "TabICL": 0.5}`. Weights are normalized
+                to sum to 1. Every base model must be given a weight; use 0 to exclude one.
+
+                Only valid with `validation_mode="none"`, where there is no held-out data to learn
+                weights from. With validation data AutoGluon learns them, so passing fixed weights
+                there is rejected rather than silently overriding the search.
             validation_structure : dict | ValidationStructure, default = None
                 Declarative description of the dataset's validation-relevant structure, as a dict with keys
                 `group_on` (str | list[str]), `time_on` (str), `group_time_on` (str, for data that is both
@@ -1435,6 +1460,12 @@ class TabularPredictor:
         # `autogluon.common.utils.validation_structure.ValidationStructure`. Resolved before the
         # validation method is chosen, because a grouped structure can supply the sample size
         # that method is chosen from (`size_validation_on_groups`).
+        validation_mode = kwargs["validation_mode"]
+        if validation_mode not in ("auto", "none"):
+            raise ValueError(f"validation_mode must be 'auto' or 'none', got {validation_mode!r}.")
+        no_validation = validation_mode == "none"
+        ensemble_weights = kwargs["ensemble_weights"]
+
         validation_structure = ValidationStructure.from_input(kwargs["validation_structure"])
         if validation_structure is not None and self._learner.groups is not None:
             raise ValueError(
@@ -1485,6 +1516,45 @@ class TabularPredictor:
             use_bag_holdout_was_auto=use_bag_holdout_was_auto,
             dynamic_stacking_was_auto=dynamic_stacking_was_auto,
         )
+
+        if no_validation:
+            # `validation_mode="none"` trains on every row and scores nothing. Stacking and bagging
+            # are defined by out-of-fold predictions, so they cannot coexist with it; refuse rather
+            # than silently produce a stack whose inputs are the training data.
+            if num_bag_folds:
+                raise ValueError(
+                    f"validation_mode='none' cannot be combined with bagging (num_bag_folds={num_bag_folds}). "
+                    "Bagging derives its validation from out-of-fold predictions, which requires holding rows out."
+                )
+            if num_stack_levels:
+                raise ValueError(
+                    f"validation_mode='none' cannot be combined with stacking (num_stack_levels={num_stack_levels}). "
+                    "Stacking is trained on out-of-fold predictions, which requires holding rows out."
+                )
+            if tuning_data is not None:
+                raise ValueError(
+                    "validation_mode='none' cannot be combined with `tuning_data`. Pass the tuning rows as part of "
+                    "`train_data`, or drop `validation_mode` to validate against them."
+                )
+            if validation_structure is not None:
+                raise ValueError(
+                    "validation_mode='none' cannot be combined with `validation_structure`, which describes how to "
+                    "split validation data off. Specify one or the other."
+                )
+            if ensemble_weights is None and fit_weighted_ensemble:
+                raise ValueError(
+                    "validation_mode='none' leaves no data to learn ensemble weights from. Pass explicit weights, "
+                    "e.g. fit(..., ensemble_weights={'TabPFN-3': 0.5, 'TABICL': 0.5}), or set "
+                    "fit_weighted_ensemble=False."
+                )
+            # Without a holdout there is nothing for dynamic stacking to detect leakage against.
+            dynamic_stacking = False
+            holdout_frac = 0.0
+        elif ensemble_weights is not None:
+            raise ValueError(
+                "`ensemble_weights` is only supported with validation_mode='none'. With validation data AutoGluon "
+                "learns the weights; pass fixed weights only when there is nothing to learn them from."
+            )
 
         if validation_structure is not None and validation_structure.splitter is not None:
             # A splitter can leave rows unvalidated exactly as forward-chaining does -- a
@@ -1637,6 +1707,8 @@ class TabularPredictor:
             raise_on_model_failure=raise_on_model_failure,
             time_limit_preprocessing=time_limit_preprocessing,
             validation_structure=validation_structure,
+            no_validation=no_validation,
+            ensemble_weights=ensemble_weights,
         )
         ag_post_fit_kwargs = dict(
             keep_only_best=kwargs["keep_only_best"],
@@ -5951,8 +6023,10 @@ class TabularPredictor:
             num_bag_sets=None,
             delay_bag_sets=False,
             num_stack_levels=None,
+            validation_mode="auto",
             validation_structure=None,
             validation_size_curves=None,
+            ensemble_weights=None,
             hyperparameter_tune_kwargs=None,
             ag_args=None,
             ag_args_fit=None,

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -1037,6 +1037,42 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
     # TODO: Consider making level be auto-determined based off of max(base_model_levels)+1
     # TODO: Remove name_suffix, hacked in
     # TODO: X can be optional because it isn't needed if fit=True
+    def _reconcile_fixed_ensemble_weights(
+        self, ensemble_weights: dict, base_model_names: list[str], on_missing: str = "error"
+    ) -> tuple[dict, list[str]]:
+        """Drop weights for models that did not fit, when the caller allows it.
+
+        Under ``on_missing="renormalize"`` a model that was named but never produced -- it failed
+        to fit, or the name was wrong -- is dropped and the remaining weights are rescaled over
+        what survived, so the surviving models keep their relative proportions. Losing every named
+        model is still an error: there would be nothing to ensemble.
+
+        Returns the weights and base models to actually use, both narrowed to their intersection.
+        """
+        if on_missing != "renormalize":
+            return ensemble_weights, base_model_names
+        present = [name for name in ensemble_weights if name in base_model_names]
+        missing = [name for name in ensemble_weights if name not in base_model_names]
+        if not present:
+            raise ValueError(
+                f"None of the models named in ensemble_weights were fit: {sorted(ensemble_weights)}. "
+                f"Fitted models: {sorted(base_model_names)}."
+            )
+        if missing:
+            kept = {name: ensemble_weights[name] for name in present}
+            logger.log(
+                30,
+                f"\tWARNING: ensemble_weights named {sorted(missing)}, which "
+                f"{'was' if len(missing) == 1 else 'were'} not fit. Rescaling the remaining weights "
+                f"over {sorted(present)}: {kept}.",
+            )
+        # Narrow the base models too: a fitted model with no weight is still an error, and should
+        # stay one even here -- this option is about named models that are absent, not the reverse.
+        return (
+            {name: ensemble_weights[name] for name in present},
+            [name for name in base_model_names if name in ensemble_weights],
+        )
+
     def _resolve_fixed_ensemble_weights(self, ensemble_weights: dict, base_model_names: list[str]) -> list[float]:
         """Order user-supplied weights to match `base_model_names`, rejecting any mismatch.
 
@@ -1128,13 +1164,25 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
             ag_args_fit["predict_1_batch_size"] = infer_limit_batch_size
 
         ensemble_weights = kwargs.pop("ensemble_weights", None)
+        ensemble_weights_missing = kwargs.pop("ensemble_weights_missing", "error")
         if ensemble_weights is not None:
             # Fixed weights are not learned from anything, so the base models' validation or
             # out-of-fold predictions are never needed -- which is what makes this reachable with
             # `validation_mode="none"`, where neither exists.
+            ensemble_weights, base_model_names = self._reconcile_fixed_ensemble_weights(
+                ensemble_weights, base_model_names, on_missing=ensemble_weights_missing
+            )
             weights = self._resolve_fixed_ensemble_weights(ensemble_weights, base_model_names)
             child_hyperparameters = dict(child_hyperparameters or {})
             child_hyperparameters["weights"] = weights
+            # The caller named exactly which models to combine, so the stacker must not prune the
+            # base set: dropping one would hand the survivors weights meant for other models. The
+            # pruning also ranks by validation score, which is None for every model here -- with
+            # two models of the same type that comparison raises rather than pruning.
+            ag_args_ensemble = dict(kwargs.pop("ag_args_ensemble", None) or {})
+            ag_args_ensemble["max_base_models"] = 0
+            ag_args_ensemble["max_base_models_per_type"] = 0
+            kwargs["ag_args_ensemble"] = ag_args_ensemble
             return self.generate_weighted_ensemble(
                 X=self._empty_stack_frame(base_model_names),
                 y=y.iloc[:0],

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -66,6 +66,14 @@ from autogluon.core.utils.savers import save_pkl
 logger = logging.getLogger(__name__)
 
 
+class AmbiguousModelBestError(AssertionError):
+    """Several models are fit, none has a validation score, and no combination was given.
+
+    Subclasses AssertionError so existing `except AssertionError` handlers around model selection
+    keep working.
+    """
+
+
 class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
     """
     AbstractTabularTrainer contains logic to train a variety of models under a variety of constraints and automatically generate a multi-layer stack ensemble.
@@ -547,7 +555,12 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
             )
             model_names_fit += base_model_names + aux_models
         if (self.model_best is None or infer_limit is not None) and len(model_names_fit) != 0:
-            self.model_best = self.get_model_best(infer_limit=infer_limit, infer_limit_as_child=True)
+            try:
+                self.model_best = self.get_model_best(infer_limit=infer_limit, infer_limit_as_child=True)
+            except AmbiguousModelBestError as err:
+                # The models are fit and usable; only the default for `predict` is undecidable.
+                # Leaving `model_best` unset defers the error to the call that actually needs it.
+                logger.log(30, f"\tWARNING: {err} Until then, `predict` requires an explicit `model`.")
         self._callbacks_conclude()
         self._fit_cleanup()
         self.save()
@@ -2072,13 +2085,19 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
                 for m in models
             ]
             if not perfs:
-                # With `validation_mode="none"` nothing has a score to rank by, and ranking is not
-                # what was asked for: the user supplied the combination explicitly. Choose the model
-                # at the top of the DAG -- the one every other fitted model feeds into. Filter over
-                # `models_scoreless`, since `models` was just narrowed to the refit-full models.
-                topological = [m for m in self.get_model_names(can_infer=True) if m in models_scoreless]
-                if topological:
-                    return topological[-1]
+                # Nothing has a score to rank by -- the `validation_mode="none"` case. One
+                # candidate is unambiguous, so use it. Several are not: picking one would be an
+                # arbitrary choice made on DAG order, and silently answering `predict` from a model
+                # the caller never chose is worse than saying so.
+                if len(models_scoreless) == 1:
+                    return models_scoreless[0]
+                if models_scoreless:
+                    raise AmbiguousModelBestError(
+                        f"No model has a validation score, so there is no basis to choose between "
+                        f"{sorted(models_scoreless)}. Combine them with "
+                        f"`fit(..., ensemble_weights={{...}})`, or name one per call with "
+                        f"`predict(..., model=...)`."
+                    )
                 raise AssertionError(
                     "No fit models that can infer exist with a validation score to choose the best model."
                 )

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -1024,6 +1024,39 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
     # TODO: Consider making level be auto-determined based off of max(base_model_levels)+1
     # TODO: Remove name_suffix, hacked in
     # TODO: X can be optional because it isn't needed if fit=True
+    def _resolve_fixed_ensemble_weights(self, ensemble_weights: dict, base_model_names: list[str]) -> list[float]:
+        """Order user-supplied weights to match `base_model_names`, rejecting any mismatch.
+
+        Names are the fitted model names as they appear in the leaderboard. A silent mismatch would
+        assign a model someone else's weight, so an unknown or missing name is an error rather than
+        a default of zero.
+        """
+        unknown = set(ensemble_weights) - set(base_model_names)
+        if unknown:
+            raise ValueError(
+                f"ensemble_weights names {sorted(unknown)} are not fitted models. "
+                f"Available: {sorted(base_model_names)}."
+            )
+        missing = set(base_model_names) - set(ensemble_weights)
+        if missing:
+            raise ValueError(
+                f"ensemble_weights is missing a weight for {sorted(missing)}. "
+                "Give every base model a weight (use 0 to exclude one)."
+            )
+        total = sum(ensemble_weights.values())
+        if total <= 0:
+            raise ValueError(f"ensemble_weights must sum to a positive value, got {total}.")
+        return [ensemble_weights[name] / total for name in base_model_names]
+
+    def _empty_stack_frame(self, base_model_names: list[str]) -> pd.DataFrame:
+        """A zero-row frame with the stack columns the weighted ensemble expects.
+
+        `SimpleWeightedEnsembleModel` installs its weights without reading the data, so the frame
+        only has to carry the right columns.
+        """
+        columns = self.get_feature_metadata(use_orig_features=False, base_models=base_model_names).get_features()
+        return pd.DataFrame({c: pd.Series(dtype="float64") for c in columns})
+
     def stack_new_level_aux(
         self,
         X,
@@ -1080,6 +1113,38 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
 
         if infer_limit_batch_size is not None:
             ag_args_fit["predict_1_batch_size"] = infer_limit_batch_size
+
+        ensemble_weights = kwargs.pop("ensemble_weights", None)
+        if ensemble_weights is not None:
+            # Fixed weights are not learned from anything, so the base models' validation or
+            # out-of-fold predictions are never needed -- which is what makes this reachable with
+            # `validation_mode="none"`, where neither exists.
+            weights = self._resolve_fixed_ensemble_weights(ensemble_weights, base_model_names)
+            child_hyperparameters = dict(child_hyperparameters or {})
+            child_hyperparameters["weights"] = weights
+            return self.generate_weighted_ensemble(
+                X=self._empty_stack_frame(base_model_names),
+                y=y.iloc[:0],
+                covered_rows=None,
+                level=level,
+                base_model_names=base_model_names,
+                k_fold=1,
+                n_repeats=1,
+                ag_args_fit=ag_args_fit,
+                stack_name=stack_name,
+                time_limit=time_limit,
+                name_suffix=name_suffix,
+                get_models_func=get_models_func,
+                check_if_best=check_if_best,
+                child_cls="SIMPLE_ENS_WEIGHTED",
+                child_hyperparameters=child_hyperparameters,
+                total_resources=total_resources,
+                # Nothing to score against: the frame is empty by construction, and with fixed
+                # weights a validation score would not have informed anything anyway.
+                compute_score=False,
+                **kwargs,
+            )
+
         X_stack_preds = self.get_inputs_to_stacker(
             X, base_models=base_model_names, fit=fit, use_orig_features=False, use_val_cache=use_val_cache
         )
@@ -2000,12 +2065,20 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
             (m, model_performances[m], models_predict_time[m]) for m in models if model_performances[m] is not None
         ]
         if not perfs:
+            models_scoreless = models
             models = [m for m in models if m in models_full]
             perfs = [
                 (m, self.get_model_attribute(model=m, attribute="refit_full_parent_val_score"), models_predict_time[m])
                 for m in models
             ]
             if not perfs:
+                # With `validation_mode="none"` nothing has a score to rank by, and ranking is not
+                # what was asked for: the user supplied the combination explicitly. Choose the model
+                # at the top of the DAG -- the one every other fitted model feeds into. Filter over
+                # `models_scoreless`, since `models` was just narrowed to the refit-full models.
+                topological = [m for m in self.get_model_names(can_infer=True) if m in models_scoreless]
+                if topological:
+                    return topological[-1]
                 raise AssertionError(
                     "No fit models that can infer exist with a validation score to choose the best model."
                 )
@@ -2226,6 +2299,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         child_hyperparameters=None,
         get_models_func=None,
         total_resources: dict | None = None,
+        compute_score: bool = True,
     ) -> list[str]:
         if get_models_func is None:
             get_models_func = self.construct_model_templates
@@ -2311,6 +2385,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
                 feature_metadata=feature_metadata, num_classes=self.num_classes, groups=None
             ),  # FIXME: Is this the right way to do this?
             total_resources=total_resources,
+            compute_score=compute_score,
         )
         if covered_rows is not None:
             for weighted_ensemble_model_name in models:

--- a/tabular/src/autogluon/tabular/trainer/auto_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/auto_trainer.py
@@ -58,6 +58,8 @@ class AutoTrainer(AbstractTabularTrainer):
         infer_limit_batch_size=None,
         use_bag_holdout=False,
         validation_structure=None,
+        no_validation: bool = False,
+        ensemble_weights: dict | None = None,
         callbacks: list[callable] = None,
         label_cleaner=None,
         **kwargs,
@@ -76,7 +78,12 @@ class AutoTrainer(AbstractTabularTrainer):
                     f"Warning: use_bag_holdout={use_bag_holdout}, but bagged mode is not enabled. use_bag_holdout will be ignored."
                 )
 
-        if (y_val is None) or (X_val is None):
+        if no_validation:
+            # Train on every row and score nothing. `_train_and_save` already treats `X_val=None`
+            # as "no score available" (it is the same path `refit_full` takes), so nothing below
+            # needs to change -- only the split has to be skipped.
+            logger.log(20, f"validation_mode='none': training on all {len(X)} rows, no validation split.")
+        elif (y_val is None) or (X_val is None):
             if not self.bagged_mode or use_bag_holdout:
                 # `groups` used to be rejected here: it had no say in the holdout, so
                 # use_bag_holdout without explicit validation data would have split rows at random
@@ -169,6 +176,9 @@ class AutoTrainer(AbstractTabularTrainer):
 
         if label_cleaner is not None:
             core_kwargs["label_cleaner"] = label_cleaner
+        if ensemble_weights is not None:
+            aux_kwargs = dict(aux_kwargs or {})
+            aux_kwargs["ensemble_weights"] = ensemble_weights
 
         self._train_multi_and_ensemble(
             X=X,

--- a/tabular/src/autogluon/tabular/trainer/auto_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/auto_trainer.py
@@ -60,6 +60,7 @@ class AutoTrainer(AbstractTabularTrainer):
         validation_structure=None,
         no_validation: bool = False,
         ensemble_weights: dict | None = None,
+        ensemble_weights_missing: str = "error",
         callbacks: list[callable] = None,
         label_cleaner=None,
         **kwargs,
@@ -179,6 +180,7 @@ class AutoTrainer(AbstractTabularTrainer):
         if ensemble_weights is not None:
             aux_kwargs = dict(aux_kwargs or {})
             aux_kwargs["ensemble_weights"] = ensemble_weights
+            aux_kwargs["ensemble_weights_missing"] = ensemble_weights_missing
 
         self._train_multi_and_ensemble(
             X=X,

--- a/tabular/tests/unittests/configs/test_validation_size_curves.py
+++ b/tabular/tests/unittests/configs/test_validation_size_curves.py
@@ -13,6 +13,7 @@ from autogluon.tabular.configs.pipeline_presets import (
     _get_validation_preset,
     get_validation_and_stacking_method,
     resolve_size_curve,
+    resolve_validation_mode,
 )
 
 
@@ -524,3 +525,81 @@ def test_default_curves_are_unchanged_by_the_fallback_fix(num_train_rows):
     for key, curve in DEFAULT_VALIDATION_SIZE_CURVES.items():
         value = resolve_size_curve(curve, num_train_rows)
         assert value is not None, f"{key} resolved to None at {num_train_rows}"
+
+
+def test_validation_mode_and_ensemble_weights_are_curve_keys():
+    """Both resolve from curves like any other knob; a dict payload survives intact."""
+    curves = {
+        "validation_mode": [[100, "none"], "auto"],
+        "ensemble_weights": [[100, {"TabPFN-3": 0.5, "TabICL": 0.5}], None],
+    }
+    assert resolve_size_curve(curves["validation_mode"], 60) == "none"
+    assert resolve_size_curve(curves["validation_mode"], 300) == "auto"
+    assert resolve_size_curve(curves["ensemble_weights"], 60) == {"TabPFN-3": 0.5, "TabICL": 0.5}
+    assert resolve_size_curve(curves["ensemble_weights"], 300) is None
+
+
+def _mode(num_train_rows, **kwargs):
+    """Resolve the knobs, then the mode, exactly as `fit` does."""
+    num_bag_folds, _, num_stack_levels, _, _, _, _ = get_validation_and_stacking_method(
+        num_bag_folds=kwargs.get("num_bag_folds"),
+        num_bag_sets=None,
+        use_bag_holdout=None,
+        holdout_frac=None,
+        auto_stack=False,
+        num_stack_levels=kwargs.get("num_stack_levels"),
+        dynamic_stacking=None,
+        refit_full=None,
+        num_train_rows=num_train_rows,
+        problem_type="binary",
+        hpo_enabled=False,
+        n_samples_minority_class=num_train_rows // 2,
+        validation_size_curves=kwargs.get("validation_size_curves"),
+    )
+    return resolve_validation_mode(
+        validation_mode=kwargs.get("validation_mode"),
+        ensemble_weights=kwargs.get("ensemble_weights"),
+        num_bag_folds=num_bag_folds,
+        num_stack_levels=num_stack_levels,
+        num_train_rows=num_train_rows,
+        validation_size_curves=kwargs.get("validation_size_curves"),
+    ) + (num_bag_folds, num_stack_levels)
+
+
+def test_validation_mode_curve_switches_with_the_coupled_knobs():
+    """The intended shape: every coupled knob flips at the same threshold."""
+    curves = {
+        "validation_mode": [[100, "none"], "auto"],
+        "num_bag_folds": [[100, 0], 8],
+        "num_stack_levels": [[100, 0], 1],
+        "ensemble_weights": [[100, {"A": 0.5, "B": 0.5}], None],
+    }
+    mode, weights, folds, levels = _mode(60, validation_size_curves=curves)
+    assert (mode, weights, folds, levels) == ("none", {"A": 0.5, "B": 0.5}, 0, 0)
+    mode, weights, folds, _ = _mode(300, validation_size_curves=curves)
+    assert (mode, weights, folds) == ("auto", None, 8)
+
+
+def test_mismatched_curve_thresholds_are_reported_at_resolution():
+    """Curves resolve one knob at a time, so a mistyped threshold makes a band of sizes disagree.
+
+    Without this check the contradiction surfaces as a fit-time error at only some data sizes.
+    """
+    curves = {"validation_mode": [[100, "none"], "auto"], "num_bag_folds": [[50, 0], 8]}
+    with pytest.raises(ValueError, match="every curve switches at the same threshold"):
+        _mode(60, validation_size_curves=curves)
+    # Below both thresholds the knobs agree, so it resolves.
+    assert _mode(40, validation_size_curves=curves)[0] == "none"
+
+
+def test_explicit_validation_mode_conflict_names_the_direct_fix():
+    """The same check covers an explicitly passed combination, with a different remedy."""
+    with pytest.raises(ValueError, match="Set them to 0, or drop"):
+        _mode(60, validation_mode="none", num_bag_folds=8)
+
+
+def test_explicit_validation_mode_beats_its_curve():
+    """A caller-supplied value wins over a curve, as every other knob here does."""
+    curves = {"validation_mode": [[100, "none"], "auto"]}
+    assert _mode(60, validation_size_curves=curves)[0] == "none"
+    assert _mode(60, validation_size_curves=curves, validation_mode="auto")[0] == "auto"

--- a/tabular/tests/unittests/configs/test_validation_size_curves.py
+++ b/tabular/tests/unittests/configs/test_validation_size_curves.py
@@ -7,6 +7,7 @@ import math
 import pytest
 
 from autogluon.tabular.configs.pipeline_presets import (
+    DEFAULT_VALIDATION_SIZE_CURVES,
     USE_BAG_HOLDOUT_AUTO_THRESHOLD,
     ValidationSizeCurves,
     _get_validation_preset,
@@ -491,3 +492,35 @@ def test__set_best_to_refit_full__is_disabled_with_a_warning_not_an_error(refit_
     assert "`set_best_to_refit_full=True` is disabled" in caplog.text
     # The fit still produced a usable predictor, and nothing was promoted.
     assert not any(name.endswith("_FULL") for name in predictor.model_names())
+
+
+def test_explicit_trailing_none_is_honoured_not_clamped():
+    """A curve ending in `None` means None above the last anchor, not the last anchor's value.
+
+    `None` is a legal curve value -- "no fixed weights", "use the built-in default" -- so
+    `[[X, value], None]` is the natural way to spell "on below X, off above X". It previously
+    returned `value` at every size, because the "no fallback supplied" state was itself `None`
+    and the two could not be told apart.
+    """
+    below = {"A": 0.5}
+    assert resolve_size_curve([[100, below], None], 40) == below
+    assert resolve_size_curve([[100, below], None], 500) is None
+
+
+def test_anchor_only_curve_still_clamps_to_the_last_anchor():
+    """The clamp is right when no trailing value was given -- that is what it is for."""
+    assert resolve_size_curve([[59, 5], [69, 6], [79, 7]], 500) == 7
+    assert resolve_size_curve([[100, "x"]], 500) == "x"
+
+
+def test_bare_none_curve_resolves_to_none():
+    """A curve of only `None` has nothing to clamp to."""
+    assert resolve_size_curve([None], 500) is None
+
+
+@pytest.mark.parametrize("num_train_rows", [20, 59, 60, 79, 100, 749, 750, 5000, 100_000])
+def test_default_curves_are_unchanged_by_the_fallback_fix(num_train_rows):
+    """Every built-in curve ends in a non-None value, so none of them can be affected."""
+    for key, curve in DEFAULT_VALIDATION_SIZE_CURVES.items():
+        value = resolve_size_curve(curve, num_train_rows)
+        assert value is not None, f"{key} resolved to None at {num_train_rows}"

--- a/tabular/tests/unittests/configs/test_validation_size_curves.py
+++ b/tabular/tests/unittests/configs/test_validation_size_curves.py
@@ -12,6 +12,7 @@ from autogluon.tabular.configs.pipeline_presets import (
     ValidationSizeCurves,
     _get_validation_preset,
     get_validation_and_stacking_method,
+    resolve_hyperparameters_curve,
     resolve_size_curve,
     resolve_validation_mode,
 )
@@ -603,3 +604,25 @@ def test_explicit_validation_mode_beats_its_curve():
     curves = {"validation_mode": [[100, "none"], "auto"]}
     assert _mode(60, validation_size_curves=curves)[0] == "none"
     assert _mode(60, validation_size_curves=curves, validation_mode="auto")[0] == "auto"
+
+
+def test_hyperparameters_is_a_curve_key_read_at_the_row_count():
+    """The portfolio switches with the rest of the bundle.
+
+    Read at the row count, not the effective size: it resolves before `validation_structure` is
+    known, so the group count is not available yet.
+    """
+    curve = [[100, {"TABPFN-3": {}, "TABICL": {}}], "default"]
+    assert resolve_hyperparameters_curve(None, 60, {"hyperparameters": curve}) == {"TABPFN-3": {}, "TABICL": {}}
+    assert resolve_hyperparameters_curve(None, 300, {"hyperparameters": curve}) == "default"
+
+
+def test_explicit_hyperparameters_beats_its_curve():
+    """A caller-supplied portfolio wins, as every other knob does."""
+    curve = [[100, {"TABPFN-3": {}}], "default"]
+    assert resolve_hyperparameters_curve({"GBM": {}}, 60, {"hyperparameters": curve}) == {"GBM": {}}
+
+
+def test_no_hyperparameters_curve_leaves_the_value_alone():
+    assert resolve_hyperparameters_curve(None, 60, {"num_bag_folds": [[100, 0], 8]}) is None
+    assert resolve_hyperparameters_curve(None, 60, None) is None

--- a/tabular/tests/unittests/test_validation_mode.py
+++ b/tabular/tests/unittests/test_validation_mode.py
@@ -65,13 +65,37 @@ def test_validation_mode_none_normalizes_weights(tmp_path):
     )
 
 
-def test_validation_mode_none_without_an_ensemble(tmp_path):
-    """`fit_weighted_ensemble=False` is the other way to have nothing to learn weights for."""
+def test_validation_mode_none_single_model_without_an_ensemble(tmp_path):
+    """One model and no score is unambiguous: it is the only thing `predict` could mean."""
     train = _data()
-    predictor = _fit(tmp_path, train, validation_mode="none", fit_weighted_ensemble=False)
+    predictor = TabularPredictor(label="label", path=str(tmp_path), verbosity=0).fit(
+        train, hyperparameters={"GBM": {}}, validation_mode="none", fit_weighted_ensemble=False
+    )
 
     assert predictor._trainer._num_rows_train == len(train)
-    assert predictor.model_best in set(predictor.model_names())
+    assert predictor.model_best == "LightGBM"
+    assert len(predictor.predict(train.drop(columns=["label"]))) == len(train)
+
+
+def test_validation_mode_none_multiple_models_without_an_ensemble(tmp_path):
+    """Several models, no scores and no weights: there is no basis for a default.
+
+    Answering `predict` from whichever model happened to be last in the DAG would be an arbitrary
+    choice the caller never made, so the ambiguity is reported instead. The models themselves are
+    fit and usable by name.
+    """
+    from autogluon.tabular.trainer.abstract_trainer import AmbiguousModelBestError
+
+    train = _data()
+    test = _data(n=50, seed=3).drop(columns=["label"])
+    predictor = _fit(tmp_path, train, validation_mode="none", fit_weighted_ensemble=False)
+
+    assert set(predictor.model_names()) == {"LightGBM", "XGBoost"}
+    assert predictor.model_best is None, "no model should be designated best without a basis"
+    with pytest.raises(AmbiguousModelBestError, match="no basis to choose between"):
+        predictor.predict(test)
+    # Naming a model is the documented way out, and it works.
+    assert len(predictor.predict(test, model="LightGBM")) == len(test)
 
 
 @pytest.mark.parametrize(

--- a/tabular/tests/unittests/test_validation_mode.py
+++ b/tabular/tests/unittests/test_validation_mode.py
@@ -101,7 +101,8 @@ def test_validation_mode_none_multiple_models_without_an_ensemble(tmp_path):
 @pytest.mark.parametrize(
     "kwargs, match",
     [
-        ({"num_bag_folds": 3}, "cannot be combined with bagging"),
+        # Reported by `resolve_validation_mode`, which sees the resolved counts.
+        ({"num_bag_folds": 3}, "cannot be combined with num_bag_folds=3"),
         ({"tuning_data": "TRAIN"}, "cannot be combined with `tuning_data`"),
         ({"validation_structure": {"group_on": "f0"}}, "cannot be combined with `validation_structure`"),
     ],

--- a/tabular/tests/unittests/test_validation_mode.py
+++ b/tabular/tests/unittests/test_validation_mode.py
@@ -135,7 +135,8 @@ def test_validation_mode_rejects_unknown_values(tmp_path):
 @pytest.mark.parametrize(
     "weights, match",
     [
-        ({"Nope": 1.0}, "are not fitted models"),
+        # Caught before fitting -- no requested model could produce this name.
+        ({"Nope": 1.0}, "do not match any requested model"),
         ({"LightGBM": 1.0}, "missing a weight for"),
         ({"LightGBM": 0.0, "XGBoost": 0.0}, "must sum to a positive value"),
     ],
@@ -144,3 +145,34 @@ def test_ensemble_weights_are_validated(tmp_path, weights, match):
     """A silent mismatch would give a model someone else's weight."""
     with pytest.raises(ValueError, match=match):
         _fit(tmp_path, _data(), validation_mode="none", ensemble_weights=weights)
+
+
+def test_ensemble_weight_names_are_checked_before_fitting(tmp_path):
+    """A name no requested model could produce fails before any model is trained.
+
+    The trainer checks names again against the models that actually fitted, but that happens after
+    every base model is trained -- for in-context models that is the expensive part.
+    """
+    train = _data()
+    with pytest.raises(ValueError, match="do not match any requested model"):
+        _fit(tmp_path, train, validation_mode="none", ensemble_weights={"LightGBM": 0.5, "CatBoost": 0.5})
+    assert not (tmp_path / "models").exists(), "no model should have been fit"
+
+
+def test_ensemble_weights_hint_at_hyperparameters_keys(tmp_path):
+    """`hyperparameters` is keyed by 'GBM'; ensemble_weights wants 'LightGBM'.
+
+    Reaching for the key is the predictable mistake, so the error names the mapping.
+    """
+    with pytest.raises(ValueError, match="look like `hyperparameters` keys"):
+        _fit(tmp_path, _data(), validation_mode="none", ensemble_weights={"GBM": 0.5, "XGB": 0.5})
+
+
+def test_ensemble_weight_name_extending_a_real_model_is_left_to_the_trainer(tmp_path):
+    """`name_suffix` concatenates without a separator, so 'LightGBMm' could have been legitimate.
+
+    Rejecting it up front would risk refusing a real suffixed name, so it is caught after fitting
+    instead -- with the exact list of models that were actually produced.
+    """
+    with pytest.raises(ValueError, match="are not fitted models"):
+        _fit(tmp_path, _data(), validation_mode="none", ensemble_weights={"LightGBMm": 0.5, "XGBoost": 0.5})

--- a/tabular/tests/unittests/test_validation_mode.py
+++ b/tabular/tests/unittests/test_validation_mode.py
@@ -176,3 +176,112 @@ def test_ensemble_weight_name_extending_a_real_model_is_left_to_the_trainer(tmp_
     """
     with pytest.raises(ValueError, match="are not fitted models"):
         _fit(tmp_path, _data(), validation_mode="none", ensemble_weights={"LightGBMm": 0.5, "XGBoost": 0.5})
+
+
+def test_validation_mode_none_with_two_models_of_the_same_type(tmp_path):
+    """Duplicate configs of one model type: 'Dummy' and 'Dummy_2'.
+
+    Regression test. The stacker prunes its base models by validation score before fitting, which
+    only compares anything when two models share a type -- and every score is None here, so the
+    comparison raised and the ensemble was silently skipped. Pruning is now disabled for fixed
+    weights, which it has to be anyway: dropping a base model would hand the survivors weights
+    meant for other models.
+    """
+    train = _data()
+    predictor = TabularPredictor(label="label", path=str(tmp_path), verbosity=0).fit(
+        train,
+        hyperparameters={"DUMMY": [{}, {}]},
+        validation_mode="none",
+        ensemble_weights={"Dummy": 0.5, "Dummy_2": 0.5},
+    )
+
+    assert set(predictor.model_names()) == {"Dummy", "Dummy_2", "WeightedEnsemble_L2"}
+    assert predictor.model_best == "WeightedEnsemble_L2"
+
+
+def test_validation_mode_none_weights_same_type_models_independently(tmp_path):
+    """Same type, different configs, different weights: each must get its own.
+
+    Uses configs that actually predict differently, so a mix-up would show up in the output rather
+    than being masked by identical base predictions.
+    """
+    train = _data(n=250)
+    test = _data(n=60, seed=4).drop(columns=["label"])
+    weights = {"LightGBM": 0.2, "LightGBM_2": 0.3, "LightGBM_3": 0.5}
+    predictor = TabularPredictor(label="label", path=str(tmp_path), verbosity=0).fit(
+        train,
+        hyperparameters={"GBM": [{"num_leaves": 4}, {"num_leaves": 20}, {"num_leaves": 60}]},
+        validation_mode="none",
+        ensemble_weights=weights,
+    )
+
+    base_names = [m for m in predictor.model_names() if not m.startswith("WeightedEnsemble")]
+    assert sorted(base_names) == sorted(weights), "no base model may be pruned away"
+
+    ensemble = predictor.predict_proba(test)[1].to_numpy()
+    expected = sum(w * predictor.predict_proba(test, model=m)[1].to_numpy() for m, w in weights.items())
+    np.testing.assert_allclose(ensemble, expected, atol=1e-6)
+
+
+def test_ensemble_weights_missing_renormalize_rescales_over_survivors(tmp_path):
+    """A named model that was not fit is dropped and the rest keep their proportions."""
+    train = _data(n=250)
+    test = _data(n=60, seed=5).drop(columns=["label"])
+    predictor = TabularPredictor(label="label", path=str(tmp_path), verbosity=0).fit(
+        train,
+        hyperparameters={"GBM": [{"num_leaves": 5}, {"num_leaves": 40}]},
+        validation_mode="none",
+        ensemble_weights={"LightGBM": 0.2, "LightGBM_2": 0.3, "CatBoost": 0.5},
+        ensemble_weights_missing="renormalize",
+    )
+
+    base_names = [m for m in predictor.model_names() if not m.startswith("WeightedEnsemble")]
+    assert sorted(base_names) == ["LightGBM", "LightGBM_2"]
+    # 0.2 / 0.3 rescaled over their own sum, not over the original 1.0.
+    ensemble = predictor.predict_proba(test)[1].to_numpy()
+    expected = (
+        0.4 * predictor.predict_proba(test, model="LightGBM")[1].to_numpy()
+        + 0.6 * predictor.predict_proba(test, model="LightGBM_2")[1].to_numpy()
+    )
+    np.testing.assert_allclose(ensemble, expected, atol=1e-6)
+
+
+def test_ensemble_weights_missing_renormalize_handles_a_model_that_failed_to_fit(tmp_path):
+    """The motivating case: the model was requested, but never produced.
+
+    `ag.max_rows` constrains XGBoost out, so it is a genuine fit failure rather than a bad name.
+    """
+    train = _data(n=250)
+    test = _data(n=60, seed=6).drop(columns=["label"])
+    predictor = TabularPredictor(label="label", path=str(tmp_path), verbosity=0).fit(
+        train,
+        hyperparameters={"GBM": {}, "XGB": {"ag.max_rows": 10}},
+        validation_mode="none",
+        ensemble_weights={"LightGBM": 0.25, "XGBoost": 0.75},
+        ensemble_weights_missing="renormalize",
+    )
+
+    assert [m for m in predictor.model_names() if not m.startswith("WeightedEnsemble")] == ["LightGBM"]
+    # The sole survivor absorbs the whole weight, so the ensemble is that model.
+    np.testing.assert_allclose(
+        predictor.predict_proba(test)[1].to_numpy(),
+        predictor.predict_proba(test, model="LightGBM")[1].to_numpy(),
+        atol=1e-6,
+    )
+
+
+def test_ensemble_weights_missing_renormalize_still_errors_when_none_were_fit(tmp_path):
+    """Dropping every named model would leave nothing to ensemble."""
+    with pytest.raises(ValueError, match="None of the models named in ensemble_weights were fit"):
+        TabularPredictor(label="label", path=str(tmp_path), verbosity=0).fit(
+            _data(),
+            hyperparameters={"GBM": {}},
+            validation_mode="none",
+            ensemble_weights={"CatBoost": 0.5, "RandomForest": 0.5},
+            ensemble_weights_missing="renormalize",
+        )
+
+
+def test_ensemble_weights_missing_rejects_unknown_values(tmp_path):
+    with pytest.raises(ValueError, match="ensemble_weights_missing must be 'error' or 'renormalize'"):
+        _fit(tmp_path, _data(), validation_mode="none", ensemble_weights=WEIGHTS, ensemble_weights_missing="skip")

--- a/tabular/tests/unittests/test_validation_mode.py
+++ b/tabular/tests/unittests/test_validation_mode.py
@@ -1,0 +1,122 @@
+"""`validation_mode="none"`: train on every row, combine with predetermined weights.
+
+The motivating case is an in-context learner such as TabPFN or TabICL, which needs no validation
+set, paired with an ensemble combination that is known up front rather than learned from held-out
+predictions. These tests use fast models so they exercise the plumbing, not the backends.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from autogluon.tabular import TabularPredictor
+
+HYPERPARAMETERS = {"GBM": {}, "XGB": {}}
+WEIGHTS = {"LightGBM": 0.5, "XGBoost": 0.5}
+
+
+def _data(n: int = 200, seed: int = 0) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    df = pd.DataFrame(rng.normal(size=(n, 5)), columns=[f"f{i}" for i in range(5)])
+    df["label"] = (df.f0 + rng.normal(scale=0.3, size=n) > 0).astype(int)
+    return df
+
+
+def _fit(tmp_path, train, **kwargs):
+    return TabularPredictor(label="label", path=str(tmp_path), verbosity=0).fit(
+        train, hyperparameters=HYPERPARAMETERS, **kwargs
+    )
+
+
+def test_validation_mode_none_trains_on_every_row(tmp_path):
+    """No holdout is carved, and no model gets a validation score."""
+    train = _data()
+    predictor = _fit(tmp_path, train, validation_mode="none", ensemble_weights=WEIGHTS)
+
+    assert predictor._trainer._num_rows_train == len(train)
+    leaderboard = predictor.leaderboard(silent=True)
+    assert leaderboard["score_val"].isna().all()
+    assert predictor.model_best == "WeightedEnsemble_L2"
+
+
+def test_validation_mode_none_applies_the_given_weights(tmp_path):
+    """The ensemble is exactly the weighted combination of its base models."""
+    train = _data()
+    test = _data(n=100, seed=1).drop(columns=["label"])
+    weights = {"LightGBM": 0.25, "XGBoost": 0.75}
+    predictor = _fit(tmp_path, train, validation_mode="none", ensemble_weights=weights)
+
+    ensemble = predictor.predict_proba(test)[1].to_numpy()
+    expected = sum(w * predictor.predict_proba(test, model=name)[1].to_numpy() for name, w in weights.items())
+    np.testing.assert_allclose(ensemble, expected, atol=1e-6)
+
+
+def test_validation_mode_none_normalizes_weights(tmp_path):
+    """Weights need not sum to 1; the ratio is what matters."""
+    train = _data()
+    test = _data(n=60, seed=2).drop(columns=["label"])
+    scaled = _fit(tmp_path / "a", train, validation_mode="none", ensemble_weights={"LightGBM": 2, "XGBoost": 6})
+    unit = _fit(tmp_path / "b", train, validation_mode="none", ensemble_weights={"LightGBM": 0.25, "XGBoost": 0.75})
+
+    np.testing.assert_allclose(
+        scaled.predict_proba(test)[1].to_numpy(), unit.predict_proba(test)[1].to_numpy(), atol=1e-6
+    )
+
+
+def test_validation_mode_none_without_an_ensemble(tmp_path):
+    """`fit_weighted_ensemble=False` is the other way to have nothing to learn weights for."""
+    train = _data()
+    predictor = _fit(tmp_path, train, validation_mode="none", fit_weighted_ensemble=False)
+
+    assert predictor._trainer._num_rows_train == len(train)
+    assert predictor.model_best in set(predictor.model_names())
+
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        ({"num_bag_folds": 3}, "cannot be combined with bagging"),
+        ({"tuning_data": "TRAIN"}, "cannot be combined with `tuning_data`"),
+        ({"validation_structure": {"group_on": "f0"}}, "cannot be combined with `validation_structure`"),
+    ],
+)
+def test_validation_mode_none_rejects_what_needs_a_holdout(tmp_path, kwargs, match):
+    """Bagging, stacking and explicit tuning data are all defined by holding rows out."""
+    train = _data()
+    if kwargs.get("tuning_data") == "TRAIN":
+        kwargs["tuning_data"] = train
+    with pytest.raises(ValueError, match=match):
+        _fit(tmp_path, train, validation_mode="none", ensemble_weights=WEIGHTS, **kwargs)
+
+
+def test_validation_mode_none_requires_weights_for_an_ensemble(tmp_path):
+    """Without validation data there is nothing to learn weights from, so they must be supplied."""
+    with pytest.raises(ValueError, match="leaves no data to learn ensemble weights from"):
+        _fit(tmp_path, _data(), validation_mode="none")
+
+
+def test_ensemble_weights_rejected_when_validation_exists(tmp_path):
+    """With validation data AutoGluon learns the weights; fixed weights would silently override."""
+    with pytest.raises(ValueError, match="only supported with validation_mode='none'"):
+        _fit(tmp_path, _data(), ensemble_weights=WEIGHTS)
+
+
+def test_validation_mode_rejects_unknown_values(tmp_path):
+    with pytest.raises(ValueError, match="validation_mode must be 'auto' or 'none'"):
+        _fit(tmp_path, _data(), validation_mode="sometimes")
+
+
+@pytest.mark.parametrize(
+    "weights, match",
+    [
+        ({"Nope": 1.0}, "are not fitted models"),
+        ({"LightGBM": 1.0}, "missing a weight for"),
+        ({"LightGBM": 0.0, "XGBoost": 0.0}, "must sum to a positive value"),
+    ],
+)
+def test_ensemble_weights_are_validated(tmp_path, weights, match):
+    """A silent mismatch would give a model someone else's weight."""
+    with pytest.raises(ValueError, match=match):
+        _fit(tmp_path, _data(), validation_mode="none", ensemble_weights=weights)

--- a/tabular/tests/unittests/test_validation_mode.py
+++ b/tabular/tests/unittests/test_validation_mode.py
@@ -138,7 +138,8 @@ def test_validation_mode_rejects_unknown_values(tmp_path):
     [
         # Caught before fitting -- no requested model could produce this name.
         ({"Nope": 1.0}, "do not match any requested model"),
-        ({"LightGBM": 1.0}, "missing a weight for"),
+        # Caught before fitting: XGBoost is requested but has no weight.
+        ({"LightGBM": 1.0}, "gives no weight to"),
         ({"LightGBM": 0.0, "XGBoost": 0.0}, "must sum to a positive value"),
     ],
 )
@@ -286,3 +287,46 @@ def test_ensemble_weights_missing_renormalize_still_errors_when_none_were_fit(tm
 def test_ensemble_weights_missing_rejects_unknown_values(tmp_path):
     with pytest.raises(ValueError, match="ensemble_weights_missing must be 'error' or 'renormalize'"):
         _fit(tmp_path, _data(), validation_mode="none", ensemble_weights=WEIGHTS, ensemble_weights_missing="skip")
+
+
+def test_hyperparameters_curve_switches_the_portfolio_with_the_mode(tmp_path):
+    """Tiny data gets a small portfolio and fixed weights; larger data the full one, bagged."""
+    curves = {
+        "validation_mode": [[100, "none"], "auto"],
+        "num_bag_folds": [[100, 0], 8],
+        "num_stack_levels": [[100, 0], 1],
+        "ensemble_weights": [[100, {"LightGBM": 0.5, "XGBoost": 0.5}], None],
+        "hyperparameters": [[100, {"GBM": {}, "XGB": {}}], {"GBM": {}, "XGB": {}, "RF": {}}],
+    }
+    tiny = TabularPredictor(label="label", path=str(tmp_path / "tiny"), verbosity=0).fit(
+        _data(n=60), validation_size_curves=curves
+    )
+    assert tiny._trainer._num_rows_train == 60
+    assert tiny.leaderboard(silent=True)["score_val"].isna().all()
+    assert {m for m in tiny.model_names() if not m.startswith("WeightedEnsemble")} == {"LightGBM", "XGBoost"}
+
+    big = TabularPredictor(label="label", path=str(tmp_path / "big"), verbosity=0).fit(
+        _data(n=300), validation_size_curves=curves
+    )
+    assert not big.leaderboard(silent=True)["score_val"].isna().all()
+    assert any("RandomForest" in m for m in big.model_names())
+
+
+def test_weights_and_hyperparameters_must_agree_before_fitting(tmp_path):
+    """A pairing that agrees above a threshold and not below is caught pre-fit.
+
+    Without this the config looks fine, works on larger data, and fails only in the band where the
+    curves disagree -- after every base model has been trained.
+    """
+    curves = {
+        "validation_mode": [[100, "none"], "auto"],
+        "num_bag_folds": [[100, 0], 8],
+        "num_stack_levels": [[100, 0], 1],
+        "ensemble_weights": [[100, {"LightGBM": 0.5, "XGBoost": 0.5}], None],
+        "hyperparameters": [[100, {"GBM": {}, "XGB": {}, "RF": {}}], {"GBM": {}}],
+    }
+    with pytest.raises(ValueError, match=r"gives no weight to \['RandomForest'\]"):
+        TabularPredictor(label="label", path=str(tmp_path / "a"), verbosity=0).fit(
+            _data(n=60), validation_size_curves=curves
+        )
+    assert not (tmp_path / "a" / "models").exists(), "no model should have been fit"


### PR DESCRIPTION
## Description of changes

Supports fitting on **every** training row with no validation split, combining models with weights given up front rather than learned from held-out predictions — and lets that whole profile switch on data size.

The motivating case is an in-context learner such as TabPFN or TabICL, which needs no validation set, with a combination that is known rather than searched:

```python
predictor.fit(
    train_data,
    hyperparameters={"TABPFN-3": {}, "TABICL": {}},
    validation_mode="none",
    ensemble_weights={"TabPFN-3": 0.5, "TabICL": 0.5},
)
```

```
MODELS:      ['WeightedEnsemble_L2', 'TabPFN-3', 'TabICL']
SCORE_VAL:   [None, None, None]
BEST:        WeightedEnsemble_L2
TRAIN ROWS:  400 of 400                <- no holdout
MAX|ens - 0.5*(a+b)|: 2.98e-08         <- weights applied exactly
```

## Most of the machinery already existed

`_train_and_save` already treats `X_val=None` as "no score available" — the same path `refit_full` takes, and `fit_helper.py` already records that `_FULL` models "legitimately have no val score". `SimpleWeightedEnsembleModel` already accepts fixed weights and learns nothing from the data it is fitted on (it fits on a single dummy row). Three things were missing:

- **No way to ask for it.** The holdout split was unconditional, and `holdout_frac=0` was silently floored to a 2-row validation set — 198 of 200 rows trained, and every model got a `val_score` computed on 2 rows that model selection then trusted.
- **Selection required a `val_score`**, so a fit where every model succeeded still had no `model_best`.
- **The aux stage materialized base-model predictions** before fitting the ensemble. Fixed weights need none.

## Size curves drive the switch

The knobs are curve-able, so the tiny → small transition is configuration rather than caller code:

```python
validation_size_curves={
    "validation_mode":  [[100, "none"], "auto"],
    "num_bag_folds":    [[100, 0], 8],
    "num_stack_levels": [[100, 0], 1],
    "ensemble_weights": [[100, {"TabPFN-3": 0.5, "TabICL": 0.5}], None],
    "hyperparameters":  [[100, {"TABPFN-3": {}, "TABICL": {}}], "default"],
}
```

```
n= 60 -> the two named models, 60/60 rows, no scores, fixed-weight ensemble
n=300 -> the full portfolio, bagged and stacked, scored
```

`resolve_size_curve` already carried arbitrary payloads, so `ensemble_weights` needed a field rather than a mechanism. `hyperparameters` resolves earlier than the other curves — the portfolio decides whether raw text features are enabled, so it must be settled before the feature generator is built — and is therefore always read at the row count, never the group count.

### Curves must agree with each other, so the resolved set is checked

Curves resolve one knob at a time. A threshold written into four curves and mistyped in the fifth produces a **band of data sizes** where the knobs disagree — a config that works on larger data and fails only in that band. Two checks close this:

- `resolve_validation_mode` rejects `validation_mode="none"` against the resolved `num_bag_folds` / `num_stack_levels`, with a remedy keyed to where the values came from (*"check that every curve switches at the same threshold"* vs *"Set them to 0, or drop validation_mode='none'"*).
- The pre-fit name check covers both directions of the weights/hyperparameters pairing:

```
weight naming no requested model -> "do not match any requested model"
requested model with no weight   -> "gives no weight to ['RandomForest']"
```

The second raises in **1.4s with nothing on disk**; previously it surfaced from the trainer after every base model had been trained — which for in-context models is the expensive part.

## Two behaviours worth reviewing

**Refusing to pick a default model.** With several models fit, no scores and no weights, an earlier version of this branch returned whichever model came last in DAG order — it picked XGBoost over LightGBM regardless of the order they were listed in, and `predict` silently answered from a model the caller never chose. Now:

| situation | `model_best` | `predict()` |
|---|---|---|
| 1 model, no score | that model | works |
| N models + weights | the ensemble | works |
| N models, no weights, no ensemble | `None` | raises `AmbiguousModelBestError` |

`fit` still succeeds in the last case, logging a warning: the models are fit and usable via `predict(model=...)`, and only the *default* is undecidable, so the error belongs at the call that needs a default. `predictor.model_best` returns `None` rather than raising — introspection should report the absence. `AmbiguousModelBestError` subclasses `AssertionError` so existing handlers keep working.

**`ensemble_weights_missing="renormalize"`** (default `"error"`) drops names that were not produced and rescales the rest over the survivors, raising only if *none* were fit. For a model constrained out by `ag.max_rows`:

```
fit=['LightGBM'], weight rescaled 0.25 -> 1.0, ensemble == LightGBM
WARNING: ensemble_weights named ['XGBoost'], which was not fit.
         Rescaling the remaining weights over ['LightGBM']
```

## Also fixed here (found while checking whether curves could carry this)

`resolve_size_curve` used `None` as both the "no trailing fallback supplied" sentinel and a legal curve value, so the two were indistinguishable:

```
[[100, X]]        @500 -> X      clamp to last anchor  (correct, documented)
[[100, X], None]  @500 -> X      explicit None swallowed  (now None)
```

The clamp is right for an anchor-only curve and is unchanged. `[[X, value], None]` is the natural way to write "on below X, off above X" — which is exactly what this feature needs — and it previously returned `value` at every size. Every curve in `DEFAULT_VALIDATION_SIZE_CURVES` ends in a non-`None` value, so no default resolution changes; verified across 9 row counts from 20 to 100k.

Separately, `_get_validation_preset`'s docstring claimed "`holdout_frac` is always sized on rows". True of the built-in policy, false of a caller-supplied curve, which is read at the effective size — the inline comment ten lines below already said so. Confirmed: with `size_on_groups` and 4,672 rows across 68 groups, a supplied curve reads at 68.

## Rejected rather than silently reinterpreted

Bagging, stacking, `tuning_data`, `validation_structure` and `holdout_frac` (each defined by holding rows out); `ensemble_weights` without `validation_mode="none"` (AutoGluon would otherwise learn them, so fixed weights would silently override the search); weights naming an unknown model, omitting a fitted one, or summing to zero.

## Known limitation

With no validation scores, anything that ranks by validation performance has nothing to work with: `leaderboard()` reports `score_val` as `None` throughout, and `fit_weighted_ensemble()`, calibration and training-data feature importance each degrade or raise. Documented in the `validation_mode` docstring; those call sites were not audited.

Scope note: `hyperparameters` now lives in a class named `ValidationSizeCurves`. Everything there is "what to do at this data size", so it is coherent, but the name understates what it holds. Renaming is a larger, more disruptive change — flagging rather than doing it.

## Tests

`test_validation_mode.py` (new, 25 tests) and `test_validation_size_curves.py` (+9) — **140 passed**. Regression suites: `test_dummy`, `test_lightgbm`, `test_validation_structure` — 101 passed. `ruff format` and `ruff check --select I` clean.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)