### PR TITLE
[tabular] Give TabPFN-3's "auto" prediction chunking slack above the training size

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfn3_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfn3_model.py
@@ -30,10 +30,18 @@ class TabPFN3Model(TabPFNModel):
     default_regression_model: str | None = "tabpfn-v3-regressor-v3_default.ckpt"
 
     max_batch_size_min: int = 100_000
-    """TabPFN-3 reuses the training context (KV cache) across prediction chunks, so
-    chunks smaller than the training set multiply predict time while saving little
-    memory — unlike TabPFN-2.5/2.6 (the base default), which re-process the joint
-    train + batch sequence per chunk and benefit from a low floor."""
+    """Every prediction chunk re-runs the forward pass over the whole training
+    context, so a chunk costs about as much as a predict on the training set even
+    when it holds a few rows; chunks smaller than the training set multiply predict
+    time while saving little memory. TabPFN-2.5/2.6 (the base default) re-process
+    the joint train + batch sequence per chunk, where a low floor bounds memory."""
+
+    max_batch_size_slack: int = 100_000
+    """A held-out fold of a two-fold bag is at most one row, or a few group or time
+    blocks, larger than its training set; without slack that split the fold's
+    prediction into a full chunk and a small second chunk that re-ran the whole
+    training context. Chunking starts once the prediction set exceeds the training
+    set by more than this."""
 
     _default_auxiliary_params_extra = {
         "max_rows": 500_000,
@@ -47,7 +55,7 @@ class TabPFN3Model(TabPFNModel):
         "max_classes": 160,
         # max_batch_size (prediction chunking) is the model's only bound on
         # test-side VRAM (peak grows linearly in unchunked prediction rows);
-        # "auto" resolves at fit time to min(1M, max(100k, n_train)).
+        # "auto" resolves at fit time to min(1M, n_train + 100k).
         "max_batch_size": "auto",
         "model_telemetry": False,
     }

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
@@ -93,9 +93,15 @@ class TabPFNModel(AbstractTorchModel):
     chunk, so peak VRAM scales with the batch size and chunks sized near the
     training set already amortize the context cost. A low floor keeps small
     datasets from paying 100k-row prediction-batch memory (and from being
-    skipped by memory estimates assuming it). Versions whose training context
-    is reused across chunks (TabPFN-3) override this with a high floor, since
-    for them small chunks multiply predict time while saving little memory."""
+    skipped by memory estimates assuming it). Versions for which every chunk
+    re-runs the forward pass over the whole training context (TabPFN-3) override
+    this with a high floor, since for them small chunks multiply predict time
+    while saving little memory."""
+
+    max_batch_size_slack: int = 0
+    """Rows a prediction set may exceed the training set by before the ``"auto"``
+    ``ag.max_batch_size`` resolution chunks it: ``"auto"`` resolves to
+    ``n_train + max_batch_size_slack`` (within ``[max_batch_size_min, 1M]``)."""
 
     _default_auxiliary_params_extra = {
         "max_rows": 100_000,
@@ -172,13 +178,11 @@ class TabPFNModel(AbstractTorchModel):
         if not self.params_aux.get("model_telemetry", False):
             self.disable_tabpfn_telemetry()
 
-        # "auto" prediction chunking resolves against the training size: chunks
-        # re-attend the full training context, so chunks smaller than the training set
-        # multiply predict time at large n_train while saving little memory. Bounded
-        # to [max_batch_size_min, 1M]. None disables chunking entirely. The resolved
+        # "auto" prediction chunking resolves against the training size (see
+        # `_resolve_auto_max_batch_size`). None disables chunking entirely. The resolved
         # value is fit state (read via `_get_max_batch_size`), not a params_aux mutation.
         if self.aux_params.max_batch_size == "auto":
-            self._max_batch_size_resolved = min(1_000_000, max(self.max_batch_size_min, len(X)))
+            self._max_batch_size_resolved = self._resolve_auto_max_batch_size(n_train=len(X))
 
         from tabpfn import TabPFNClassifier, TabPFNRegressor
 
@@ -446,6 +450,17 @@ class TabPFNModel(AbstractTorchModel):
                 inner_model.to(device)
 
     @classmethod
+    def _resolve_auto_max_batch_size(cls, *, n_train: int) -> int:
+        """The prediction chunk size ``ag.max_batch_size="auto"`` stands for at this training size.
+
+        Chunks re-attend the full training context, so chunks smaller than the training
+        set multiply predict time at large ``n_train`` while saving little memory; the
+        slack keeps a prediction set slightly larger than the training set (a held-out
+        fold of a two-fold bag) in a single chunk. Bounded to ``[max_batch_size_min, 1M]``.
+        """
+        return min(1_000_000, max(cls.max_batch_size_min, n_train + cls.max_batch_size_slack))
+
+    @classmethod
     def _n_test_for_memory_estimate(cls, *, n_train: int, hyperparameters: dict | None) -> int:
         """Proxy for the prediction batch size in memory estimates.
 
@@ -458,9 +473,8 @@ class TabPFNModel(AbstractTorchModel):
         """
         max_batch_size = (hyperparameters or {}).get("ag.max_batch_size", "auto")
         if max_batch_size is None or max_batch_size == "auto":
-            # "auto" resolves to at least max_batch_size_min at fit time; explicit
-            # None (chunking disabled) has no bound, so use the same proxy.
-            max_batch_size = max(cls.max_batch_size_min, n_train)
+            # explicit None (chunking disabled) has no bound, so use the "auto" proxy.
+            max_batch_size = cls._resolve_auto_max_batch_size(n_train=n_train)
         return min(int(max_batch_size), n_train)
 
     @classmethod

--- a/tabular/tests/unittests/models/test_tabpfn3.py
+++ b/tabular/tests/unittests/models/test_tabpfn3.py
@@ -354,3 +354,21 @@ def test_tabpfn_memory_size_of_an_unfit_model_is_the_pickle():
 
     model = TabPFNModel(problem_type="binary", eval_metric=None)
     assert model.get_memory_size() == AbstractModel._get_memory_size(model)
+
+
+def test_tabpfn_auto_max_batch_size_resolution():
+    """ "auto" chunking starts only once the prediction set exceeds the training set by the slack."""
+    from autogluon.tabular.models.tabpfnv2.tabpfnv2_5_model import TabPFNModel
+
+    assert TabPFNModel._resolve_auto_max_batch_size(n_train=500) == 1_000, "floor for TabPFN-2.5"
+    assert TabPFNModel._resolve_auto_max_batch_size(n_train=20_000) == 20_000, "no slack for TabPFN-2.5"
+    assert TabPFN3Model._resolve_auto_max_batch_size(n_train=500) == 100_500
+    assert TabPFN3Model._resolve_auto_max_batch_size(n_train=100_000) == 200_000
+    assert TabPFN3Model._resolve_auto_max_batch_size(n_train=500_000) == 600_000
+    assert TabPFN3Model._resolve_auto_max_batch_size(n_train=950_000) == 1_000_000, "capped at 1M"
+    # the memory-estimate proxy stays bounded by the training size
+    assert TabPFN3Model._n_test_for_memory_estimate(n_train=500_000, hyperparameters=None) == 500_000
+    assert (
+        TabPFN3Model._n_test_for_memory_estimate(n_train=500_000, hyperparameters={"ag.max_batch_size": 20_000})
+        == 20_000
+    )


### PR DESCRIPTION
## Description of changes

For TabPFN-3, `ag.max_batch_size="auto"` resolved to the training size, so a held-out fold that is one row, or a few group or time blocks, larger than its training set was predicted as a full chunk plus a small second chunk. Every chunk re-runs the forward pass over the whole training context in the default fit mode, so that second chunk cost about half of the fold's predict time for a handful of rows. `"auto"` now resolves to `n_train + 100k` (still capped at 1M) through a new `max_batch_size_slack` class attribute; TabPFN-2.5/2.6 keep a slack of 0 and resolve as before. The memory-estimate proxy is unchanged. Docstrings describe the chunk cost as measured rather than assuming a reused context.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi