### PR TITLE
[tabular] Drop validation_structure where a size curve resolves validation_mode to none

### DIFF
--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1571,6 +1571,7 @@ class TabularPredictor:
 
         # Resolved after the knobs above, because whether `validation_mode="none"` is legal
         # depends on the bagging and stacking counts they settled.
+        validation_mode_requested = validation_mode
         validation_mode, ensemble_weights = resolve_validation_mode(
             validation_mode=validation_mode,
             ensemble_weights=ensemble_weights,
@@ -1604,10 +1605,23 @@ class TabularPredictor:
                     "`train_data`, or drop `validation_mode` to validate against them."
                 )
             if validation_structure is not None:
-                raise ValueError(
-                    "validation_mode='none' cannot be combined with `validation_structure`, which describes how to "
-                    "split validation data off. Specify one or the other."
+                if validation_mode_requested == "none":
+                    raise ValueError(
+                        "validation_mode='none' cannot be combined with `validation_structure`, which describes how "
+                        "to split validation data off. Specify one or the other."
+                    )
+                # The mode came from a size curve, so this data size falls in a regime that holds
+                # nothing out. The structure describes how a validation split must respect the
+                # data's groups or time order; with no split there is nothing for it to constrain,
+                # so it is dropped for this fit rather than treated as a contradiction. A caller
+                # who declares the structure alongside a curve gets the structure exactly where
+                # the curve validates and no error where it does not.
+                logger.log(
+                    20,
+                    "validation_mode resolved to 'none' from `validation_size_curves`: no validation data is split "
+                    "off at this size, so the declared `validation_structure` does not apply and is ignored.",
                 )
+                validation_structure = None
             if ensemble_weights is not None:
                 # Check the names before fitting anything. The trainer checks them again against
                 # the models that actually fitted, but that is after every base model has been

--- a/tabular/tests/unittests/test_validation_mode.py
+++ b/tabular/tests/unittests/test_validation_mode.py
@@ -312,6 +312,41 @@ def test_hyperparameters_curve_switches_the_portfolio_with_the_mode(tmp_path):
     assert any("RandomForest" in m for m in big.model_names())
 
 
+def test_validation_structure_is_dropped_where_a_curve_validates_nothing(tmp_path):
+    """A structure declared alongside a curve applies exactly where the curve holds data out.
+
+    Below the curve's threshold nothing is split off, so there is nothing for the structure to
+    constrain and the fit proceeds without it; above the threshold the structure is honoured.
+    An explicit `validation_mode="none"` with a structure is still a contradiction.
+    """
+    curves = {
+        "validation_mode": [[100, "none"], "auto"],
+        "num_bag_folds": [[100, 0], 8],
+        "num_stack_levels": [[100, 0], 1],
+        "ensemble_weights": [[100, WEIGHTS], None],
+    }
+    train = _data(n=60)
+    train["group"] = np.arange(len(train)) % 10
+    tiny = TabularPredictor(label="label", path=str(tmp_path / "tiny"), verbosity=0).fit(
+        train,
+        hyperparameters=HYPERPARAMETERS,
+        validation_size_curves=curves,
+        validation_structure={"group_on": "group"},
+    )
+    assert tiny._trainer._num_rows_train == len(train)
+    assert tiny.leaderboard(silent=True)["score_val"].isna().all()
+
+    big_train = _data(n=300)
+    big_train["group"] = np.arange(len(big_train)) % 10
+    big = TabularPredictor(label="label", path=str(tmp_path / "big"), verbosity=0).fit(
+        big_train,
+        hyperparameters=HYPERPARAMETERS,
+        validation_size_curves=curves,
+        validation_structure={"group_on": "group"},
+    )
+    assert not big.leaderboard(silent=True)["score_val"].isna().all()
+
+
 def test_weights_and_hyperparameters_must_agree_before_fitting(tmp_path):
     """A pairing that agrees above a threshold and not below is caught pre-fit.
 


### PR DESCRIPTION
## Description of changes

When `validation_size_curves` resolves `validation_mode` to `"none"` for a data size, no validation data is split off, so a declared `validation_structure` has nothing to constrain. `fit` now logs that the structure does not apply at this size and drops it for the fit, instead of raising the "cannot be combined" error. An explicit `validation_mode="none"` together with a `validation_structure` is still rejected.

Adds a test that the structure is ignored below the curve's threshold and honoured above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi