### PR TITLE
[timeseries] Fix DirectTabular/RecursiveTabular failing on static features named unique_id, ds or y

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/mlforecast.py
@@ -306,6 +306,11 @@ class AbstractMLForecastModel(AbstractTimeSeriesModel):
         float64_cols = list(df.select_dtypes(include="float64"))
         df[float64_cols] = df[float64_cols].astype("float32")
 
+        # Rename covariates & static features that clash with the reserved column names used by MLForecast
+        for reserved_name in [MLF_ITEMID, MLF_TIMESTAMP, MLF_TARGET]:
+            if reserved_name in df.columns and reserved_name not in column_name_mapping:
+                column_name_mapping[reserved_name] = f"__{reserved_name}"
+
         # We assume that df is sorted by 'unique_id' inside `TimeSeriesPredictor._check_and_prepare_data_frame`
         return df.rename(columns=column_name_mapping)
 

--- a/timeseries/tests/unittests/models/test_mlforecast.py
+++ b/timeseries/tests/unittests/models/test_mlforecast.py
@@ -141,6 +141,33 @@ def test_when_covariates_and_features_present_then_model_can_predict(temp_model_
     assert len(predictions) == data.num_items * model.prediction_length
 
 
+def test_when_static_feature_columns_have_reserved_names_then_model_can_fit_and_predict(
+    temp_model_path, mlforecast_model_class
+):
+    # Static features with names reserved for internal use by MLForecast must be renamed by the model
+    prediction_length = 3
+    item_id_to_length = {1: 30, 5: 40, 2: 25}
+    data = get_data_frame_with_variable_lengths(item_id_to_length)
+    data.static_features = pd.DataFrame(
+        {name: np.random.normal(size=data.num_items) for name in ["unique_id", "ds", "y"]},
+        index=data.item_ids,
+    )
+
+    feat_gen = TimeSeriesFeatureGenerator(target="target", known_covariates_names=[])
+    data = feat_gen.fit_transform(data)
+
+    model = mlforecast_model_class(
+        path=temp_model_path,
+        prediction_length=prediction_length,
+        freq=data.freq,
+        covariate_metadata=feat_gen.covariate_metadata,
+    )
+    model.fit(train_data=data, time_limit=10)
+    predictions = model.predict(data)
+    assert isinstance(predictions, TimeSeriesDataFrame)
+    assert len(predictions) == data.num_items * model.prediction_length
+
+
 @pytest.mark.parametrize("eval_metric", ["RMSE", "WQL", "MAPE", None])
 def test_when_eval_metric_is_changed_then_model_can_predict(temp_model_path, mlforecast_model_class, eval_metric):
     data = DUMMY_VARIABLE_LENGTH_TS_DATAFRAME.copy()


### PR DESCRIPTION
*Issue #, if available:* Fixes #3862

*Description of changes:*

`_to_mlforecast_df` renames `item_id`/`timestamp`/target to `unique_id`/`ds`/`y` after merging in the static features, so a static feature (or known covariate) that already uses one of those names ends up as a duplicate column and MLForecast fails with `Grouper for 'unique_id' not 1-dimensional`.

Before the rename, any clashing column is now mapped to `__unique_id`/`__ds`/`__y`, following the same `__` convention as the `__scaled_` columns. Since every fit and predict path goes through `_to_mlforecast_df`, the train and predict frames stay consistent. Added a test that fits and predicts DirectTabular and RecursiveTabular with static features named `unique_id`, `ds` and `y`.

PerStepTabular does the same merge + rename in `_ag_to_nixtla` and probably hits the same problem. Kept it out of this PR to stay focused, happy to add it here or in a follow-up.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.