### PR TITLE
[core][tabular] refit_folds="after_ensemble": refit only the bags the best model uses

### DIFF
--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -115,6 +115,10 @@ class BaggedEnsembleModel(AbstractModel):
         # Whether fit forced fold-saving on despite `save_bag_folds=False` (children that
         # cannot refit_full must keep a fold model to copy); see `save_bag_folds`.
         self._save_bag_folds_forced = False
+        # `refit_folds="after_ensemble"`: the folds were fit for their out-of-fold predictions
+        # only and not kept; the trainer refits this bag on all rows once the ensemble has chosen
+        # it, so a bag the ensemble leaves out is never refit. See `TabularPredictor._post_fit`.
+        self._refit_folds_pending = False
 
         self._predict_n_size_lst = None  # A list of the predict row count for each child, useful to calculate the expected inference throughput of the bag.
 
@@ -128,6 +132,7 @@ class BaggedEnsembleModel(AbstractModel):
             # 'use_child_oof': False,  # [Advanced] Whether to defer to child model for OOF preds and only train a single child.
             "save_bag_folds": True,
             # 'refit_folds': False,  # [Advanced, Experimental] Whether to refit bags immediately to a refit_full model in a single .fit call.
+            #   "after_ensemble" defers the refit to the trainer, which refits only the bags the final ensemble uses.
             # 'num_folds' None,  # Number of bagged folds per set. If specified, overrides .fit `k_fold` value.
             # 'max_sets': None,  # Maximum bagged repeats to allow, if specified, will set `self.can_fit()` to `self._n_repeats_finished < max_repeats`
             "stratify": "auto",
@@ -151,6 +156,8 @@ class BaggedEnsembleModel(AbstractModel):
         """
         if self._save_bag_folds_forced:
             return True
+        if self._refit_folds_pending:
+            return False
         return self.params.get("save_bag_folds", True)
 
     def can_infer(self) -> bool:
@@ -439,6 +446,12 @@ class BaggedEnsembleModel(AbstractModel):
                 # Only log in the situation where functionality is currently suboptimal
                 logger.log(20, "\tForcing `save_bag_folds=True` because child model does not support `refit_full`.")
 
+        refit_folds = self.params.get("refit_folds", False)
+        if refit_folds == "after_ensemble":
+            # A child that cannot refit_full keeps its folds (forced above) and is copied by the
+            # refit instead, so nothing is pending for it.
+            self._refit_folds_pending = can_refit_full and k_fold != 1
+            refit_folds = False
         save_bag_folds = self.save_bag_folds
         if k_fold == 1:
             self._fit_single(
@@ -453,7 +466,6 @@ class BaggedEnsembleModel(AbstractModel):
             )
             return self
         else:
-            refit_folds = self.params.get("refit_folds", False)
             if refit_folds:
                 if n_repeat_start != 0 or k_fold_start != 0:
                     raise AssertionError(

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -4,7 +4,6 @@ import copy
 import inspect
 import logging
 import os
-import shutil
 import time
 from collections import Counter
 from statistics import mean
@@ -1059,16 +1058,11 @@ class BaggedEnsembleModel(AbstractModel):
         if self._refit_folds_pending:
             # The refit needs nothing of the folds but their trained parameters (their times went
             # into the bag as they finished, their predictions into the OOF arrays), so those are
-            # taken now and the fold models are not kept. The sequential strategy left them in
-            # memory as weightless objects; a parallel one wrote them to disk.
-            params_trained = []
-            for child in models:
-                if isinstance(child, str):
-                    params_trained.append(self._load_child_from_disk(child).params_trained)
-                    shutil.rmtree(self.create_contexts(os.path.join(self.path, child)), ignore_errors=True)
-                else:
-                    params_trained.append(child.params_trained)
-            self._params_trained_children = self._get_compressed_params(model_params_list=params_trained)
+            # taken now and the fold models are not kept: the strategies hand them back as
+            # weightless objects, or as `_UnsavedFold` records from Ray workers, never as files.
+            self._params_trained_children = self._get_compressed_params(
+                model_params_list=[child.params_trained for child in models]
+            )
 
         # Do this to maintain model name order based on kfold split regardless of which model finished first in parallel mode
         for fold_fit_args in fold_fit_args_list:

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -4,6 +4,7 @@ import copy
 import inspect
 import logging
 import os
+import shutil
 import time
 from collections import Counter
 from statistics import mean
@@ -118,7 +119,10 @@ class BaggedEnsembleModel(AbstractModel):
         # `refit_folds="after_ensemble"`: the folds were fit for their out-of-fold predictions
         # only and not kept; the trainer refits this bag on all rows once the ensemble has chosen
         # it, so a bag the ensemble leaves out is never refit. See `TabularPredictor._post_fit`.
+        # Nothing of the folds is written to disk: `self.models` holds their names for the
+        # counts, and `_params_trained_children` what the refit template reads from them.
         self._refit_folds_pending = False
+        self._params_trained_children: dict | None = None
 
         self._predict_n_size_lst = None  # A list of the predict row count for each child, useful to calculate the expected inference throughput of the bag.
 
@@ -1052,6 +1056,19 @@ class BaggedEnsembleModel(AbstractModel):
         for fold_fit_args in fold_fit_args_list:
             fold_fitting_strategy.schedule_fold_model_fit(**fold_fit_args)
         fold_fitting_strategy.after_all_folds_scheduled()
+        if self._refit_folds_pending:
+            # The refit needs nothing of the folds but their trained parameters (their times went
+            # into the bag as they finished, their predictions into the OOF arrays), so those are
+            # taken now and the fold models are not kept. The sequential strategy left them in
+            # memory as weightless objects; a parallel one wrote them to disk.
+            params_trained = []
+            for child in models:
+                if isinstance(child, str):
+                    params_trained.append(self._load_child_from_disk(child).params_trained)
+                    shutil.rmtree(self.create_contexts(os.path.join(self.path, child)), ignore_errors=True)
+                else:
+                    params_trained.append(child.params_trained)
+            self._params_trained_children = self._get_compressed_params(model_params_list=params_trained)
 
         # Do this to maintain model name order based on kfold split regardless of which model finished first in parallel mode
         for fold_fit_args in fold_fit_args_list:
@@ -1283,10 +1300,18 @@ class BaggedEnsembleModel(AbstractModel):
 
     def load_child(self, model: AbstractModel | str, verbose: bool = False) -> AbstractModel:
         if isinstance(model, str):
-            child_path = self.create_contexts(os.path.join(self.path, model))
-            return self._child_type.load(path=child_path, verbose=verbose)
+            if self._refit_folds_pending:
+                raise AssertionError(
+                    f"{self.name} was fit with refit_folds='after_ensemble' and kept no fold models; "
+                    "refit it (`refit_full`) before using it."
+                )
+            return self._load_child_from_disk(model, verbose=verbose)
         else:
             return model
+
+    def _load_child_from_disk(self, model_name: str, verbose: bool = False) -> AbstractModel:
+        child_path = self.create_contexts(os.path.join(self.path, model_name))
+        return self._child_type.load(path=child_path, verbose=verbose)
 
     def add_child(self, model: AbstractModel | str, add_child_times: bool = False, add_child_resources: bool = False):
         """
@@ -1475,6 +1500,8 @@ class BaggedEnsembleModel(AbstractModel):
         return model_params_compressed
 
     def _get_compressed_params_trained(self):
+        if self._params_trained_children is not None:
+            return dict(self._params_trained_children)
         model_params_list = [self.load_child(child).params_trained for child in self.models]
         return self._get_compressed_params(model_params_list=model_params_list)
 
@@ -1663,7 +1690,7 @@ class BaggedEnsembleModel(AbstractModel):
                 os.rmdir(os.path.join(self.path, "utils"))
             except OSError:
                 pass
-        if reduce_children:
+        if reduce_children and not self._refit_folds_pending:
             for model in self.models:
                 model = self.load_child(model)
                 model.reduce_memory_size(
@@ -1683,7 +1710,7 @@ class BaggedEnsembleModel(AbstractModel):
         children_info = dict()
         children_params_trained = []
         child_hyperparameters_info = None
-        for model in self.models:
+        for model in [] if self._refit_folds_pending else self.models:
             child = self.load_child(model)
             children_info[child.name] = child.get_info(include_feature_metadata=include_feature_metadata)
             children_params_trained.append(child.params_trained)

--- a/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
+++ b/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
@@ -267,7 +267,9 @@ class FoldFittingStrategy(AbstractFoldFittingStrategy):
         model_to_append = fold_model
         if not self.save_folds:
             fold_model.model = None
-        if self.bagged_ensemble_model.low_memory:
+        # A bag awaiting its refit keeps the (now weightless) fold model in memory: nothing of the
+        # folds goes to disk, and the bag reads what the refit needs from it before dropping it.
+        if self.bagged_ensemble_model.low_memory and not self.bagged_ensemble_model._refit_folds_pending:
             self.bagged_ensemble_model.save_child(fold_model, verbose=False)
             model_to_append = fold_model.name
         self.models.append(model_to_append)

--- a/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
+++ b/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
@@ -9,6 +9,7 @@ import pickle
 import time
 import traceback
 from abc import abstractmethod
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple, Type, Union
 
 import pandas as pd
@@ -503,6 +504,14 @@ def plan_gpu_assignments(
     return plan
 
 
+@dataclass
+class _UnsavedFold:
+    """A fold a worker fit and did not save: what a bag awaiting its refit keeps of it."""
+
+    name: str
+    params_trained: dict
+
+
 def _ray_fit(
     *,
     model_base: AbstractModel,
@@ -520,7 +529,13 @@ def _ray_fit(
     kwargs_fold: Dict[str, Any],
     head_node_id: str,
     model_sync_path: Optional[str] = None,
+    keep_fold: bool = True,
 ):
+    """Fit one fold on a Ray worker.
+
+    With `keep_fold`, the fold model is saved under the bag's path and handed back by name. Without
+    it (a bag awaiting its refit), nothing is written and its trained parameters come back instead.
+    """
     import ray  # ray must be present
 
     if task_gpu_ids:
@@ -599,7 +614,8 @@ def _ray_fit(
             num_cpus=resources["num_cpus"],
             save_bag_folds=save_bag_folds,
         )
-        save_path = fold_model.save()
+        if keep_fold:
+            save_path = fold_model.save()
     except (AutoGluonException, ImportError, MemoryError) as e:
         e = encode_exception(e)
         return {
@@ -607,7 +623,7 @@ def _ray_fit(
             "error": e,
         }
 
-    if model_sync_path is not None and not is_head_node:
+    if keep_fold and model_sync_path is not None and not is_head_node:
         model_sync_path = model_sync_path + f"{fold_model.name}/"  # s3 path hence need "/" as the saperator
         bucket, prefix = s3_path_to_bucket_prefix(model_sync_path)
         upload_s3_folder(bucket=bucket, prefix=prefix, folder_to_upload=save_path, verbose=False)
@@ -621,6 +637,7 @@ def _ray_fit(
         fold_model.predict_n_size,
         fold_model.fit_num_cpus,
         fold_model.fit_num_gpus,
+        None if keep_fold else dict(fold_model.params_trained),
     )
 
 
@@ -856,7 +873,10 @@ class ParallelFoldFittingStrategy(FoldFittingStrategy):
                     predict_n_size,
                     fit_num_cpus,
                     fit_num_gpus,
+                    params_trained,
                 ) = out
+                if params_trained is not None:
+                    fold_model = _UnsavedFold(name=fold_model, params_trained=params_trained)
             assert fold_ctx is not None
             self._update_bagged_ensemble(
                 fold_model=fold_model,
@@ -870,14 +890,16 @@ class ParallelFoldFittingStrategy(FoldFittingStrategy):
                 fit_num_gpus=fit_num_gpus,
                 fold_ctx=fold_ctx,
             )
-            model_sync_path = None
-            if self.model_sync_path is not None:
-                model_sync_path: str = self.model_sync_path + fold_model
-                if not model_sync_path.endswith("/"):
-                    model_sync_path += "/"
-            self.sync_model_artifact(
-                local_path=os.path.join(self.bagged_ensemble_model.path, fold_model), model_sync_path=model_sync_path
-            )
+            if isinstance(fold_model, str):
+                model_sync_path = None
+                if self.model_sync_path is not None:
+                    model_sync_path: str = self.model_sync_path + fold_model
+                    if not model_sync_path.endswith("/"):
+                        model_sync_path += "/"
+                self.sync_model_artifact(
+                    local_path=os.path.join(self.bagged_ensemble_model.path, fold_model),
+                    model_sync_path=model_sync_path,
+                )
         except TimeLimitExceeded:
             # Terminate all ray tasks because a fold failed
             self.terminate_all_unfinished_tasks(unfinished)
@@ -1139,6 +1161,7 @@ class ParallelFoldFittingStrategy(FoldFittingStrategy):
             kwargs_fold=kwargs_fold,
             head_node_id=head_node_id,
             model_sync_path=self.model_sync_path,
+            keep_fold=not self.bagged_ensemble_model._refit_folds_pending,
         )
 
     def _update_bagged_ensemble(

--- a/core/tests/unittests/models/test_ray_fit_unsaved_fold.py
+++ b/core/tests/unittests/models/test_ray_fit_unsaved_fold.py
@@ -5,6 +5,7 @@ import os
 import numpy as np
 import pandas as pd
 import pytest
+
 from autogluon.common.utils.cv_splitter import CVSplitter
 from autogluon.core.models import BaggedEnsembleModel
 from autogluon.core.models.dummy.dummy_model import DummyModel

--- a/core/tests/unittests/models/test_ray_fit_unsaved_fold.py
+++ b/core/tests/unittests/models/test_ray_fit_unsaved_fold.py
@@ -1,0 +1,59 @@
+"""`_ray_fit` with `keep_fold=False`: the worker saves nothing and returns the fold's trained parameters."""
+
+import os
+
+import numpy as np
+import pandas as pd
+import pytest
+from autogluon.common.utils.cv_splitter import CVSplitter
+from autogluon.core.models import BaggedEnsembleModel
+from autogluon.core.models.dummy.dummy_model import DummyModel
+from autogluon.core.models.ensemble.fold_fitting_strategy import _ray_fit
+
+
+@pytest.mark.parametrize("keep_fold", [True, False])
+def test_ray_fit_keep_fold(tmp_path, keep_fold):
+    ray = pytest.importorskip("ray")
+    ray.init(num_cpus=1, include_dashboard=False, ignore_reinit_error=True, log_to_driver=False)
+    rng = np.random.default_rng(0)
+    X = pd.DataFrame(rng.normal(size=(40, 3)), columns=["a", "b", "c"])
+    y = pd.Series(rng.integers(0, 2, size=40))
+    fold_fit_args_list, _, _ = BaggedEnsembleModel._generate_fold_configs(
+        X=X,
+        y=y,
+        cv_splitter=CVSplitter(n_splits=2, n_repeats=1, stratify=True, random_state=0),
+        k_fold_start=0,
+        k_fold_end=2,
+        n_repeat_start=0,
+        n_repeat_end=1,
+        vary_seed_across_folds=False,
+        random_seed_offset=0,
+    )
+    bag_path = str(tmp_path / "bag")
+    model_base = DummyModel(path=bag_path, name="Dummy", problem_type="binary", eval_metric="log_loss")
+    model_base.initialize(X=X, y=y)
+    out = _ray_fit(
+        model_base=model_base,
+        bagged_ensemble_model_path=bag_path,
+        X=X,
+        y=y,
+        X_pseudo=None,
+        y_pseudo=None,
+        task_id=0,
+        fold_ctx=fold_fit_args_list[0],
+        task_gpu_ids=[],
+        time_limit_fold=None,
+        save_bag_folds=False,
+        resources={"num_cpus": 1, "num_gpus": 0},
+        kwargs_fold={},
+        head_node_id=ray.get_runtime_context().get_node_id(),
+        keep_fold=keep_fold,
+    )
+    assert isinstance(out, tuple) and len(out) == 10
+    name, params_trained = out[0], out[-1]
+    assert name == "DummyS1F1"
+    assert os.path.isdir(os.path.join(bag_path, name)) == keep_fold
+    if keep_fold:
+        assert params_trained is None
+    else:
+        assert isinstance(params_trained, dict)

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -2421,6 +2421,17 @@ class TabularPredictor:
             # Unspecified. `fit` resolves this before calling, but `fit_extra` passes the raw
             # argument, and the `is not False` check below would read None as a request.
             refit_full = False
+        pending = self._trainer.models_with_refit_pending()
+        if pending and refit_full is False:
+            # Bags fit with `refit_folds="after_ensemble"` kept no folds: the best model's members
+            # are refit here and become the model to predict with.
+            logger.log(
+                20,
+                f"Refitting the best model's members on all of the data: {len(pending)} bagged models were fit "
+                f"with refit_folds='after_ensemble' and only the ones the best model uses are refit ...",
+            )
+            refit_full = "best"
+            set_best_to_refit_full = True
 
         if refit_full is True:
             if keep_only_best is True:

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -2794,6 +2794,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
             can_infer=model.can_infer(),
             can_fit=model.can_fit(),
             is_valid=model.is_valid(),
+            refit_folds_pending=isinstance(model, BaggedEnsembleModel) and model._refit_folds_pending,
             stack_name=stack_name,
             level=level,
             num_children=num_children,
@@ -4252,6 +4253,11 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
             model = model.name
         base_model_set = list(self.model_graph.predecessors(model))
         return base_model_set
+
+    def models_with_refit_pending(self) -> list[str]:
+        """Bagged models fit with `refit_folds="after_ensemble"`: their folds are gone and they
+        cannot infer until refit, which `refit_ensemble_full` does for the ones the ensemble uses."""
+        return [m for m in self.get_model_names() if self.get_model_attribute(m, "refit_folds_pending", default=False)]
 
     def model_refit_map(self, inverse=False) -> dict[str, str]:
         """

--- a/tabular/tests/unittests/test_refit_folds_after_ensemble.py
+++ b/tabular/tests/unittests/test_refit_folds_after_ensemble.py
@@ -1,0 +1,68 @@
+"""`refit_folds="after_ensemble"`: bag for the out-of-fold predictions, refit only what the ensemble keeps."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from autogluon.tabular import TabularPredictor
+
+# Two bagged LightGBM configs; RandomForest uses its out-of-bag predictions as a single child and
+# never bags, so it has no folds to defer.
+HYPERPARAMETERS = {"GBM": [{}, {"num_leaves": 8}], "RF": {}}
+
+
+def _data(n: int = 400, seed: int = 0) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    df = pd.DataFrame(rng.normal(size=(n, 5)), columns=[f"f{i}" for i in range(5)])
+    df["label"] = (df.f0 + rng.normal(scale=0.3, size=n) > 0).astype(int)
+    return df
+
+
+def _fit(path, **kwargs) -> TabularPredictor:
+    return TabularPredictor(label="label", path=str(path), verbosity=0).fit(
+        _data(), hyperparameters=HYPERPARAMETERS, num_bag_folds=2, keep_only_best=False, **kwargs
+    )
+
+
+def test_refit_folds_after_ensemble_refits_only_the_ensemble_members(tmp_path):
+    predictor = _fit(tmp_path, ag_args_ensemble={"refit_folds": "after_ensemble"})
+    trainer = predictor._trainer
+    bags = [m for m in predictor.model_names() if m.startswith("LightGBM") and m.endswith("_BAG_L1")]
+    assert len(bags) == 2 and trainer.models_with_refit_pending() == bags
+    for name in bags:
+        assert not trainer.get_model_attribute(name, "can_infer")
+    assert trainer.get_model_attribute("RandomForest_BAG_L1", "can_infer")
+
+    # `get_model_best` scores the fitted models, so it still names the pre-refit best; the refit
+    # covered exactly that model's set, and the predictor serves its refit copy.
+    used = set(trainer.get_minimum_model_set(trainer.get_model_best()))
+    refit_map = predictor.model_refit_map()
+    assert set(refit_map) == used, (refit_map, used)
+    for name in bags:
+        assert (name in refit_map) == (name in used)
+    assert predictor.model_best == refit_map[trainer.get_model_best()]
+    assert len(predictor.predict(_data(50, seed=1).drop(columns="label"))) == 50
+
+
+def test_refit_folds_after_ensemble_matches_an_immediate_refit(tmp_path):
+    """Deferring the refit changes when it happens, not what is fit."""
+    kwargs = dict(hyperparameters={"GBM": {}}, num_bag_folds=2, fit_weighted_ensemble=False, keep_only_best=False)
+    deferred = TabularPredictor(label="label", path=str(tmp_path / "deferred"), verbosity=0).fit(
+        _data(), ag_args_ensemble={"refit_folds": "after_ensemble"}, **kwargs
+    )
+    immediate = TabularPredictor(label="label", path=str(tmp_path / "immediate"), verbosity=0).fit(
+        _data(), ag_args_ensemble={"refit_folds": True}, **kwargs
+    )
+    X = _data(100, seed=2).drop(columns="label")
+    assert deferred.model_best == "LightGBM_BAG_L1_FULL"
+    np.testing.assert_array_equal(
+        deferred.predict_proba(X).to_numpy(), immediate.predict_proba(X, model="LightGBM_BAG_L1").to_numpy()
+    )
+
+
+def test_refit_folds_after_ensemble_with_an_explicit_refit_full(tmp_path):
+    """A caller asking for `refit_full="all"` keeps that: every bag is refit, pending or not."""
+    predictor = _fit(tmp_path, ag_args_ensemble={"refit_folds": "after_ensemble"}, refit_full="all")
+    bags = [m for m in predictor.model_names() if m.endswith("_BAG_L1")]
+    assert all(name in predictor.model_refit_map() for name in bags)

--- a/tabular/tests/unittests/test_refit_folds_after_ensemble.py
+++ b/tabular/tests/unittests/test_refit_folds_after_ensemble.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from autogluon.tabular import TabularPredictor
 
@@ -25,8 +26,11 @@ def _fit(path, **kwargs) -> TabularPredictor:
     )
 
 
-def test_refit_folds_after_ensemble_refits_only_the_ensemble_members(tmp_path):
-    predictor = _fit(tmp_path, ag_args_ensemble={"refit_folds": "after_ensemble"})
+@pytest.mark.parametrize("fold_fitting_strategy", ["sequential_local", "parallel_local"])
+def test_refit_folds_after_ensemble_refits_only_the_ensemble_members(tmp_path, fold_fitting_strategy):
+    predictor = _fit(
+        tmp_path, ag_args_ensemble={"refit_folds": "after_ensemble", "fold_fitting_strategy": fold_fitting_strategy}
+    )
     trainer = predictor._trainer
     bags = [m for m in predictor.model_names() if m.startswith("LightGBM") and m.endswith("_BAG_L1")]
     assert len(bags) == 2 and trainer.models_with_refit_pending() == bags
@@ -43,6 +47,17 @@ def test_refit_folds_after_ensemble_refits_only_the_ensemble_members(tmp_path):
         assert (name in refit_map) == (name in used)
     assert predictor.model_best == refit_map[trainer.get_model_best()]
     assert len(predictor.predict(_data(50, seed=1).drop(columns="label"))) == 50
+
+    # nothing of a pending bag's folds reaches the disk: no child directories, only the bag, its
+    # out-of-fold predictions and the template
+    import os
+
+    for name in bags:
+        entries = sorted(os.listdir(os.path.join(predictor.path, "models", name)))
+        assert entries == ["model.pkl", "utils"], entries
+    # the paths that read children cope with their absence
+    assert set(predictor.leaderboard(extra_info=True, silent=True)["model"]) >= set(bags)
+    predictor.save_space()
 
 
 def test_refit_folds_after_ensemble_matches_an_immediate_refit(tmp_path):


### PR DESCRIPTION
## Description of changes

Stacked on #5902.

`refit_folds=True` refits every bagged model on all rows inside its own fit, before the ensemble has decided which models it uses, so bags that end up with zero weight pay a refit and a pickle for nothing. `refit_folds="after_ensemble"` fits the folds for their out-of-fold predictions only and marks the bag as pending. After the weighted ensemble is fit, `_post_fit` runs `refit_full="best"` with `set_best_to_refit_full=True` whenever pending bags exist, so exactly the members of the best model are refit and served; the trainer records `refit_folds_pending` per model and exposes `models_with_refit_pending`. A caller who passes `refit_full` explicitly keeps that choice. A child that cannot `refit_full` keeps its folds and is copied by the refit as before.

Nothing of a pending bag's folds reaches the disk. The refit needs only their trained parameters (their times are added to the bag as they finish, their predictions go into the OOF arrays), so those are taken from the fold models right after the folds finish and the models are dropped. The sequential strategy keeps the weightless fold models in memory; a Ray worker skips the fold save and returns the trained parameters in its payload (`keep_fold=False`), which the driver wraps as an `_UnsavedFold` record. A pending bag's directory holds its own pickle, its OOF predictions and the model template; `load_child`, `get_info` and `reduce_memory_size` account for the absent children.

Tests: exactly the best model's set is refit while the pending bags report `can_infer=False` and hold no fold directories, for both fold strategies; the deferred refit gives bit-identical predictions to the immediate one; an explicit `refit_full="all"` still refits everything; `_ray_fit` saves the fold and returns no parameters with `keep_fold=True`, and the reverse without.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi