### PR TITLE
[common][core] Consistent GPU detection: one count, NVML initialized once, NVMLError fixes

### DIFF
--- a/common/src/autogluon/common/utils/gpu_count.py
+++ b/common/src/autogluon/common/utils/gpu_count.py
@@ -126,7 +126,7 @@ def _cuda_visible_device_count() -> int | None:
     visible = parse_visible_devices()
     if not visible:
         return 0
-    if not nvutil.cudaInit():
+    if not nvutil.ensure_initialized():
         return None
     try:
         if isinstance(visible[0], str):
@@ -140,8 +140,6 @@ def _cuda_visible_device_count() -> int | None:
         return len(visible)
     except nvutil.NVMLError:
         return None
-    finally:
-        nvutil.cudaShutdown()
 
 
 def visible_device_memory() -> list[tuple[int, int, int]] | None:
@@ -152,7 +150,7 @@ def visible_device_memory() -> list[tuple[int, int, int]] | None:
     visible = parse_visible_devices()
     if not visible:
         return []
-    if isinstance(visible[0], str) or not nvutil.cudaInit():
+    if isinstance(visible[0], str) or not nvutil.ensure_initialized():
         return None
     try:
         raw_count = nvutil.cudaDeviceGetCount()
@@ -164,8 +162,6 @@ def visible_device_memory() -> list[tuple[int, int, int]] | None:
         return [nvutil.cudaDeviceGetMemoryInfo(index) for index in indices]
     except nvutil.NVMLError:
         return None
-    finally:
-        nvutil.cudaShutdown()
 
 
 def gpu_count_without_torch(cuda_only: bool = False) -> int | None:

--- a/common/src/autogluon/common/utils/gpu_count.py
+++ b/common/src/autogluon/common/utils/gpu_count.py
@@ -173,12 +173,9 @@ def gpu_count_without_torch(cuda_only: bool = False) -> int | None:
     has_cuda = torch_build_has_cuda()
     if has_cuda is None:
         return None
-    if not has_cuda:
-        count = 0
-    else:
-        count = cuda_visible_device_count()
-        if count is None:
-            return None
+    count = cuda_visible_device_count() if has_cuda else 0
+    if count is None:
+        return None
     if count == 0 and not cuda_only and sys.platform == "darwin":
         return None
     return count

--- a/common/src/autogluon/common/utils/nvutil.py
+++ b/common/src/autogluon/common/utils/nvutil.py
@@ -6,12 +6,10 @@ from ctypes import *
 
 __all__ = [
     "ensure_initialized",
-    "cudaInit",
     "cudaDeviceGetCount",
     "cudaDeviceGetUUIDs",
     "cudaDeviceGetMemoryInfo",
     "cudaSystemGetNVMLVersion",
-    "cudaShutdown",
 ]
 
 NVML_SUCCESS = 0
@@ -57,16 +55,6 @@ def _shutdown_at_exit():
         except NVMLError:
             pass
         _initialized_pid = None
-
-
-def cudaInit():
-    """Make NVML available to the caller; see `ensure_initialized`."""
-    return ensure_initialized()
-
-
-def cudaShutdown():
-    """Kept for callers pairing it with `cudaInit`; NVML stays initialized until the process exits."""
-    return None
 
 
 ## Device get functions

--- a/common/src/autogluon/common/utils/nvutil.py
+++ b/common/src/autogluon/common/utils/nvutil.py
@@ -1,9 +1,11 @@
+import atexit
 import os
 import sys
 import threading
 from ctypes import *
 
 __all__ = [
+    "ensure_initialized",
     "cudaInit",
     "cudaDeviceGetCount",
     "cudaDeviceGetUUIDs",
@@ -20,30 +22,51 @@ NVML_SYSTEM_NVML_VERSION_BUFFER_SIZE = 80
 
 cudaLib = None
 libLoadLock = threading.Lock()
-_cudaLib_refcount = 0  # Incremented on each cudaInit and decremented on cudaShutdown
 
 
 ## C function wrappers ##
-def cudaInit():
+_initialized_pid = None
+
+
+def ensure_initialized():
+    """Initialize NVML for this process once; a forked child initializes again for itself.
+
+    Returns False when the library or a driver is missing. NVML stays initialized for the life of
+    the process (an init/shutdown pair costs about 15 ms while no CUDA context exists); it is shut
+    down at interpreter exit.
+    """
+    global _initialized_pid
+    if _initialized_pid == os.getpid():
+        return True
     if not _LoadNvmlLibrary():
         return False
-
-    #
-    # Initialize the library
-    #
-    fn = _cudaGetFunctionPointer("nvmlInit_v2")
-    ret = fn()
-    try:
-        _cudaCheckReturn(ret)
-    except NVMLError:
+    ret = _cudaGetFunctionPointer("nvmlInit_v2")()
+    if ret != NVML_SUCCESS:
         return False
-
-    # Atomically update refcount
-    global _cudaLib_refcount
-    libLoadLock.acquire()
-    _cudaLib_refcount += 1
-    libLoadLock.release()
+    if _initialized_pid is None:
+        atexit.register(_shutdown_at_exit)
+    _initialized_pid = os.getpid()
     return True
+
+
+def _shutdown_at_exit():
+    global _initialized_pid
+    if _initialized_pid == os.getpid():
+        try:
+            _cudaGetFunctionPointer("nvmlShutdown")()
+        except NVMLError:
+            pass
+        _initialized_pid = None
+
+
+def cudaInit():
+    """Make NVML available to the caller; see `ensure_initialized`."""
+    return ensure_initialized()
+
+
+def cudaShutdown():
+    """Kept for callers pairing it with `cudaInit`; NVML stays initialized until the process exits."""
+    return None
 
 
 ## Device get functions
@@ -97,16 +120,24 @@ def _LoadNvmlLibrary():
             if cudaLib == None:
                 try:
                     if sys.platform[:3] == "win":
-                        # cdecl calling convention
-                        # load cuda.dll from %ProgramFiles%/NVIDIA Corporation/NVSMI/cuda.dll
-                        cudaLib = CDLL(
+                        # The driver installs nvml.dll into System32; older drivers only into NVSMI.
+                        candidates = [
+                            os.path.join(os.getenv("SystemRoot", "C:/Windows"), "System32", "nvml.dll"),
                             os.path.join(
-                                os.getenv("ProgramFiles", "C:/Program Files"), "NVIDIA Corporation/NVSMI/cuda.dll"
-                            )
-                        )
+                                os.getenv("ProgramFiles", "C:/Program Files"),
+                                "NVIDIA Corporation",
+                                "NVSMI",
+                                "nvml.dll",
+                            ),
+                        ]
                     else:
-                        # assume linux
-                        cudaLib = CDLL("libnvidia-ml.so.1")
+                        candidates = ["libnvidia-ml.so.1"]
+                    for candidate in candidates:
+                        try:
+                            cudaLib = CDLL(candidate)
+                            break
+                        except OSError:
+                            continue
                 except OSError:
                     pass
 
@@ -159,48 +190,30 @@ def _cudaCheckReturn(ret):
 
 
 class NVMLError(Exception):
-    _valClassMapping = dict()
-    # List of currently known error codes
     _errcode_to_string = {
         NVML_ERROR_UNINITIALIZED: "Uninitialized",
         NVML_ERROR_LIBRARY_NOT_FOUND: "NVML Shared Library Not Found",
+        NVML_ERROR_FUNCTION_NOT_FOUND: "NVML Function Not Found",
     }
 
-    def __new__(typ, value):
-        """
-        Maps value to a proper subclass of NVMLError.
-        See _extractNVMLErrorsAsClasses function for more details
-        """
-        if typ == NVMLError:
-            typ = NVMLError._valClassMapping.get(value, typ)
-        obj = Exception.__new__(typ)
-        obj.value = value
-        return obj
+    def __init__(self, value):
+        super().__init__(value)
+        self.value = value
 
     def __str__(self):
-        try:
-            if self.value not in NVMLError._errcode_to_string:
-                NVMLError._errcode_to_string[self.value] = str(cudaErrorString(self.value))
+        if self.value in NVMLError._errcode_to_string:
             return NVMLError._errcode_to_string[self.value]
+        try:
+            if not _LoadNvmlLibrary():
+                raise NVMLError(NVML_ERROR_LIBRARY_NOT_FOUND)
+            fn = _cudaGetFunctionPointer("nvmlErrorString")
+            fn.restype = c_char_p
+            return fn(c_uint(self.value)).decode("utf-8")
         except Exception:
             return "NVML Error with code %d" % self.value
 
     def __eq__(self, other):
-        return self.value == other.value
+        return isinstance(other, NVMLError) and self.value == other.value
 
-
-def cudaShutdown():
-    #
-    # Leave the library loaded, but shutdown the interface
-    #
-    fn = _cudaGetFunctionPointer("nvmlShutdown")
-    ret = fn()
-    _cudaCheckReturn(ret)
-
-    # Atomically update refcount
-    global _cudaLib_refcount
-    libLoadLock.acquire()
-    if 0 < _cudaLib_refcount:
-        _cudaLib_refcount -= 1
-    libLoadLock.release()
-    return None
+    def __hash__(self):
+        return hash(self.value)

--- a/common/src/autogluon/common/utils/resource_utils.py
+++ b/common/src/autogluon/common/utils/resource_utils.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import shutil
-import subprocess
 import sys
 from typing import Union
 
@@ -44,10 +43,8 @@ class ResourceManager:
 
     @staticmethod
     def get_gpu_count() -> int:
-        num_gpus = ResourceManager._get_gpu_count_cuda()
-        if num_gpus == 0:
-            num_gpus = ResourceManager.get_gpu_count_torch()
-        return num_gpus
+        """The GPUs this process can use: `get_gpu_count_torch`, so every consumer sees one count."""
+        return ResourceManager.get_gpu_count_torch()
 
     @staticmethod
     def get_gpu_count_torch(cuda_only: bool = False) -> int:
@@ -87,11 +84,8 @@ class ResourceManager:
             else:
                 num_gpus = 0
         except Exception:
-            logger.log(
-                40,
-                "\tFailed to import torch or check CUDA availability!"
-                "Please ensure you have the correct version of PyTorch installed by running `pip install -U torch`",
-            )
+            # An install without torch has no GPU it could use; that is an answer, not an error.
+            logger.log(10, "\tCould not import torch to count GPUs; assuming none are available.")
             num_gpus = 0
         return num_gpus
 
@@ -110,8 +104,8 @@ class ResourceManager:
         2. `torch.cuda.set_per_process_memory_fraction` caps this process below the
            device total. The cap is not visible to `mem_get_info`, so it is applied here —
            a process allocating past its fraction OOMs even with the device free.
-        3. Without torch/CUDA, `nvidia-smi` gives device-level free memory only (no
-           allocator or fraction information available).
+        3. Without torch/CUDA, NVML gives device-level free memory only (no allocator or
+           fraction information available).
         """
         try:
             import torch
@@ -140,22 +134,13 @@ class ResourceManager:
 
     @staticmethod
     def get_gpu_free_memory():
-        """Grep gpu free memory from nvidia-smi tool.
-        This function can fail due to many reasons(driver, nvidia-smi tool, envs, etc) so please simply use
-        it as a suggestion, stay away with any rules bound to it.
-        E.g. for a 4-gpu machine, the result can be list of int
-        >>> print(get_gpu_free_memory)
-        >>> [13861, 13859, 13859, 13863]
-        """
-        _output_to_list = lambda x: x.decode("ascii").split("\n")[:-1]
+        """Free memory in MiB of each GPU this process can see, in visible-device order; `[]` when NVML cannot tell."""
+        from .gpu_count import visible_device_memory
 
-        try:
-            COMMAND = "nvidia-smi --query-gpu=memory.free --format=csv"
-            memory_free_info = _output_to_list(subprocess.check_output(COMMAND.split()))[1:]
-            memory_free_values = [int(x.split()[0]) for i, x in enumerate(memory_free_info)]
-        except:
-            memory_free_values = []
-        return memory_free_values
+        memory = visible_device_memory()
+        if memory is None:
+            return []
+        return [int(free // (1024**2)) for total, free, used in memory]
 
     @staticmethod
     def get_memory_size(format: str = "B") -> float:
@@ -239,18 +224,6 @@ class ResourceManager:
         Returns obj with variables `free`, `total`, `used`, representing bytes as integers.
         """
         return shutil.disk_usage(path=path)
-
-    @staticmethod
-    def _get_gpu_count_cuda():
-        # FIXME: Sometimes doesn't detect GPU on Windows
-        # FIXME: Doesn't ensure the GPUs are actually usable by the model (PyTorch, etc.)
-        from .nvutil import cudaDeviceGetCount, cudaInit, cudaShutdown
-
-        if not cudaInit():
-            return 0
-        gpu_count = cudaDeviceGetCount()
-        cudaShutdown()
-        return gpu_count
 
     @staticmethod
     def _get_custom_memory_size():

--- a/common/tests/unittests/utils/test_gpu_count.py
+++ b/common/tests/unittests/utils/test_gpu_count.py
@@ -53,9 +53,8 @@ def test_torch_build_has_cuda_matches_torch():
 
 
 def test_gpu_count_without_torch_matches_torch_in_this_process():
-    if not nvutil.cudaInit():
+    if not nvutil.ensure_initialized():
         pytest.skip("NVML is not available")
-    nvutil.cudaShutdown()
     count = gpu_count.gpu_count_without_torch(cuda_only=True)
     assert count == torch.cuda.device_count()
     assert ResourceManager.get_gpu_count_torch(cuda_only=True) == torch.cuda.device_count()
@@ -80,9 +79,8 @@ def test_get_gpu_count_torch_does_not_import_torch(tmp_path):
 
 
 def test_visible_device_memory_matches_torch_totals():
-    if not nvutil.cudaInit():
+    if not nvutil.ensure_initialized():
         pytest.skip("NVML is not available")
-    nvutil.cudaShutdown()
     memory = gpu_count.visible_device_memory()
     assert memory is not None and len(memory) == torch.cuda.device_count()
     for i, (total, free, used) in enumerate(memory):
@@ -101,3 +99,70 @@ def test_cuda_visible_device_count_is_cached_per_visibility(monkeypatch):
     assert gpu_count.cuda_visible_device_count() == 7, "a cached value is returned for its visibility setting"
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "-1")
     assert gpu_count.cuda_visible_device_count() == 0, "another setting is computed on its own"
+
+
+def test_get_gpu_count_is_the_torch_count():
+    assert ResourceManager.get_gpu_count() == ResourceManager.get_gpu_count_torch() == torch.cuda.device_count()
+
+
+@pytest.mark.parametrize("setting", ["", "0", "1,0", "-1", "GPU-none"])
+def test_get_gpu_count_follows_visible_devices_like_torch(setting):
+    """A fresh process with restricted visibility reports the devices it can use, as torch does."""
+    import subprocess
+
+    code = (
+        "from autogluon.common.utils.resource_utils import ResourceManager; n = ResourceManager.get_gpu_count(); "
+        "import torch; print(n, torch.cuda.device_count())"
+    )
+    env = {**os.environ, "CUDA_VISIBLE_DEVICES": setting}
+    out = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True, env=env)
+    count, torch_count = out.stdout.split()
+    assert count == torch_count
+
+
+def test_get_gpu_free_memory_one_entry_per_visible_device():
+    if not nvutil.ensure_initialized():
+        pytest.skip("NVML is not available")
+    free = ResourceManager.get_gpu_free_memory()
+    assert len(free) == torch.cuda.device_count()
+    for i, free_mib in enumerate(free):
+        assert isinstance(free_mib, int)
+        assert 0 <= free_mib <= torch.cuda.get_device_properties(i).total_memory * 1.02 // 2**20
+
+
+def test_nvml_error_string_and_equality():
+    assert str(nvutil.NVMLError(nvutil.NVML_ERROR_UNINITIALIZED)) == "Uninitialized"
+    assert str(nvutil.NVMLError(nvutil.NVML_ERROR_LIBRARY_NOT_FOUND)) == "NVML Shared Library Not Found"
+    if nvutil._LoadNvmlLibrary():
+        assert str(nvutil.NVMLError(2)) == "Invalid Argument", "other codes are named by the driver"
+    else:
+        assert str(nvutil.NVMLError(2)) == "NVML Error with code 2"
+    assert nvutil.NVMLError(3) == nvutil.NVMLError(3)
+    assert nvutil.NVMLError(3) != nvutil.NVMLError(4)
+    assert nvutil.NVMLError(3) != 3
+    assert len({nvutil.NVMLError(3), nvutil.NVMLError(3)}) == 1
+
+
+def test_ensure_initialized_is_per_process():
+    """NVML state does not survive a fork: the child initializes for itself, the parent keeps its own."""
+    if not sys.platform.startswith("linux"):
+        pytest.skip("fork semantics are tested on Linux")
+    if not nvutil.ensure_initialized():
+        pytest.skip("NVML is not available")
+    assert nvutil._initialized_pid == os.getpid()
+    assert nvutil.ensure_initialized(), "a second call in the same process is a no-op"
+    count = nvutil.cudaDeviceGetCount()
+    read_fd, write_fd = os.pipe()
+    pid = os.fork()
+    if pid == 0:  # pragma: no cover - runs in the child
+        os.close(read_fd)
+        result = "reinit" if nvutil.ensure_initialized() and nvutil._initialized_pid == os.getpid() else "stale"
+        result += f" {nvutil.cudaDeviceGetCount()}"
+        os.write(write_fd, result.encode())
+        os._exit(0)
+    os.close(write_fd)
+    _, status = os.waitpid(pid, 0)
+    child = os.read(read_fd, 64).decode()
+    os.close(read_fd)
+    assert status == 0 and child == f"reinit {count}"
+    assert nvutil.cudaDeviceGetCount() == count

--- a/core/src/autogluon/core/utils/version_utils.py
+++ b/core/src/autogluon/core/utils/version_utils.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from importlib.metadata import distribution, version
 
 import autogluon
-from autogluon.common.utils.nvutil import cudaInit, cudaSystemGetNVMLVersion
+from autogluon.common.utils.nvutil import cudaSystemGetNVMLVersion, ensure_initialized
 from autogluon.common.utils.resource_utils import ResourceManager
 
 
@@ -50,7 +50,7 @@ def _get_sys_info():
     """Retrieve system information"""
     uname = platform.uname()
     cuda_version = None
-    if cudaInit():
+    if ensure_initialized():
         try:
             cuda_version = cudaSystemGetNVMLVersion()
         except:

--- a/timeseries/tests/unittests/conftest.py
+++ b/timeseries/tests/unittests/conftest.py
@@ -23,7 +23,7 @@ def patch_naive_models():
         mock.patch("autogluon.timeseries.models.local.naive.NaiveModel.predict", mock_predict),
         mock.patch("autogluon.timeseries.models.local.naive.SeasonalNaiveModel.predict", mock_predict),
         mock.patch("autogluon.timeseries.models.ensemble.weighted.greedy.GreedyEnsemble.fit", mock_greedy_fit),
-        # nvutil cudaInit and cudaShutdown is triggered for each run of the trainer. we disable this here
+        # GPU detection runs for each run of the trainer. we disable this here
         mock.patch("autogluon.common.utils.resource_utils.ResourceManager.get_gpu_count", return_value=0),
     ):
         yield


### PR DESCRIPTION
## Description of changes

Stacked on #5907.

`ResourceManager.get_gpu_count` returns `get_gpu_count_torch`, so every consumer sees the devices the process can use instead of the physical NVML count that ignored `CUDA_VISIBLE_DEVICES`. NVML is initialized once per process through `nvutil.ensure_initialized` (a forked child initializes again) instead of an init/shutdown pair per query; `cudaInit` and `cudaShutdown` are removed. `NVMLError.__str__` uses `nvmlErrorString` (it called an undefined name), Windows loads `nvml.dll` instead of `cuda.dll`, `get_gpu_free_memory` reads NVML instead of parsing `nvidia-smi`, and a missing torch logs at debug level.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi