### PR TITLE
[core][tabular] Model class settings: process-wide knobs set once at fit

### DIFF
--- a/core/src/autogluon/core/models/abstract/_class_settings.py
+++ b/core/src/autogluon/core/models/abstract/_class_settings.py
@@ -1,0 +1,38 @@
+"""Settings a model class owns for the whole process, as opposed to per-config hyperparameters.
+
+A hyperparameter belongs to one config: two configs of the same class can hold different
+values without affecting each other. Some knobs cannot work that way, because they steer
+state every model of the class in the process shares -- a registry of built networks, a
+cache size, a telemetry switch. Setting such a knob on one config would silently change
+what every other config of the class sees. A model class declares those knobs as a
+:class:`ClassSettings` dataclass in ``class_settings_cls``; ``AbstractModel`` holds one
+instance per declaring class, and ``TabularPredictor.fit(model_class_settings=...)`` sets
+them once, before any model trains.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ClassSettings:
+    """Base for a model class's process-wide settings; subclasses declare fields with defaults."""
+
+    @classmethod
+    def field_names(cls) -> list[str]:
+        return [f.name for f in dataclasses.fields(cls)]
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+    def replace(self, **values: Any) -> ClassSettings:
+        """A copy with ``values`` applied; an unknown key raises ``ValueError``."""
+        unknown = sorted(set(values) - set(self.field_names()))
+        if unknown:
+            raise ValueError(
+                f"Unknown {type(self).__name__} setting(s) {unknown}; valid settings are {self.field_names()}."
+            )
+        return dataclasses.replace(self, **values)

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -12,7 +12,7 @@ import time
 from abc import ABC, abstractmethod
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any, Type
+from typing import Any, ClassVar, Type
 
 import numpy as np
 import pandas as pd
@@ -67,6 +67,7 @@ from ...utils.loaders import load_json, load_pkl
 from ...utils.savers import save_json, save_pkl
 from ...utils.time import sample_df_for_time_func, time_func
 from ._auxiliary_params import AuxiliaryParams, ParamsAuxDict
+from ._class_settings import ClassSettings
 from ._mutation_deprecated_dict import ParamsDict
 from ._tags import _DEFAULT_CLASS_TAGS, _DEFAULT_TAGS
 from .model_trial import model_trial, skip_hpo
@@ -265,6 +266,59 @@ class AbstractModel(ModelBase, Tunable):
 
     default_random_seed: int | None = 0
 
+    class_settings_cls: ClassVar[type[ClassSettings] | None] = None
+    """The :class:`ClassSettings` dataclass this class declares for knobs shared by every model of
+    the class in the process, or None. A subclass inherits its base's declaration and shares
+    the base's settings instance rather than declaring its own."""
+
+    @classmethod
+    def _class_settings_owner(cls) -> type | None:
+        """The nearest class in the MRO that declares ``class_settings_cls``, or None."""
+        for base in cls.__mro__:
+            if base.__dict__.get("class_settings_cls") is not None:
+                return base
+        return None
+
+    @classmethod
+    def get_class_settings(cls) -> ClassSettings | None:
+        """The process-wide settings of this class's declaring base, defaults until set; None if undeclared."""
+        owner = cls._class_settings_owner()
+        if owner is None:
+            return None
+        settings = owner.__dict__.get("_class_settings")
+        if settings is None:
+            settings = owner.class_settings_cls()
+            owner._class_settings = settings
+        return settings
+
+    @classmethod
+    def set_class_settings(cls, **values: Any) -> ClassSettings:
+        """Set process-wide settings for every model of this class's declaring base.
+
+        Raises ``ValueError`` for an unknown key or a class that declares no settings. A change
+        to a value set earlier in the process is logged, since models fit under the old value
+        see the new one from now on.
+        """
+        owner = cls._class_settings_owner()
+        if owner is None:
+            raise ValueError(f"{cls.__name__} declares no class settings; nothing to set from {sorted(values)}.")
+        current = cls.get_class_settings()
+        new = current.replace(**values)
+        if owner.__dict__.get("_class_settings_set", False) and new != current:
+            logger.log(
+                30,
+                f"\t{owner.__name__} class settings change from {current.to_dict()} to {new.to_dict()}: "
+                f"every model of this class in the process now uses the new values.",
+            )
+        owner._class_settings = new
+        owner._class_settings_set = True
+        return new
+
+    def _apply_class_settings_snapshot(self) -> None:
+        """Re-apply the class settings this model was initialized under, for a fit or load in another process."""
+        if self._class_settings_snapshot is not None:
+            type(self).set_class_settings(**self._class_settings_snapshot)
+
     def __init__(
         self,
         path: str | None = None,
@@ -337,6 +391,9 @@ class AbstractModel(ModelBase, Tunable):
         self._memory_usage_estimate: float | None = None  # Peak training memory usage estimate in bytes
 
         self._user_params, self._user_params_aux = self._init_user_params(params=hyperparameters)
+        #: The class settings in force when this model was initialized; a fit or load in another
+        #: process applies them there. None until `initialize`, or for a class without settings.
+        self._class_settings_snapshot: dict | None = None
 
         self.params: dict = {}
         self.params_aux: dict = {}
@@ -927,6 +984,8 @@ class AbstractModel(ModelBase, Tunable):
     def initialize(self, **kwargs) -> dict:
         if not self._is_initialized:
             self._initialize(**kwargs)
+            settings = self.get_class_settings()
+            self._class_settings_snapshot = None if settings is None else settings.to_dict()
             self._is_initialized = True
 
         kwargs.pop("feature_metadata", None)
@@ -1350,6 +1409,8 @@ class AbstractModel(ModelBase, Tunable):
             Any additional fit arguments a model supports.
         """
         time_start = time.time()
+        # A fold model fit in a worker process starts from class defaults there.
+        self._apply_class_settings_snapshot()
         kwargs = self.initialize(
             **kwargs
         )  # FIXME: This might have to go before self._preprocess_fit_args, but then time_limit might be incorrect in **kwargs init to initialize
@@ -2008,6 +2069,7 @@ class AbstractModel(ModelBase, Tunable):
         """
         file_path = os.path.join(path, cls.model_file_name)
         model = load_pkl.load(path=file_path, verbose=verbose)
+        model._apply_class_settings_snapshot()
         if reset_paths:
             model.set_contexts(path)
         if hasattr(model, "_compiler"):

--- a/core/tests/unittests/models/abstract_model/test_class_settings.py
+++ b/core/tests/unittests/models/abstract_model/test_class_settings.py
@@ -1,0 +1,91 @@
+"""Class settings: process-wide knobs a model class owns, set once rather than per config."""
+
+from __future__ import annotations
+
+import logging
+import pickle
+from dataclasses import dataclass
+
+import pytest
+
+from autogluon.core.models import AbstractModel
+from autogluon.core.models.abstract._class_settings import ClassSettings
+
+
+@dataclass(frozen=True)
+class _Settings(ClassSettings):
+    capacity: int = 1
+    verbose: bool = False
+
+
+class _Model(AbstractModel):
+    class_settings_cls = _Settings
+
+
+class _SubModel(_Model):
+    pass
+
+
+class _PlainModel(AbstractModel):
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings(monkeypatch):
+    monkeypatch.setattr(_Model, "_class_settings", None, raising=False)
+    monkeypatch.setattr(_Model, "_class_settings_set", False, raising=False)
+
+
+def test_class_settings_default_until_set_and_shared_with_subclasses():
+    assert _Model.get_class_settings() == _Settings()
+    assert _SubModel.get_class_settings() is _Model.get_class_settings(), "a subclass shares the base's settings"
+    _SubModel.set_class_settings(capacity=3)
+    assert _Model.get_class_settings().capacity == 3
+    assert _SubModel.get_class_settings().verbose is False
+    assert _PlainModel.get_class_settings() is None
+
+
+def test_class_settings_reject_unknown_keys_and_undeclared_classes():
+    with pytest.raises(ValueError, match="valid settings are"):
+        _Model.set_class_settings(capacty=2)
+    with pytest.raises(ValueError, match="declares no class settings"):
+        _PlainModel.set_class_settings(capacity=2)
+
+
+def test_class_settings_change_is_logged(caplog):
+    logger = logging.getLogger("autogluon.core.models.abstract.abstract_model")
+    logger.addHandler(caplog.handler)  # autogluon's loggers do not propagate to the root logger
+    try:
+        _Model.set_class_settings(capacity=2)
+        with caplog.at_level(logging.WARNING, logger=logger.name):
+            _Model.set_class_settings(capacity=2)
+            assert not caplog.records, "setting the same value again is silent"
+            _Model.set_class_settings(capacity=5)
+        assert any("class settings change" in record.getMessage() for record in caplog.records)
+    finally:
+        logger.removeHandler(caplog.handler)
+
+
+def test_class_settings_snapshot_follows_the_model_into_another_process(tmp_path):
+    """A model initialized under some settings re-applies them where its pickle is fit or loaded."""
+    _Model.set_class_settings(capacity=4)
+    model = _SubModel(path=str(tmp_path), name="m", problem_type="binary", eval_metric="log_loss")
+    model.initialize()
+    assert model._class_settings_snapshot == {"capacity": 4, "verbose": False}
+    saved_path = model.save()
+
+    # Another process starts from defaults.
+    _Model._class_settings = None
+    _Model._class_settings_set = False
+    restored = pickle.loads(pickle.dumps(model))
+    restored._apply_class_settings_snapshot()
+    assert _Model.get_class_settings().capacity == 4
+
+    _Model._class_settings = None
+    _Model._class_settings_set = False
+    _SubModel.load(saved_path)
+    assert _Model.get_class_settings().capacity == 4
+
+    plain = _PlainModel(path=str(tmp_path / "plain"), name="p", problem_type="binary", eval_metric="log_loss")
+    plain.initialize()
+    assert plain._class_settings_snapshot is None

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -60,6 +60,8 @@ class AbstractTabularLearner(AbstractLearner):
             self.ignored_columns = []
         self.threshold = label_count_threshold
         self.problem_type = problem_type
+        #: `model_class_settings` applied by the predictor's fit, re-applied when the predictor loads.
+        self.model_class_settings: dict | None = None
         self._eval_metric_was_str = eval_metric is not None and isinstance(eval_metric, str)
         self.eval_metric = get_metric(eval_metric, self.problem_type, "eval_metric")
 

--- a/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
+++ b/tabular/src/autogluon/tabular/models/tabpfnv2/tabpfnv2_5_model.py
@@ -5,11 +5,13 @@ import logging
 import os
 import threading
 from collections import OrderedDict
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
 import numpy as np
 
+from autogluon.core.models.abstract._class_settings import ClassSettings
 from autogluon.tabular.models.abstract.abstract_torch_model import AbstractTorchModel
 
 from ._weight_fetch import weight_fetch_policy
@@ -138,6 +140,15 @@ def _detach_network(estimator):
     return est
 
 
+@dataclass(frozen=True)
+class TabPFNClassSettings(ClassSettings):
+    shared_network_capacity: int = 1
+    """Built networks the process keeps for reuse across TabPFN fits and loads, one per
+    (checkpoint, estimator type, device), most recently used first. A fit or load whose network
+    is not registered builds it and evicts the least recently used entry beyond the capacity; an
+    estimator holding an evicted network keeps it until it is released. 0 shares nothing."""
+
+
 class TabPFNModel(AbstractTorchModel):
     """TabPFN-2.5 is a tabular foundation model that is developed and maintained by PriorLabs: https://priorlabs.ai/.
 
@@ -209,13 +220,7 @@ class TabPFNModel(AbstractTorchModel):
     default_resources_physical_cores_only = True
     default_num_gpus = max_gpus
 
-    shared_network_capacity: ClassVar[int] = 1
-    """Built networks the process keeps for reuse across this class's fits and loads, one per
-    (checkpoint, estimator type, device), most recently used first. A fit or load whose network
-    is not registered builds it and evicts the least recently used entry beyond the capacity; an
-    estimator holding an evicted network keeps it until it is released. 0 shares nothing.
-    Process-wide, so not a per-config hyperparameter: a value set for one config changes what
-    every other config of the class sees."""
+    class_settings_cls = TabPFNClassSettings
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -334,9 +339,9 @@ class TabPFNModel(AbstractTorchModel):
             checkpoint_path = str(Path(model_path).resolve())
             self._checkpoint_path = checkpoint_path
             self._estimator_type = "classifier" if is_classification else "regressor"
-            if self._shares_module(hps, device) and self.shared_network_capacity > 0:
+            if self._shares_module(hps, device) and self.get_class_settings().shared_network_capacity > 0:
                 hps["model_path"] = _shared_model_specs(
-                    checkpoint_path, self._estimator_type, device, self.shared_network_capacity
+                    checkpoint_path, self._estimator_type, device, self.get_class_settings().shared_network_capacity
                 )
             else:
                 hps["model_path"] = checkpoint_path
@@ -359,7 +364,11 @@ class TabPFNModel(AbstractTorchModel):
                 y=y,
             )
         self._narrow_inference_context()
-        if model_path is not None and self._shares_module(hps, device) and self.shared_network_capacity > 0:
+        if (
+            model_path is not None
+            and self._shares_module(hps, device)
+            and self.get_class_settings().shared_network_capacity > 0
+        ):
             # The string keeps the specs out of `get_params()` and the pickle.
             self.model.model_path = checkpoint_path
             if self._estimator_type == "regressor":
@@ -391,7 +400,7 @@ class TabPFNModel(AbstractTorchModel):
         # fetch policy decides whether a missing one may be downloaded now.
         with weight_fetch_policy(self.aux_params.fetch_pretrained_weights, stage="load", model_name=self.name):
             spec = _shared_model_specs(
-                self._checkpoint_path, self._estimator_type, device, self.shared_network_capacity
+                self._checkpoint_path, self._estimator_type, device, self.get_class_settings().shared_network_capacity
             )
         est = self.model
         est.models_ = [spec.model]

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -54,6 +54,7 @@ from autogluon.core.constants import (
 )
 from autogluon.core.data.label_cleaner import LabelCleanerMulticlassToBinary
 from autogluon.core.metrics import Scorer, get_metric
+from autogluon.core.models import AbstractModel
 from autogluon.core.problem_type import problem_type_info
 from autogluon.core.pseudolabeling.pseudolabeling import filter_ensemble_pseudo, filter_pseudo
 from autogluon.core.scheduler.scheduler_factory import scheduler_factory
@@ -1083,6 +1084,13 @@ class TabularPredictor:
                 See the `ag_args` argument from "Advanced functionality: Custom AutoGluon model arguments" in the `hyperparameters` argument documentation for valid values.
                 Identical to specifying `ag_args` parameter for all models in `hyperparameters`.
                 If a key in `ag_args` is already specified for a model in `hyperparameters`, it will not be altered through this argument.
+            model_class_settings : dict, default = None
+                Process-wide settings of model classes, keyed like `hyperparameters` (a model key such as
+                `'TABPFN-3'` or a model class) with a dict of the settings the class declares in
+                `class_settings_cls`, e.g. `{'TABPFN-3': {'shared_network_capacity': 3}}`.
+                Unlike a hyperparameter, a class setting steers state every model of that class in the
+                process shares, so it is set once here rather than per config, and a predictor re-applies
+                it when loaded. A key the class does not declare raises before any model trains.
             ag_args_fit : dict, default = None
                 Keyword arguments to pass to all models.
                 See the `ag_args_fit` argument from "Advanced functionality: Custom AutoGluon model arguments" in the `hyperparameters` argument documentation for valid values.
@@ -1375,6 +1383,7 @@ class TabularPredictor:
         unlabeled_data = kwargs["unlabeled_data"]
         ag_args = kwargs["ag_args"]
         ag_args_fit = kwargs["ag_args_fit"]
+        self._apply_model_class_settings(kwargs["model_class_settings"])
         ag_args_ensemble = kwargs["ag_args_ensemble"]
         core_kwargs = kwargs["core_kwargs"]
         aux_kwargs = kwargs["aux_kwargs"]
@@ -2704,6 +2713,7 @@ class TabularPredictor:
 
         ag_args = kwargs["ag_args"]
         ag_args_fit = kwargs["ag_args_fit"]
+        self._apply_model_class_settings(kwargs["model_class_settings"])
         ag_args_ensemble = kwargs["ag_args_ensemble"]
         core_kwargs = kwargs["core_kwargs"]
         aux_kwargs = kwargs["aux_kwargs"]
@@ -5850,7 +5860,22 @@ class TabularPredictor:
         predictor: TabularPredictor = load_pkl.load(path=os.path.join(path, cls.predictor_file_name))
         learner = predictor._learner_type.load(path)
         predictor._set_post_fit_vars(learner=learner)
+        predictor._apply_model_class_settings(learner.model_class_settings)
         return predictor
+
+    def _apply_model_class_settings(self, model_class_settings: dict | None) -> None:
+        """Set each named model class's process-wide settings and record them on the learner."""
+        if not model_class_settings:
+            return
+        applied = dict(self._learner.model_class_settings or {})
+        for key, values in model_class_settings.items():
+            model_cls = ag_model_registry.key_to_cls(key) if isinstance(key, str) else key
+            if not (isinstance(model_cls, type) and issubclass(model_cls, AbstractModel)):
+                raise ValueError(f"model_class_settings key {key!r} is neither a model key nor a model class.")
+            model_cls.set_class_settings(**values)
+            registered = ag_model_registry.exists(model_cls)
+            applied[ag_model_registry.key(model_cls) if registered else model_cls] = dict(values)
+        self._learner.model_class_settings = applied
 
     @classmethod
     def load(
@@ -6265,6 +6290,7 @@ class TabularPredictor:
             ag_args=None,
             ag_args_fit=None,
             ag_args_ensemble=None,
+            model_class_settings=None,
             core_kwargs=None,
             aux_kwargs=None,
             included_model_types=None,

--- a/tabular/tests/unittests/models/test_tabpfn3.py
+++ b/tabular/tests/unittests/models/test_tabpfn3.py
@@ -254,7 +254,8 @@ def test_tabpfn_save_keeps_foundation_weights_out_of_the_pickle(tmp_path, monkey
     assert loaded.is_fit()
     assert loaded.model.models_ == [shared]
     assert loaded.model.executor_.models == [shared]
-    assert requests == [("checkpoint.ckpt", "classifier", "cpu", TabPFNModel.shared_network_capacity)]
+    capacity = TabPFNModel.get_class_settings().shared_network_capacity
+    assert requests == [("checkpoint.ckpt", "classifier", "cpu", capacity)]
 
 
 def test_tabpfn_references_pretrained_weights_by_default(tmp_path):

--- a/tabular/tests/unittests/models/test_tabpfnv2.py
+++ b/tabular/tests/unittests/models/test_tabpfnv2.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from autogluon.tabular.models.tabpfnv2.tabpfnv2_5_model import RealTabPFNv2Model
+from autogluon.tabular.models.tabpfnv2.tabpfnv2_5_model import RealTabPFNv2Model, TabPFNModel
 from autogluon.tabular.testing import FitHelper
 
 toy_model_params = {"n_estimators": 1}
@@ -155,7 +155,8 @@ def test_tabpfn_shared_network_capacity_bounds_the_registry(tmp_path, monkeypatc
         return model
 
     tabpfnv2_5_model.release_shared_networks()
-    monkeypatch.setattr(RealTabPFNv2Model, "shared_network_capacity", 1)
+    monkeypatch.setattr(TabPFNModel, "_class_settings", TabPFNModel.get_class_settings(), raising=False)
+    RealTabPFNv2Model.set_class_settings(shared_network_capacity=1)
     classifier = fit("classifier", "binary")
     regressor = fit("regressor", "regression")
     assert len(tabpfnv2_5_model._MODEL_SPECS) == 1, "the regressor's network evicted the classifier's"
@@ -165,13 +166,13 @@ def test_tabpfn_shared_network_capacity_bounds_the_registry(tmp_path, monkeypatc
     assert rebuilt.model.models_[0] is not classifier.model.models_[0], "rebuilt after eviction"
     assert regressor.model.models_[0] is not rebuilt.model.models_[0]
 
-    monkeypatch.setattr(RealTabPFNv2Model, "shared_network_capacity", 2)
+    RealTabPFNv2Model.set_class_settings(shared_network_capacity=2)
     regressor_again = fit("regressor_again", "regression")
     assert regressor_again.model.models_[0] is not regressor.model.models_[0], "the rebuild evicted it"
     assert fit("classifier_third", "binary").model.models_[0] is rebuilt.model.models_[0], "still registered"
     assert len(tabpfnv2_5_model._MODEL_SPECS) == 2
 
-    monkeypatch.setattr(RealTabPFNv2Model, "shared_network_capacity", 0)
+    RealTabPFNv2Model.set_class_settings(shared_network_capacity=0)
     tabpfnv2_5_model.release_shared_networks()
     unshared = fit("unshared", "binary")
     assert unshared.model.models_[0] is not fit("unshared_too", "binary").model.models_[0]

--- a/tabular/tests/unittests/test_model_class_settings.py
+++ b/tabular/tests/unittests/test_model_class_settings.py
@@ -1,0 +1,72 @@
+"""`model_class_settings`: process-wide settings a model class owns, set once at fit and re-applied on load."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from autogluon.core.models.abstract._class_settings import ClassSettings
+from autogluon.core.models.dummy.dummy_model import DummyModel
+from autogluon.tabular import TabularPredictor
+from autogluon.tabular.models.tabpfnv2.tabpfnv2_5_model import TabPFNModel
+
+
+@dataclass(frozen=True)
+class _DummySettings(ClassSettings):
+    knob: int = 1
+
+
+class _SettingsDummyModel(DummyModel):
+    class_settings_cls = _DummySettings
+
+
+def _data(n: int = 60) -> pd.DataFrame:
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame(rng.normal(size=(n, 3)), columns=["a", "b", "c"])
+    df["label"] = rng.integers(0, 2, n)
+    return df
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings(monkeypatch):
+    monkeypatch.setattr(_SettingsDummyModel, "_class_settings", None, raising=False)
+    monkeypatch.setattr(_SettingsDummyModel, "_class_settings_set", False, raising=False)
+
+
+def test_fit_applies_model_class_settings_and_load_reapplies_them(tmp_path):
+    predictor = TabularPredictor(label="label", path=str(tmp_path / "p"), verbosity=0).fit(
+        _data(),
+        hyperparameters={_SettingsDummyModel: {}},
+        model_class_settings={_SettingsDummyModel: {"knob": 7}},
+        fit_weighted_ensemble=False,
+    )
+    assert _SettingsDummyModel.get_class_settings().knob == 7
+    assert predictor._learner.model_class_settings == {_SettingsDummyModel: {"knob": 7}}
+    model = predictor._trainer.load_model(predictor.model_names()[0])
+    assert model._class_settings_snapshot == {"knob": 7}
+
+    _SettingsDummyModel._class_settings = None
+    _SettingsDummyModel._class_settings_set = False
+    loaded = TabularPredictor.load(predictor.path)
+    assert _SettingsDummyModel.get_class_settings().knob == 7
+    assert loaded.predict(_data(5)).shape == (5,)
+
+
+def test_model_class_settings_resolve_model_keys_and_reject_unknown_settings(tmp_path, monkeypatch):
+    predictor = TabularPredictor(label="label", path=str(tmp_path / "p"), verbosity=0)
+    monkeypatch.setattr(TabPFNModel, "_class_settings", TabPFNModel.get_class_settings(), raising=False)
+    predictor._apply_model_class_settings({"TABPFN-3": {"shared_network_capacity": 3}})
+    assert TabPFNModel.get_class_settings().shared_network_capacity == 3, "TabPFN-3 shares the TabPFN base's settings"
+    assert predictor._learner.model_class_settings == {"TABPFN-3": {"shared_network_capacity": 3}}
+
+    with pytest.raises(ValueError, match="valid settings are"):
+        TabularPredictor(label="label", path=str(tmp_path / "q"), verbosity=0).fit(
+            _data(), hyperparameters={"DUMMY": {}}, model_class_settings={_SettingsDummyModel: {"knobb": 1}}
+        )
+    with pytest.raises(ValueError, match="declares no class settings"):
+        TabularPredictor(label="label", path=str(tmp_path / "r"), verbosity=0).fit(
+            _data(), hyperparameters={"DUMMY": {}}, model_class_settings={"DUMMY": {"anything": 1}}
+        )


### PR DESCRIPTION
## Description of changes

Stacked on #5912.

A hyperparameter belongs to one config: two configs of the same class hold different values without affecting each other. Some knobs cannot work that way because they steer state every model of the class in the process shares, such as #5912's registry of built TabPFN networks; setting such a knob on one config silently changes what the other configs of the class see.

A model class now declares those knobs as a `ClassSettings` dataclass in `class_settings_cls`. `AbstractModel` keeps one settings instance per declaring class, shared by its subclasses, with `get_class_settings()` and `set_class_settings(**values)`; an unknown key raises, and a change to a value set earlier in the process is logged since models fit under the old value see the new one. Each model snapshots the settings at `initialize` and re-applies them at the start of `fit` and in `load`, so a fold fit in a worker process or a model loaded elsewhere runs under the settings it was configured with.

`TabularPredictor.fit(model_class_settings={'TABPFN-3': {'shared_network_capacity': 3}})` (also on `fit_extra`) resolves each key through the model registry, or takes a model class directly, applies the settings before any model trains, and records them on the learner so a loaded predictor applies them again. TabPFN's `shared_network_capacity` moves from a class attribute to `TabPFNClassSettings`.

Tests: defaults, subclass sharing, unknown keys, undeclared classes, the change log line, and the snapshot surviving a pickle and a model load (core); a predictor fit that applies settings, records them and re-applies them on load, key resolution through the registry, and validation before any model trains (tabular).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi