### PR TITLE
[common] Make FeatureMetadata bookkeeping linear in the number of features

### DIFF
--- a/common/src/autogluon/common/features/feature_metadata.py
+++ b/common/src/autogluon/common/features/feature_metadata.py
@@ -209,7 +209,19 @@ class FeatureMetadata:
         return self._get_feature_types(feature=feature, feature_types_dict=self.type_group_map_special)
 
     def get_type_map_special(self) -> dict:
-        return {feature: self.get_feature_types_special(feature) for feature in self.get_features()}
+        type_map_special = self._type_map_special_full()
+        return {feature: type_map_special.get(feature, []) for feature in self.get_features()}
+
+    def _type_map_special_full(self) -> Dict[str, List[str]]:
+        """feature -> sorted special types, computed in one pass over `type_group_map_special`.
+
+        Equivalent to calling `_get_feature_types` per feature, without rescanning every type group for each one.
+        """
+        special_types_per_feature: Dict[str, set] = defaultdict(set)
+        for dtype_family, features in self.type_group_map_special.items():
+            for feature in features:
+                special_types_per_feature[feature].add(dtype_family)
+        return {feature: sorted(dtype_families) for feature, dtype_families in special_types_per_feature.items()}
 
     @staticmethod
     def get_type_group_map_special_from_type_map_special(type_map_special: Dict[str, List[str]]):
@@ -231,7 +243,8 @@ class FeatureMetadata:
             metadata = self
         else:
             metadata = copy.deepcopy(self)
-        features_invalid = [feature for feature in features if feature not in self.get_features()]
+        features_present = set(self.get_features())
+        features_invalid = [feature for feature in features if feature not in features_present]
         if features_invalid:
             raise KeyError(
                 f"remove_features was called with a feature that does not exist in feature metadata. Invalid Features: {features_invalid}"
@@ -242,12 +255,15 @@ class FeatureMetadata:
 
     def keep_features(self, features: list, inplace=False):
         """Removes all features from metadata except for those in features"""
-        features_invalid = [feature for feature in features if feature not in self.get_features()]
+        features_present = self.get_features()
+        features_present_set = set(features_present)
+        features_invalid = [feature for feature in features if feature not in features_present_set]
         if features_invalid:
             raise KeyError(
                 f"keep_features was called with a feature that does not exist in feature metadata. Invalid Features: {features_invalid}"
             )
-        features_to_remove = [feature for feature in self.get_features() if feature not in features]
+        features_to_keep = set(features)
+        features_to_remove = [feature for feature in features_present if feature not in features_to_keep]
         return self.remove_features(features=features_to_remove, inplace=inplace)
 
     def add_special_types(self, type_map_special: Dict[str, List[str]], inplace=False):
@@ -289,6 +305,7 @@ class FeatureMetadata:
 
     @staticmethod
     def _remove_features_from_type_group_map(d, features):
+        features = set(features)
         for key, features_orig in d.items():
             d[key] = [feature for feature in features_orig if feature not in features]
 
@@ -407,9 +424,10 @@ class FeatureMetadata:
         else:
             feature_metadata_dict = defaultdict(list)
 
+        type_map_special = self._type_map_special_full()
         for feature in self.get_features():
             feature_type_raw = self.type_map_raw[feature]
-            feature_types_special = tuple(self.get_feature_types_special(feature))
+            feature_types_special = tuple(type_map_special.get(feature, []))
             if not inverse:
                 feature_metadata_dict[feature] = (feature_type_raw, feature_types_special)
             else:
@@ -423,6 +441,12 @@ class FeatureMetadata:
     def print_feature_metadata_full(
         self, log_prefix="", print_only_one_special=False, log_level=20, max_list_len=5, return_str=False
     ):
+        if not return_str:
+            # Skip building the output when nothing could be emitted. `print_only_one_special` may also log a
+            # warning, so with it the output is built whenever warnings are enabled.
+            check_level = max(log_level, logging.WARNING) if print_only_one_special else log_level
+            if not logger.isEnabledFor(check_level):
+                return None
         feature_metadata_dict = self.to_dict(inverse=True)
         if not feature_metadata_dict:
             if return_str:

--- a/common/src/autogluon/common/features/feature_metadata.py
+++ b/common/src/autogluon/common/features/feature_metadata.py
@@ -236,11 +236,15 @@ class FeatureMetadata:
 
         Equivalent to calling `_get_feature_types` per feature, without rescanning every type group for each one.
         """
-        special_types_per_feature: Dict[str, set] = defaultdict(set)
-        for dtype_family, features in self.type_group_map_special.items():
-            for feature in features:
-                special_types_per_feature[feature].add(dtype_family)
-        return {feature: sorted(dtype_families) for feature, dtype_families in special_types_per_feature.items()}
+        # Visiting the groups in sorted order builds every feature's list already sorted; a feature listed
+        # twice in one group is seen consecutively, so the last-entry check deduplicates it.
+        special_types_per_feature: Dict[str, List[str]] = {}
+        for dtype_family in sorted(self.type_group_map_special):
+            for feature in self.type_group_map_special[dtype_family]:
+                dtype_families = special_types_per_feature.setdefault(feature, [])
+                if not dtype_families or dtype_families[-1] != dtype_family:
+                    dtype_families.append(dtype_family)
+        return special_types_per_feature
 
     @staticmethod
     def get_type_group_map_special_from_type_map_special(type_map_special: Dict[str, List[str]]):

--- a/common/src/autogluon/common/features/feature_metadata.py
+++ b/common/src/autogluon/common/features/feature_metadata.py
@@ -56,6 +56,25 @@ class FeatureMetadata:
 
         self._validate()
 
+    def copy(self) -> "FeatureMetadata":
+        """A copy sharing no containers with `self`.
+
+        The maps hold strings and lists of strings, so copying the two containers (and each list) is equivalent
+        to a deep copy at a fraction of the cost on wide frames.
+        """
+        metadata = copy.copy(self)
+        metadata.type_map_raw = dict(self.type_map_raw)
+        metadata.type_group_map_special = self._copy_type_group_map(self.type_group_map_special)
+        return metadata
+
+    @staticmethod
+    def _copy_type_group_map(type_group_map: dict) -> dict:
+        """The map with its lists copied; keeps the dict type (a `defaultdict` stays one)."""
+        type_group_map = copy.copy(type_group_map)
+        for key, features in type_group_map.items():
+            type_group_map[key] = list(features)
+        return type_group_map
+
     def __eq__(self, other) -> bool:
         if set(self.type_map_raw.keys()) != set(other.type_map_raw.keys()):
             return False
@@ -177,7 +196,7 @@ class FeatureMetadata:
         if required_at_least_one_special:
             features = [feature for feature in features if self.get_feature_types_special(feature)]
         if required_raw_special_pairs is not None:
-            features_og = copy.deepcopy(features)
+            features_og = list(features)
             features_to_keep = []
             for valid_raw, valid_special in required_raw_special_pairs:
                 if valid_special is not None:
@@ -242,7 +261,7 @@ class FeatureMetadata:
         if inplace:
             metadata = self
         else:
-            metadata = copy.deepcopy(self)
+            metadata = self.copy()
         features_present = set(self.get_features())
         features_invalid = [feature for feature in features if feature not in features_present]
         if features_invalid:
@@ -291,7 +310,7 @@ class FeatureMetadata:
         if inplace:
             metadata = self
         else:
-            metadata = copy.deepcopy(self)
+            metadata = self.copy()
         valid_features = set(self.get_features())
 
         for feature, special_types in type_map_special.items():
@@ -320,7 +339,7 @@ class FeatureMetadata:
         if inplace:
             metadata = self
         else:
-            metadata = copy.deepcopy(self)
+            metadata = self.copy()
         before_len = len(metadata.type_map_raw.keys())
         metadata.type_map_raw = {rename_map.get(key, key): val for key, val in metadata.type_map_raw.items()}
         after_len = len(metadata.type_map_raw.keys())
@@ -341,7 +360,7 @@ class FeatureMetadata:
             raise ValueError(
                 f"shared_raw_features must be one of {['error', 'error_if_diff', 'overwrite']}, but was: '{shared_raw_features}'"
             )
-        type_map_raw = copy.deepcopy(self.type_map_raw)
+        type_map_raw = dict(self.type_map_raw)
         shared_features = []
         shared_features_diff_types = []
         for key, features in metadata.type_map_raw.items():
@@ -389,7 +408,7 @@ class FeatureMetadata:
     def _add_type_group_map_special(type_group_map_special_lst: List[dict]) -> dict:
         if not type_group_map_special_lst:
             return defaultdict(list)
-        type_group_map_special_combined = copy.deepcopy(type_group_map_special_lst[0])
+        type_group_map_special_combined = FeatureMetadata._copy_type_group_map(type_group_map_special_lst[0])
         for type_group_map_special in type_group_map_special_lst[1:]:
             for key, features in type_group_map_special.items():
                 if key in type_group_map_special_combined:
@@ -413,7 +432,7 @@ class FeatureMetadata:
     # Joins a list of metadata objects together, returning a new metadata object
     @staticmethod
     def join_metadatas(metadata_list, shared_raw_features="error"):
-        metadata_new = copy.deepcopy(metadata_list[0])
+        metadata_new = metadata_list[0].copy()
         for metadata in metadata_list[1:]:
             metadata_new = metadata_new.join_metadata(metadata, shared_raw_features=shared_raw_features)
         return metadata_new

--- a/common/src/autogluon/common/features/infer_types.py
+++ b/common/src/autogluon/common/features/infer_types.py
@@ -63,10 +63,27 @@ def _get_type_family_raw(dtype) -> tuple[str, bool]:
         return dtype.name, cacheable
 
 
+#: dtype -> `dtype.name`. numpy's name lookup is slow enough to matter when it runs per column at
+#: every generator stage of a wide frame; the columns share a handful of dtypes.
+_DTYPE_NAME_CACHE: dict = {}
+
+
+def _dtype_name(dtype) -> str:
+    try:
+        return _DTYPE_NAME_CACHE[dtype]
+    except KeyError:
+        pass
+    except TypeError:  # unhashable dtype
+        return dtype.name
+    name = dtype.name
+    _DTYPE_NAME_CACHE[dtype] = name
+    return name
+
+
 # Real dtypes
 def get_type_map_real(df: DataFrame) -> dict:
     features_types = df.dtypes.to_dict()
-    return {k: v.name for k, v in features_types.items()}
+    return {k: _dtype_name(v) for k, v in features_types.items()}
 
 
 # Raw dtypes (Real dtypes family)

--- a/common/src/autogluon/common/features/infer_types.py
+++ b/common/src/autogluon/common/features/infer_types.py
@@ -94,7 +94,11 @@ def get_type_map_raw(df: DataFrame) -> dict:
 
 def get_type_map_special(X: DataFrame) -> dict:
     type_map_special = {}
-    for column in X:
+    for column, dtype in zip(X.columns, X.dtypes):
+        # Only sparse and object-family columns can carry a special type (see `get_types_special`), and both
+        # are decided from the dtype, so the other columns are skipped without materializing a Series.
+        if not isinstance(dtype, pd.SparseDtype) and get_type_family_raw(dtype) != "object":
+            continue
         types_special = get_types_special(X[column])
         if types_special:
             type_map_special[column] = types_special

--- a/common/src/autogluon/common/features/infer_types.py
+++ b/common/src/autogluon/common/features/infer_types.py
@@ -9,34 +9,58 @@ from pandas import DataFrame, Series
 logger = logging.getLogger(__name__)
 
 
+#: dtype -> family, for the dtypes seen so far. A frame's columns share a handful of dtypes, so
+#: classifying each dtype once instead of once per column removes most of the type-inference cost
+#: on wide frames. Only successful classifications are cached, so an unrecognized dtype is logged
+#: every time as before.
+_TYPE_FAMILY_RAW_CACHE: dict = {}
+
+
 def get_type_family_raw(dtype) -> str:
     """From dtype, gets the dtype family."""
+    try:
+        return _TYPE_FAMILY_RAW_CACHE[dtype]
+    except (KeyError, TypeError):  # TypeError: an unhashable dtype is classified without the cache
+        pass
+    type_family, cacheable = _get_type_family_raw(dtype)
+    if cacheable:
+        try:
+            _TYPE_FAMILY_RAW_CACHE[dtype] = type_family
+        except TypeError:
+            pass
+    return type_family
+
+
+def _get_type_family_raw(dtype) -> tuple[str, bool]:
+    """The dtype family, and whether the classification went through without an error log."""
+    cacheable = True
     try:
         if isinstance(dtype, pd.SparseDtype):
             dtype = dtype.subtype
         if dtype.name == "category":
-            return "category"
+            return "category", cacheable
         if "datetime" in dtype.name:
-            return "datetime"
+            return "datetime", cacheable
         if "string" in dtype.name:
-            return "object"
+            return "object", cacheable
         elif np.issubdtype(dtype, np.integer):
-            return "int"
+            return "int", cacheable
         elif np.issubdtype(dtype, np.floating):
-            return "float"
+            return "float", cacheable
     except Exception as err:
         logger.error(
             f"Warning: dtype {dtype} is not recognized as a valid dtype by numpy! "
             f"AutoGluon may incorrectly handle this feature..."
         )
         logger.error(err)
+        cacheable = False
 
     if dtype.name in ["bool", "bool_"]:
-        return "bool"
+        return "bool", cacheable
     elif dtype.name in ["str", "string", "object"]:
-        return "object"
+        return "object", cacheable
     else:
-        return dtype.name
+        return dtype.name, cacheable
 
 
 # Real dtypes
@@ -104,9 +128,10 @@ def check_if_datetime_as_object_feature(X: Series) -> bool:
     type_family = get_type_family_raw(X.dtype)
     # TODO: Check if low numeric numbers, could be categorical encoding!
     # TODO: If low numeric, potentially it is just numeric instead of date
-    if X.isnull().all():
-        return False
     if type_family != "object":  # TODO: seconds from epoch support
+        return False
+    # checked after the dtype so that the (many) non-object columns never pay for a full pass over their values
+    if X.isnull().all():
         return False
     try:
         # TODO: pd.Series(['20170204','20170205','20170206']) is incorrectly not detected as datetime_as_object

--- a/common/src/autogluon/common/utils/pandas_utils.py
+++ b/common/src/autogluon/common/utils/pandas_utils.py
@@ -53,6 +53,62 @@ def _object_column_mem_usage(values, num_rows: int, sample_ratio: float) -> int:
 _OBJECT_DTYPE = np.dtype(object)
 
 
+def get_two_valued_columns(df: DataFrame, columns: list | None = None) -> dict:
+    """The columns of `df` (or of `columns`) holding exactly two distinct values, mapped to those values.
+
+    The values come in order of first appearance and with the column's dtype, as ``df[column].unique()``
+    returns them; missing counts as a value, as with ``unique``. numpy numeric and bool columns are tested
+    block-wise per dtype, the other columns through ``unique``.
+    """
+    if columns is None:
+        columns = list(df.columns)
+    if len(df) < 2:
+        return {}
+    if df.columns.has_duplicates:
+        return _two_valued_through_unique(df, columns)
+    dtypes = dict(zip(df.columns, df.dtypes))
+    by_dtype: dict = {}
+    other = []
+    for column in columns:
+        dtype = dtypes[column]
+        if isinstance(dtype, np.dtype) and dtype.kind in "biuf":
+            by_dtype.setdefault(dtype, []).append(column)
+        else:
+            other.append(column)
+    two_valued: dict = {}
+    for dtype, dtype_columns in by_dtype.items():
+        values = df[dtype_columns].to_numpy()
+        is_first = _equal_or_both_missing(values, values[0], dtype)
+        # the first row that differs from the first value, per column (0 where none does)
+        second_position = np.argmax(~is_first, axis=0)
+        second = values[second_position, np.arange(values.shape[1])]
+        is_second = _equal_or_both_missing(values, second, dtype)
+        has_second = ~is_first.all(axis=0)
+        exactly_two = has_second & (is_first | is_second).all(axis=0)
+        for column, first, second_value, is_two in zip(dtype_columns, values[0], second, exactly_two):
+            if is_two:
+                two_valued[column] = np.array([first, second_value], dtype=dtype)
+    two_valued.update(_two_valued_through_unique(df, other))
+    return {column: two_valued[column] for column in columns if column in two_valued}
+
+
+def _equal_or_both_missing(values: np.ndarray, reference: np.ndarray, dtype: np.dtype) -> np.ndarray:
+    """Element-wise equality against a per-column reference, with NaN equal to NaN on float blocks."""
+    equal = values == reference
+    if dtype.kind == "f":
+        equal |= np.isnan(values) & np.isnan(reference)
+    return equal
+
+
+def _two_valued_through_unique(df: DataFrame, columns: list) -> dict:
+    two_valued = {}
+    for column in columns:
+        uniques = df[column].unique()
+        if len(uniques) == 2:
+            two_valued[column] = uniques
+    return two_valued
+
+
 def get_constant_columns(df: DataFrame, columns: list | None = None) -> list:
     """The columns of `df` (or of `columns`) holding a single distinct value: ``len(df[column].unique()) == 1``.
 

--- a/common/src/autogluon/common/utils/pandas_utils.py
+++ b/common/src/autogluon/common/utils/pandas_utils.py
@@ -3,7 +3,9 @@ import math
 import sys
 from functools import wraps
 
-from pandas import DataFrame
+import numpy as np
+import pandas as pd
+from pandas import DataFrame, Series
 
 from ..features.infer_types import get_type_map_raw
 from ..features.types import R_CATEGORY, R_FLOAT, R_INT
@@ -48,14 +50,33 @@ def _object_column_mem_usage(values, num_rows: int, sample_ratio: float) -> int:
     return int(values.itemsize * num_rows + unique_bytes / sample_ratio)
 
 
+_OBJECT_DTYPE = np.dtype(object)
+
+
+def _memory_usage_shallow(df: DataFrame) -> Series:
+    """`df.memory_usage()` (index included, not deep) without building a Series per column.
+
+    A numpy-dtype column's shallow usage is `itemsize * len`, which is what pandas reports for it; the
+    extension-dtype columns are asked individually, as pandas would.
+    """
+    num_rows = len(df)
+    values = [
+        dtype.itemsize * num_rows if isinstance(dtype, np.dtype) else df[column].memory_usage(index=False)
+        for column, dtype in zip(df.columns, df.dtypes)
+    ]
+    index_usage = Series([df.index.memory_usage()], index=["Index"], dtype=np.intp)
+    return pd.concat([index_usage, Series(values, index=df.columns, dtype=np.intp)])
+
+
 # suspend_logging to hide the Pandas log of NumExpr initialization
 @_suspend_logging_for_package("pandas")
 def get_approximate_df_mem_usage(df: DataFrame, sample_ratio=0.2):
     num_rows = len(df)
+    dtypes = dict(zip(df.columns, df.dtypes))
     if sample_ratio >= 1 or num_rows == 0:
         memory_usage = df.memory_usage(deep=True)
         for column in df:
-            if df[column].dtype == object:
+            if dtypes[column] == _OBJECT_DTYPE:
                 memory_usage[column] = _object_column_mem_usage(df[column].to_numpy(), num_rows, 1.0)
         return memory_usage
     else:
@@ -65,9 +86,9 @@ def get_approximate_df_mem_usage(df: DataFrame, sample_ratio=0.2):
         columns_category = [column for column in df if dtypes_raw[column] == R_CATEGORY]
         columns_inexact = [column for column in df if dtypes_raw[column] not in [R_INT, R_FLOAT, R_CATEGORY]]
         # Object columns need per-object accounting, the rest extrapolate from a deep sample.
-        columns_object = [column for column in columns_inexact if df[column].dtype == object]
-        columns_inexact = [column for column in columns_inexact if df[column].dtype != object]
-        memory_usage = df.memory_usage()
+        columns_object = [column for column in columns_inexact if dtypes[column] == _OBJECT_DTYPE]
+        columns_inexact = [column for column in columns_inexact if dtypes[column] != _OBJECT_DTYPE]
+        memory_usage = _memory_usage_shallow(df)
         if columns_category:
             for column in columns_category:
                 num_categories = max(len(df[column].cat.categories), 1)

--- a/common/src/autogluon/common/utils/pandas_utils.py
+++ b/common/src/autogluon/common/utils/pandas_utils.py
@@ -53,6 +53,42 @@ def _object_column_mem_usage(values, num_rows: int, sample_ratio: float) -> int:
 _OBJECT_DTYPE = np.dtype(object)
 
 
+def get_constant_columns(df: DataFrame, columns: list | None = None) -> list:
+    """The columns of `df` (or of `columns`) holding a single distinct value: ``len(df[column].unique()) == 1``.
+
+    All-missing counts as one value, ``-0.0`` equals ``0.0``, and an empty frame has no constant column, as
+    with ``unique``. numpy numeric and bool columns are tested block-wise per dtype; every other column is
+    asked through ``unique`` as before.
+    """
+    if columns is None:
+        columns = list(df.columns)
+    num_rows = len(df)
+    if num_rows == 0:
+        return []
+    if df.columns.has_duplicates:
+        return [column for column in columns if len(df[column].unique()) == 1]
+    dtypes = dict(zip(df.columns, df.dtypes))
+    by_dtype: dict = {}
+    other = []
+    for column in columns:
+        dtype = dtypes[column]
+        if isinstance(dtype, np.dtype) and dtype.kind in "biuf":
+            by_dtype.setdefault(dtype, []).append(column)
+        else:
+            other.append(column)
+    constant = set()
+    for dtype, dtype_columns in by_dtype.items():
+        values = df[dtype_columns].to_numpy()
+        same_as_first = (values == values[0]).all(axis=0)
+        if dtype.kind == "f":
+            missing = np.isnan(values)
+            all_missing = missing.all(axis=0)
+            same_as_first = np.where(missing.any(axis=0), all_missing, same_as_first)
+        constant.update(column for column, is_constant in zip(dtype_columns, same_as_first) if is_constant)
+    constant.update(column for column in other if len(df[column].unique()) == 1)
+    return [column for column in columns if column in constant]
+
+
 def _memory_usage_shallow(df: DataFrame) -> Series:
     """`df.memory_usage()` (index included, not deep) without building a Series per column.
 

--- a/common/tests/unittests/test_infer_types.py
+++ b/common/tests/unittests/test_infer_types.py
@@ -96,3 +96,23 @@ def test_check_if_datetime_as_object_feature(series, expected):
     from autogluon.common.features.infer_types import check_if_datetime_as_object_feature
 
     assert check_if_datetime_as_object_feature(series) is expected
+
+
+def test_get_type_map_real_names():
+    from autogluon.common.features.infer_types import get_type_map_real
+
+    df = pd.DataFrame(
+        {
+            "i": [1, 2],
+            "f": [1.0, 2.0],
+            "b": [True, False],
+            "o": ["a", "b"],
+            "s": pd.Series(["a", "b"], dtype="string"),
+            "c": pd.Series(["a", "b"], dtype="category"),
+            "d": pd.to_datetime(["2020-01-01", "2020-01-02"]),
+            "sp": pd.arrays.SparseArray([0, 1]),
+        }
+    )
+    expected = {column: dtype.name for column, dtype in df.dtypes.items()}
+    assert get_type_map_real(df) == expected
+    assert get_type_map_real(df) == expected

--- a/common/tests/unittests/test_infer_types.py
+++ b/common/tests/unittests/test_infer_types.py
@@ -56,3 +56,43 @@ def test_when_nullable_dtype_with_pd_na_then_na_not_chosen_as_true(series, expec
     uniques = series.unique()
     assert len(uniques) == 2
     assert get_bool_true_val(uniques) == expected
+
+
+@pytest.mark.parametrize(
+    ("series", "expected"),
+    [
+        (pd.Series([1, 2, 3]), "int"),
+        (pd.Series([1.0, np.nan]), "float"),
+        (pd.Series(["a", "b"]), "object"),
+        (pd.Series(["a", "b"], dtype="string"), "object"),
+        (pd.Series(["a", "b"], dtype="category"), "category"),
+        (pd.Series([True, False]), "bool"),
+        (pd.Series(pd.to_datetime(["2020-01-01", "2020-01-02"])), "datetime"),
+        (pd.Series(pd.arrays.SparseArray([0, 1, 0])), "int"),
+    ],
+)
+def test_get_type_family_raw_is_stable_across_repeated_calls(series, expected):
+    from autogluon.common.features.infer_types import get_type_family_raw
+
+    assert get_type_family_raw(series.dtype) == expected
+    assert get_type_family_raw(series.dtype) == expected
+    # a categorical with other categories is a different dtype and must not hit a stale entry
+    other = pd.Series([1, 2], dtype="category")
+    assert get_type_family_raw(other.dtype) == "category"
+
+
+@pytest.mark.parametrize(
+    ("series", "expected"),
+    [
+        (pd.Series([np.nan, np.nan]), False),  # all missing, float
+        (pd.Series([None, None], dtype=object), False),  # all missing, object
+        (pd.Series([1.5, 2.5]), False),
+        (pd.Series(["2020-01-01", "2020-01-02", "2020-01-03"]), True),
+        (pd.Series(["184", "822828", "20170206"]), False),
+        (pd.Series(["a", "b", "c"]), False),
+    ],
+)
+def test_check_if_datetime_as_object_feature(series, expected):
+    from autogluon.common.features.infer_types import check_if_datetime_as_object_feature
+
+    assert check_if_datetime_as_object_feature(series) is expected

--- a/common/tests/unittests/test_infer_types.py
+++ b/common/tests/unittests/test_infer_types.py
@@ -116,3 +116,23 @@ def test_get_type_map_real_names():
     expected = {column: dtype.name for column, dtype in df.dtypes.items()}
     assert get_type_map_real(df) == expected
     assert get_type_map_real(df) == expected
+
+
+def test_get_type_map_special_matches_per_column_check():
+    from autogluon.common.features.infer_types import get_type_map_special, get_types_special
+
+    df = pd.DataFrame(
+        {
+            "i": [1, 2, 3],
+            "f": [1.0, np.nan, 3.0],
+            "b": [True, False, True],
+            "dt_obj": ["2020-01-01", "2020-01-02", "2020-01-03"],
+            "text": ["one two three four", "five six seven eight", "nine ten eleven twelve"],
+            "cat": pd.Series(["a", "b", "a"], dtype="category"),
+            "sp": pd.arrays.SparseArray([0, 1, 0]),
+            "sp_obj": pd.arrays.SparseArray(["2020-01-01", "2020-01-02", "2020-01-03"], fill_value=None),
+        }
+    )
+    per_column = {c: get_types_special(df[c]) for c in df.columns}
+    assert get_type_map_special(df) == {c: t for c, t in per_column.items() if t}
+    assert set(get_type_map_special(df)) == {"dt_obj", "text", "sp", "sp_obj"}

--- a/common/tests/unittests/utils/test_pandas_utils.py
+++ b/common/tests/unittests/utils/test_pandas_utils.py
@@ -194,3 +194,83 @@ def test_memory_usage_shallow_matches_pandas():
     pd.testing.assert_series_equal(_memory_usage_shallow(sliced), sliced.memory_usage())
     empty = df.iloc[:0]
     pd.testing.assert_series_equal(_memory_usage_shallow(empty), empty.memory_usage())
+
+
+def _constant_columns_reference(df):
+    return [column for column in df.columns if len(df[column].unique()) == 1]
+
+
+def test_get_constant_columns_edge_cases():
+    import numpy as np
+    import pandas as pd
+
+    from autogluon.common.utils.pandas_utils import get_constant_columns
+
+    df = pd.DataFrame(
+        {
+            "zero_signs": [0.0, -0.0, 0.0],
+            "all_nan": [np.nan, np.nan, np.nan],
+            "nan_and_value": [np.nan, 1.0, 1.0],
+            "inf": [np.inf, np.inf, np.inf],
+            "inf_mixed": [np.inf, -np.inf, np.inf],
+            "f32": np.array([1.5, 1.5, 1.5], dtype=np.float32),
+            "big_int": [2**53, 2**53 + 1, 2**53],
+            "int_const": [7, 7, 7],
+            "uint": np.array([3, 3, 3], dtype=np.uint8),
+            "bool_const": [True, True, True],
+            "bool_var": [True, False, True],
+            "obj_none": [None, None, None],
+            "obj_none_nan": [None, np.nan, None],
+            "obj_const": ["a", "a", "a"],
+            "string_na": pd.array(["a", None, "a"], dtype="string"),
+            "cat_const": pd.Categorical(["a", "a", "a"]),
+            "cat_nan": pd.Categorical(["a", None, "a"]),
+            "int64_na": pd.array([pd.NA, pd.NA, pd.NA], dtype="Int64"),
+            "nat": pd.Series([pd.NaT, pd.NaT, pd.NaT], dtype="datetime64[ns]"),
+            "dt_const": pd.to_datetime(["2020-01-01"] * 3),
+            "sparse_const": pd.arrays.SparseArray([0, 0, 0]),
+        }
+    )
+    assert get_constant_columns(df) == _constant_columns_reference(df)
+    assert get_constant_columns(df, columns=["int_const", "bool_var", "all_nan"]) == ["int_const", "all_nan"]
+    assert get_constant_columns(df.iloc[:0]) == []
+    assert get_constant_columns(df.iloc[:1]) == list(df.columns)
+    duplicated = pd.concat([df[["int_const", "bool_var"]], df[["int_const"]]], axis=1)
+    assert duplicated.columns.has_duplicates
+    assert get_constant_columns(duplicated[["bool_var"]]) == []
+
+
+def test_get_constant_columns_matches_unique_on_random_frames():
+    import numpy as np
+    import pandas as pd
+
+    from autogluon.common.utils.pandas_utils import get_constant_columns
+
+    def random_column(rng, n):
+        kind = rng.integers(10)
+        pick = lambda pool: rng.choice(pool, size=n)  # noqa: E731
+        if kind == 0:
+            return pick(np.array([0.0, -0.0, np.nan, np.inf, -np.inf, 1.5]))
+        if kind == 1:
+            return pick(np.array([2**53, 2**53 + 1, -1, 0])).astype(np.int64)
+        if kind == 2:
+            return pick(np.array([True, False]))
+        if kind == 3:
+            return pd.Series(pick(np.array(["a", "b", None], dtype=object)), dtype=object)
+        if kind == 4:
+            return pd.Categorical(pick(np.array(["a", "b", None], dtype=object)))
+        if kind == 5:
+            return pd.array(pick(np.array([1, 2, None], dtype=object)), dtype="Int64")
+        if kind == 6:
+            return pd.Series(pick(np.array(["2020-01-01", "2020-01-02", None], dtype=object))).astype("datetime64[ns]")
+        if kind == 7:
+            return pd.array(pick(np.array(["x", "y", None], dtype=object)), dtype="string")
+        if kind == 8:
+            return pick(np.array([0.25, np.nan], dtype=np.float32))
+        return pd.arrays.SparseArray(pick(np.array([0, 0, 3])))
+
+    for seed in range(150):
+        rng = np.random.default_rng(seed)
+        n = int(rng.choice([1, 2, 3, 20]))
+        df = pd.DataFrame({f"c{i}": random_column(rng, n) for i in range(int(rng.integers(1, 9)))})
+        assert get_constant_columns(df) == _constant_columns_reference(df), (seed, df.dtypes.to_dict())

--- a/common/tests/unittests/utils/test_pandas_utils.py
+++ b/common/tests/unittests/utils/test_pandas_utils.py
@@ -166,3 +166,31 @@ def test_object_column_distinct_values_are_not_undercounted():
 
     # Every value is a distinct object, so the estimate should track deep accounting closely.
     assert 0.9 * deep <= estimate <= 1.1 * deep, f"{estimate} vs {deep}"
+
+
+def test_memory_usage_shallow_matches_pandas():
+    import numpy as np
+    import pandas as pd
+
+    from autogluon.common.utils.pandas_utils import _memory_usage_shallow
+
+    df = pd.DataFrame(
+        {
+            "i8": np.arange(7, dtype=np.int8),
+            "i64": np.arange(7),
+            "f32": np.arange(7, dtype=np.float32),
+            "b": [True, False] * 3 + [True],
+            "o": ["x", "yy", None, "zzz", "", "a", "b"],
+            "dt": pd.date_range("2020", periods=7),
+            "s": pd.Series(["a", "b", None, "d", "e", "f", "g"], dtype="string"),
+            "c": pd.Series(list("abababa"), dtype="category"),
+            "ni": pd.Series([1, None, 3, 4, 5, 6, 7], dtype="Int64"),
+            "sp": pd.arrays.SparseArray([0, 0, 1, 0, 0, 2, 0]),
+            "tz": pd.date_range("2020", periods=7, tz="UTC"),
+        }
+    )
+    pd.testing.assert_series_equal(_memory_usage_shallow(df), df.memory_usage())
+    sliced = df.iloc[1:5]
+    pd.testing.assert_series_equal(_memory_usage_shallow(sliced), sliced.memory_usage())
+    empty = df.iloc[:0]
+    pd.testing.assert_series_equal(_memory_usage_shallow(empty), empty.memory_usage())

--- a/common/tests/unittests/utils/test_pandas_utils.py
+++ b/common/tests/unittests/utils/test_pandas_utils.py
@@ -274,3 +274,98 @@ def test_get_constant_columns_matches_unique_on_random_frames():
         n = int(rng.choice([1, 2, 3, 20]))
         df = pd.DataFrame({f"c{i}": random_column(rng, n) for i in range(int(rng.integers(1, 9)))})
         assert get_constant_columns(df) == _constant_columns_reference(df), (seed, df.dtypes.to_dict())
+
+
+def _two_valued_reference(df):
+    out = {}
+    for column in df.columns:
+        uniques = df[column].unique()
+        if len(uniques) == 2:
+            out[column] = uniques
+    return out
+
+
+def _assert_same_two_valued(got, expected):
+    import numpy as np
+    import pandas as pd
+
+    assert list(got) == list(expected)
+    for column in expected:
+        a, b = got[column], expected[column]
+        assert len(a) == len(b) == 2
+        for x, y in zip(a, b):
+            assert (pd.isna(x) and pd.isna(y)) or x == y, (column, a, b)
+        if isinstance(b, np.ndarray):
+            assert a.dtype == b.dtype, (column, a.dtype, b.dtype)
+
+
+def test_get_two_valued_columns_edge_cases():
+    import numpy as np
+    import pandas as pd
+
+    from autogluon.common.utils.pandas_utils import get_two_valued_columns
+
+    df = pd.DataFrame(
+        {
+            "two": [1.0, 2.0, 1.0, 2.0],
+            "nan_value": [np.nan, 3.0, np.nan, 3.0],  # NaN first, kept in first-appearance order
+            "value_nan": [3.0, np.nan, 3.0, 3.0],
+            "signed_zero": [0.0, -0.0, 1.0, 0.0],  # -0.0 == 0.0, so two values
+            "inf": [np.inf, -np.inf, np.inf, np.inf],
+            "three": [1.0, 2.0, 3.0, 1.0],
+            "constant": [5.0, 5.0, 5.0, 5.0],
+            "all_nan": [np.nan] * 4,
+            "int": [2**53, 2**53 + 1, 2**53, 2**53],
+            "int_three": [1, 2, 3, 1],
+            "bool": [True, False, True, True],
+            "bool_const": [True] * 4,
+            "u8": np.array([0, 255, 0, 0], dtype=np.uint8),
+            "obj": ["y", "n", "y", "y"],
+            "obj_none": ["y", None, "y", "y"],
+            "cat": pd.Categorical(["a", "b", "a", "a"]),
+            "int64_na": pd.array([1, pd.NA, 1, 1], dtype="Int64"),
+            "string": pd.array(["a", "b", "a", "a"], dtype="string"),
+            "dt": pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-01", "2020-01-01"]),
+        }
+    )
+    _assert_same_two_valued(get_two_valued_columns(df), _two_valued_reference(df))
+    subset = ["bool", "three", "obj"]
+    _assert_same_two_valued(
+        get_two_valued_columns(df, columns=subset), {c: _two_valued_reference(df)[c] for c in ["bool", "obj"]}
+    )
+    assert get_two_valued_columns(df.iloc[:1]) == {}
+    assert get_two_valued_columns(df.iloc[:0]) == {}
+
+
+def test_get_two_valued_columns_matches_unique_on_random_frames():
+    import numpy as np
+    import pandas as pd
+
+    from autogluon.common.utils.pandas_utils import get_two_valued_columns
+
+    def random_column(rng, n):
+        kind = rng.integers(9)
+        pick = lambda pool: rng.choice(pool, size=n)  # noqa: E731
+        if kind == 0:
+            return pick(np.array([0.0, -0.0, np.nan, np.inf, 1.5]))
+        if kind == 1:
+            return pick(np.array([2**53, 2**53 + 1, -1])).astype(np.int64)
+        if kind == 2:
+            return pick(np.array([True, False]))
+        if kind == 3:
+            return pd.Series(pick(np.array(["a", "b", None], dtype=object)), dtype=object)
+        if kind == 4:
+            return pd.Categorical(pick(np.array(["a", "b", None], dtype=object)))
+        if kind == 5:
+            return pd.array(pick(np.array([1, 2, None], dtype=object)), dtype="Int64")
+        if kind == 6:
+            return pd.Series(pick(np.array(["2020-01-01", "2020-01-02", None], dtype=object))).astype("datetime64[ns]")
+        if kind == 7:
+            return pick(np.array([0.25, np.nan, 0.5], dtype=np.float32))
+        return pick(np.array([7, 8], dtype=np.uint8))
+
+    for seed in range(200):
+        rng = np.random.default_rng(seed)
+        n = int(rng.choice([1, 2, 3, 4, 30]))
+        df = pd.DataFrame({f"c{i}": random_column(rng, n) for i in range(int(rng.integers(1, 9)))})
+        _assert_same_two_valued(get_two_valued_columns(df), _two_valued_reference(df))

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -775,7 +775,7 @@ class AbstractModel(ModelBase, Tunable):
             feature_metadata = copy.deepcopy(feature_metadata)
         feature_metadata = self._update_feature_metadata(X=X, feature_metadata=feature_metadata)
 
-        valid_features = self._get_valid_features(feature_metadata=feature_metadata)
+        valid_features = set(self._get_valid_features(feature_metadata=feature_metadata))
         dropped_features = [feature for feature in self.features if feature not in valid_features]
         if dropped_features:
             logger.log(10, f"\tDropped {len(dropped_features)} of {len(self.features)} features.")

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -21,9 +21,8 @@ from typing_extensions import Self
 from autogluon.common.features.feature_metadata import FeatureMetadata
 from autogluon.common.space import Space
 from autogluon.common.utils.distribute_utils import DistributedContext
-from autogluon.common.utils.pandas_utils import get_constant_columns
 from autogluon.common.utils.log_utils import DuplicateFilter
-from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
+from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage, get_constant_columns
 from autogluon.common.utils.resource_utils import ResourceManager, get_resource_manager
 from autogluon.common.utils.try_import import try_import_ray
 from autogluon.common.utils.utils import setup_outputdir

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -21,6 +21,7 @@ from typing_extensions import Self
 from autogluon.common.features.feature_metadata import FeatureMetadata
 from autogluon.common.space import Space
 from autogluon.common.utils.distribute_utils import DistributedContext
+from autogluon.common.utils.pandas_utils import get_constant_columns
 from autogluon.common.utils.log_utils import DuplicateFilter
 from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
 from autogluon.common.utils.resource_utils import ResourceManager, get_resource_manager
@@ -787,10 +788,11 @@ class AbstractModel(ModelBase, Tunable):
         # TODO: If unique_counts == 2 (including NaN), then treat as boolean
         #  FIXME: v1.3: Need to do this on a per-fold basis
         if self.aux_params.drop_unique:
-            # TODO: Could this be optimized to be faster? This might be a bit slow for large data.
-            unique_counts = X[self.features].nunique(axis=0, dropna=False)
-            columns_to_drop = list(unique_counts[unique_counts < 2].index)
-            features_to_drop_internal = columns_to_drop
+            # at most one distinct value, missing included (`nunique(dropna=False) < 2`); block-wise on numeric columns
+            if len(X) == 0:
+                features_to_drop_internal = list(self.features)
+            else:
+                features_to_drop_internal = get_constant_columns(X, columns=self.features)
             if not features_to_drop_internal:
                 features_to_drop_internal = None
         else:

--- a/features/src/autogluon/features/generators/abstract.py
+++ b/features/src/autogluon/features/generators/abstract.py
@@ -688,8 +688,9 @@ class AbstractFeatureGenerator:
             self.feature_metadata = self.feature_metadata.remove_features(features=features)
             self.feature_metadata_real = self.feature_metadata_real.remove_features(features=features)
             self.features_out = self.feature_metadata.get_features()
+            features_set = set(features)
             feature_links_chain[-1] = {
-                feature_in: [feature_out for feature_out in features_out if feature_out not in features]
+                feature_in: [feature_out for feature_out in features_out if feature_out not in features_set]
                 for feature_in, features_out in feature_links_chain[-1].items()
             }
         self._remove_unused_features(feature_links_chain=feature_links_chain)
@@ -859,21 +860,18 @@ class AbstractFeatureGenerator:
     def _get_unused_features_generic(
         feature_links_chain: List[Dict[str, List[str]]], features_in_list: List[List[str]]
     ) -> List[List[str]]:
-        unused_features = []
+        unused_features: set = set()
         unused_features_by_stage = []
         for i, chain in enumerate(reversed(feature_links_chain)):
             stage = len(feature_links_chain) - i
             used_features = set()
             for key in chain.keys():
-                new_val = [val for val in chain[key] if val not in unused_features]
-                if new_val:
+                if any(val not in unused_features for val in chain[key]):
                     used_features.add(key)
             features_in = features_in_list[stage - 1]
-            unused_features = []
-            for feature in features_in:
-                if feature not in used_features:
-                    unused_features.append(feature)
-            unused_features_by_stage.append(unused_features)
+            unused_features_stage = [feature for feature in features_in if feature not in used_features]
+            unused_features = set(unused_features_stage)
+            unused_features_by_stage.append(unused_features_stage)
         unused_features_by_stage = list(reversed(unused_features_by_stage))
         return unused_features_by_stage
 

--- a/features/src/autogluon/features/generators/abstract.py
+++ b/features/src/autogluon/features/generators/abstract.py
@@ -828,10 +828,6 @@ class AbstractFeatureGenerator:
     @staticmethod
     def _get_feature_links_from_chain(feature_links_chain: List[Dict[str, List[str]]]) -> Dict[str, List[str]]:
         """Get the final input and output feature links by travelling the feature link chain"""
-        features_out = []
-        for val in feature_links_chain[-1].values():
-            if val not in features_out:
-                features_out.append(val)
         features_in = list(feature_links_chain[0].keys())
         feature_links = feature_links_chain[0]
         for i in range(1, len(feature_links_chain)):

--- a/features/src/autogluon/features/generators/abstract.py
+++ b/features/src/autogluon/features/generators/abstract.py
@@ -804,7 +804,7 @@ class AbstractFeatureGenerator:
                 feature_links[feature_in] = features_out
         else:
             for feat_old, feat_new in zip(features_in, features_out):
-                feature_links[feat_old] = feature_links.get(feat_old, []) + [feat_new]
+                feature_links.setdefault(feat_old, []).append(feat_new)
         return feature_links
 
     def get_feature_links_chain(self) -> List[Dict[str, List[str]]]:

--- a/features/src/autogluon/features/generators/abstract.py
+++ b/features/src/autogluon/features/generators/abstract.py
@@ -11,10 +11,9 @@ import pandas as pd
 from pandas import DataFrame, Series
 
 from autogluon.common.features.feature_metadata import FeatureMetadata
-from autogluon.common.utils.pandas_utils import get_constant_columns
 from autogluon.common.features.infer_types import get_type_group_map_special, get_type_map_raw, get_type_map_real
 from autogluon.common.savers import save_pkl
-
+from autogluon.common.utils.pandas_utils import get_constant_columns
 
 logger = logging.getLogger(__name__)
 

--- a/features/src/autogluon/features/generators/abstract.py
+++ b/features/src/autogluon/features/generators/abstract.py
@@ -11,10 +11,10 @@ import pandas as pd
 from pandas import DataFrame, Series
 
 from autogluon.common.features.feature_metadata import FeatureMetadata
+from autogluon.common.utils.pandas_utils import get_constant_columns
 from autogluon.common.features.infer_types import get_type_group_map_special, get_type_map_raw, get_type_map_real
 from autogluon.common.savers import save_pkl
 
-from ..utils import is_useless_feature
 
 logger = logging.getLogger(__name__)
 
@@ -748,13 +748,12 @@ class AbstractFeatureGenerator:
     # TODO: Move to a generator
     @staticmethod
     def _get_useless_features(X: DataFrame, columns_to_check: List[str] = None) -> list:
-        useless_features = []
+        """The columns with at most one distinct value (see `is_useless_feature`), tested block-wise."""
         if columns_to_check is None:
             columns_to_check = list(X.columns)
-        for column in columns_to_check:
-            if is_useless_feature(X[column]):
-                useless_features.append(column)
-        return useless_features
+        if len(X) == 0:
+            return list(columns_to_check)
+        return get_constant_columns(X, columns=columns_to_check)
 
     # TODO: Consider adding _log and verbosity methods to mixin
     def set_log_prefix(self, log_prefix, prepend=False):

--- a/features/src/autogluon/features/generators/astype.py
+++ b/features/src/autogluon/features/generators/astype.py
@@ -5,6 +5,7 @@ import pandas as pd
 from pandas import DataFrame
 
 from autogluon.common.features.feature_metadata import FeatureMetadata
+from autogluon.common.utils.pandas_utils import get_constant_columns, get_two_valued_columns
 from autogluon.common.features.infer_types import get_bool_true_val, get_type_map_raw, get_type_map_real
 from autogluon.common.features.types import R_INT, S_BOOL
 
@@ -104,17 +105,14 @@ class AsTypeFeatureGenerator(AbstractFeatureGenerator):
             if num_rows > 1000:
                 # Sample and filter out features that already have >2 unique values
                 # in the first 500 rows from bool consideration
-                X_nunique_sample = X[self.features_in].head(500).nunique(dropna=False)
-                X_nunique_sample = X_nunique_sample[X_nunique_sample <= 2]
-                bool_candidates = list(X_nunique_sample.index)
+                X_sample = X[self.features_in].head(500)
+                at_most_two = set(get_constant_columns(X_sample)) | set(get_two_valued_columns(X_sample))
+                bool_candidates = [feature for feature in self.features_in if feature in at_most_two]
             else:
                 bool_candidates = self.features_in
-            for feature in bool_candidates:
-                if S_BOOL not in type_map_special[feature]:
-                    uniques = X[feature].unique()
-                    if len(uniques) == 2:
-                        feature_bool_val = get_bool_true_val(uniques=uniques)
-                        self._bool_features[feature] = feature_bool_val
+            bool_candidates = [feature for feature in bool_candidates if S_BOOL not in type_map_special[feature]]
+            for feature, uniques in get_two_valued_columns(X, columns=bool_candidates).items():
+                self._bool_features[feature] = get_bool_true_val(uniques=uniques)
 
         if self._bool_features:
             self._log(

--- a/features/src/autogluon/features/generators/astype.py
+++ b/features/src/autogluon/features/generators/astype.py
@@ -5,9 +5,9 @@ import pandas as pd
 from pandas import DataFrame
 
 from autogluon.common.features.feature_metadata import FeatureMetadata
-from autogluon.common.utils.pandas_utils import get_constant_columns, get_two_valued_columns
 from autogluon.common.features.infer_types import get_bool_true_val, get_type_map_raw, get_type_map_real
 from autogluon.common.features.types import R_INT, S_BOOL
+from autogluon.common.utils.pandas_utils import get_constant_columns, get_two_valued_columns
 
 from .abstract import AbstractFeatureGenerator
 

--- a/features/src/autogluon/features/generators/bulk.py
+++ b/features/src/autogluon/features/generators/bulk.py
@@ -283,10 +283,9 @@ class BulkFeatureGenerator(AbstractFeatureGenerator):
     def _remove_unused_features(self, feature_links_chain):
         unused_features_by_stage = self._get_unused_features(feature_links_chain)
         if unused_features_by_stage:
+            unused_features_in_set = set(unused_features_by_stage[0])
             unused_features_in = [
-                feature
-                for feature in self.feature_metadata_in.get_features()
-                if feature in unused_features_by_stage[0]
+                feature for feature in self.feature_metadata_in.get_features() if feature in unused_features_in_set
             ]
             feature_metadata_in_unused = self.feature_metadata_in.keep_features(features=unused_features_in)
             if self._feature_metadata_in_unused:
@@ -304,9 +303,7 @@ class BulkFeatureGenerator(AbstractFeatureGenerator):
                 for feature_in in unused_features_in_stage
                 if feature_in in feature_links_chain[i]
             ]
-            unused_features_out_stage = list(
-                set([feature for sublist in unused_features_out_stage for feature in sublist])
-            )
+            unused_features_out_stage = {feature for sublist in unused_features_out_stage for feature in sublist}
             for generator in generator_group:
                 unused_features_out_generator = [
                     feature for feature in generator.features_out if feature in unused_features_out_stage

--- a/features/src/autogluon/features/generators/drop_duplicates.py
+++ b/features/src/autogluon/features/generators/drop_duplicates.py
@@ -191,9 +191,9 @@ class DropDuplicatesFeatureGenerator(AbstractFeatureGenerator):
         ).round(6)
 
         # ---- Bucket by stats ----
+        # One pass over the rows of `stats` (indexed like `cols`) instead of four `.at` lookups per column.
         bucket_map: dict[tuple[float, float, float, float], list[str]] = defaultdict(list)
-        for c in cols:
-            key = (stats.at[c, "sum"], stats.at[c, "std"], stats.at[c, "min"], stats.at[c, "max"])
+        for c, key in zip(cols, stats[["sum", "std", "min", "max"]].itertuples(index=False, name=None)):
             bucket_map[key].append(c)
 
         # ---- Within each stats bucket, bucket by full fingerprint ----

--- a/features/src/autogluon/features/generators/drop_unique.py
+++ b/features/src/autogluon/features/generators/drop_unique.py
@@ -3,6 +3,7 @@ import logging
 from pandas import DataFrame
 
 from autogluon.common.features.feature_metadata import FeatureMetadata
+from autogluon.common.utils.pandas_utils import get_constant_columns
 from autogluon.common.features.types import R_CATEGORY, R_OBJECT, S_IMAGE_BYTEARRAY, S_IMAGE_PATH, S_TEXT
 
 from .abstract import AbstractFeatureGenerator
@@ -39,13 +40,13 @@ class DropUniqueFeatureGenerator(AbstractFeatureGenerator):
         features_to_drop = []
         X_len = len(X)
         max_unique_value_count = X_len * max_unique_ratio
+        constant_features = set(get_constant_columns(X))
         for column in X:
-            unique_value_count = len(X[column].unique())
             # Drop features that are always the same
-            if unique_value_count == 1:
+            if column in constant_features:
                 features_to_drop.append(column)
             elif feature_metadata.get_feature_type_raw(column) in [R_CATEGORY, R_OBJECT] and (
-                unique_value_count > max_unique_value_count
+                len(X[column].unique()) > max_unique_value_count
             ):
                 special_types = feature_metadata.get_feature_types_special(column)
                 if S_TEXT in special_types:

--- a/features/src/autogluon/features/generators/drop_unique.py
+++ b/features/src/autogluon/features/generators/drop_unique.py
@@ -3,8 +3,8 @@ import logging
 from pandas import DataFrame
 
 from autogluon.common.features.feature_metadata import FeatureMetadata
-from autogluon.common.utils.pandas_utils import get_constant_columns
 from autogluon.common.features.types import R_CATEGORY, R_OBJECT, S_IMAGE_BYTEARRAY, S_IMAGE_PATH, S_TEXT
+from autogluon.common.utils.pandas_utils import get_constant_columns
 
 from .abstract import AbstractFeatureGenerator
 

--- a/features/tests/features/generators/test_drop_duplicates.py
+++ b/features/tests/features/generators/test_drop_duplicates.py
@@ -264,3 +264,42 @@ def test_drop_duplicates_category_edge_cases():
     expected_dropped_7 = ["D"]
     actual_dropped_7 = feature_generator._drop_duplicate_features(X=df, feature_metadata_in=feature_metadata_in)
     assert expected_dropped_7 == actual_dropped_7
+
+
+def test_get_unused_features_generic_matches_reference():
+    """The set-based unused-feature walk agrees with the original list-based one on random chains."""
+    import random
+
+    from autogluon.features.generators.abstract import AbstractFeatureGenerator
+
+    def reference(feature_links_chain, features_in_list):
+        unused_features = []
+        unused_features_by_stage = []
+        for i, chain in enumerate(reversed(feature_links_chain)):
+            stage = len(feature_links_chain) - i
+            used_features = set()
+            for key in chain.keys():
+                new_val = [val for val in chain[key] if val not in unused_features]
+                if new_val:
+                    used_features.add(key)
+            features_in = features_in_list[stage - 1]
+            unused_features = [feature for feature in features_in if feature not in used_features]
+            unused_features_by_stage.append(unused_features)
+        return list(reversed(unused_features_by_stage))
+
+    rng = random.Random(0)
+    for _ in range(200):
+        n_stages = rng.randint(1, 4)
+        features_in_list, chain = [], []
+        stage_in = [f"f{i}" for i in range(rng.randint(1, 8))]
+        for _stage in range(n_stages):
+            stage_out = [f"{f}_o{_stage}" for f in stage_in if rng.random() < 0.7] + [
+                f"new{_stage}_{k}" for k in range(rng.randint(0, 2))
+            ]
+            links = {f: [o for o in stage_out if rng.random() < 0.4] for f in stage_in if rng.random() < 0.9}
+            features_in_list.append(list(stage_in))
+            chain.append(links)
+            stage_in = stage_out
+        assert AbstractFeatureGenerator._get_unused_features_generic(chain, features_in_list) == reference(
+            chain, features_in_list
+        )

--- a/features/tests/features/test_feature_metadata.py
+++ b/features/tests/features/test_feature_metadata.py
@@ -251,3 +251,81 @@ def test_feature_metadata_equals():
 
     feature_metadata_2 = feature_metadata_2.add_special_types(type_map_special={"a": ["s2", "s3"]})
     assert feature_metadata == feature_metadata_2
+
+
+def test_feature_metadata_keep_remove_invalid_features():
+    feature_metadata = FeatureMetadata(
+        type_map_raw={"a": "int", "b": "float", "c": "object"},
+        type_group_map_special={"text": ["c"], "bool": ["a"]},
+    )
+    with pytest.raises(KeyError, match=r"Invalid Features: \['z', 'y'\]"):
+        feature_metadata.keep_features(features=["a", "z", "y"])
+    with pytest.raises(KeyError, match=r"Invalid Features: \['z', 'y'\]"):
+        feature_metadata.remove_features(features=["a", "z", "y"])
+    # order of the kept features follows the metadata, not the argument; duplicates in the argument are harmless
+    kept = feature_metadata.keep_features(features=["c", "a", "a"])
+    assert kept.get_features() == ["a", "c"]
+    assert kept.type_group_map_special == {"text": ["c"], "bool": ["a"]}
+    removed = feature_metadata.remove_features(features=["a", "a"])
+    assert removed.get_features() == ["b", "c"]
+    assert removed.type_group_map_special == {"text": ["c"], "bool": []}
+
+
+def test_feature_metadata_special_types_consistent():
+    """`to_dict` / `get_type_map_special` agree with the per-feature `get_feature_types_special`."""
+    feature_metadata = FeatureMetadata(
+        type_map_raw={"a": "int", "b": "float", "c": "object", "d": "object"},
+        # a feature listed twice in one group counts once
+        type_group_map_special={"text": ["c", "c"], "bool": ["a"], "datetime_as_object": ["c", "d"]},
+    )
+    per_feature = {f: feature_metadata.get_feature_types_special(f) for f in feature_metadata.get_features()}
+    assert per_feature == {"a": ["bool"], "b": [], "c": ["datetime_as_object", "text"], "d": ["datetime_as_object"]}
+    assert feature_metadata.get_type_map_special() == per_feature
+    assert feature_metadata.to_dict() == {
+        f: (feature_metadata.type_map_raw[f], tuple(t)) for f, t in per_feature.items()
+    }
+    assert feature_metadata.to_dict(inverse=True) == {
+        ("int", ("bool",)): ["a"],
+        ("float", ()): ["b"],
+        ("object", ("datetime_as_object", "text")): ["c"],
+        ("object", ("datetime_as_object",)): ["d"],
+    }
+
+
+def test_feature_metadata_print_full_builds_output_only_when_needed(monkeypatch):
+    """Nothing is computed when nothing would be logged; a returned string is always built."""
+    import logging
+
+    from autogluon.common.features import feature_metadata as feature_metadata_module
+
+    feature_metadata = FeatureMetadata(
+        type_map_raw={"a": "int", "b": "object"}, type_group_map_special={"text": ["b"]}
+    )
+    calls = []
+    original_to_dict = FeatureMetadata.to_dict
+
+    def counting_to_dict(self, inverse=False):
+        calls.append(inverse)
+        return original_to_dict(self, inverse=inverse)
+
+    monkeypatch.setattr(FeatureMetadata, "to_dict", counting_to_dict)
+    logger = logging.getLogger(feature_metadata_module.__name__)
+    previous_level = logger.level
+    try:
+        logger.setLevel(logging.ERROR)
+        assert feature_metadata.print_feature_metadata_full(log_level=20) is None
+        assert calls == []
+        as_str = feature_metadata.print_feature_metadata_full(return_str=True, log_level=20)
+        assert calls == [True]
+        assert "('int', [])" in as_str and "('object', ['text'])" in as_str
+        # at WARNING a plain call still has nothing to emit, but `print_only_one_special` may warn
+        logger.setLevel(logging.WARNING)
+        feature_metadata.print_feature_metadata_full(log_level=20)
+        assert calls == [True]
+        feature_metadata.print_feature_metadata_full(print_only_one_special=True, log_level=20)
+        assert calls == [True, True]
+        logger.setLevel(logging.INFO)
+        feature_metadata.print_feature_metadata_full(log_level=20)
+        assert calls == [True, True, True]
+    finally:
+        logger.setLevel(previous_level)

--- a/features/tests/features/test_feature_metadata.py
+++ b/features/tests/features/test_feature_metadata.py
@@ -329,3 +329,26 @@ def test_feature_metadata_print_full_builds_output_only_when_needed(monkeypatch)
         assert calls == [True, True, True]
     finally:
         logger.setLevel(previous_level)
+
+
+def test_feature_metadata_copies_share_nothing():
+    """Copies made by the non-inplace operations can be mutated without touching the source."""
+    source = FeatureMetadata(
+        type_map_raw={"a": "int", "b": "object", "c": "object"},
+        type_group_map_special={"text": ["b", "c"]},
+    )
+    copies = {
+        "copy": source.copy(),
+        "remove": source.remove_features(["a"]),
+        "rename": source.rename_features({"a": "a2"}),
+        "add": source.add_special_types({"a": ["binned"]}),
+        "join": FeatureMetadata.join_metadatas([source, FeatureMetadata(type_map_raw={"d": "float"})]),
+    }
+    for metadata in copies.values():
+        metadata.type_group_map_special["text"].append("zz")
+        metadata.type_group_map_special["new"].append("zz")
+        metadata.type_map_raw["zz"] = "int"
+    assert source.type_map_raw == {"a": "int", "b": "object", "c": "object"}
+    assert dict(source.type_group_map_special) == {"text": ["b", "c"]}
+    assert isinstance(copies["copy"].type_group_map_special, type(source.type_group_map_special))
+    assert copies["copy"].type_map_raw == {"a": "int", "b": "object", "c": "object", "zz": "int"}


### PR DESCRIPTION
Several places in the feature pipeline scaled quadratically with the number of columns, and several more paid a Python-level cost per column at every generator stage; together they dominated fit time on wide frames (tens of thousands of features) while the model itself took seconds. Results are unchanged throughout.

Quadratic:
- `FeatureMetadata.keep_features` / `remove_features` tested membership against a feature list rebuilt per feature, and `to_dict` / `get_type_map_special` rescanned every special type group for every feature. Membership now goes through sets and the special types are inverted once. `print_feature_metadata_full` skips building its output when the logger would discard it (a returned string is always built, and with `print_only_one_special` the output is built whenever warnings are enabled, since it may warn).
- `AbstractFeatureGenerator._get_feature_links_from_chain` collected the distinct output lists of the last link with a `not in` over lists and never used them; the loop is removed.
- `AbstractModel._preprocess_set_features` filtered the model's features against the valid-feature list; it now uses a set.

Per column:
- `get_type_family_raw` and `get_type_map_real` cache the family / name per dtype (a frame's columns share a handful of dtypes; unrecognized dtypes are not cached, so they are still logged each time).
- `check_if_datetime_as_object_feature` checks the dtype before scanning the values for missingness, and `get_type_map_special` skips columns whose dtype rules out a special type without materializing a Series.
- `FeatureMetadata` copies structurally (the maps hold strings and lists of strings) instead of `copy.deepcopy`.
- `DropDuplicatesFeatureGenerator` buckets numeric columns in one pass over the stats frame instead of four `.at` lookups per column.
- `get_approximate_df_mem_usage` computes the shallow usage of numpy-dtype columns as `itemsize * len` (what pandas reports) instead of a Series per column, and reads `df.dtypes` once.
- `get_constant_columns` finds the columns with a single distinct value (`len(unique()) == 1`) block-wise per numpy dtype, asking `unique` only for the other dtypes; all-missing counts as one value and `-0.0` equals `0.0`, as with `unique`. `DropUniqueFeatureGenerator`, the generators' useless-feature check and `AbstractModel`'s `drop_unique` use it instead of a Series per column. A randomized test checks it against `unique` over ten dtype families (float with NaN / signed zeros / infinities, int64 beyond 2^53, bool, object with None, category, nullable Int64, datetime with NaT, string, float32, sparse).
- `get_two_valued_columns` finds the columns with exactly two distinct values the same way, returning the values in order of first appearance and in the column's dtype as `unique` does; `AsTypeFeatureGenerator` uses it for its bool candidates, both for the full scan on small frames and for the 500-row prefilter on larger ones, instead of a `unique` / `nunique` per column. A randomized test checks it against `unique`.
- `FeatureMetadata`'s bulk special-type map is built by visiting the groups in sorted order, so no list is sorted per feature, and `_get_feature_links` appends to each feature's list instead of rebuilding it. The unused-feature walk and the output pruning after a fit test feature names against sets instead of lists, which were quadratic whenever a stage dropped many columns; a randomized test checks the walk against the previous implementation.

On a 22k-column frame `keep_features` goes from 3.7 s to 0.01 s and `to_dict(inverse=True)` from 0.47 s to under 0.01 s; a TabArena-style feature-generator pipeline plus a single model fit on that frame went from 206 s to 4.9 s, of which the model is about 2.5 s (1.4 s of that being the model's own per-column modality detection). Tests cover the invalid-feature errors, agreement between the per-feature and bulk lookups (special types, dtype names, memory usage against `DataFrame.memory_usage`, constant and two-valued columns against `unique`), copy independence, when the printer builds its output, and the datetime check on all-missing and non-object columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi


