### PR TITLE
[core] Fail fast when eval_metric is an unwrapped callable

### DIFF
--- a/core/src/autogluon/core/metrics/__init__.py
+++ b/core/src/autogluon/core/metrics/__init__.py
@@ -800,7 +800,9 @@ def _get_valid_metric_problem_types(metric: str):
 
 def get_metric(metric, problem_type: str = None, metric_type: str = None) -> Scorer:
     """Returns metric function by using its name if the metric is str.
-    Performs basic check for metric compatibility with given problem type."""
+    Performs basic check for metric compatibility with given problem type.
+    Raises a ValueError if the metric is neither None, a str, nor a Scorer,
+    as an unwrapped metric function has to be wrapped via `make_scorer` first."""
     if metric_type is None:
         metric_type = "metric"
 
@@ -842,4 +844,12 @@ def get_metric(metric, problem_type: str = None, metric_type: str = None) -> Sco
             f"autogluon.core.metrics to see how to define your own {metric_type} function"
         )
     else:
+        if metric is not None and not isinstance(metric, Scorer):
+            raise ValueError(
+                f"Invalid {metric_type} of type '{type(metric).__name__}': {metric_type} must be a str or a Scorer.\n"
+                f"If you are passing a custom metric function, wrap it with `autogluon.core.metrics.make_scorer` first:\n"
+                f"\tfrom autogluon.core.metrics import make_scorer\n"
+                f"\t{metric_type} = make_scorer(name='my_metric', score_func=my_func, optimum=0, greater_is_better=False)\n"
+                f"Refer to autogluon.core.metrics.make_scorer for the full list of arguments."
+            )
         return metric

--- a/core/tests/unittests/metrics/test_metrics.py
+++ b/core/tests/unittests/metrics/test_metrics.py
@@ -5,7 +5,7 @@ import pytest
 import sklearn
 
 from autogluon.core.constants import BINARY, MULTICLASS, QUANTILE, REGRESSION
-from autogluon.core.metrics import METRICS, Scorer, make_scorer, rmse_func
+from autogluon.core.metrics import METRICS, Scorer, get_metric, make_scorer, rmse_func
 
 METRICS_NEEDS_CLASS = {}
 METRICS_NEEDS_PROBA = {}
@@ -433,3 +433,28 @@ def test_invalid_scorer():
     with pytest.raises(ValueError):
         # Invalid: Specifying needs_pred=True when needs_proba=True
         make_scorer("dummy", score_func=sklearn.metrics.accuracy_score, needs_pred=True, needs_proba=True)
+
+
+def test_get_metric_raw_callable_fails_fast():
+    """
+    Ensure `get_metric` rejects a raw callable instead of returning it as if it were a Scorer.
+
+    `get_metric` is annotated `-> Scorer`, but its non-str branch returns the object unchanged,
+    so an unwrapped metric function (e.g. `eval_metric=sklearn.metrics.root_mean_squared_log_error`)
+    passes straight through. The caller then treats it as a Scorer and dies later on Scorer-only
+    attribute access -- `AttributeError: 'function' object has no attribute 'needs_proba'` -- with no
+    hint that `make_scorer` is the required wrapper.
+    """
+    raw_metric = sklearn.metrics.root_mean_squared_log_error
+    assert not isinstance(raw_metric, Scorer)
+    assert not hasattr(raw_metric, "needs_proba")
+
+    with pytest.raises((TypeError, ValueError), match="make_scorer"):
+        get_metric(raw_metric, problem_type=REGRESSION, metric_type="eval_metric")
+
+    # Valid: an explicitly wrapped Scorer is still returned unchanged.
+    wrapped = make_scorer("rmsle", score_func=raw_metric, optimum=0, greater_is_better=False)
+    assert get_metric(wrapped, problem_type=REGRESSION, metric_type="eval_metric") is wrapped
+
+    # Valid: `metric=None` means "use the default" and must keep passing through.
+    assert get_metric(None, problem_type=REGRESSION, metric_type="eval_metric") is None


### PR DESCRIPTION
*Issue #, if available:* #4704 — referenced deliberately **without** a closing keyword; see "Issue scope" below.

*Description of changes:*

## Problem

`get_metric()` is annotated `-> Scorer`, but its terminal branch returned any non-`str` object verbatim:

```python
else:
    return metric
```

So `eval_metric=sklearn.metrics.root_mean_squared_log_error` (the repro in #4704) was handed back as a bare function carrying none of `needs_proba` / `needs_threshold` / `needs_class` / `needs_pred` / `greater_is_better` / `name` / `optimum`. Callers treat the return value as a `Scorer`, so the failure surfaced much later at Scorer-only attribute access — `metrics/score_func.py:86`, `tabular/learner/default_learner.py:324`, `tabular/predictor/predictor.py:2441` — as:

```
AttributeError: 'function' object has no attribute 'needs_proba'
```

## Why it matters

The error arrives mid-`fit`, after preprocessing, pointing at an internal attribute rather than at the user's `eval_metric` argument, and never mentions `make_scorer` — which is the API the user actually needed. The documented type is already `str or Scorer` (`predictor.py:106`, `abstract_model.py:207`); the function simply did not enforce it.

Note on the diagnosis in the issue: `needs_proba` here is AutoGluon's own `Scorer` attribute, not the scikit-learn scorer keyword deprecated in scikit-learn 1.4. This is not the `response_method` migration, and no sklearn-compatibility change is included.

## What changed

Validate at the seam instead of deferring the failure. `get_metric` now raises `ValueError` when the metric is neither `None`, a `str`, nor a `Scorer`, with a message that names `make_scorer` and shows a usage line:

```
Invalid eval_metric of type 'function': eval_metric must be a str or a Scorer.
If you are passing a custom metric function, wrap it with `autogluon.core.metrics.make_scorer` first:
	from autogluon.core.metrics import make_scorer
	eval_metric = make_scorer(name='my_metric', score_func=my_func, optimum=0, greater_is_better=False)
Refer to autogluon.core.metrics.make_scorer for the full list of arguments.
```

`None`, `str` and `Scorer` behaviour is unchanged. `ValueError` matches the surrounding convention — every one of the 16 existing raises in this module is a `ValueError`, and no caller wraps `get_metric` in `try`/`except`.

**The callable is deliberately not auto-wrapped.** `optimum`, `greater_is_better` and the `needs_*` flags cannot be inferred from a function. RMSLE is lower-is-better with `optimum=0`, so a default wrap (`optimum=1`, `greater_is_better=True`) would silently optimize in the wrong direction — a worse outcome than a clear error. If maintainers would prefer auto-wrapping for a recognised subset, I'm happy to redo it that way.

## Issue scope — the `make_scorer` half already works

#4704 reports two failures. Only one reproduces on current `master`:

| Reported | Status on `master` |
|---|---|
| `eval_metric=root_mean_squared_log_error` (unwrapped) | **Reproduces** — fixed here |
| `eval_metric=make_scorer(...)` | **Does not reproduce** — already works |

Verified on this branch's base with scikit-learn 1.9: `make_scorer("rmsle", score_func=root_mean_squared_log_error, optimum=0, greater_is_better=False)` builds a valid `Scorer`, passes through `get_metric` unchanged (`is` identity), and scores correctly. Rather than guess at what went wrong on the reporter's 1.2 install, that half is left out of scope.

That is why there is **no `Fixes #4704` trailer**: whether the issue should close depends on a maintainer call on the auto-wrap question and on the unexplained 1.2 `make_scorer` report. Happy to add the trailer if you'd like it to close on merge.

## Tests

`core/tests/unittests/metrics/test_metrics.py::test_get_metric_raw_callable_fails_fast`, added next to the existing `test_invalid_scorer`. It locks in three things:

- an unwrapped callable raises with `make_scorer` named in the message
- an explicitly wrapped `Scorer` is still returned unchanged (`is` identity)
- `metric=None` still passes through — this guards the most likely way a naive version of this fix would break the default-metric path

Written test-first: against unpatched code it fails with `Failed: DID NOT RAISE any of (TypeError, ValueError)`.

## Verification

Run offline in a minimal `core`-only environment (Python 3.12, scikit-learn 1.9, `common` + `core` + `features` editable, no models installed, no data, no GPU, no training):

- `pytest core/tests/unittests/metrics/` — **239 passed, 37 skipped** (baseline was 238 passed + this test failing)
- `pytest core/tests` (excluding `ray`/`hpo`-dependent modules, which cannot import in this env) — **363 passed, 37 skipped**; failure set diffed against baseline: **zero new failures**, the only delta being this test flipping to pass. The 5 remaining failures are pre-existing and environmental (e.g. `TypeError: Cannot interpret '<StringDtype(na_value=nan)>' as a data type` in `test_infer_problem_type_*`)
- `ruff format --check` and `ruff check` (project config: `E4,E7,E9,F`) — clean on both changed files
- `ruff check --select I` (isort) — clean
- `core/tests/test_check_style.py::test_check_style` (flake8) — passes; the sole flake8 warning on the changed file is the pre-existing bare `except` at line 14
- `mypy --ignore-missing-imports` — 27 errors before and after, all pre-existing. The one error that moved (`get_metric`'s return) has its inferred type *narrowed* by the new `isinstance` check, from `Any | None` to `Scorer | None`

**Caller audit.** I checked all 11 `get_metric` call sites by hand — `abstract_model.py` (×4), `abstract_learner.py` (×6), `predictor.py`, `abstract_trainer.py`. Every one passes only `str`, `Scorer`, or `None`; three of them (`abstract_learner.py:996`, `predictor.py:6493`, `abstract_trainer.py:5258`) are already behind explicit `isinstance(..., str)` guards, and `abstract_learner.py:1337` passes `eval_metric.name`. No in-repo path can reach the new raise. I also exercised the real `abstract_model.py:310` caller directly: constructing a core model with a raw callable now fails fast with the actionable message, while `str`, `Scorer` and `None` all still resolve correctly.

The tabular integration suites were not run — they need model backends and datasets that are out of scope for an offline change of this size. CI covers them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
