### PR TITLE
[common] Cheaper installed-package enumeration for the predictor metadata

### DIFF
--- a/common/src/autogluon/common/utils/utils.py
+++ b/common/src/autogluon/common/utils/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import logging
 import os
 import platform
@@ -150,7 +151,17 @@ def get_package_versions(*, strict: bool = False) -> tuple[dict[str, str], list[
     invalid_distributions:
         List of strings describing distributions that could not be read safely
         (e.g., missing/None name metadata, unexpected metadata errors).
+
+    Computed once per process: the installed distributions do not change while a process runs,
+    and enumerating them costs up to a second on a large environment, which `TabularPredictor.save`
+    would otherwise pay at every fit. The caller gets its own copies of the cached containers.
     """
+    package_version_dict, invalid = _get_package_versions_cached(strict=strict)
+    return dict(package_version_dict), list(invalid)
+
+
+@functools.lru_cache(maxsize=None)
+def _get_package_versions_cached(*, strict: bool) -> tuple[dict[str, str], list[str]]:
     import importlib.metadata
 
     package_version_dict: dict[str, str] = {}

--- a/common/src/autogluon/common/utils/utils.py
+++ b/common/src/autogluon/common/utils/utils.py
@@ -160,6 +160,38 @@ def get_package_versions(*, strict: bool = False) -> tuple[dict[str, str], list[
     return dict(package_version_dict), list(invalid)
 
 
+def _name_and_version_from_metadata_header(dist) -> tuple[str | None, str | None]:
+    """
+    Read a distribution's Name and Version from the header of its METADATA (or PKG-INFO) file.
+
+    `Distribution.metadata` parses the whole file, long description included, with the email
+    parser; the two fields sit in the header, above the first blank line, so reading up to there
+    gives the same values at a fraction of the cost. `(None, None)` when the file is not there or
+    holds no Name, in which case the caller falls back to `Distribution.metadata`.
+    """
+    base = getattr(dist, "_path", None)
+    if base is None:
+        return None, None
+    for file_name in ("METADATA", "PKG-INFO"):
+        path = Path(base) / file_name
+        if not path.is_file():
+            continue
+        name = version = None
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                if line in ("\n", "\r\n"):
+                    break
+                if line.startswith("Name: "):
+                    name = line[len("Name: ") :].strip()
+                elif line.startswith("Version: "):
+                    version = line[len("Version: ") :].strip()
+                if name and version:
+                    break
+        if name:
+            return name, version
+    return None, None
+
+
 @functools.lru_cache(maxsize=None)
 def _get_package_versions_cached(*, strict: bool) -> tuple[dict[str, str], list[str]]:
     import importlib.metadata
@@ -169,6 +201,10 @@ def _get_package_versions_cached(*, strict: bool) -> tuple[dict[str, str], list[
 
     for dist in importlib.metadata.distributions():
         try:
+            name, version = _name_and_version_from_metadata_header(dist)
+            if name:
+                package_version_dict[str(name).lower()] = str(version) if version is not None else "unknown"
+                continue
             # dist.metadata is typically an email.message.Message-like mapping.
             name = None
             md = getattr(dist, "metadata", None)

--- a/common/tests/unittests/utils/test_get_package_versions.py
+++ b/common/tests/unittests/utils/test_get_package_versions.py
@@ -1,8 +1,17 @@
-import types
-
 import pytest
 
-from autogluon.common.utils.utils import get_package_versions
+from autogluon.common.utils.utils import (
+    _get_package_versions_cached,
+    get_package_versions,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_package_versions():
+    """Each test enumerates its own fake distributions, so the per-process cache is emptied around it."""
+    _get_package_versions_cached.cache_clear()
+    yield
+    _get_package_versions_cached.cache_clear()
 
 
 class _FakeDist:
@@ -94,3 +103,24 @@ def test_get_package_versions_strict_raises(monkeypatch):
 
     with pytest.raises(ValueError):
         get_package_versions(strict=True)
+
+
+def test_get_package_versions_is_computed_once_per_process(monkeypatch):
+    import importlib.metadata as im
+
+    calls = []
+
+    def distributions():
+        calls.append(1)
+        return iter([_FakeDist(metadata={"Name": "NumPy"}, version="2.0.0")])
+
+    monkeypatch.setattr(im, "distributions", distributions)
+    first, first_invalid = get_package_versions()
+    second, second_invalid = get_package_versions()
+    assert first == second == {"numpy": "2.0.0"} and first_invalid == second_invalid == []
+    assert len(calls) == 1
+    # callers get their own containers: mutating one result must not leak into the next
+    first["numpy"] = "changed"
+    first_invalid.append("x")
+    third, third_invalid = get_package_versions()
+    assert third == {"numpy": "2.0.0"} and third_invalid == []

--- a/common/tests/unittests/utils/test_get_package_versions.py
+++ b/common/tests/unittests/utils/test_get_package_versions.py
@@ -2,6 +2,7 @@ import pytest
 
 from autogluon.common.utils.utils import (
     _get_package_versions_cached,
+    _name_and_version_from_metadata_header,
     get_package_versions,
 )
 
@@ -124,3 +125,64 @@ def test_get_package_versions_is_computed_once_per_process(monkeypatch):
     first_invalid.append("x")
     third, third_invalid = get_package_versions()
     assert third == {"numpy": "2.0.0"} and third_invalid == []
+
+
+class _DiskDist:
+    """A distribution whose metadata lives on disk, like importlib's `PathDistribution`."""
+
+    def __init__(self, path, *, name="Fallback", version="9.9"):
+        self._path = path
+        self.name = name
+        self.version = version
+        self.metadata = {"Name": name}
+
+
+def test_metadata_header_read(tmp_path):
+    dist_info = tmp_path / "some_pkg-1.2.3.dist-info"
+    dist_info.mkdir()
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: Some_Pkg\nVersion: 1.2.3\nSummary: x\n\n"
+        "Name: not-the-name\nVersion: 0.0\nlong description\n",
+        encoding="utf-8",
+    )
+    assert _name_and_version_from_metadata_header(_DiskDist(dist_info)) == ("Some_Pkg", "1.2.3")
+
+    egg_info = tmp_path / "legacy.egg-info"
+    egg_info.mkdir()
+    (egg_info / "PKG-INFO").write_text("Metadata-Version: 1.0\nName: legacy\nVersion: 0.1\n", encoding="utf-8")
+    assert _name_and_version_from_metadata_header(_DiskDist(egg_info)) == ("legacy", "0.1")
+
+    empty = tmp_path / "empty.dist-info"
+    empty.mkdir()
+    assert _name_and_version_from_metadata_header(_DiskDist(empty)) == (None, None)
+    (empty / "METADATA").write_text("Version: 1.0\n\n", encoding="utf-8")  # no Name: fall back
+    assert _name_and_version_from_metadata_header(_DiskDist(empty)) == (None, None)
+    assert _name_and_version_from_metadata_header(_FakeDist(metadata={"Name": "x"})) == (None, None)
+
+
+def test_get_package_versions_prefers_the_header_and_falls_back_to_metadata(tmp_path, monkeypatch):
+    import importlib.metadata as im
+
+    dist_info = tmp_path / "some_pkg-1.2.3.dist-info"
+    dist_info.mkdir()
+    (dist_info / "METADATA").write_text("Name: Some_Pkg\nVersion: 1.2.3\n\nbody\n", encoding="utf-8")
+    on_disk = _DiskDist(dist_info, name="ignored", version="0")
+    no_file = _DiskDist(tmp_path / "missing.dist-info", name="FromMetadata", version="4.5")
+    monkeypatch.setattr(im, "distributions", lambda: iter([on_disk, no_file]))
+    versions, invalid = get_package_versions()
+    assert versions == {"some_pkg": "1.2.3", "frommetadata": "4.5"}
+    assert invalid == []
+
+
+def test_get_package_versions_matches_the_full_metadata_parse_on_this_environment():
+    """The header read must agree with `Distribution.metadata` for every installed distribution."""
+    import importlib.metadata as im
+
+    expected = {}
+    for dist in im.distributions():
+        name = dist.metadata.get("Name") if dist.metadata is not None else None
+        name = name or getattr(dist, "name", None)
+        if name:
+            expected[str(name).lower()] = str(dist.version) if dist.version is not None else "unknown"
+    versions, _ = get_package_versions()
+    assert versions == expected


### PR DESCRIPTION
`TabularPredictor.save` writes a metadata file listing the installed packages, and `fit` saves twice (before training, so an interrupted fit leaves a loadable predictor, and after). Each save enumerated every distribution with `importlib.metadata`, about 0.4 to 0.8 s on a few hundred packages, so a fit on a small dataset spent more time listing packages than training.

- `get_package_versions` is computed once per process: the installed distributions do not change while a process runs, so the memoised result is what a fresh enumeration would return. Callers receive their own copies of the containers, and the test module clears the cache around each test since the tests fake the distribution list.
- The name and version are read from the header of a distribution's METADATA or PKG-INFO file, above the first blank line, instead of through `Distribution.metadata`, which parses the whole file including the long description with the email parser. The full parse remains the fallback for a distribution without such a file. On 389 installed distributions the first call goes from 380 ms to 168 ms and every later call is free; a test checks the header read agrees with the full parse for every distribution in the running environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi
