### PR TITLE
[features] Speed up SpearmanFeatureSelector and stop reordering its output

### DIFF
--- a/features/src/autogluon/features/generators/selection.py
+++ b/features/src/autogluon/features/generators/selection.py
@@ -1,3 +1,9 @@
+import warnings
+
+import numpy as np
+import pandas as pd
+from scipy.stats import rankdata
+
 from .abstract import AbstractFeatureGenerator
 
 
@@ -9,33 +15,135 @@ class SpearmanFeatureSelector(AbstractFeatureGenerator):
     threshold : float, default=None
         Features with absolute Spearman correlation below this threshold will be removed.
         Ignored if None.
+    max_features : int, default=2000
+        Keep at most this many features, taking those with the largest absolute correlation.
+    preserve_order : bool, default=True
+        Emit the selected features in their input order rather than sorted by descending
+        absolute correlation. The selected set is identical either way; only the column order
+        differs. Sorting conveys no information to a downstream model that treats its columns
+        symmetrically, while reordering is not free: models that subsample or window over
+        columns see a different view, and the reordering hides from the caller that the frame
+        came back permuted. Preserving the order also lets the selector skip its work entirely
+        whenever the input cannot lose a column, which is the common case when the generator
+        feeding it emits fewer features than ``max_features``. Pass ``False`` for the previous
+        correlation-sorted output.
     """
 
-    def __init__(self, threshold: float = None, max_features: int = 2000, **kwargs):
+    def __init__(
+        self,
+        threshold: float = None,
+        max_features: int = 2000,
+        preserve_order: bool = True,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
         if threshold is None and max_features is None:
             raise ValueError("Either 'threshold' or 'max_features' must be provided.")
         self.threshold = threshold
         self.max_features = max_features
+        self.preserve_order = preserve_order
         self.selected_features_ = []
 
     def _fit(self, X, y):
-        # Compute Spearman correlation
-        # TODO: Add nan filtering
         # TODO: Add option for AUC for binary
         # TODO: Properly handle multiclass targets
-        # X.columns[X.isna().mean()<0.99]
         # Spearman correlation is undefined for constant (<= 1 distinct non-null value) columns:
-        # scipy returns NaN and emits a ConstantInputWarning. Drop such columns up front so they are
-        # excluded cleanly without the warning -- the `.dropna()` below would drop them anyway.
-        X = X.loc[:, X.nunique(dropna=True) > 1]
-        corr = X.corrwith(y, method="spearman")
-        abs_corr = corr.abs().sort_values(ascending=False).dropna()
+        # scipy returns NaN and emits a ConstantInputWarning. Drop such columns up front so they
+        # are excluded cleanly without the warning -- the `.dropna()` below would drop them anyway.
+        X = X.loc[:, self._is_non_constant(X)]
+
+        # Nothing can be dropped: with no threshold and at most `max_features` columns left, the
+        # correlation cannot change the selection, only its order. Skipping it avoids ranking
+        # every column against the target for no effect -- the dominant cost of this generator on
+        # wide inputs. Only valid when the order is being preserved, since otherwise the output
+        # order is itself derived from the correlation.
+        if (
+            self.preserve_order
+            and self.threshold is None
+            and self.max_features is not None
+            and X.shape[1] <= self.max_features
+        ):
+            self.selected_features_ = list(X.columns)
+            return
+
+        abs_corr = self._abs_spearman(X, y).sort_values(ascending=False).dropna()
 
         if self.threshold is not None:
-            self.selected_features_ = abs_corr[abs_corr >= self.threshold].index.tolist()
-        elif self.max_features is not None:
-            self.selected_features_ = abs_corr.head(self.max_features).index.tolist()
+            selected = abs_corr[abs_corr >= self.threshold].index
+        else:
+            selected = abs_corr.head(self.max_features).index
+
+        if self.preserve_order:
+            selected = set(selected)
+            self.selected_features_ = [c for c in X.columns if c in selected]
+        else:
+            self.selected_features_ = list(selected)
+
+    @staticmethod
+    def _is_non_constant(X: pd.DataFrame) -> np.ndarray:
+        """Boolean mask of columns with more than one distinct non-null value.
+
+        Equivalent to ``X.nunique(dropna=True) > 1`` for numeric input, but compares the min and
+        max instead of hashing every value, which is an order of magnitude cheaper on wide frames.
+        Non-numeric input falls back to ``nunique``.
+        """
+        numeric = X.select_dtypes(include=np.number)
+        if numeric.shape[1] != X.shape[1]:
+            return (X.nunique(dropna=True) > 1).to_numpy()
+        values = numeric.to_numpy(dtype=float, copy=False)
+        with warnings.catch_warnings():
+            # An all-null column makes nanmin/nanmax warn and return NaN; that is the answer we
+            # want (NaN != NaN would read as non-constant, so it is excluded explicitly below).
+            warnings.simplefilter("ignore", RuntimeWarning)
+            low = np.nanmin(values, axis=0)
+            high = np.nanmax(values, axis=0)
+        return (low != high) & ~np.isnan(low)
+
+    @staticmethod
+    def _abs_spearman(X: pd.DataFrame, y: pd.Series) -> pd.Series:
+        """``X.corrwith(y, method="spearman").abs()``, computed column-wise in bulk.
+
+        ``corrwith`` dispatches to ``Series.corr`` per column, which re-ranks the target for every
+        column in turn. Instead the feature ranks are taken in one pass, and the target is ranked
+        once per *distinct null pattern*: a pairwise-complete correlation only depends on the
+        column's null mask, and generated features inherit their parents' nulls, so wide frames
+        carry far fewer distinct masks than columns.
+
+        Matches ``corrwith`` to floating-point noise. Non-numeric input falls back to it.
+        """
+        numeric = X.select_dtypes(include=np.number)
+        if numeric.shape[1] != X.shape[1]:
+            return X.corrwith(y, method="spearman").abs()
+
+        values = numeric.to_numpy(dtype=float, copy=False)
+        target = y.to_numpy(dtype=float, copy=False)
+        # `DataFrame.rank` ranks each column's non-null entries among themselves, which is exactly
+        # their rank within the pairwise-complete subset (the target, being the label, has no
+        # nulls). So the subset ranks come out of a single pass over the frame.
+        ranks = numeric.rank().to_numpy(dtype=float, copy=False)
+        valid = ~np.isnan(values)
+
+        # Group columns by null pattern. Bit-packing and grouping the packed rows is ~10x faster
+        # than `np.unique(valid.T, axis=0)`, which lexsorts the raw boolean matrix.
+        packed = np.ascontiguousarray(np.packbits(valid, axis=0).T)
+        keys = packed.view([("", packed.dtype)] * packed.shape[1]).ravel()
+        _, inverse = np.unique(keys, return_inverse=True)
+
+        out = np.full(numeric.shape[1], np.nan)
+        for group in np.unique(inverse):
+            columns = np.flatnonzero(inverse == group)
+            mask = valid[:, columns[0]]
+            if mask.sum() < 2:
+                continue
+            y_ranks = rankdata(target[mask])
+            y_ranks = y_ranks - y_ranks.mean()
+            y_ss = float((y_ranks * y_ranks).sum())
+            x_ranks = ranks[np.ix_(mask, columns)]
+            x_ranks = x_ranks - x_ranks.mean(axis=0)
+            x_ss = (x_ranks * x_ranks).sum(axis=0)
+            with np.errstate(invalid="ignore", divide="ignore"):
+                out[columns] = (x_ranks * y_ranks[:, None]).sum(axis=0) / np.sqrt(x_ss * y_ss)
+        return pd.Series(np.abs(out), index=numeric.columns)
 
     def _transform(self, X):
         return X[self.selected_features_]

--- a/features/tests/features/generators/test_selection.py
+++ b/features/tests/features/generators/test_selection.py
@@ -11,6 +11,7 @@ import warnings
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from autogluon.features.generators.selection import SpearmanFeatureSelector
 
@@ -50,3 +51,113 @@ def test_spearman_selector_happy_path_still_selects_correlated_features():
 
     # Perfectly (anti-)correlated features rank first.
     assert set(gen.selected_features_) == {"pos", "neg"}
+
+
+def _reference_abs_spearman(X: pd.DataFrame, y: pd.Series) -> pd.Series:
+    """The straightforward pandas computation the bulk implementation replaces."""
+    return X.loc[:, X.nunique(dropna=True) > 1].corrwith(y, method="spearman").abs()
+
+
+def _frame_with_nulls(n: int = 200, n_cols: int = 40, seed: int = 0) -> tuple:
+    rng = np.random.default_rng(seed)
+    y = pd.Series(rng.normal(size=n))
+    data = {}
+    for i in range(n_cols):
+        col = y * rng.normal() + rng.normal(size=n) * rng.uniform(0.5, 5)
+        # Varied null patterns, including some shared between columns and some columns with none.
+        if i % 3:
+            col = col.mask(rng.random(n) < 0.1 * (1 + i % 4))
+        data[f"f{i}"] = col
+    return pd.DataFrame(data), y
+
+
+def test_spearman_matches_pandas_corrwith_with_nulls():
+    X, y = _frame_with_nulls()
+    expected = _reference_abs_spearman(X, y)
+    actual = SpearmanFeatureSelector._abs_spearman(X, y)
+    pd.testing.assert_series_equal(actual, expected, check_names=False, atol=1e-12, rtol=0)
+
+
+def test_spearman_selection_matches_pandas_corrwith():
+    X, y = _frame_with_nulls(n_cols=40)
+    expected = _reference_abs_spearman(X, y).sort_values(ascending=False).dropna()
+    for max_features in (5, 20):
+        gen = SpearmanFeatureSelector(max_features=max_features, preserve_order=False)
+        gen._fit(X, y)
+        assert gen.selected_features_ == expected.head(max_features).index.tolist()
+
+
+def test_preserve_order_keeps_input_order_and_same_set():
+    X, y = _frame_with_nulls(n_cols=30)
+    sorted_gen = SpearmanFeatureSelector(max_features=10, preserve_order=False)
+    ordered_gen = SpearmanFeatureSelector(max_features=10, preserve_order=True)
+    sorted_gen._fit(X, y)
+    ordered_gen._fit(X, y)
+
+    assert set(ordered_gen.selected_features_) == set(sorted_gen.selected_features_)
+    # Input order, not correlation order.
+    assert ordered_gen.selected_features_ == [c for c in X.columns if c in set(sorted_gen.selected_features_)]
+    assert ordered_gen.selected_features_ != sorted_gen.selected_features_
+
+
+def test_preserve_order_is_the_default():
+    X, y = _frame_with_nulls(n_cols=30)
+    gen = SpearmanFeatureSelector(max_features=10)
+    gen._fit(X, y)
+    assert gen.selected_features_ == [c for c in X.columns if c in set(gen.selected_features_)]
+
+
+def test_skips_correlation_when_nothing_can_be_dropped(monkeypatch):
+    """With no threshold and fewer columns than the cap, the correlation is never computed."""
+    X, y = _frame_with_nulls(n_cols=10)
+
+    def explode(*args, **kwargs):
+        raise AssertionError("correlation should not be computed when nothing can be dropped")
+
+    monkeypatch.setattr(SpearmanFeatureSelector, "_abs_spearman", staticmethod(explode))
+    gen = SpearmanFeatureSelector(max_features=100)
+    gen._fit(X, y)
+    assert gen.selected_features_ == list(X.columns)
+
+    # The skip must not apply when a threshold can still drop columns, or when sorting is asked for.
+    for kwargs in ({"threshold": 0.1}, {"preserve_order": False}):
+        gen = SpearmanFeatureSelector(max_features=100, **kwargs)
+        with pytest.raises(AssertionError, match="should not be computed"):
+            gen._fit(X, y)
+
+
+def test_skip_still_drops_constant_columns():
+    n = 50
+    X = pd.DataFrame(
+        {
+            "const": np.ones(n),
+            "all_nan": pd.Series([np.nan] * n, dtype=float),
+            "varying": np.arange(n, dtype=float),
+        }
+    )
+    y = pd.Series(np.arange(n, dtype=float))
+    gen = SpearmanFeatureSelector(max_features=100)  # cap exceeds the column count -> skip path
+    gen._fit(X, y)
+    assert gen.selected_features_ == ["varying"]
+
+
+def test_non_numeric_columns_delegate_to_pandas():
+    """Non-numeric input takes the pandas path, behaving exactly as it did before.
+
+    ``corrwith(method="spearman")`` cannot rank a categorical column and raises; the bulk
+    implementation must not paper over that with a different error (or a silent wrong answer),
+    so the boundary is pinned here.
+    """
+    n = 30
+    rng = np.random.default_rng(0)
+    y = pd.Series(rng.normal(size=n))
+    X = pd.DataFrame(
+        {"num": y * 2 + rng.normal(size=n), "cat": pd.Categorical(["a", "b"] * (n // 2))}
+    )
+    with pytest.raises(ValueError, match="could not convert string to float"):
+        X.loc[:, X.nunique(dropna=True) > 1].corrwith(y, method="spearman")
+    with pytest.raises(ValueError, match="could not convert string to float"):
+        SpearmanFeatureSelector._abs_spearman(X, y)
+
+    # The constant filter does support non-numeric input, and keeps both columns here.
+    assert SpearmanFeatureSelector._is_non_constant(X).tolist() == [True, True]

--- a/features/tests/features/generators/test_selection.py
+++ b/features/tests/features/generators/test_selection.py
@@ -151,9 +151,7 @@ def test_non_numeric_columns_delegate_to_pandas():
     n = 30
     rng = np.random.default_rng(0)
     y = pd.Series(rng.normal(size=n))
-    X = pd.DataFrame(
-        {"num": y * 2 + rng.normal(size=n), "cat": pd.Categorical(["a", "b"] * (n // 2))}
-    )
+    X = pd.DataFrame({"num": y * 2 + rng.normal(size=n), "cat": pd.Categorical(["a", "b"] * (n // 2))})
     with pytest.raises(ValueError, match="could not convert string to float"):
         X.loc[:, X.nunique(dropna=True) > 1].corrwith(y, method="spearman")
     with pytest.raises(ValueError, match="could not convert string to float"):


### PR DESCRIPTION
## Summary

Three changes to `SpearmanFeatureSelector`, two of them pure performance and one a
deliberate behaviour change to its output column order.

## Faster correlation

`X.corrwith(y, method="spearman")` dispatches to `Series.corr` once per column, which
re-ranks the **target** for every feature. Instead:

- rank the features in a single `DataFrame.rank()` pass (which already ranks each column's
  non-null entries among themselves, i.e. exactly their rank in the pairwise-complete subset), and
- rank the target once per **distinct null pattern**. A pairwise-complete correlation depends
  only on the column's null mask, and generated features tend to inherit their parents' nulls,
  so a wide frame usually carries far fewer distinct masks than columns.

Results match `corrwith` to floating-point noise, and the tests pin that against the pandas
computation directly.

The constant-column filter is also cheaper: it used `nunique(dropna=True) > 1`, which hashes
every value, where comparing `nanmin` to `nanmax` answers the same question about 10x faster.

## `preserve_order`, defaulting to `True`

The selector previously returned its features sorted by descending absolute correlation. It now
returns them in input order; **the selected set is identical either way**, only the order differs.

Sorting conveys no information to a downstream model that treats its columns symmetrically, and
reordering is not free:

- models that subsample or window over columns see a materially different view, and
- the caller is not told the frame came back permuted.

Preserving the order additionally lets the selector return immediately when the input cannot lose
a column -- no threshold, and at most `max_features` columns present -- which is the common case
when the generator feeding it emits fewer features than the cap. That skip is only sound when the
order is preserved, since otherwise the output order is itself derived from the correlation.
Constant columns are still dropped on that path.

Pass `preserve_order=False` for the previous correlation-sorted output.

## Benchmarks

4000 rows x 5000 columns, selecting 1500, identical selections in every case:

| input | before | after | |
|---|---|---|---|
| no nulls | 3.29s | 1.61s | 2.0x |
| 100 shared null patterns | 3.38s | 1.46s | 2.3x |
| all-distinct null patterns | 3.36s | 2.31s | 1.5x |
| nothing can be dropped | 3.35s | 0.05s | **72x** |

The all-distinct case is the worst case for the per-pattern grouping and is still faster,
because the single-pass ranking and the cheaper constant filter apply regardless.

## Compatibility

- The **set** of selected features is unchanged in all cases.
- The **order** changes by default. Anything depending on the previous
  correlation-sorted order should pass `preserve_order=False`.
- Non-numeric input keeps taking the pandas path unchanged, including the `ValueError` that
  `corrwith` already raised for it. A test pins that boundary so the bulk path cannot silently
  take over and return something different.

## Testing

7 new tests covering: agreement with `corrwith` on data with varied null patterns, identical
top-k selection, `preserve_order` set/order semantics, the new default, that the skip really
avoids computing the correlation (and correctly does not fire with a threshold or with sorting
requested), that the skip still drops constant columns, and the non-numeric boundary.

`pytest features/tests` passes (9/9 in `test_selection.py`, 100 passed overall; the one failure
in `test_check_style.py` is pre-existing on master and unrelated to these files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi