### PR TITLE
[core][tabular][timeseries] Replace networkx with a native model graph

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -25,7 +25,6 @@ install_requires = [
     "numpy",
     "scipy",
     "scikit-learn",
-    "networkx",
     "pandas",
     "tqdm",
     "requests",

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -21,7 +21,6 @@ DEPENDENT_PACKAGES = {
     "matplotlib": ">=3.7.0,<3.12",  # "<{N+2}" upper cap
     "psutil": ">=5.7.3,<7.3.0",  # Major version cap
     "s3fs": ">=2024.2,<2026",  # Yearly cap
-    "networkx": ">=3.0,<4",  # Major version cap
     "tqdm": ">=4.38,<5",  # Major version cap
     "Pillow": ">=10.0.1,<13",  # Major version cap
     # Major version cap, sync with common/src/autogluon/common/utils/try_import.py. torchvision version in multimodelal/setup.py can effectively constrain version as well

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -7,6 +7,7 @@ from typing_extensions import Self
 
 from autogluon.core.models import ModelBase
 from autogluon.core.utils.loaders import load_pkl
+from autogluon.core.utils.model_graph import ModelGraph
 from autogluon.core.utils.savers import save_json, save_pkl
 
 ModelTypeT = TypeVar("ModelTypeT", bound=ModelBase)
@@ -18,8 +19,6 @@ class AbstractTrainer(Generic[ModelTypeT]):
     trainer_info_json_name = "info.json"
 
     def __init__(self, path: str, *, low_memory: bool, save_data: bool):
-        import networkx as nx
-
         self.path = path
         self.reset_paths = False
 
@@ -31,7 +30,7 @@ class AbstractTrainer(Generic[ModelTypeT]):
 
         #: Directed Acyclic Graph (DAG) of model interactions. Describes how certain models depend on the predictions of certain
         #: other models. Contains numerous metadata regarding each model.
-        self.model_graph = nx.DiGraph()
+        self.model_graph = ModelGraph()
         self.model_best: str | None = None
 
         #: Names which are banned but are not used by a trained model.
@@ -98,11 +97,9 @@ class AbstractTrainer(Generic[ModelTypeT]):
         """Gets the minimum set of models that the provided model depends on, including itself
         Returns a list of model names
         """
-        import networkx as nx
-
         if not isinstance(model, str):
             model = model.name
-        minimum_model_set = list(nx.bfs_tree(self.model_graph, model, reverse=True))
+        minimum_model_set = self.model_graph.ancestors_with_self(model)
         if not include_self:
             minimum_model_set = [m for m in minimum_model_set if m != model]
         return minimum_model_set

--- a/core/src/autogluon/core/utils/model_graph.py
+++ b/core/src/autogluon/core/utils/model_graph.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import heapq
+from collections import deque
+from collections.abc import Iterable, Iterator
+from typing import Any
+
+
+class _NodeView:
+    """Read access to a graph's nodes and their attributes: `name in nodes`, `nodes[name]`, iteration."""
+
+    def __init__(self, attributes: dict[str, dict[str, Any]]):
+        self._attributes = attributes
+
+    def __contains__(self, name: object) -> bool:
+        return name in self._attributes
+
+    def __getitem__(self, name: str) -> dict[str, Any]:
+        return self._attributes[name]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._attributes)
+
+    def __len__(self) -> int:
+        return len(self._attributes)
+
+
+class ModelGraph:
+    """Directed acyclic graph of model names with per-node attributes.
+
+    The trainer's record of which models feed which: an edge ``base -> stacker`` means the
+    stacker consumes the base model's predictions. Nodes carry a dict of attributes
+    (``path``, ``type``, ``level``, ``fit_time``, ...). Insertion order of nodes is kept.
+    """
+
+    def __init__(self):
+        self._attributes: dict[str, dict[str, Any]] = {}
+        self._successors: dict[str, set[str]] = {}
+        self._predecessors: dict[str, set[str]] = {}
+
+    # --- nodes and edges ---
+
+    def __contains__(self, name: object) -> bool:
+        return name in self._attributes
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._attributes)
+
+    def __len__(self) -> int:
+        return len(self._attributes)
+
+    @property
+    def nodes(self) -> _NodeView:
+        return _NodeView(self._attributes)
+
+    def add_node(self, name: str, **attributes: Any) -> None:
+        """Add ``name`` with ``attributes``, or update the attributes of an existing node."""
+        if name not in self._attributes:
+            self._attributes[name] = {}
+            self._successors[name] = set()
+            self._predecessors[name] = set()
+        self._attributes[name].update(attributes)
+
+    def add_edge(self, source: str, target: str) -> None:
+        """Add ``source -> target``, adding either node if it is missing."""
+        self.add_node(source)
+        self.add_node(target)
+        self._successors[source].add(target)
+        self._predecessors[target].add(source)
+
+    def remove_node(self, name: str) -> None:
+        for successor in self._successors.pop(name):
+            self._predecessors[successor].discard(name)
+        for predecessor in self._predecessors.pop(name):
+            self._successors[predecessor].discard(name)
+        del self._attributes[name]
+
+    def remove_edges_from(self, edges: Iterable[tuple[str, str]]) -> None:
+        for source, target in edges:
+            self._successors[source].discard(target)
+            self._predecessors[target].discard(source)
+
+    def in_edges(self, name: str) -> list[tuple[str, str]]:
+        return [(predecessor, name) for predecessor in self._predecessors[name]]
+
+    def edges(self) -> list[tuple[str, str]]:
+        return [(source, target) for source, targets in self._successors.items() for target in targets]
+
+    def predecessors(self, name: str) -> Iterator[str]:
+        return iter(self._predecessors[name])
+
+    def successors(self, name: str) -> Iterator[str]:
+        return iter(self._successors[name])
+
+    def copy(self) -> ModelGraph:
+        """An independent graph with the same nodes, edges and attribute dicts (attribute values are shared)."""
+        graph = ModelGraph()
+        for name, attributes in self._attributes.items():
+            graph.add_node(name, **attributes)
+        for source, target in self.edges():
+            graph.add_edge(source, target)
+        return graph
+
+    def subgraph(self, names: Iterable[str]) -> ModelGraph:
+        """An independent graph of ``names`` and the edges among them."""
+        names = set(names)
+        graph = ModelGraph()
+        for name in self._attributes:
+            if name in names:
+                graph.add_node(name, **self._attributes[name])
+        for source, target in self.edges():
+            if source in names and target in names:
+                graph.add_edge(source, target)
+        return graph
+
+    def get_node_attributes(self, attribute: str) -> dict[str, Any]:
+        """``name -> value`` for every node that has ``attribute``."""
+        return {
+            name: attributes[attribute] for name, attributes in self._attributes.items() if attribute in attributes
+        }
+
+    # --- traversal ---
+
+    def _reachable(self, name: str, neighbors: dict[str, set[str]]) -> list[str]:
+        """Nodes reachable from ``name`` along ``neighbors`` in breadth-first order, ``name`` first."""
+        seen = {name}
+        order = [name]
+        queue = deque([name])
+        while queue:
+            current = queue.popleft()
+            for neighbor in sorted(neighbors[current]):
+                if neighbor not in seen:
+                    seen.add(neighbor)
+                    order.append(neighbor)
+                    queue.append(neighbor)
+        return order
+
+    def ancestors_with_self(self, name: str) -> list[str]:
+        """``name`` and every node it depends on, transitively, in breadth-first order."""
+        return self._reachable(name, self._predecessors)
+
+    def ancestors(self, name: str) -> set[str]:
+        return set(self.ancestors_with_self(name)) - {name}
+
+    def descendants(self, name: str) -> set[str]:
+        return set(self._reachable(name, self._successors)) - {name}
+
+    def has_path(self, source: str, target: str) -> bool:
+        return target in self._reachable(source, self._successors)
+
+    def lexicographical_topological_sort(self) -> list[str]:
+        """Nodes ordered so that every edge points forward; ties broken by name."""
+        in_degree = {name: len(predecessors) for name, predecessors in self._predecessors.items()}
+        ready = [name for name, degree in in_degree.items() if degree == 0]
+        heapq.heapify(ready)
+        order: list[str] = []
+        while ready:
+            name = heapq.heappop(ready)
+            order.append(name)
+            for successor in self._successors[name]:
+                in_degree[successor] -= 1
+                if in_degree[successor] == 0:
+                    heapq.heappush(ready, successor)
+        if len(order) != len(self._attributes):
+            raise ValueError("The model graph contains a cycle.")
+        return order

--- a/core/src/autogluon/core/utils/model_graph.py
+++ b/core/src/autogluon/core/utils/model_graph.py
@@ -148,6 +148,37 @@ class ModelGraph:
     def has_path(self, source: str, target: str) -> bool:
         return target in self._reachable(source, self._successors)
 
+    def bfs_layers(self, sources: Iterable[str]) -> list[list[str]]:
+        """Nodes grouped by their distance from the nearest of ``sources`` along successor edges, nearest first."""
+        current = list(dict.fromkeys(sources))
+        seen = set(current)
+        layers: list[list[str]] = []
+        while current:
+            layers.append(current)
+            following: list[str] = []
+            for name in current:
+                for successor in sorted(self._successors[name]):
+                    if successor not in seen:
+                        seen.add(successor)
+                        following.append(successor)
+            current = following
+        return layers
+
+    def shortest_path_lengths(self) -> dict[str, dict[str, int]]:
+        """``source -> {reachable node -> number of edges}`` for every node, following successor edges."""
+        lengths: dict[str, dict[str, int]] = {}
+        for source in self._attributes:
+            distance = {source: 0}
+            queue = deque([source])
+            while queue:
+                current = queue.popleft()
+                for successor in self._successors[current]:
+                    if successor not in distance:
+                        distance[successor] = distance[current] + 1
+                        queue.append(successor)
+            lengths[source] = distance
+        return lengths
+
     def lexicographical_topological_sort(self) -> list[str]:
         """Nodes ordered so that every edge points forward; ties broken by name."""
         in_degree = {name: len(predecessors) for name, predecessors in self._predecessors.items()}

--- a/core/tests/unittests/utils/test_model_graph.py
+++ b/core/tests/unittests/utils/test_model_graph.py
@@ -1,0 +1,85 @@
+import pickle
+import random
+
+import networkx as nx
+import pytest
+
+from autogluon.core.utils.model_graph import ModelGraph
+
+
+def _random_dag(seed: int, n_nodes: int = 12, edge_prob: float = 0.3):
+    """The same random DAG as a `ModelGraph` and a `networkx.DiGraph`, with node attributes."""
+    rng = random.Random(seed)
+    names = [f"m{i}" for i in range(n_nodes)]
+    rng.shuffle(names)
+    graph, reference = ModelGraph(), nx.DiGraph()
+    for level, name in enumerate(names):
+        attributes = {"level": level, "fit_time": float(level)} if level % 3 else {"level": level}
+        graph.add_node(name, **attributes)
+        reference.add_node(name, **attributes)
+    for i, source in enumerate(names):
+        for target in names[i + 1 :]:
+            if rng.random() < edge_prob:
+                graph.add_edge(source, target)
+                reference.add_edge(source, target)
+    return graph, reference, names
+
+
+@pytest.mark.parametrize("seed", range(20))
+def test_model_graph_matches_networkx(seed):
+    graph, reference, names = _random_dag(seed)
+
+    assert list(graph.nodes) == list(reference.nodes)
+    assert set(graph.edges()) == set(reference.edges)
+    assert graph.get_node_attributes("fit_time") == nx.get_node_attributes(reference, "fit_time")
+    assert graph.lexicographical_topological_sort() == list(nx.lexicographical_topological_sort(reference))
+    for name in names:
+        assert name in graph.nodes and graph.nodes[name] == reference.nodes[name]
+        assert graph.ancestors(name) == nx.ancestors(reference, name)
+        assert graph.descendants(name) == nx.descendants(reference, name)
+        assert set(graph.ancestors_with_self(name)) == set(nx.bfs_tree(reference, name, reverse=True))
+        assert graph.ancestors_with_self(name)[0] == name
+        assert set(graph.predecessors(name)) == set(reference.predecessors(name))
+        assert set(graph.successors(name)) == set(reference.successors(name))
+        assert set(graph.in_edges(name)) == set(reference.in_edges(name))
+        for other in names:
+            assert graph.has_path(name, other) == nx.has_path(reference, name, other)
+
+    keep = names[::2]
+    subgraph = graph.subgraph(keep)
+    reference_subgraph = nx.subgraph(reference, keep)
+    assert set(subgraph.nodes) == set(reference_subgraph.nodes)
+    assert set(subgraph.edges()) == set(reference_subgraph.edges)
+    assert subgraph.lexicographical_topological_sort() == list(nx.lexicographical_topological_sort(reference_subgraph))
+
+
+def test_model_graph_mutation_and_copy():
+    graph, reference, names = _random_dag(seed=3)
+    copied = graph.copy()
+    copied.nodes[names[0]]["level"] = -1
+    assert graph.nodes[names[0]]["level"] != -1, "a copy has its own attribute dicts"
+
+    victim = names[len(names) // 2]
+    graph.remove_node(victim)
+    reference.remove_node(victim)
+    assert set(graph.nodes) == set(reference.nodes) and set(graph.edges()) == set(reference.edges)
+
+    survivor = names[-1]
+    graph.remove_edges_from(list(graph.in_edges(survivor)))
+    reference.remove_edges_from(list(reference.in_edges(survivor)))
+    assert set(graph.edges()) == set(reference.edges)
+    assert list(graph.predecessors(survivor)) == []
+
+    graph.add_node(survivor, level=99)
+    assert graph.nodes[survivor]["level"] == 99, "adding an existing node updates its attributes"
+
+    restored = pickle.loads(pickle.dumps(graph))
+    assert set(restored.edges()) == set(graph.edges()) and restored.nodes[survivor] == graph.nodes[survivor]
+
+
+def test_model_graph_cycle_is_rejected():
+    graph = ModelGraph()
+    graph.add_edge("a", "b")
+    graph.add_edge("b", "a")
+    with pytest.raises(ValueError, match="cycle"):
+        graph.lexicographical_topological_sort()

--- a/core/tests/unittests/utils/test_model_graph.py
+++ b/core/tests/unittests/utils/test_model_graph.py
@@ -1,10 +1,11 @@
 import pickle
 import random
 
-import networkx as nx
 import pytest
 
 from autogluon.core.utils.model_graph import ModelGraph
+
+nx = pytest.importorskip("networkx")
 
 
 def _random_dag(seed: int, n_nodes: int = 12, edge_prob: float = 0.3):
@@ -44,6 +45,15 @@ def test_model_graph_matches_networkx(seed):
         assert set(graph.in_edges(name)) == set(reference.in_edges(name))
         for other in names:
             assert graph.has_path(name, other) == nx.has_path(reference, name, other)
+
+    roots = [name for name in names if not list(graph.predecessors(name))]
+    # networkx orders a layer by set iteration; the layers' membership is what is defined.
+    assert [set(layer) for layer in graph.bfs_layers(roots)] == [
+        set(layer) for layer in nx.bfs_layers(reference, roots)
+    ]
+    assert graph.shortest_path_lengths() == {
+        source: dict(lengths) for source, lengths in nx.shortest_path_length(reference)
+    }
 
     keep = names[::2]
     subgraph = graph.subgraph(keep)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ lint.ignore = [
 lint.isort.known-first-party = ["autogluon"]
 lint.isort.known-third-party = [
     "gluonts",
-    "networkx",
     "numpy",
     "pandas",
     "psutil",

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -26,7 +26,6 @@ install_requires = [
     "scipy",
     "pandas",
     "scikit-learn",
-    "networkx",
     f"autogluon.core=={version}",
     f"autogluon.features=={version}",
 ]

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -5608,14 +5608,13 @@ class TabularPredictor:
 
         """
         self._assert_is_fit("plot_ensemble_model")
-        import networkx as nx
-
         try:
+            import networkx as nx
             import pygraphviz  # noqa: F401
         except ImportError:
             raise ImportError(
-                "Visualizing ensemble network architecture requires the `pygraphviz` library. "
-                "Try `sudo apt-get install graphviz graphviz-dev` followed by `pip install pygraphviz` to install on Linux, "
+                "Visualizing ensemble network architecture requires the `networkx` and `pygraphviz` libraries. "
+                "Try `sudo apt-get install graphviz graphviz-dev` followed by `pip install networkx pygraphviz` to install on Linux, "
                 "or refer to the method docstring for detailed installation instructions for other operating systems."
             )
 
@@ -5628,12 +5627,14 @@ class TabularPredictor:
         assert primary_model in all_models, f'Unknown model "{primary_model}"! Valid models: {all_models}'
         if prune_unused_nodes == True:
             models_to_keep = self._trainer.get_minimum_model_set(model=primary_model)
-            G = nx.subgraph(G, models_to_keep)
+            G = G.subgraph(models_to_keep)
 
         models = list(G.nodes)
         fit_times = self._trainer.get_models_attribute_full(models=models, attribute="fit_time")
         predict_times = self._trainer.get_models_attribute_full(models=models, attribute="predict_time")
 
+        G = nx.DiGraph(G.edges()) if G.edges() else nx.DiGraph()
+        G.add_nodes_from(models)
         A = nx.nx_agraph.to_agraph(G)
 
         for node in A.iternodes():

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -1398,8 +1398,6 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         -------
         Returns list of models in inference call order, including dependency models of those specified in the input.
         """
-        import networkx as nx
-
         model_set = set()
         model_order = []
         for model in models:
@@ -1407,8 +1405,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
                 continue
             min_models_set = set(self.get_minimum_model_set(model))
             models_to_load = list(min_models_set.difference(model_set))
-            subgraph = nx.subgraph(self.model_graph, models_to_load)
-            model_pred_order = list(nx.lexicographical_topological_sort(subgraph))
+            model_pred_order = self.model_graph.subgraph(models_to_load).lexicographical_topological_sort()
             model_order += [m for m in model_pred_order if m not in model_set]
             model_set = set(model_order)
         return model_order
@@ -1433,8 +1430,6 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         -------
         Returns list of models in inference call order, including dependency models of those specified in the input.
         """
-        import networkx as nx
-
         model_set = set()
         for model in models:
             if model in model_set:
@@ -1444,7 +1439,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         if models_to_ignore is not None:
             model_set = model_set.difference(set(models_to_ignore))
         models_to_load = list(model_set)
-        subgraph = nx.DiGraph(nx.subgraph(self.model_graph, models_to_load))  # Wrap subgraph in DiGraph to unfreeze it
+        subgraph = self.model_graph.subgraph(models_to_load)
         # For model in models_to_ignore, remove model node from graph and all ancestors that have no remaining descendants and are not in `models`
         models_to_ignore = [
             model for model in models_to_load if (model not in models) and (not list(subgraph.successors(model)))
@@ -1463,13 +1458,11 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
                     models_to_ignore.append(predecessor)
 
         # Get model prediction order
-        return list(nx.lexicographical_topological_sort(subgraph))
+        return subgraph.lexicographical_topological_sort()
 
     def get_models_attribute_dict(self, attribute: str, models: list | None = None) -> dict[str, Any]:
         """Returns dictionary of model name -> attribute value for the provided attribute."""
-        import networkx as nx
-
-        models_attribute_dict = nx.get_node_attributes(self.model_graph, attribute)
+        models_attribute_dict = self.model_graph.get_node_attributes(attribute)
         if models is not None:
             model_names = []
             for model in models:
@@ -4374,8 +4367,6 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         model_info_dict = defaultdict(list)
         extra_info_dict = dict()
         if extra_info:
-            import networkx as nx
-
             # TODO: feature_metadata
             # TODO: disk size
             # TODO: load time
@@ -4444,8 +4435,8 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
                             for model_name in model_names
                         ]
 
-            ancestors = [list(nx.dag.ancestors(self.model_graph, model_name)) for model_name in model_names]
-            descendants = [list(nx.dag.descendants(self.model_graph, model_name)) for model_name in model_names]
+            ancestors = [list(self.model_graph.ancestors(model_name)) for model_name in model_names]
+            descendants = [list(self.model_graph.descendants(model_name)) for model_name in model_names]
 
             model_info_dict["num_ancestors"] = [len(ancestor_lst) for ancestor_lst in ancestors]
             model_info_dict["num_descendants"] = [len(descendant_lst) for descendant_lst in descendants]
@@ -4727,8 +4718,6 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         delete_from_disk=True,
         dry_run=True,
     ):
-        import networkx as nx
-
         if models_to_keep is not None and models_to_delete is not None:
             raise ValueError("Exactly one of [models_to_keep, models_to_delete] must be set.")
         if models_to_keep is not None:
@@ -4745,7 +4734,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
             minimum_model_set = set(models_to_delete)
             minimum_model_set_orig = copy.deepcopy(minimum_model_set)
             for model in models_to_delete:
-                minimum_model_set.update(nx.algorithms.dag.descendants(self.model_graph, model))
+                minimum_model_set.update(self.model_graph.descendants(model))
             if not allow_delete_cascade:
                 if minimum_model_set != minimum_model_set_orig:
                     raise AssertionError(

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -33,7 +33,6 @@ install_requires = [
     "huggingface_hub[torch]",  # version range defined in `core/_setup_utils.py`
     "safetensors>=0.4,<1",  # used to load the Toto 2.0 checkpoints. Major version cap
     "gluonts>=0.17.0,<0.18.0",
-    "networkx",
     "statsforecast>=1.7.0,<2.1.2",
     "mlforecast>=0.14.0,<0.15.0",  # cannot upgrade since v0.15.0 introduced a breaking change to DirectTabular
     "utilsforecast>=0.2.3,<0.2.12",  # to prevent breaking changes that propagate through mlforecast's dependency

--- a/timeseries/src/autogluon/timeseries/trainer/ensemble_composer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/ensemble_composer.py
@@ -5,10 +5,10 @@ import traceback
 from pathlib import Path
 from typing import Any, Iterator
 
-import networkx as nx
 import numpy as np
 from typing_extensions import Self
 
+from autogluon.core.utils.model_graph import ModelGraph
 from autogluon.timeseries import TimeSeriesDataFrame
 from autogluon.timeseries.metrics import TimeSeriesScorer
 from autogluon.timeseries.models.ensemble import (
@@ -77,7 +77,7 @@ class EnsembleComposer:
         num_windows_per_layer: tuple[int, ...],
         ensemble_hyperparameters: list[dict[str, dict | list[dict]]],
         quantile_levels: list[float],
-        model_graph: nx.DiGraph,
+        model_graph: ModelGraph,
     ):
         self.eval_metric = eval_metric
         self.path = path
@@ -100,21 +100,21 @@ class EnsembleComposer:
         self.model_graph = self._get_base_model_graph(source_graph=model_graph)
 
     @staticmethod
-    def _get_base_model_graph(source_graph: nx.DiGraph) -> nx.DiGraph:
+    def _get_base_model_graph(source_graph: ModelGraph) -> ModelGraph:
         """Return a model graph by copying only base models (nodes without predecessors).
 
         This ensures we start fresh for training ensembles.
         """
         rootset = EnsembleComposer._get_rootset(source_graph)
 
-        dst_graph = nx.DiGraph()
+        dst_graph = ModelGraph()
         for node in rootset:
             dst_graph.add_node(node, **source_graph.nodes[node])
 
         return dst_graph
 
     @staticmethod
-    def _get_rootset(graph: nx.DiGraph) -> list[str]:
+    def _get_rootset(graph: ModelGraph) -> list[str]:
         return [n for n in graph.nodes if not list(graph.predecessors(n))]
 
     def _load_model(self, model_name: str) -> Any:
@@ -139,7 +139,7 @@ class EnsembleComposer:
             Loaded model instance
         """
         rootset = self._get_rootset(self.model_graph)
-        layer_iter = nx.traversal.bfs_layers(self.model_graph, rootset)
+        layer_iter = self.model_graph.bfs_layers(rootset)
         for layer_idx, layer_keys in enumerate(layer_iter):
             if layer_idx != layer:
                 continue
@@ -418,7 +418,7 @@ class EnsembleComposer:
         """Calculate ensemble predict time as sum of base model predict times."""
         assert model.predict_time_marginal is not None
         predict_time = model.predict_time_marginal
-        for model_name in nx.ancestors(self.model_graph, model.name):
+        for model_name in self.model_graph.ancestors(model.name):
             ancestor = self._load_model(model_name)
             if isinstance(ancestor, AbstractTimeSeriesEnsembleModel):
                 assert ancestor.predict_time_marginal is not None

--- a/timeseries/src/autogluon/timeseries/trainer/trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/trainer.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any, Literal
 
-import networkx as nx
 import numpy as np
 import pandas as pd
 from tqdm import tqdm
@@ -199,7 +198,7 @@ class TimeSeriesTrainer(AbstractTrainer[TimeSeriesModelBase]):
 
         # get shortest paths
         paths_from = defaultdict(dict)
-        for source_node, paths_to in nx.shortest_path_length(self.model_graph):
+        for source_node, paths_to in self.model_graph.shortest_path_lengths().items():
             for dest_node in paths_to:
                 paths_from[dest_node][source_node] = paths_to[dest_node]
 

--- a/timeseries/tests/unittests/trainer/test_ensemble_composer.py
+++ b/timeseries/tests/unittests/trainer/test_ensemble_composer.py
@@ -2,7 +2,6 @@ import sys
 from pathlib import Path
 from unittest import mock
 
-import networkx as nx
 import numpy as np
 import pandas as pd
 import pytest
@@ -180,7 +179,7 @@ class TestTwoLayerStacking:
 
         graph = ensemble_composer.model_graph
         rootset = [n for n in graph.nodes if not list(graph.predecessors(n))]
-        layers = list(nx.traversal.bfs_layers(graph, rootset))
+        layers = graph.bfs_layers(rootset)
 
         assert len(layers) == 3  # Base models (layer 0), L2 (layer 1), L3 (layer 2)
         assert len(layers[0]) == 2  # 2 base models
@@ -566,7 +565,7 @@ class TestEnsemblePredictTime:
         ensembles = list(ensemble_composer.iter_ensembles())
         for _, ensemble, base_models in ensembles:
             ancestor_sum = 0
-            for ancestor_name in nx.ancestors(ensemble_composer.model_graph, ensemble.name):
+            for ancestor_name in ensemble_composer.model_graph.ancestors(ensemble.name):
                 ancestor_model = ensemble_composer._load_model(ancestor_name)
                 # Use predict_time_marginal for ensembles, predict_time for base models
                 if ancestor_model.predict_time_marginal is not None:

--- a/uv.lock
+++ b/uv.lock
@@ -376,8 +376,6 @@ dependencies = [
     { name = "autogluon-features" },
     { name = "boto3" },
     { name = "matplotlib" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "numpy" },
     { name = "pandas" },
     { name = "requests" },
@@ -425,7 +423,6 @@ requires-dist = [
     { name = "hyperopt", marker = "extra == 'all'", specifier = ">=0.2.7,<0.2.8" },
     { name = "hyperopt", marker = "extra == 'raytune'", specifier = ">=0.2.7,<0.2.8" },
     { name = "matplotlib", specifier = ">=3.7.0,<3.12" },
-    { name = "networkx", specifier = ">=3.0,<4" },
     { name = "numpy", specifier = ">=1.25.0,<2.6.0" },
     { name = "pandas", specifier = ">=2.0.0,<2.4.0" },
     { name = "pre-commit", marker = "extra == 'tests'" },
@@ -578,8 +575,6 @@ source = { editable = "tabular" }
 dependencies = [
     { name = "autogluon-core" },
     { name = "autogluon-features" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "numpy" },
     { name = "pandas" },
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -766,7 +761,6 @@ requires-dist = [
     { name = "loguru", marker = "extra == 'all'" },
     { name = "loguru", marker = "extra == 'mitra'" },
     { name = "loguru", marker = "extra == 'tabarena'" },
-    { name = "networkx", specifier = ">=3.0,<4" },
     { name = "numpy", specifier = ">=1.25.0,<2.6.0" },
     { name = "omegaconf", marker = "extra == 'all'" },
     { name = "omegaconf", marker = "extra == 'mitra'" },
@@ -848,8 +842,6 @@ dependencies = [
     { name = "joblib" },
     { name = "lightning" },
     { name = "mlforecast" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "numpy" },
     { name = "orjson" },
     { name = "pandas" },
@@ -899,7 +891,6 @@ requires-dist = [
     { name = "joblib", specifier = ">=1.2,<1.7" },
     { name = "lightning", specifier = ">=2.5.1,<2.7" },
     { name = "mlforecast", specifier = ">=0.14.0,<0.15.0" },
-    { name = "networkx", specifier = ">=3.0,<4" },
     { name = "numpy", specifier = ">=1.25.0,<2.6.0" },
     { name = "orjson", specifier = "~=3.9" },
     { name = "pandas", specifier = ">=2.0.0,<2.4.0" },
@@ -7069,9 +7060,9 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.12' and sys_platform == 'darwin'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform == 'darwin'" },
-    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' and sys_platform == 'darwin'" },
+    { name = "numpy" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.11.*'" },
+    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/91/bb/1eb0242409d22db725d7a88088e6cfd6556829fb0736f9ff69aa9f1e9455/xgboost-3.2.0.tar.gz", hash = "sha256:99b0e9a2a64896cdaf509c5e46372d336c692406646d20f2af505003c0c5d70d", size = 1263936, upload-time = "2026-02-10T11:03:05.542Z" }
 wheels = [
@@ -7088,8 +7079,8 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.12' and sys_platform == 'darwin'" },
-    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and sys_platform == 'darwin'" },
+    { name = "numpy" },
+    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/41/846d4de2b8fc694073fd3ac5052caf68caa1ea11cb7fa32d7ad9c049b232/xgboost-3.3.0.tar.gz", hash = "sha256:58bcb8a4cace648cdab7b94fa4f16d2c9ff26d90dd4d26907168106fa06d8746", size = 1224702, upload-time = "2026-06-17T21:26:50.846Z" }
 wheels = [
@@ -7108,9 +7099,9 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.12' and sys_platform != 'darwin'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform != 'darwin'" },
-    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' and sys_platform != 'darwin'" },
+    { name = "numpy" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.11.*'" },
+    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/43/89437af879315468860b0ef566647113102be898f28fc094b667166d6fe3/xgboost_cpu-3.2.0.tar.gz", hash = "sha256:27f1b1642815c23ee73065d5702ad24c1c1649d63e4e2f498dc7e6a961012281", size = 1264279, upload-time = "2026-02-10T10:34:51.922Z" }
 wheels = [
@@ -7131,8 +7122,8 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.12' and sys_platform != 'darwin'" },
-    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and sys_platform != 'darwin'" },
+    { name = "numpy" },
+    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/e2/8acfd6c51c64494284200320def6dec8a92c97c1a306e7033ea6ef16f530/xgboost_cpu-3.3.0.tar.gz", hash = "sha256:9bf15e819f57ab8b83c9c34510b13711f79faf0cef1a92a5fbe5cef9178f72a6", size = 1225043, upload-time = "2026-06-17T21:10:24.981Z" }
 wheels = [


### PR DESCRIPTION
## Description of changes

The trainers' model graph is a small DAG of model names with attributes, for which `networkx` was imported lazily inside fit. A native `ModelGraph` in `autogluon.core.utils.model_graph` provides the operations the trainers use (ancestors, descendants, subgraph, lexicographical topological sort, BFS layers, shortest path lengths), and `networkx` is removed from the core, tabular and timeseries requirements. Importing `networkx` costs about 0.3 s from a local disk and more from a network file system, and it was paid inside the first fit of every process. `plot_ensemble_model` still builds a `networkx` graph for `pygraphviz` and now names both as optional requirements.

Tests compare `ModelGraph` against `networkx` on random DAGs for every operation, and run the timeseries trainer and ensemble composer on the new graph.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi