### PR TITLE
[common] Fit banner without importing torch

### DIFF
--- a/common/src/autogluon/common/utils/gpu_count.py
+++ b/common/src/autogluon/common/utils/gpu_count.py
@@ -8,6 +8,7 @@ to seconds, which a fit without GPU models should not pay for a count.
 
 from __future__ import annotations
 
+import functools
 import importlib.util
 import os
 import sys
@@ -18,6 +19,7 @@ from . import nvutil
 _MAX_DEVICES = 64
 
 
+@functools.lru_cache(maxsize=1)
 def torch_version_info() -> tuple[str, str | None] | None:
     """The installed torch's `(__version__, cuda)`, or None when torch is not installed.
 
@@ -103,12 +105,24 @@ def _uuid_ordinals(candidates: list[str], uuids: list[str]) -> list[int]:
     return ordinals
 
 
+#: Count per `CUDA_VISIBLE_DEVICES` value: the only thing that changes a process's visible devices,
+#: and an NVML query costs a 15 ms init/shutdown cycle.
+_count_cache: dict[str | None, int | None] = {}
+
+
 def cuda_visible_device_count() -> int | None:
     """Number of CUDA devices visible to a process, from NVML and `CUDA_VISIBLE_DEVICES`.
 
     None when NVML is unavailable or the ids are MIG partitions, which NVML does not enumerate
     the way the driver does; callers then fall back to torch.
     """
+    key = os.getenv("CUDA_VISIBLE_DEVICES")
+    if key not in _count_cache:
+        _count_cache[key] = _cuda_visible_device_count()
+    return _count_cache[key]
+
+
+def _cuda_visible_device_count() -> int | None:
     visible = parse_visible_devices()
     if not visible:
         return 0
@@ -124,6 +138,30 @@ def cuda_visible_device_count() -> int | None:
             if ordinal >= raw_count:
                 return idx
         return len(visible)
+    except nvutil.NVMLError:
+        return None
+    finally:
+        nvutil.cudaShutdown()
+
+
+def visible_device_memory() -> list[tuple[int, int, int]] | None:
+    """`(total, free, used)` bytes of each visible CUDA device, in visible order, or None when only torch can tell.
+
+    Visible ordinals name NVML devices directly; UUID and MIG ids are left to torch.
+    """
+    visible = parse_visible_devices()
+    if not visible:
+        return []
+    if isinstance(visible[0], str) or not nvutil.cudaInit():
+        return None
+    try:
+        raw_count = nvutil.cudaDeviceGetCount()
+        indices = []
+        for ordinal in visible:
+            if ordinal >= raw_count:
+                break
+            indices.append(ordinal)
+        return [nvutil.cudaDeviceGetMemoryInfo(index) for index in indices]
     except nvutil.NVMLError:
         return None
     finally:

--- a/common/src/autogluon/common/utils/gpu_count.py
+++ b/common/src/autogluon/common/utils/gpu_count.py
@@ -18,10 +18,11 @@ from . import nvutil
 _MAX_DEVICES = 64
 
 
-def torch_build_has_cuda() -> bool | None:
-    """Whether the installed torch was built with CUDA; None when torch is not installed.
+def torch_version_info() -> tuple[str, str | None] | None:
+    """The installed torch's `(__version__, cuda)`, or None when torch is not installed.
 
-    Read from torch's `version.py`, which is a few assignments, rather than by importing torch.
+    Read from torch's `version.py`, which is a few assignments, rather than by importing torch;
+    `cuda` is the CUDA version the build targets, None for a CPU-only build.
     """
     spec = importlib.util.find_spec("torch")
     if spec is None or not spec.submodule_search_locations:
@@ -32,7 +33,13 @@ def torch_build_has_cuda() -> bool | None:
     namespace: dict = {}
     with open(version_file) as f:
         exec(f.read(), namespace)
-    return namespace.get("cuda") is not None
+    return str(namespace.get("__version__")), namespace.get("cuda")
+
+
+def torch_build_has_cuda() -> bool | None:
+    """Whether the installed torch was built with CUDA; None when torch is not installed."""
+    info = torch_version_info()
+    return None if info is None else info[1] is not None
 
 
 def _strtoul(s: str) -> int:

--- a/common/src/autogluon/common/utils/nvutil.py
+++ b/common/src/autogluon/common/utils/nvutil.py
@@ -3,7 +3,14 @@ import sys
 import threading
 from ctypes import *
 
-__all__ = ["cudaInit", "cudaDeviceGetCount", "cudaDeviceGetUUIDs", "cudaSystemGetNVMLVersion", "cudaShutdown"]
+__all__ = [
+    "cudaInit",
+    "cudaDeviceGetCount",
+    "cudaDeviceGetUUIDs",
+    "cudaDeviceGetMemoryInfo",
+    "cudaSystemGetNVMLVersion",
+    "cudaShutdown",
+]
 
 NVML_SUCCESS = 0
 NVML_ERROR_UNINITIALIZED = 1
@@ -62,6 +69,19 @@ def cudaDeviceGetUUIDs():
     return uuids
 
 
+class _nvmlMemory_t(Structure):
+    _fields_ = [("total", c_ulonglong), ("free", c_ulonglong), ("used", c_ulonglong)]
+
+
+def cudaDeviceGetMemoryInfo(index):
+    """`(total, free, used)` bytes of the device at NVML index `index`."""
+    handle = c_void_p()
+    _cudaCheckReturn(_cudaGetFunctionPointer("nvmlDeviceGetHandleByIndex_v2")(c_uint(index), byref(handle)))
+    memory = _nvmlMemory_t()
+    _cudaCheckReturn(_cudaGetFunctionPointer("nvmlDeviceGetMemoryInfo")(handle, byref(memory)))
+    return memory.total, memory.free, memory.used
+
+
 def _LoadNvmlLibrary():
     """
     Load the library if it isn't loaded already
@@ -87,7 +107,7 @@ def _LoadNvmlLibrary():
                     else:
                         # assume linux
                         cudaLib = CDLL("libnvidia-ml.so.1")
-                except OSError as ose:
+                except OSError:
                     pass
 
                 if cudaLib == None:

--- a/common/src/autogluon/common/utils/system_info.py
+++ b/common/src/autogluon/common/utils/system_info.py
@@ -3,7 +3,7 @@ import sys
 from typing import Tuple
 
 from .. import __version__
-from .gpu_count import torch_version_info
+from .gpu_count import torch_version_info, visible_device_memory
 from .resource_utils import ResourceManager, get_resource_manager
 
 
@@ -90,17 +90,27 @@ def get_ag_system_info(*, path: str = None, include_gpu_count=False, include_pyt
         msg_list.append(f"CUDA Version:       {cuda_version}")
     if include_gpu_count:
         try:
-            import torch
+            # Per-device memory from NVML while torch is not imported (device-wide free and used
+            # bytes, since this process holds none yet, and the physical total, which is a few hundred
+            # MB above the total CUDA reports); from torch once it is.
+            device_memory = None if "torch" in sys.modules else visible_device_memory()
+            if device_memory is not None:
+                system_num_gpus = len(device_memory)
+                per_device = [(total, total - free) for total, free, used in device_memory]
+            else:
+                import torch
 
-            system_num_gpus = resource_manager.get_gpu_count_torch()
+                system_num_gpus = resource_manager.get_gpu_count_torch()
+                per_device = [
+                    (torch.cuda.get_device_properties(i).total_memory, torch.cuda.memory_allocated(i))
+                    for i in range(system_num_gpus)
+                ]
             gpu_memory_info = []
             combined_free_memory = 0
             total_allocated_memory = 0
             combined_gpu_memory = 0
-            for i in range(system_num_gpus):
-                total_memory_gpu = torch.cuda.get_device_properties(i).total_memory
+            for i, (total_memory_gpu, allocated_memory) in enumerate(per_device):
                 total_memory_gb = total_memory_gpu / (1024**3)  # Convert bytes to GB
-                allocated_memory = torch.cuda.memory_allocated(i)
                 allocated_memory_gb = allocated_memory / (1024**3)
                 free_memory_gb = total_memory_gb - allocated_memory_gb
 

--- a/common/src/autogluon/common/utils/system_info.py
+++ b/common/src/autogluon/common/utils/system_info.py
@@ -3,6 +3,7 @@ import sys
 from typing import Tuple
 
 from .. import __version__
+from .gpu_count import torch_version_info
 from .resource_utils import ResourceManager, get_resource_manager
 
 
@@ -49,7 +50,7 @@ def get_ag_system_info(*, path: str = None, include_gpu_count=False, include_pyt
     version = __version__
     python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
     msg_list = [
-        f"=================== System Info ===================",
+        "=================== System Info ===================",
         f"AutoGluon Version:  {version}",
         f"Python Version:     {python_version}",
         f"Operating System:   {platform.system()}",
@@ -57,24 +58,35 @@ def get_ag_system_info(*, path: str = None, include_gpu_count=False, include_pyt
         f"Platform Version:   {platform.version()}",
         f"CPU Count:          {system_num_cpus}",
     ]
+    # torch's version and CUDA build come from its version file while torch is not imported:
+    # importing torch for two banner lines costs seconds on a network file system.
+    version_info = None if "torch" in sys.modules else torch_version_info()
     if include_pytorch:
-        try:
-            import torch
+        if version_info is not None:
+            torch_version = version_info[0]
+        else:
+            try:
+                import torch
 
-            torch_version = torch.__version__
-        except Exception as e:
-            torch_version = "Can't import torch"
+                torch_version = torch.__version__
+            except Exception:
+                torch_version = "Can't import torch"
         msg_list.append(f"Pytorch Version:    {torch_version}")
     if include_cuda:
-        try:
-            import torch
-
-            if torch.cuda.is_available():
-                cuda_version = torch.version.cuda
-            else:
+        if version_info is not None:
+            cuda_version = version_info[1]
+            if cuda_version is None or not resource_manager.get_gpu_count_torch(cuda_only=True):
                 cuda_version = "CUDA is not available"
-        except Exception as e:
-            cuda_version = "Can't get cuda version from torch"
+        else:
+            try:
+                import torch
+
+                if torch.cuda.is_available():
+                    cuda_version = torch.version.cuda
+                else:
+                    cuda_version = "CUDA is not available"
+            except Exception:
+                cuda_version = "Can't get cuda version from torch"
         msg_list.append(f"CUDA Version:       {cuda_version}")
     if include_gpu_count:
         try:
@@ -115,7 +127,7 @@ def get_ag_system_info(*, path: str = None, include_gpu_count=False, include_pyt
     if path is not None:
         disk_avail_msg, _ = get_ag_system_info_disk_space(path=path)
         msg_list.append(disk_avail_msg)
-    msg_list.append(f"===================================================")
+    msg_list.append("===================================================")
 
     msg = "\n".join(msg_list)
     return msg

--- a/common/tests/unittests/utils/test_gpu_count.py
+++ b/common/tests/unittests/utils/test_gpu_count.py
@@ -77,3 +77,27 @@ def test_get_gpu_count_torch_does_not_import_torch(tmp_path):
         pytest.skip("this platform needs torch for the count")
     assert torch_imported == "False"
     assert int(count) == torch.cuda.device_count()
+
+
+def test_visible_device_memory_matches_torch_totals():
+    if not nvutil.cudaInit():
+        pytest.skip("NVML is not available")
+    nvutil.cudaShutdown()
+    memory = gpu_count.visible_device_memory()
+    assert memory is not None and len(memory) == torch.cuda.device_count()
+    for i, (total, free, used) in enumerate(memory):
+        cuda_total = torch.cuda.get_device_properties(i).total_memory
+        assert cuda_total <= total <= cuda_total * 1.02, "NVML reports the physical total, CUDA the usable one"
+        assert 0 <= used <= total and 0 <= free <= total
+
+
+def test_cuda_visible_device_count_is_cached_per_visibility(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
+    assert gpu_count.cuda_visible_device_count() == 0
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "-1")
+    assert gpu_count.cuda_visible_device_count() == 0
+    monkeypatch.setattr(gpu_count, "_count_cache", {"": 7})
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
+    assert gpu_count.cuda_visible_device_count() == 7, "a cached value is returned for its visibility setting"
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "-1")
+    assert gpu_count.cuda_visible_device_count() == 0, "another setting is computed on its own"


### PR DESCRIPTION
## Description of changes

Stacked on #5906.

The system-info banner takes torch's version and CUDA build from its `version.py` and per-GPU memory from NVML while torch is not imported. The visible-device count is cached per `CUDA_VISIBLE_DEVICES` value: nothing else changes it, and each NVML query costs an init/shutdown cycle.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi