### PR TITLE
[features] Reuse categorical codes in OOFTargetEncodingFeatureGenerator

### DIFF
--- a/features/src/autogluon/features/generators/oof_target_encoder.py
+++ b/features/src/autogluon/features/generators/oof_target_encoder.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+from pandas.api.types import CategoricalDtype
 from sklearn.model_selection import KFold, StratifiedKFold
 
 from autogluon.common.features.types import (
@@ -96,8 +97,12 @@ class OOFTargetEncodingFeatureGenerator(AbstractFeatureGenerator):
             self.train_encoded_ = pd.DataFrame(index=original_index)
             return self
 
-        # Work only on the categorical part (for encoding), keep object dtype
-        X_cat = X[self.cols_].reset_index(drop=True).astype("object")
+        # Work only on the categorical part (for encoding). Category columns keep their dtype:
+        # casting them to object throws away the codes this method is about to recompute.
+        X_cat = X[self.cols_].reset_index(drop=True)
+        object_cols = [c for c in self.cols_ if not isinstance(X_cat[c].dtype, CategoricalDtype)]
+        if object_cols:
+            X_cat[object_cols] = X_cat[object_cols].astype("object")
         y = pd.Series(y).reset_index(drop=True)
 
         n = len(X_cat)
@@ -157,8 +162,22 @@ class OOFTargetEncodingFeatureGenerator(AbstractFeatureGenerator):
         for col in self.cols_:
             col_values = X_cat[col]
 
-            # Factorize categories once; sorted to mimic groupby index order
-            codes, uniques = pd.factorize(col_values, sort=True)
+            # Resolve each column to integer codes plus the categories they index.
+            #
+            # `sort=False`: the category order is never read. Codes only index `enc_matrix`, and
+            # `categories` is stored so `transform` reproduces the same codes, so sorting only
+            # relabels. It is not free -- it argsorts every column's uniques.
+            #
+            # A category column already carries its codes, so reuse them rather than factorizing
+            # the values again. Unused categories are dropped first: `factorize` only ever yields
+            # observed categories, and an unobserved one would get a zero count here and so a NaN
+            # encoding rather than the global mean.
+            if isinstance(col_values.dtype, CategoricalDtype):
+                col_values = col_values.cat.remove_unused_categories()
+                codes = col_values.cat.codes.to_numpy()
+                uniques = col_values.cat.categories
+            else:
+                codes, uniques = pd.factorize(col_values, sort=False)
             # codes == -1 corresponds to NaN / missing category
             mask_valid = codes >= 0
             codes_valid = codes[mask_valid]

--- a/features/tests/features/generators/test_oof_target_encoder.py
+++ b/features/tests/features/generators/test_oof_target_encoder.py
@@ -354,3 +354,62 @@ def test_oof_target_encoding_normal_categorical_global_mean_finite_no_warning():
     messages = _fit_capture_warnings(gen, X, y)
     assert not any("empty slice" in m for m in messages), messages
     assert np.isfinite(gen.encodings_["cat"]["global_mean"]).all()
+
+
+def test_categorical_and_object_inputs_encode_identically():
+    """A category column and the same values as objects must produce the same encodings.
+
+    The category path reuses the column's existing codes instead of factorizing its values, so
+    the two representations have to stay interchangeable.
+    """
+    rng = np.random.default_rng(0)
+    n = 300
+    values = rng.integers(0, 25, size=n).astype(str)
+    y = pd.Series(rng.integers(0, 2, size=n))
+    as_object = pd.DataFrame({"k": values.astype(object)})
+    as_category = pd.DataFrame({"k": pd.Categorical(values)})
+
+    def encode(frame):
+        gen = OOFTargetEncodingFeatureGenerator(target_type="binary", verbosity=0, random_state=0)
+        return gen.fit_transform(frame.copy(), y)
+
+    pd.testing.assert_frame_equal(encode(as_object), encode(as_category))
+
+
+def test_unused_categories_do_not_leak_nan_encodings():
+    """A declared-but-absent category must not produce NaN encodings.
+
+    ``factorize`` only yields observed categories. Reusing a column's own categories can surface
+    unobserved ones, which would take a zero count and (with ``alpha=0``) a 0/0 encoding.
+    """
+    rng = np.random.default_rng(0)
+    n = 200
+    values = rng.integers(0, 5, size=n).astype(str)
+    y = pd.Series(rng.integers(0, 2, size=n))
+    # "99" is declared but never observed.
+    frame = pd.DataFrame({"k": pd.Categorical(values, categories=[*sorted(set(values)), "99"])})
+
+    gen = OOFTargetEncodingFeatureGenerator(target_type="binary", verbosity=0, alpha=0, random_state=0)
+    out = gen.fit_transform(frame.copy(), y)
+    assert out.notna().all().all()
+
+    # And a row carrying the unobserved category at predict time falls back to the global mean.
+    unseen = pd.DataFrame({"k": pd.Categorical(["99"], categories=frame["k"].cat.categories)})
+    assert gen.transform(unseen).notna().all().all()
+
+
+def test_encodings_are_independent_of_category_order():
+    """Category order only relabels codes; the encoded values must not depend on it."""
+    rng = np.random.default_rng(0)
+    n = 300
+    values = rng.integers(0, 12, size=n).astype(str)
+    y = pd.Series(rng.integers(0, 2, size=n))
+    ascending = sorted(set(values))
+    frame_a = pd.DataFrame({"k": pd.Categorical(values, categories=ascending)})
+    frame_b = pd.DataFrame({"k": pd.Categorical(values, categories=ascending[::-1])})
+
+    def encode(frame):
+        gen = OOFTargetEncodingFeatureGenerator(target_type="binary", verbosity=0, random_state=0)
+        return gen.fit_transform(frame.copy(), y)
+
+    pd.testing.assert_frame_equal(encode(frame_a), encode(frame_b))


### PR DESCRIPTION
Stacked on #5885 (which is stacked on #5884) — this PR's diff is the final commit only.

## Summary

Two redundancies in `OOFTargetEncodingFeatureGenerator`'s per-column encoding loop.

**Sorting categories nobody reads.** `pd.factorize(col_values, sort=True)` sorts every column's
uniques. The order is never read — codes only index `enc_matrix`, and `categories` is stored at fit
so `transform` reproduces the same codes — so sorting only relabels, at the cost of argsorting
every column's uniques.

**Discarding codes it was handed.** `X_cat = X[self.cols_].astype("object")` cast every column to
object, including category columns that already carry exactly the codes the loop is about to
recompute.

This takes the codes from a category column directly and drops the sort. Object columns keep the
previous path apart from the sort.

## Correctness

Unused categories are dropped before the codes are read. `factorize` only ever yields *observed*
categories, so a declared-but-unobserved category would otherwise take a zero count and — with
`alpha=0` — a 0/0 `NaN` encoding instead of the global mean. There is a test for exactly that.

Encodings are unchanged up to floating-point noise (~1e-16). They are not bit-identical: category
order changes the order in which the `bincount` accumulations are summed. Two tests pin the
invariants that matter — that object and category inputs encode identically, and that the result
does not depend on category order.

## Benchmarks

Per-column category resolution, 4994 rows x 1500 category columns:

| | time |
|---|---|
| `astype(object)` + `factorize(sort=True)` (before) | 1.218s |
| `factorize(sort=False)` | 0.486s |
| reuse the existing codes (after) | **0.035s** |

plus the 0.263s `astype("object")` that is no longer needed.

End to end for the generator that motivated this, together with #5885 (4994 rows, 86 base
features, one key column per subset):

| n_subsets | fit before | after | | transform before | after | |
|---|---|---|---|---|---|---|
| 50 | 0.31s | 0.08s | 4.1x | 0.10s | 0.03s | 3.4x |
| 200 | 1.44s | 0.25s | 5.7x | 0.41s | 0.11s | 3.8x |
| 500 | 3.43s | 0.67s | 5.1x | 1.06s | 0.27s | 4.0x |
| 1500 | 10.24s | 1.95s | 5.3x | 3.07s | 0.79s | 3.9x |

## Testing

3 new tests: object vs category inputs encode identically, unused categories do not produce NaN
encodings (at fit or at transform), and encodings are independent of category order.

`pytest features/tests` passes (13/13 in `test_oof_target_encoder.py`); the one failure in
`test_check_style.py` is pre-existing on master and unrelated to these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi