### PR TITLE
[common] Count GPUs through NVML while torch is not imported

### DIFF
--- a/common/src/autogluon/common/utils/gpu_count.py
+++ b/common/src/autogluon/common/utils/gpu_count.py
@@ -1,0 +1,143 @@
+"""The CUDA device count torch would report, computed without importing torch.
+
+`torch.cuda.device_count()` reads the device list from NVML and applies `CUDA_VISIBLE_DEVICES`
+itself; this module does the same through `nvutil`, plus the one input NVML cannot see: whether
+the installed torch was built with CUDA at all. Importing torch costs hundreds of milliseconds
+to seconds, which a fit without GPU models should not pay for a count.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+from . import nvutil
+
+#: `CUDA_VISIBLE_DEVICES` unset: torch treats every device as visible.
+_MAX_DEVICES = 64
+
+
+def torch_build_has_cuda() -> bool | None:
+    """Whether the installed torch was built with CUDA; None when torch is not installed.
+
+    Read from torch's `version.py`, which is a few assignments, rather than by importing torch.
+    """
+    spec = importlib.util.find_spec("torch")
+    if spec is None or not spec.submodule_search_locations:
+        return None
+    version_file = os.path.join(list(spec.submodule_search_locations)[0], "version.py")
+    if not os.path.exists(version_file):
+        return None
+    namespace: dict = {}
+    with open(version_file) as f:
+        exec(f.read(), namespace)
+    return namespace.get("cuda") is not None
+
+
+def _strtoul(s: str) -> int:
+    """The non-negative integer `s` starts with, else -1, as the CUDA driver parses ordinals."""
+    if not s:
+        return -1
+    idx = 0
+    for idx, c in enumerate(s):
+        if not (c.isdigit() or (idx == 0 and c in "+-")):
+            break
+        if idx + 1 == len(s):
+            idx += 1
+    return int(s[:idx]) if idx > 0 else -1
+
+
+def _parse_list_with_prefix(lst: str, prefix: str) -> list[str]:
+    ids: list[str] = []
+    for elem in lst.split(","):
+        # A repeated id results in an empty set.
+        if elem in ids:
+            return []
+        # Anything but the prefix ends the list.
+        if not elem.startswith(prefix):
+            break
+        ids.append(elem)
+    return ids
+
+
+def parse_visible_devices() -> list[int] | list[str]:
+    """`CUDA_VISIBLE_DEVICES` as ordinals, or as `GPU-`/`MIG-` prefixed ids, as the CUDA driver reads it."""
+    var = os.getenv("CUDA_VISIBLE_DEVICES")
+    if var is None:
+        return list(range(_MAX_DEVICES))
+    if var.startswith("GPU-"):
+        return _parse_list_with_prefix(var, "GPU-")
+    if var.startswith("MIG-"):
+        return _parse_list_with_prefix(var, "MIG-")
+    ordinals: list[int] = []
+    for elem in var.split(","):
+        x = _strtoul(elem.strip())
+        # A repeated ordinal results in an empty set.
+        if x in ordinals:
+            return []
+        # A negative value ends the list.
+        if x < 0:
+            break
+        ordinals.append(x)
+    return ordinals
+
+
+def _uuid_ordinals(candidates: list[str], uuids: list[str]) -> list[int]:
+    """Ordinals of the devices whose UUID starts with each candidate; an ambiguous or unknown one ends the list."""
+    ordinals: list[int] = []
+    for candidate in candidates:
+        matches = [idx for idx, uuid in enumerate(uuids) if uuid.startswith(candidate)]
+        if len(matches) != 1:
+            break
+        if matches[0] in ordinals:
+            return []
+        ordinals.append(matches[0])
+    return ordinals
+
+
+def cuda_visible_device_count() -> int | None:
+    """Number of CUDA devices visible to a process, from NVML and `CUDA_VISIBLE_DEVICES`.
+
+    None when NVML is unavailable or the ids are MIG partitions, which NVML does not enumerate
+    the way the driver does; callers then fall back to torch.
+    """
+    visible = parse_visible_devices()
+    if not visible:
+        return 0
+    if not nvutil.cudaInit():
+        return None
+    try:
+        if isinstance(visible[0], str):
+            if visible[0].startswith("MIG-"):
+                return None
+            return len(_uuid_ordinals(visible, nvutil.cudaDeviceGetUUIDs()))
+        raw_count = nvutil.cudaDeviceGetCount()
+        for idx, ordinal in enumerate(visible):
+            if ordinal >= raw_count:
+                return idx
+        return len(visible)
+    except nvutil.NVMLError:
+        return None
+    finally:
+        nvutil.cudaShutdown()
+
+
+def gpu_count_without_torch(cuda_only: bool = False) -> int | None:
+    """The count `ResourceManager.get_gpu_count_torch` would return, or None when only torch can tell.
+
+    None is returned when torch is not installed, when NVML gives no answer, and on macOS when
+    the CUDA count is zero and other accelerators (MPS) are allowed, since only torch reports those.
+    """
+    has_cuda = torch_build_has_cuda()
+    if has_cuda is None:
+        return None
+    if not has_cuda:
+        count = 0
+    else:
+        count = cuda_visible_device_count()
+        if count is None:
+            return None
+    if count == 0 and not cuda_only and sys.platform == "darwin":
+        return None
+    return count

--- a/common/src/autogluon/common/utils/nvutil.py
+++ b/common/src/autogluon/common/utils/nvutil.py
@@ -3,7 +3,7 @@ import sys
 import threading
 from ctypes import *
 
-__all__ = ["cudaInit", "cudaDeviceGetCount", "cudaSystemGetNVMLVersion", "cudaShutdown"]
+__all__ = ["cudaInit", "cudaDeviceGetCount", "cudaDeviceGetUUIDs", "cudaSystemGetNVMLVersion", "cudaShutdown"]
 
 NVML_SUCCESS = 0
 NVML_ERROR_UNINITIALIZED = 1
@@ -46,6 +46,20 @@ def cudaDeviceGetCount():
     ret = fn(byref(c_count))
     _cudaCheckReturn(ret)
     return c_count.value
+
+
+def cudaDeviceGetUUIDs():
+    """UUID of every device NVML enumerates, in NVML index order."""
+    uuids = []
+    get_handle = _cudaGetFunctionPointer("nvmlDeviceGetHandleByIndex_v2")
+    get_uuid = _cudaGetFunctionPointer("nvmlDeviceGetUUID")
+    for idx in range(cudaDeviceGetCount()):
+        handle = c_void_p()
+        _cudaCheckReturn(get_handle(c_uint(idx), byref(handle)))
+        buf = create_string_buffer(96)
+        _cudaCheckReturn(get_uuid(handle, buf, c_uint(96)))
+        uuids.append(buf.value.decode("ascii"))
+    return uuids
 
 
 def _LoadNvmlLibrary():

--- a/common/src/autogluon/common/utils/resource_utils.py
+++ b/common/src/autogluon/common/utils/resource_utils.py
@@ -2,6 +2,7 @@ import logging
 import os
 import shutil
 import subprocess
+import sys
 from typing import Union
 
 from autogluon.common.utils.try_import import try_import_ray
@@ -63,7 +64,17 @@ class ResourceManager:
         -------
         int
             Number of available GPUs. When cuda_only=True, returns the actual CUDA device count.
+
+        The count is what torch reports. While torch is not imported yet it is computed from
+        NVML and `CUDA_VISIBLE_DEVICES` instead (see `gpu_count`), so a fit without GPU models
+        does not pay for importing torch.
         """
