### PR TITLE
[features] Faster category maps and categorical duplicate detection

### DIFF
--- a/features/src/autogluon/features/generators/category.py
+++ b/features/src/autogluon/features/generators/category.py
@@ -4,7 +4,6 @@ import logging
 import numpy as np
 import pandas as pd
 from pandas import DataFrame
-from pandas.api.types import CategoricalDtype
 
 from autogluon.common.features.types import (
     R_BOOL,
@@ -145,68 +144,70 @@ class CategoryFeatureGenerator(AbstractFeatureGenerator):
         return X_category
 
     def _generate_category_map(self, X: DataFrame) -> (DataFrame, dict):
-        if self.features_in:
-            fill_nan_map = dict()
-            category_map = dict()
-            X_category = X.astype("category")
-            for column in X_category:
-                rank = X_category[column].value_counts().sort_index().sort_values(ascending=True, kind="stable")
-                if self._minimum_cat_count is not None:
-                    rank = rank[rank >= self._minimum_cat_count]
-                if self._maximum_num_cat is not None:
-                    rank = rank[-self._maximum_num_cat :]
-                if (
-                    self.cat_order == "count"
-                    or self._minimum_cat_count is not None
-                    or self._maximum_num_cat is not None
-                ):
-                    category_list = list(rank.index)  # category_list in 'count' order
-                    if len(category_list) > 1:
-                        if self.cat_order == "original":
-                            original_cat_order = list(X_category[column].cat.categories)
-                            set_category_list = set(category_list)
-                            category_list = [cat for cat in original_cat_order if cat in set_category_list]
-                        elif self.cat_order == "alphanumeric":
-                            category_list.sort()
-                    X_category[column] = X_category[column].astype(
-                        CategoricalDtype(categories=category_list)
-                    )  # TODO: Remove columns if all NaN after this?
-                    X_category[column] = X_category[column].cat.reorder_categories(category_list)
-                elif self.cat_order == "alphanumeric":
-                    category_list = list(X_category[column].cat.categories)
-                    category_list.sort()
-                    X_category[column] = X_category[column].astype(CategoricalDtype(categories=category_list))
-                    X_category[column] = X_category[column].cat.reorder_categories(category_list)
-                if self._fillna_flag and len(rank) > 0:
-                    if self._fillna == "mode":
-                        fill_nan_map[column] = rank.index[-1]
-                    elif self._fillna == "rare":
-                        nan_count = X_category[column].isna().sum()
-                        if self._minimum_cat_count is None or (nan_count >= self._minimum_cat_count):
-                            # Add a dedicated category for the missing values. This also absorbs the
-                            # values that `minimum_cat_count`/`maximum_num_cat` turned into NaN above.
-                            category_list = list(X_category[column].cat.categories)
-                            # `isinstance(c, int)` alone would miss numpy integers, which is what a
-                            # category index is normally backed by, sending integer columns down the
-                            # string branch and leaving them with mixed-type categories.
-                            if all(isinstance(c, (int, np.integer)) for c in category_list):
-                                fillna_category = max(rank.index) + 1
-                            else:
-                                fillna_category = "_NaN_"
-                            category_list.append(fillna_category)
-                            X_category[column] = X_category[column].astype(CategoricalDtype(categories=category_list))
-                            X_category[column] = X_category[column].cat.reorder_categories(category_list)
-                            fill_nan_map[column] = fillna_category
-                        else:
-                            # Too few missing values to justify their own category: fold them into the
-                            # rarest surviving one rather than create a category below the minimum count.
-                            fill_nan_map[column] = rank.index[0]
-                category_map[column] = copy.deepcopy(X_category[column].cat.categories)
-            if not self._fillna_flag:
-                fill_nan_map = None
-            return X_category, category_map, fill_nan_map
-        else:
+        if not self.features_in:
             return DataFrame(index=X.index), None, None
+        fill_nan_map = dict()
+        category_map = dict()
+        columns_out = dict()
+        X_category = X.astype("category")
+        for column in X_category:
+            series = X_category[column]
+            categories = series.cat.categories
+            codes = series.cat.codes.to_numpy()
+            counts = np.bincount(codes[codes >= 0], minlength=len(categories))
+            # Categories by ascending count, ties in category-value order: the order
+            # `value_counts().sort_index().sort_values(kind="stable")` gives.
+            by_value = np.argsort(np.asarray(categories), kind="stable")
+            rank_order = by_value[np.argsort(counts[by_value], kind="stable")]
+            rank_index = categories[rank_order]
+            rank_counts = counts[rank_order]
+            if self._minimum_cat_count is not None:
+                frequent = rank_counts >= self._minimum_cat_count
+                rank_index, rank_counts = rank_index[frequent], rank_counts[frequent]
+            if self._maximum_num_cat is not None:
+                rank_index = rank_index[-self._maximum_num_cat :]
+            if self.cat_order == "count" or self._minimum_cat_count is not None or self._maximum_num_cat is not None:
+                category_list = list(rank_index)  # category_list in 'count' order
+                if len(category_list) > 1:
+                    if self.cat_order == "original":
+                        set_category_list = set(category_list)
+                        category_list = [cat for cat in categories if cat in set_category_list]
+                    elif self.cat_order == "alphanumeric":
+                        category_list.sort()
+                # Values outside `category_list` become NaN.
+                series = series.cat.set_categories(category_list)  # TODO: Remove columns if all NaN after this?
+            elif self.cat_order == "alphanumeric":
+                series = series.cat.set_categories(sorted(categories))
+            if self._fillna_flag and len(rank_index) > 0:
+                if self._fillna == "mode":
+                    fill_nan_map[column] = rank_index[-1]
+                elif self._fillna == "rare":
+                    nan_count = series.isna().sum()
+                    if self._minimum_cat_count is None or (nan_count >= self._minimum_cat_count):
+                        # Add a dedicated category for the missing values. This also absorbs the
+                        # values that `minimum_cat_count`/`maximum_num_cat` turned into NaN above.
+                        category_list = list(series.cat.categories)
+                        # `isinstance(c, int)` alone would miss numpy integers, which is what a
+                        # category index is normally backed by, sending integer columns down the
+                        # string branch and leaving them with mixed-type categories.
+                        if all(isinstance(c, (int, np.integer)) for c in category_list):
+                            fillna_category = max(rank_index) + 1
+                        else:
+                            fillna_category = "_NaN_"
+                        category_list.append(fillna_category)
+                        series = series.cat.set_categories(category_list)
+                        fill_nan_map[column] = fillna_category
+                    else:
+                        # Too few missing values to justify their own category: fold them into the
+                        # rarest surviving one rather than create a category below the minimum count.
+                        fill_nan_map[column] = rank_index[0]
+            columns_out[column] = series
+            category_map[column] = copy.deepcopy(series.cat.categories)
+        # One frame from the finished columns, instead of assigning each back into `X_category`.
+        X_category = DataFrame(columns_out, index=X.index) if columns_out else X_category
+        if not self._fillna_flag:
+            fill_nan_map = None
+        return X_category, category_map, fill_nan_map
 
     def _remove_features_in(self, features: list):
         super()._remove_features_in(features)

--- a/features/src/autogluon/features/generators/drop_duplicates.py
+++ b/features/src/autogluon/features/generators/drop_duplicates.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import warnings
 from collections import defaultdict
 from typing import Union
 
@@ -180,20 +181,27 @@ class DropDuplicatesFeatureGenerator(AbstractFeatureGenerator):
         cols = list(X.columns)
 
         # ---- Vectorized stats pass (cheap) ----
-        # Note: pandas reductions skipna by default, consistent across these stats.
-        stats = pd.DataFrame(
-            {
-                "sum": X.sum(axis=0),
-                "std": X.std(axis=0, ddof=0),
-                "min": X.min(axis=0),
-                "max": X.max(axis=0),
-            }
-        ).round(6)
+        # On one float64 array: a frame of many single-column blocks reduces column by column.
+        # Missing values are skipped, as pandas' reductions skip them; an all-missing column gets
+        # NaN statistics and never shares a bucket, as before.
+        values = X.to_numpy(dtype=np.float64, na_value=np.nan)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            stats = np.round(
+                np.column_stack(
+                    [
+                        np.nansum(values, axis=0),
+                        np.nanstd(values, axis=0),
+                        np.nanmin(values, axis=0),
+                        np.nanmax(values, axis=0),
+                    ]
+                ),
+                6,
+            )
 
         # ---- Bucket by stats ----
-        # One pass over the rows of `stats` (indexed like `cols`) instead of four `.at` lookups per column.
         bucket_map: dict[tuple[float, float, float, float], list[str]] = defaultdict(list)
-        for c, key in zip(cols, stats[["sum", "std", "min", "max"]].itertuples(index=False, name=None)):
+        for c, key in zip(cols, map(tuple, stats.tolist())):
             bucket_map[key].append(c)
 
         # ---- Within each stats bucket, bucket by full fingerprint ----
@@ -232,38 +240,19 @@ class DropDuplicatesFeatureGenerator(AbstractFeatureGenerator):
         Drops duplicate features if they contain the same information, ignoring the actual values in the features.
         For example, ['a', 'b', 'b'] is considered a duplicate of ['b', 'a', 'a'], but not ['a', 'b', 'a'].
         """
-        X_columns = list(X.columns)
-        mapping_features_val_dict = {}
-        features_unique_count_dict = defaultdict(list)
-        features_to_remove = []
-        for feature in X_columns:
-            feature_unique_vals = X[feature].unique()
-            mapping_features_val_dict[feature] = dict(zip(feature_unique_vals, range(len(feature_unique_vals))))
-            features_unique_count_dict[len(feature_unique_vals)].append(feature)
+        # Codes in order of first appearance, missing values included as a value of their own:
+        # ['a', 'd', 'f', 'a'] and [5, 'a', np.nan, 5] both become [0, 1, 2, 0], so they are duplicates.
+        features_by_unique_count = defaultdict(list)
+        for feature in X.columns:
+            codes, uniques = pd.factorize(X[feature].to_numpy(dtype=object), use_na_sentinel=False)
+            features_by_unique_count[len(uniques)].append((feature, codes))
 
-        for feature_unique_count in features_unique_count_dict:
+        features_to_remove = []
+        for features_to_check in features_by_unique_count.values():
             # Only need to check features that have same amount of unique values.
-            features_to_check = features_unique_count_dict[feature_unique_count]
             if len(features_to_check) <= 1:
                 continue
-            mapping_features_val_dict_cur = {
-                feature: mapping_features_val_dict[feature] for feature in features_to_check
-            }
-            # Converts ['a', 'd', 'f', 'a'] to [0, 1, 2, 0]
-            # Converts [5, 'a', np.nan, 5] to [0, 1, 2, 0], these would be considered duplicates since they carry the same information.
-
-            # Have to convert to object dtype because category dtype for unknown reasons will refuse to replace NaNs.
-            try:
-                # verify that the option exists (pandas >2.1)
-                pd.get_option("future.no_silent_downcasting")
-            except pd.errors.OptionError:
-                X_cur = X[features_to_check].astype("object").replace(mapping_features_val_dict_cur).astype(np.int64)
-            else:
-                # refer to https://pandas.pydata.org/docs/whatsnew/v2.2.0.html#deprecated-automatic-downcasting
-                with pd.option_context("future.no_silent_downcasting", True):
-                    X_cur = (
-                        X[features_to_check].astype("object").replace(mapping_features_val_dict_cur).astype(np.int64)
-                    )
+            X_cur = DataFrame({feature: codes.astype(np.int64) for feature, codes in features_to_check}, index=X.index)
             features_to_remove += cls._drop_duplicate_features_numeric(X=X_cur, keep=keep)
 
         return features_to_remove


### PR DESCRIPTION
## Description of changes

`CategoryFeatureGenerator` ranks categories from the codes with a bincount instead of `value_counts` plus two sorts, applies the kept categories with `set_categories`, and builds the output frame once. `DropDuplicatesFeatureGenerator` factorizes categorical columns instead of replacing values through an object frame. Outputs are unchanged; existing tests cover both generators.

Stacked on #5903.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi