### PR TITLE
[core] Add ag.refit_hyperparameters to fit and refit a model differently

### DIFF
--- a/core/src/autogluon/core/models/abstract/_auxiliary_params.py
+++ b/core/src/autogluon/core/models/abstract/_auxiliary_params.py
@@ -125,6 +125,21 @@ class AuxiliaryParams:
     """If specified, predictions on more than `max_batch_size` rows are computed in chunks of at most
     `max_batch_size` rows each (see `_predict_proba_batch`), bounding prediction-time memory usage.
     Models may declare the sentinel "auto" and resolve it to an int during `_fit`."""
+    refit_hyperparameters: dict | None = field(default=None, metadata=_WRAPPER_ONLY)
+    """Hyperparameter overrides applied only when the model is refit on all the data.
+
+    A refit trains one model on every row, with no validation data and no folds, so it can afford
+    settings the fitted model could not. The canonical case is an in-context model whose ensemble
+    size is a direct cost multiplier: fit the folds cheaply and spend the budget once on the model
+    that is actually served::
+
+        hyperparameters={"TABICL": {"n_estimators": 1, "ag.refit_hyperparameters": {"n_estimators": 8}}}
+
+    Applies to both refit paths -- a bagged model's `refit_folds` / `refit_full`, and a
+    holdout-fitted model's `refit_full` -- and is merged over the hyperparameters the fit
+    concluded with, so values learned during fit (such as an early-stopped iteration count) are
+    kept unless named here. Ignored by a model that is never refit."""
+
     drop_unique: bool = field(default=True, metadata=_WRAPPER_ONLY)
     """Whether to drop features that have only 1 unique value."""
     save_pretrained_weights: bool = field(default=False, metadata=_WRAPPER_ONLY)

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -2443,6 +2443,47 @@ class AbstractModel(ModelBase, Tunable):
             hyperparameters[AG_ARGS_FIT] = self._user_params_aux.copy()
         return hyperparameters
 
+    def declared_refit_hyperparameters(self) -> dict:
+        """The ``ag.refit_hyperparameters`` this model was configured with, or ``{}``.
+
+        Read from the raw hyperparameters rather than ``aux_params`` so it answers the same way for
+        an unfit template, whose ``params_aux`` has not been populated -- which is what a bagged
+        model's ``model_base`` is.
+        """
+        hyperparameters = self.get_params().get("hyperparameters") or {}
+        aux = hyperparameters.get(AG_ARGS_FIT)
+        declared = aux.get("refit_hyperparameters") if isinstance(aux, dict) else None
+        if declared is None:
+            declared = hyperparameters.get(f"{AG_ARG_PREFIX}refit_hyperparameters")
+        return declared or {}
+
+    @staticmethod
+    def _apply_refit_hyperparameters(hyperparameters: dict) -> None:
+        """Consume ``ag.refit_hyperparameters`` from ``hyperparameters`` and merge it in, in place.
+
+        Read out of the hyperparameters dict rather than from ``self.aux_params``, because a bagged
+        model builds its refit child from ``model_base`` -- an unfit template whose ``params_aux``
+        has not been populated yet, so the value is only present in its raw form here.
+
+        Applied after ``params_trained``, so an explicitly requested refit value wins over one the
+        fit concluded with; overriding what the fit settled on is the point of the option.
+
+        The override is consumed rather than copied through: it has been applied, and leaving it
+        would re-apply on any further refit of the refit.
+        """
+        aux = hyperparameters.get(AG_ARGS_FIT)
+        overrides = aux.pop("refit_hyperparameters", None) if isinstance(aux, dict) else None
+        prefixed = hyperparameters.pop(f"{AG_ARG_PREFIX}refit_hyperparameters", None)
+        if overrides is None:
+            overrides = prefixed
+        if not overrides:
+            return
+        for key, value in overrides.items():
+            if isinstance(key, str) and key.startswith(AG_ARG_PREFIX):
+                hyperparameters.setdefault(AG_ARGS_FIT, {})[key[len(AG_ARG_PREFIX) :]] = value
+            else:
+                hyperparameters[key] = value
+
     @staticmethod
     def _update_hyperparameters_with_params_trained(hyperparameters: dict, params_trained: dict) -> None:
         """Merge ``params_trained`` into ``hyperparameters`` in place, keeping one encoding per parameter.
@@ -2495,6 +2536,7 @@ class AbstractModel(ModelBase, Tunable):
         )
 
         self._update_hyperparameters_with_params_trained(params["hyperparameters"], self.params_trained)
+        self._apply_refit_hyperparameters(params["hyperparameters"])
         params["name"] = params["name"] + REFIT_FULL_SUFFIX
         template = self.__class__(**params)
 

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -1361,10 +1361,18 @@ class BaggedEnsembleModel(AbstractModel):
         model_full_template = self.__class__(**init_args)
         return model_full_template
 
+    def declared_refit_hyperparameters(self) -> dict:
+        """Declared on the child: the bag wrapper has no hyperparameters of its own to override."""
+        return self._get_model_base().declared_refit_hyperparameters()
+
     def convert_to_refit_full_template_child(self) -> AbstractModel:
+        model_base = self._get_model_base()
         refit_params_trained = self._get_compressed_params_trained()
-        refit_params = copy.deepcopy(self._get_model_base().get_params())
+        refit_params = copy.deepcopy(model_base.get_params())
         self._update_hyperparameters_with_params_trained(refit_params["hyperparameters"], refit_params_trained)
+        # `ag.refit_hyperparameters` is declared on the child, since it names the child's
+        # hyperparameters -- the bag wrapper has none of its own to override.
+        self._apply_refit_hyperparameters(refit_params["hyperparameters"])
         refit_child_template = self._child_type(**refit_params)
 
         return refit_child_template

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -709,6 +709,12 @@ class TabularPredictor:
                         Example: `hyperparameters = {'RF': {..., 'ag_args': {'name_suffix': 'CustomModelSuffix', 'disable_in_hpo': True}}`
                         Individual arguments can be passed for ag_args_fit by adding the prefix `ag.`: `hyperparameters = {'RF': {..., 'ag.num_cpus': 1}}`
                         Individual arguments can be passed for ag_args_ensemble by adding the prefix `ag.ens`: `hyperparameters = {'RF': {..., 'ag.ens.fold_fitting_strategy': 'sequential_local'}}`
+                        `ag.refit_hyperparameters` overrides hyperparameters for the refit only, so a model can be
+                        fit and refit differently: `hyperparameters = {'TABICL': {'n_estimators': 1, 'ag.refit_hyperparameters': {'n_estimators': 8}}}`
+                        trains the folds cheaply and spends the budget once on the model that is served. Applies to
+                        both `refit_full` and the in-fit refit that `ag.ens.refit_folds` performs, and to holdout as
+                        well as bagged fits. Merged over what the fit concluded with, so a value learned during fit
+                        (such as an early-stopped iteration count) is kept unless named here.
                     ag_args: Dictionary of customization options related to meta properties of the model such as its name, the order it is trained, the problem types it is valid for, and the type of HPO it utilizes.
                         Valid keys:
                             name: (str) The name of the model. This overrides AutoGluon's naming logic and all other name arguments if present.

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -5493,7 +5493,14 @@ def _detached_refit_single_full(
     if not reuse_first_fold:
         model_full = model.convert_to_refit_full_template()
         # Mitigates situation where bagged models barely had enough memory and refit requires more. Worst case results in OOM, but this lowers chance of failure.
-        model_full._user_params_aux["max_memory_usage_ratio"] = model.params_aux["max_memory_usage_ratio"] * 1.15
+        # Skipped only when `ag.refit_hyperparameters` named this ratio: an explicit request for
+        # the refit is a decision, and replacing it with the heuristic bump would make this the one
+        # auxiliary parameter the option cannot set. Checked against what the user declared, not
+        # against the template -- the template always carries this key, so testing it there would
+        # disable the bump for every refit.
+        declared_refit = model.declared_refit_hyperparameters()
+        if not any(key in ("max_memory_usage_ratio", "ag.max_memory_usage_ratio") for key in declared_refit):
+            model_full._user_params_aux["max_memory_usage_ratio"] = model.params_aux["max_memory_usage_ratio"] * 1.15
         # Re-set user specified training resources.
         # FIXME: this is technically also a bug for non-distributed mode, but there it is good to use more/all resources per refit.
         # FIXME: Unsure if it is better to do model.fit_num_cpus or model.fit_num_cpus_child,

--- a/tabular/tests/unittests/test_refit_hyperparameters.py
+++ b/tabular/tests/unittests/test_refit_hyperparameters.py
@@ -1,0 +1,143 @@
+"""`ag.refit_hyperparameters`: fit the folds one way, refit on all the data another.
+
+A refit trains a single model on every row with no validation data, so it can afford settings the
+fitted model could not. The motivating case is an in-context model whose ensemble size is a direct
+cost multiplier -- fit cheaply, spend the budget once on the model that is served.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from autogluon.tabular import TabularPredictor
+
+
+def _data(n: int = 400, seed: int = 0) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    df = pd.DataFrame(rng.normal(size=(n, 5)), columns=[f"f{i}" for i in range(5)])
+    df["label"] = (df.f0 + rng.normal(scale=0.3, size=n) > 0).astype(int)
+    return df
+
+
+def _child_param(predictor, model_name: str, param: str):
+    """The value a bagged model's child actually holds, or the model's own if not bagged."""
+    model = predictor._trainer.load_model(model_name)
+    if getattr(model, "models", None):
+        return model.load_child(model.models[0]).params.get(param)
+    return model.params.get(param)
+
+
+def test_refit_hyperparameters_apply_to_a_bagged_refit(tmp_path):
+    """`refit_full` on a bagged model refits the child with the override."""
+    predictor = TabularPredictor(label="label", path=str(tmp_path), verbosity=0).fit(
+        _data(),
+        hyperparameters={"GBM": {"num_leaves": 5, "ag.refit_hyperparameters": {"num_leaves": 40}}},
+        num_bag_folds=3,
+        fit_weighted_ensemble=False,
+    )
+    predictor.refit_full()
+
+    assert _child_param(predictor, "LightGBM_BAG_L1", "num_leaves") == 5
+    assert _child_param(predictor, "LightGBM_BAG_L1_FULL", "num_leaves") == 40
+
+
+def test_refit_hyperparameters_apply_to_a_holdout_refit(tmp_path):
+    """The same override works without bagging, where the refit follows a holdout fit."""
+    predictor = TabularPredictor(label="label", path=str(tmp_path), verbosity=0).fit(
+        _data(),
+        hyperparameters={"GBM": {"num_leaves": 5, "ag.refit_hyperparameters": {"num_leaves": 40}}},
+        num_bag_folds=0,
+        fit_weighted_ensemble=False,
+    )
+    predictor.refit_full()
+
+    assert _child_param(predictor, "LightGBM", "num_leaves") == 5
+    assert _child_param(predictor, "LightGBM_FULL", "num_leaves") == 40
+
+
+def test_refit_hyperparameters_apply_when_refit_folds_refits_during_fit(tmp_path):
+    """`refit_folds=True` refits inside `fit`, discarding the folds -- as TabICLv2 does by default.
+
+    Only the refit survives, so the override has to have reached it during the original fit.
+    """
+    predictor = TabularPredictor(label="label", path=str(tmp_path), verbosity=0).fit(
+        _data(),
+        hyperparameters={
+            "GBM": {
+                "num_leaves": 5,
+                "ag.refit_hyperparameters": {"num_leaves": 40},
+                "ag.ens.refit_folds": True,
+            }
+        },
+        num_bag_folds=3,
+        fit_weighted_ensemble=False,
+    )
+
+    assert _child_param(predictor, "LightGBM_BAG_L1", "num_leaves") == 40
+
+
+def test_refit_override_beats_a_value_the_fit_concluded_with(tmp_path):
+    """LightGBM records its early-stopped iteration count in `params_trained`.
+
+    That value carries into the refit by default, which is what makes refits cheap. An explicit
+    override of the same key has to win, or the option could not change anything the fit settled.
+    """
+    data = _data(n=500, seed=1)
+    common = dict(num_bag_folds=0, fit_weighted_ensemble=False)
+
+    default = TabularPredictor(label="label", path=str(tmp_path / "a"), verbosity=0).fit(
+        data, hyperparameters={"GBM": {"num_boost_round": 200}}, **common
+    )
+    default.refit_full()
+    learned = default._trainer.load_model("LightGBM").params_trained["num_boost_round"]
+    assert _child_param(default, "LightGBM_FULL", "num_boost_round") == learned
+
+    overridden = TabularPredictor(label="label", path=str(tmp_path / "b"), verbosity=0).fit(
+        data,
+        hyperparameters={"GBM": {"num_boost_round": 200, "ag.refit_hyperparameters": {"num_boost_round": 7}}},
+        **common,
+    )
+    overridden.refit_full()
+    assert _child_param(overridden, "LightGBM_FULL", "num_boost_round") == 7
+
+
+def test_refit_hyperparameters_is_consumed_by_the_refit(tmp_path):
+    """The override is applied once, not carried into the refit's own auxiliary parameters."""
+    predictor = TabularPredictor(label="label", path=str(tmp_path), verbosity=0).fit(
+        _data(),
+        hyperparameters={"GBM": {"num_leaves": 5, "ag.refit_hyperparameters": {"num_leaves": 40}}},
+        num_bag_folds=0,
+        fit_weighted_ensemble=False,
+    )
+    predictor.refit_full()
+
+    refit = predictor._trainer.load_model("LightGBM_FULL")
+    assert refit.aux_params.refit_hyperparameters is None
+
+
+def test_no_refit_hyperparameters_leaves_the_refit_unchanged(tmp_path):
+    """Without the option the refit inherits the fitted hyperparameters, as before."""
+    predictor = TabularPredictor(label="label", path=str(tmp_path), verbosity=0).fit(
+        _data(),
+        hyperparameters={"GBM": {"num_leaves": 5}},
+        num_bag_folds=0,
+        fit_weighted_ensemble=False,
+    )
+    predictor.refit_full()
+
+    assert _child_param(predictor, "LightGBM_FULL", "num_leaves") == 5
+
+
+def test_refit_hyperparameters_can_set_an_auxiliary_parameter(tmp_path):
+    """An `ag.`-prefixed key inside the override routes to the refit's auxiliary parameters."""
+    predictor = TabularPredictor(label="label", path=str(tmp_path), verbosity=0).fit(
+        _data(),
+        hyperparameters={"GBM": {"ag.refit_hyperparameters": {"ag.max_memory_usage_ratio": 3.0}}},
+        num_bag_folds=0,
+        fit_weighted_ensemble=False,
+    )
+    predictor.refit_full()
+
+    assert predictor._trainer.load_model("LightGBM_FULL").aux_params.max_memory_usage_ratio == 3.0


### PR DESCRIPTION
## Description of changes

A refit trains one model on every row, with no validation data and no folds, so it can afford settings the fitted model could not. Today it inherits the fitted hyperparameters wholesale, so there is no way to fit cheaply and spend the budget once on the model that is actually served.

The motivating case is an in-context model whose ensemble size is a direct cost multiplier — TabICLv2 sets `refit_folds=True` by default, so the fold models are discarded and only the refit survives:

```python
hyperparameters={"TABICL": {"n_estimators": 1,
                            "ag.refit_hyperparameters": {"n_estimators": 8}}}
```

Verified on TabICL, instrumenting both `_fit` calls:

```
bag fit, child n_estimators: 1        <- the folds
bag fit, child n_estimators: 8        <- the refit
final model TabICL_BAG_L1: child n_estimators=8
```

## Covers all three refit paths

They converge on building a hyperparameters dict for the refit template, so one helper serves all of them:

| path | site |
|---|---|
| bagged → `refit_full` | `BaggedEnsembleModel.convert_to_refit_full_template_child` |
| bagged → `refit_folds` (during the original fit) | same |
| holdout → `refit_full` | `AbstractModel.convert_to_refit_full_template` |

## Precedence

Applied after `params_trained`, so an explicit override wins over a value the fit concluded with — overriding what the fit settled on is the point of the option — while anything not named still carries over, which is what keeps refits cheap.

Verified with LightGBM's early stopping: `num_boost_round` settles at 9 during fit, carries into the refit by default, and an override to 7 wins.

## Two things worth a reviewer's attention

**Reading `aux_params` does not work here, and fails silently.** A bagged model builds its refit child from `model_base` — an unfit template whose `params_aux` is never populated — so `self.aux_params.refit_hyperparameters` was `None` and the override vanished, while the holdout path worked. The value is read from the raw hyperparameters instead, which answers correctly for both. Worth knowing if similar options are added later.

**`max_memory_usage_ratio` needed a carve-out.** `abstract_trainer.py` bumps it by 1.15 *after* the template is built, which would have made it the one auxiliary parameter this option cannot set. The bump is now skipped when the user names that ratio.

The guard checks **what the user declared**, not the template. My first version tested the template, which always carries that key — so it disabled the bump for every refit and moved the default from 1.15 to 1.25. Caught by measuring the default before and after, and confirmed unchanged now:

```
no override, holdout   refit ratio=1.15   (master: 1.15)
no override, bagged    refit ratio=1.15   (master: 1.15)
override 3.0           refit ratio=3.0    (master: 1.15)
```

## Notes

- The override is consumed by the refit rather than copied through, so it cannot re-apply to a refit of a refit.
- An `ag.`-prefixed key inside the override routes to the refit's auxiliary parameters, e.g. `{"ag.max_memory_usage_ratio": 3.0}`.
- Ignored by a model that is never refit; no behaviour changes without the option set.

## Tests

`tabular/tests/unittests/test_refit_hyperparameters.py` (new, 7 tests): each of the three refit paths, precedence against `params_trained`, consumption by the refit, the no-override default, and an `ag.`-prefixed override.

Regressions: `core/tests/unittests/models` 69 passed; `test_dummy` + the new file 24 passed; `test_lightgbm` 15 passed. `ruff format` and `ruff check --select I` clean.

Documented in the `hyperparameters` docstring alongside `ag.` and `ag.ens.`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)