### PR TITLE
[core] Fix test_core: drop the autogluon.tabular import from core's bagged tests

### DIFF
--- a/core/tests/unittests/models/test_bagged_ensemble_model.py
+++ b/core/tests/unittests/models/test_bagged_ensemble_model.py
@@ -7,6 +7,23 @@ from autogluon.core.models import BaggedEnsembleModel
 from autogluon.core.models.dummy.dummy_model import DummyModel
 
 
+class ChildOOFDummyModel(DummyModel):
+    """A core-only stand-in for a model that produces its own out-of-fold predictions.
+
+    ``use_child_oof`` requires a child tagged ``valid_oof`` with a working ``predict_proba_oof``
+    (RandomForest's OOB, KNN's leave-one-out). No model in ``autogluon.core`` has that, so these
+    tests reached into ``autogluon.tabular`` for one -- which is not installed in the ``test_core``
+    CI job, where they failed with ``ModuleNotFoundError``. The behaviour under test belongs to the
+    bag, not to the child, so a local child keeps the tests in core and running everywhere.
+    """
+
+    def predict_proba_oof(self, X, **kwargs) -> np.ndarray:
+        return self.predict_proba(X=X, **kwargs)
+
+    def _more_tags(self) -> dict:
+        return {"valid_oof": True}
+
+
 def test_generate_fold_configs():
     y = pd.Series([0, 0, 0, 1, 1, 1, 1, 1])
     X = pd.DataFrame([[0], [0], [0], [0], [0], [0], [0], [0]])
@@ -337,9 +354,7 @@ def test_oof_provenance_refit_folds():
 
 def test_oof_provenance_child_oof():
     """A child-OOF model's OOF is internal to one model, with no per-fold models to re-predict."""
-    from autogluon.tabular.models.knn.knn_model import KNNModel
-
-    bag = _fit_bag({"use_child_oof": True}, model_base=KNNModel())
+    bag = _fit_bag({"use_child_oof": True}, model_base=ChildOOFDummyModel())
     assert bag._child_oof and not bag._refit_oof
     assert bag.has_oof and bag.is_valid_oof()
     assert not bag.can_infer_oof
@@ -347,8 +362,6 @@ def test_oof_provenance_child_oof():
 
 def test_get_oof_fold_val_idx_covers_every_provenance():
     """One call answers "which rows did each child validate?" for all three provenances."""
-    from autogluon.tabular.models.knn.knn_model import KNNModel
-
     rng = np.random.default_rng(0)
     # A shifted, shuffled index: positions and labels coincide under a RangeIndex, so a
     # trivial index would hide the `_child_oof` case emitting labels.
@@ -357,7 +370,7 @@ def test_get_oof_fold_val_idx_covers_every_provenance():
     y = pd.Series(rng.integers(0, 2, size=60), index=index)
 
     cases = [(_fit_bag({}), 4), (_fit_bag({"refit_folds": True}), 4)]
-    cases.append((_fit_bag({"use_child_oof": True}, model_base=KNNModel()), 1))
+    cases.append((_fit_bag({"use_child_oof": True}, model_base=ChildOOFDummyModel()), 1))
     for model, n_entries in cases:
         val_idx = model.get_oof_fold_val_idx(X=X, y=y)
         assert len(val_idx) == n_entries


### PR DESCRIPTION
## Description of changes

**`master` is currently red.** `test_core` has failed since #5875 landed, on two tests it added:

```
E  ModuleNotFoundError: No module named 'autogluon.tabular'
   tests/unittests/models/test_bagged_ensemble_model.py:340   test_oof_provenance_child_oof
   tests/unittests/models/test_bagged_ensemble_model.py:350   test_get_oof_fold_val_idx_covers_every_provenance
```

Both import `KNNModel` from `autogluon.tabular`, which the `test_core` CI job does not install. They pass in a development checkout, where every package is installed editable — which is why it was not caught before merge.

Confirmed on master's own CI run for `f3bc3319` ([run 33219546730](https://github.com/autogluon/autogluon/actions/runs/33219546730)), same two tests, same error. Every PR branched after that commit inherits it.

## The fix

`use_child_oof` requires a child tagged `valid_oof` with a working `predict_proba_oof` — RandomForest's OOB, KNN's leave-one-out — and no model in `autogluon.core` has one, which is why the tests reached into tabular.

But the behaviour under test belongs to the **bag**, not to the child: that a child-OOF bag reports `has_oof` and `is_valid_oof` but not `can_infer_oof`, and that `get_oof_fold_val_idx` returns positions for all three provenances. A four-line local subclass of `DummyModel` supplies what the bag needs:

```python
class ChildOOFDummyModel(DummyModel):
    def predict_proba_oof(self, X, **kwargs) -> np.ndarray:
        return self.predict_proba(X=X, **kwargs)

    def _more_tags(self) -> dict:
        return {"valid_oof": True}
```

That keeps both tests **in core and running in the core CI job**, rather than skipping them there with `pytest.importorskip` — which would have been smaller but would have left the coverage unexercised in exactly the job that owns it.

## Verification

Reproduced the CI condition locally by blocking `autogluon.tabular` at import:

```
before:  2 failed, 12 passed
after:  14 passed
```

Full core suite: **416 passed, 41 skipped**. `ruff format` and `ruff check --select I` clean.

## Note

This is the only place in `core/tests` that imports `autogluon.tabular` — checked — so nothing else in the core suite has the same problem.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)