### PR TITLE
fix(multimodal/mmdet): _reset_classes never reloads the weights it just saved

### DIFF
--- a/multimodal/src/autogluon/multimodal/models/mmdet_image.py
+++ b/multimodal/src/autogluon/multimodal/models/mmdet_image.py
@@ -96,7 +96,7 @@ class MMDetAutoModelForObjectDetection(nn.Module):
         temp_ckpt_file = f"temp_ckpt_{int(time.time() * 1000)}.pth"
         self._save_weights(temp_ckpt_file)
         self._update_classes(classes)
-        self._load_checkpoint()
+        self._load_checkpoint(temp_ckpt_file)
         os.remove(temp_ckpt_file)
 
     def _update_classes(self, classes: Optional[list] = None):


### PR DESCRIPTION
## Problem

`MMDetAutoModelForObjectDetection._reset_classes`
([`mmdet_image.py:95`](https://github.com/autogluon/autogluon/blob/master/multimodal/src/autogluon/multimodal/models/mmdet_image.py#L95))
does a save → rebuild → reload round trip so the detector keeps its learned weights
when the class list changes:

```python
def _reset_classes(self, classes: list):
    temp_ckpt_file = f"temp_ckpt_{int(time.time() * 1000)}.pth"
    self._save_weights(temp_ckpt_file)
    self._update_classes(classes)
    self._load_checkpoint()          # ← no argument
    os.remove(temp_ckpt_file)
```

but `_load_checkpoint` is declared `(self, checkpoint_file)`, so the reload raises

```
TypeError: MMDetAutoModelForObjectDetection._load_checkpoint() missing 1 required positional argument: 'checkpoint_file'
```

Two independent signals that `temp_ckpt_file` is the intended argument:

1. **`temp_ckpt_file` is written and then deleted without ever being read.** It is
   assigned on the first line, passed to `_save_weights`, and removed on the last line —
   `_load_checkpoint()` is the only place it could have been consumed. A local that is
   produced and destroyed without a reader is the leftover of exactly this kind of
   dropped argument.
2. **The sibling call site passes its checkpoint.** `__init__` at line 91 calls
   `self._load_checkpoint(self.checkpoint_file)`.

## Where it came from

`5fc06b36` ("[object detection] Model Save/Load and Objects365 Pretraining") split the
old `_load_checkpoint_and_config(self, checkpoint_name=None)` into
`_load_checkpoint(self, checkpoint_file)` and introduced `_reset_classes` in the same
commit. The `__init__` call site was written against the new signature; `_reset_classes`
was not.

`_reset_classes` currently has no in-repo callers, so this is latent rather than a live
crash today — but it is the only code path that would restore the weights, and as written
it cannot run at all.

## Verification

`_load_checkpoint`'s signature was rebuilt from the source with `ast` and both call sites
replayed through `inspect.Signature.bind`:

```
MMDetAutoModelForObjectDetection._load_checkpoint (self, checkpoint_file)

[PASS] mmdet_image.py:99 _reset_classes (BUG)  self._load_checkpoint()
         bind -> TypeError: missing a required argument: 'checkpoint_file'
[PASS] mmdet_image.py:91 __init__      (control) self._load_checkpoint(self.checkpoint_file)
         bind -> OK
[PASS] AFTER PATCH                              self._load_checkpoint(temp_ckpt_file)
         bind -> OK
```

`ruff format` (line-length 119) leaves both the original and the patched file unchanged,
so the diff is formatter-neutral.

## Scope

One line. No signature, behaviour or public API change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