+        if "torch" not in sys.modules:
+            from .gpu_count import gpu_count_without_torch
+
+            num_gpus = gpu_count_without_torch(cuda_only=cuda_only)
+            if num_gpus is not None:
+                return num_gpus
         try:
             import torch
 

--- a/common/tests/unittests/utils/test_gpu_count.py
+++ b/common/tests/unittests/utils/test_gpu_count.py
@@ -1,0 +1,79 @@
+import os
+import sys
+
+import pytest
+
+from autogluon.common.utils import gpu_count, nvutil
+from autogluon.common.utils.resource_utils import ResourceManager
+
+torch = pytest.importorskip("torch")
+
+VISIBLE_DEVICE_SETTINGS = [
+    None,
+    "",
+    "0",
+    "1",
+    "0,1",
+    "1,0",
+    "-1",
+    "0,-1,1",
+    "5",
+    "0,5,1",
+    "0,0",
+    " 1 , 0 ",
+    "1gpu2,2ampere",
+    "GPU-abc",
+    "GPU-abc,GPU-abc",
+    "GPU-abc,1",
+    "MIG-abc",
+    "junk",
+]
+
+
+@pytest.mark.parametrize("setting", VISIBLE_DEVICE_SETTINGS)
+def test_parse_visible_devices_matches_torch(setting, monkeypatch):
+    if setting is None:
+        monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    else:
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", setting)
+    assert gpu_count.parse_visible_devices() == torch.cuda._parse_visible_devices()
+
+
+def test_uuid_ordinals():
+    uuids = ["GPU-aaaa1111", "GPU-aaaa2222", "GPU-bbbb0000"]
+    assert gpu_count._uuid_ordinals(["GPU-bbbb"], uuids) == [2]
+    assert gpu_count._uuid_ordinals(["GPU-aaaa1", "GPU-bbbb"], uuids) == [0, 2]
+    assert gpu_count._uuid_ordinals(["GPU-aaaa"], uuids) == [], "an ambiguous prefix ends the list"
+    assert gpu_count._uuid_ordinals(["GPU-bbbb", "GPU-cccc", "GPU-aaaa1"], uuids) == [2], "an unknown id ends the list"
+    assert gpu_count._uuid_ordinals(["GPU-bbbb", "GPU-bbbb0"], uuids) == [], "a repeated device gives an empty set"
+
+
+def test_torch_build_has_cuda_matches_torch():
+    assert gpu_count.torch_build_has_cuda() is (torch.version.cuda is not None)
+
+
+def test_gpu_count_without_torch_matches_torch_in_this_process():
+    if not nvutil.cudaInit():
+        pytest.skip("NVML is not available")
+    nvutil.cudaShutdown()
+    count = gpu_count.gpu_count_without_torch(cuda_only=True)
+    assert count == torch.cuda.device_count()
+    assert ResourceManager.get_gpu_count_torch(cuda_only=True) == torch.cuda.device_count()
+
+
+def test_get_gpu_count_torch_does_not_import_torch(tmp_path):
+    """In a fresh interpreter the count comes from NVML; torch stays unimported."""
+    import subprocess
+
+    code = (
+        "import sys; from autogluon.common.utils.resource_utils import ResourceManager; "
+        "n = ResourceManager.get_gpu_count_torch(); print(n, 'torch' in sys.modules)"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True, env=os.environ.copy()
+    )
+    count, torch_imported = out.stdout.split()
+    if gpu_count.gpu_count_without_torch() is None:
+        pytest.skip("this platform needs torch for the count")
+    assert torch_imported == "False"
+    assert int(count) == torch.cuda.device_count()


### PR DESCRIPTION
## Description of changes

`ResourceManager.get_gpu_count_torch` reads the device count from NVML and applies `CUDA_VISIBLE_DEVICES` the way torch does while torch is not imported, and takes whether the build has CUDA from torch's `version.py`. A fit without GPU models no longer imports torch to learn the count, which costs hundreds of milliseconds to seconds. Once torch is imported the torch path is used as before. Tests check parity with `torch.cuda._parse_visible_devices` and `torch.cuda.device_count` and that torch stays unimported.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi